### PR TITLE
Incorrect use of {{language_attributes}} inside conditional comments.

### DIFF
--- a/timber-starter-theme/views/html-header.twig
+++ b/timber-starter-theme/views/html-header.twig
@@ -1,7 +1,7 @@
 <!doctype html>
-<!--[if lt IE 7]><html class="no-js ie ie6 lt-ie9 lt-ie8 lt-ie7" lang="{{language_attributes}}"> <![endif]-->
-<!--[if IE 7]><html class="no-js ie ie7 lt-ie9 lt-ie8" lang="{{language_attributes}}"> <![endif]-->
-<!--[if IE 8]><html class="no-js ie ie8 lt-ie9" lang="{{language_attributes}}"> <![endif]-->
+<!--[if lt IE 7]><html class="no-js ie ie6 lt-ie9 lt-ie8 lt-ie7" {{language_attributes}}> <![endif]-->
+<!--[if IE 7]><html class="no-js ie ie7 lt-ie9 lt-ie8" {{language_attributes}}> <![endif]-->
+<!--[if IE 8]><html class="no-js ie ie8 lt-ie9" {{language_attributes}}> <![endif]-->
 <!--[if gt IE 8]><!--><html class="no-js" {{language_attributes}}> <!--<![endif]-->
 	<head>
     <meta charset="{{ bloginfo('charset') }}" />


### PR DESCRIPTION
In the example theme the current use of {{language_attributes}} inside the IE conditional comments outputs as lang="lang="en-GB"", so here's a pull request to amend that.
