### PR TITLE
Alternative functions API

### DIFF
--- a/functions/functions-wp-helper.php
+++ b/functions/functions-wp-helper.php
@@ -32,6 +32,10 @@ class WPHelper {
 		return $data;
 	}
 
+    public static function function_wrapper($function_name, $defaults = array(), $return_output_buffer = false) {
+        return new TimberFunctionWrapper($function_name, $defaults, $return_output_buffer);
+    }
+
 	public static function is_url($url) {
 		if (!is_string($url)){
 			return false;
@@ -266,7 +270,7 @@ class WPHelper {
 		return $wpdb->get_var($query);
 	}
 
-	/* this $args thing is a fucking mess, fix at some point: 
+	/* this $args thing is a fucking mess, fix at some point:
 
 	http://codex.wordpress.org/Function_Reference/comment_form */
 

--- a/functions/timber-function-wrapper.php
+++ b/functions/timber-function-wrapper.php
@@ -1,0 +1,52 @@
+<?php
+
+class TimberFunctionWrapper
+{
+
+    private $_function;
+    private $_args;
+    private $_use_ob;
+
+    public function __toString() {
+        return $this->call();
+    }
+
+    public function __construct( $function, $args = array( ), $return_output_buffer = false ) {
+        $this->_function = $function;
+        $this->_args     = $args;
+        $this->_use_ob   = $return_output_buffer;
+
+        add_filter( 'get_twig', array( &$this, 'add_to_twig' ) );
+    }
+
+    public function add_to_twig( $twig ) {
+        $wrapper = $this;
+
+        $twig->addFunction( new Twig_SimpleFunction( $this->_function, function() use ( $wrapper ) {
+            return call_user_func_array( array( $wrapper, 'call' ), func_get_args() );
+        } ) );
+
+        return $twig;
+    }
+
+    public function call() {
+        $args = $this->_parse_args( func_get_args(), $this->_args );
+
+        if ( $this->_use_ob )
+            return WPHelper::ob_function( $this->_function, $args );
+        else
+            return (string) call_user_func_array( $this->_function, $args );
+    }
+
+        private function _parse_args( $args, $defaults ) {
+            $_arg = reset( $defaults );
+
+            foreach ( $args as $index => $arg ) {
+                $defaults[$index] = is_null( $arg ) ? $_arg : $arg;
+                $_arg             = next( $defaults );
+            }
+
+            return $defaults;
+        }
+
+}

--- a/timber.php
+++ b/timber.php
@@ -24,6 +24,7 @@ require_once(__DIR__ . '/functions/timber-image.php');
 require_once(__DIR__ . '/functions/timber-menu.php');
 
 require_once(__DIR__ . '/functions/timber-loader.php');
+require_once(__DIR__ . '/functions/timber-function-wrapper.php');
 
 require_once(__DIR__ . '/admin/timber-admin.php');
 
@@ -274,14 +275,14 @@ class Timber {
         $data = array();
         $data['http_host'] = 'http://' . $_SERVER['HTTP_HOST'];
         $data['wp_title'] = get_bloginfo('name');
-        $data['wp_head'] = WPHelper::ob_function('wp_head');
-        $data['wp_footer'] = WPHelper::ob_function('wp_footer');
+        $data['wp_head'] = WPHelper::function_wrapper('wp_head');
+        $data['wp_footer'] = WPHelper::function_wrapper('wp_footer');
         $data['body_class'] = implode(' ', get_body_class());
         if (function_exists('wp_nav_menu')) {
             $data['wp_nav_menu'] = wp_nav_menu(array('container_class' => 'menu-header', 'echo' => false, 'menu_class' => 'nav-menu'));
         }
         $data['theme_dir'] = str_replace($_SERVER['DOCUMENT_ROOT'], '', get_stylesheet_directory());
-        $data['language_attributes'] = WPHelper::ob_function('language_attributes');
+        $data['language_attributes'] = WPHelper::function_wrapper('language_attributes');
         $data['stylesheet_uri'] = get_stylesheet_uri();
         $data['template_uri'] = get_template_directory_uri();
         $data = apply_filters('timber_context', $data);


### PR DESCRIPTION
This started as a way to call template functions (wp_footer, wp_header) only at the moment taht they are called in view files, but it turned into a whole alternative functions api..
## The problem

Currently, template functions (primarily, wp_header and wp_footer) are called when the Twig context is generated. This means that they are always called before any parts of the template have actually rendered. In cases like wp_footer, this could be disadvantageous.

Practical example: in plugins, I generally avoid enqueueing footer scripts, unless the plugin's 'render' method has actually been called at least once (to avoid loading resources unnecessarily). Using Timber, wp_footer has already been generated by the time render is called, so the footer script is never added.

Quick fix would be using `{{ function('wp_footer') }}` or `{% do action('wp_footer') %}` instead. But I figured that's not the most elegant way out ;)
## Enter the Function Wrapper

The function wrapper only actually executes the function when it's called in the template. Otherwise, it will function exactly the same as ob_function does currently. This means that we can simply substitute all WPHelper::ob_function calls in place without breaking a thing.
## Function API

Functions that have been added using the function wrapper are also added as full-fledged Twig functions, accepting all their ordinary arguments, but with defaults as defined when set up in the function wrapper. Functions added like this look far more elegant than the normal function api (#71) and can only be called if they are added to the context (encouraging good practice). The normal function api would then be more of a last resort.
# Usage

``` php
/**
 * @param string $function_name
 * @param array (optional) $defaults
 * @param bool (optional) $return_output_buffer Return function output instead of return value (default: false)
 * @return \TimberFunctionWrapper
 */
WPHelper::function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false );
```
#### Examples

``` php
/* single.php */
$data = Timber::get_context();
$data['post'] = new TimberPost();
$data['edit_post_link'] = WPHelper::function_wrapper( 'edit_post_link', array( __( 'Edit' ), '<span class="edit-link">', '</span>' ) );
Timber::render('single.twig', $data);
```

```
{# single.twig #}
<div class="admin-tools">
    {{edit_post_link}}
</div>
{# Calls edit_post_link using default arguments #}
```

```
{# single-my-post-type.twig #}
<div class="admin-tools">
    {{edit_post_link(null, '<span class="edit-my-post-type-link">')}}
</div>
{# Calls edit_post_link with all defaults, except for second argument #}
```

Let me know what your thoughts are!
