### PR TITLE
adding comments order from admin settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .sass-cache
 twig-cache/*
 .DS_Store
+.idea

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -269,8 +269,8 @@ class TimberPost extends TimberCore {
 	*  {% endfor %}
 	*/
 
-	function get_comments($ct = 0, $type = 'comment', $status = 'approve', $CommentClass = 'TimberComment') {
-		$args = array('post_id' => $this->ID, 'status' => $status);
+	function get_comments($ct = 0, $type = 'comment', $status = 'approve', $CommentClass = 'TimberComment', $order = 'desc') {
+		$args = array('post_id' => $this->ID, 'status' => $status, 'order' => get_option('comment_order'));
 		if ($ct > 0) {
 			$args['number'] = $ct;
 		}
@@ -283,7 +283,7 @@ class TimberPost extends TimberCore {
 
 	/**
 	*  <ul class="categories">
-	*  {% for cateogry in post.get_categories %}
+	*  {% for category in post.get_categories %}
 	*    <li>{{category.name}}</li>
 	*  {% endfor %}
 	*  </ul>


### PR DESCRIPTION
This commit concern 3 updates:
- Adding comments order from administrator settings (asc or desc). By default, the order is on the comment date.
- Adding .idea in .gitignore. .idea are JetBrains IDEs projects files.
- Correcting comments.
