### PR TITLE
get_content(length) does not limit the amount of words

### DIFF
--- a/objects/timber-post.php
+++ b/objects/timber-post.php
@@ -399,7 +399,7 @@ class TimberPost extends TimberCore
   {
     $content = $this->post_content;
     if ($len) {
-      wp_trim_words($content, $len);
+      $content = wp_trim_words($content, $len);
     }
     if ($page) {
       $contents = explode('<!--nextpage-->', $content);


### PR DESCRIPTION
This fixes an issue where the variable isn't set for the wp_trim_words() function, therefore post_content is returned without actually trimming the length of get_content().
