### PR TITLE
Relocate add_filter call to within constructor method

### DIFF
--- a/admin/timber-admin.php
+++ b/admin/timber-admin.php
@@ -1,7 +1,5 @@
 <?php
 
-add_filter( 'plugin_action_links', array('TimberAdmin', 'settings_link'), 10, 2 );
-
 class TimberAdmin {
 
 	function __construct() {
@@ -14,6 +12,7 @@ class TimberAdmin {
 		}
 		add_action('admin_menu', array(&$this, 'create_menu'));
 		add_action('admin_enqueue_scripts', array(&$this, 'load_styles'));
+		add_filter( 'plugin_action_links', array(&$this, 'settings_link'), 10, 2 );
 	}
 
 	function settings_link( $links, $file ) {


### PR DESCRIPTION
The position of the add_filter call produces PHP Notices on the Plugins page.
