### PR TITLE
Add theme URI to context

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -282,7 +282,7 @@ class Timber {
         $data['theme_dir'] = str_replace($_SERVER['DOCUMENT_ROOT'], '', get_stylesheet_directory());
         $data['language_attributes'] = WPHelper::ob_function('language_attributes');
         $data['stylesheet_uri'] = get_stylesheet_uri();
-        $data['theme_uri'] = get_template_directory_uri();
+        $data['template_uri'] = get_template_directory_uri();
         $data = apply_filters('timber_context', $data);
         return $data;
     }


### PR DESCRIPTION
Hey Jared,

Thinking this might be useful to others, we have stylesheet_uri but not the base theme_uri to use for things such as images that might be included with a theme.  It's the first thing I had to add in the hook to start using Timber as intended.
