### PR TITLE
Router improvements, fixes #74

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -371,15 +371,22 @@ class Timber {
         $timber->router->map($route, $callback);
     }
 
-    public static function load_template($template, $query = false) {
+    public static function load_template($template, $query = false, $force_header = 0) {
         $template = locate_template($template);
 
+        if ($force_header) {
+            add_filter('status_header', function($status_header, $header, $text, $protocol) use ($force_header) {
+                $text = get_status_header_desc($force_header);
+                return "$protocol $force_header $text";
+            }, 10, 4 );
+        }
+
         if ($query) {
-            add_action('do_parse_request',function() use ($query) {
+            add_action('do_parse_request', function() use ($query) {
                 global $wp;
 
-                if ( is_callable( $query ) )
-                    $query = call_user_func( $query );
+                if ( is_callable($query) )
+                    $query = call_user_func($query);
 
                 if ( is_array($query) )
                     $wp->query_vars = $query;


### PR DESCRIPTION
Fixes for the bugs in #74, as well as:
- Allow callables for the query param in load_template. Makes it possible to pass closures to generate the query. Useful if you want to generate the query based on plugin data that's not available when the route is setup.
- Added $force_header parameter, that can be used to override the status header set by the wp object. When using the router to load an arbitrary template that does not use WP_Query, wp will set 404 otherwise.
