### PR TITLE
Fixed str_replace of document root/DIR so it generates the correct path on windows

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@
 		Required external files
 		============================ */
 
-	$timber = str_replace($_SERVER['DOCUMENT_ROOT'], '', __DIR__);
+	$timber = str_replace(realpath($_SERVER['DOCUMENT_ROOT']), '', realpath(__DIR__));
 	define("TIMBER", $timber);
 	define("TIMBER_URL", 'http://'.$_SERVER["HTTP_HOST"].TIMBER);
 	define("TIMBER_LOC", $_SERVER["DOCUMENT_ROOT"].TIMBER);


### PR DESCRIPTION
On windows the paths is escaped in $_SERVER['DOCUMENT_ROOT'] and the __DIR__ is not. The str_replace doesnt work then.
