### PR TITLE
Wrong TIMBER_URL_PATH on Windows

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -61,6 +61,7 @@ class Timber {
         $plugin_url_path = str_replace('https://', '', $plugin_url_path);
         $plugin_url_path = str_replace('http://', '', $plugin_url_path);
         $timber_dirs = dirname(__FILE__);
+        $timber_dirs = str_replace('\\', '/', $timber_dirs);
         $timber_dirs = explode('/', $timber_dirs);
         $timber_dirname = array_pop($timber_dirs);
         define("TIMBER", $timber_loc);


### PR DESCRIPTION
I found `timber-admin.css` returns 404 on windows machine.
To solve this, simply replace backslashes into slashes before `explode()`.
