### PR TITLE
added timber-post.php / get_preview() readmore-link disable option

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -161,7 +161,9 @@ class TimberPost extends TimberCore {
 				}
 			}
 
-			$text .= ' <a href="' . $this->get_permalink() . '" class="read-more">' . $readmore . '</a>';
+			if($readmore) {
+				$text .= ' <a href="' . $this->get_permalink() . '" class="read-more">' . $readmore . '</a>';
+			}
 			if (!$strip){
 				$text .= '</p>';
 			}


### PR DESCRIPTION
This tiny modification lets us call _get_preview()_ as the following:

```
{{post.get_preview(50,false,false,true)}}
```

By setting the 3rd parameter ($readmore) to false we can disable the readmore link generation.
