### PR TITLE
Get the WordPress Uploads Directory when Calling Images

### DIFF
--- a/objects/timber-image.php
+++ b/objects/timber-image.php
@@ -21,7 +21,7 @@
 			}
 			if (isset($this->file)){
 				$dir = wp_upload_dir();
-				return $dir["url"].'/'.$this->file;
+				return $dir["baseurl"].'/'.$this->file;
 			}
 			return false;
 		}


### PR DESCRIPTION
Ran into this when trying to use a theme that changes the uploads directory to be at the root and calls it /media.  Timber had the wp-content/uploads. directory hardcoded, but this change should get the right url when using Timber with a theme that changes it.
