### PR TITLE
Use wp() instead of manually querying posts in Timber::load_template

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -373,18 +373,22 @@ class Timber {
 
     public function load_template($template, $query = false) {
         $template = locate_template($template);
-        add_action('send_headers', function () {
-            header('HTTP/1.1 200 OK');
-        });
-        add_action('wp_loaded', function ($template) use ( $template, $query ) {
-            if ($query) {
-                query_posts( $query );
-            }
-            if ($template) {
+
+        if ($query) {
+            add_action('do_parse_request',function() use ($query) {
+                global $wp;
+                $wp->query_vars = $query;
+                return false;
+            });
+        }
+        if ($template) {
+            add_action('wp_loaded', function() use ($template) {
+                wp();
+                do_action('template_redirect');
                 load_template($template);
                 die;
-            }
-        }, 10, 1);
+            });
+        }
     }
 
     /*  Pagination


### PR DESCRIPTION
Sorry for making a pull request on the same bit of code again, but I realized that the logic used in load_template does not reflect the way WP loads templates enough. (almost, though)

Most salient is that because template_redirect is not called, the admin bar doesn't show. But also, a lot of plugins rely on that hook to set up global vars or do further set up (WooCommerce and BuddyPress for example).

Also, no headers were sent because the header in the method was hooked to send_headers, which was never called. No big deal, unless you want to (say) add extra cache headers.

Other potentially useful hooks missed are pre_get_posts and wp.

Instead of calling them manually, we can really emulate the way WP loads templates by using the WP object itself. Only difference really is that we're injecting our query into the object, and preventing WP from parsing the request itself (that's the whole point of the router).

As far as I can tell, there are no further repercussions to this change, except that if other plugins use template_redirect to push their own templates, their templates have precedence of the route. But this is expected behaviour, I think. Better yet, it allows you to do fancy things like build routes on top of plugin pages, like BuddyPress.
If someone does not want this to happen, they can always remove the plugin action.

Now the router really is a full-fledged alternative to wp_rewrite :)

Ps. Added bonus: if the template is not located, the query is still passed in the same way, and WP only takes over the template loading, as a fallback.

Thanks again for an awesome library Jared!
