### PR TITLE
Set query in load_template on wp_loaded hook

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -378,8 +378,7 @@ class Timber {
         });
         add_action('wp_loaded', function ($template) use ( $template, $query ) {
             if ($query) {
-                global $wp_query;
-                $wp_query = new WP_Query($query);
+                query_posts( $query );
             }
             if ($template) {
                 load_template($template);


### PR DESCRIPTION
First of all, thanks for the great work on this library! It is everything WP lacks and more.. makes developing with WP a whole lot more fun :+1:

The router is awesome, but if you call Timber::load_template in a plugin or functions.php directly (as per the docs), the query is also directly made. However, if you want to do something with a custom taxonomy, you can only start querying after the init hook (because that's where custom tax's should be registered).

This pull request fixes that by only actually querying just in time before loading the template.
