### PR TITLE
change get_path() to get_permalink()

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -152,7 +152,7 @@ class TimberPost extends TimberCore {
 			if ($last != '.' && $trimmed) {
 				$text .= ' &hellip; ';
 			}
-			$text .= ' <a href="' . $this->get_path() . '" class="read-more">' . $readmore . '</a>';
+			$text .= ' <a href="' . $this->get_permalink() . '" class="read-more">' . $readmore . '</a>';
 		}
 		return $text;
 	}


### PR DESCRIPTION
get_path() was returning the site url instead of the post's url.
