### PR TITLE
Add filter to get_preview()

### DIFF
--- a/objects/timber-post.php
+++ b/objects/timber-post.php
@@ -162,7 +162,7 @@ class TimberPost extends TimberCore
       }
       $text .= ' <a href="' . $this->get_path() . '" class="read-more">' . $readmore . '</a>';
     }
-    return $text;
+    return apply_filters('timber_get_preview', $text);
   }
 
   /**


### PR DESCRIPTION
get_preview() currently feels a little too opinionated by forcing the "Read More" link at the end of the preview text regardless if you want that or not.

By adding a filter one can remove the link with preg_replace. It also has the advantage of being able to globally set wpautop by default if preferred.
