### PR TITLE
Fix for cache mode 'none'

### DIFF
--- a/functions/timber-loader.php
+++ b/functions/timber-loader.php
@@ -202,7 +202,7 @@ class TimberLoader {
 
         $cache_mode = $this->_get_cache_mode( $cache_mode );
 
-        $value = null;
+        $value = false;
 
         $trans_key = substr($group . '_' . $key, 0, self::TRANS_KEY_LEN);
         if ( self::CACHE_TRANSIENT === $cache_mode )


### PR DESCRIPTION
Hi Jared! Just ran into a bug with the caching: if the cache mode is set to none, the default value is returned, which was null. The in-template caching stuff expects a cache miss to return false, so the template wasn't rendered at all. Here's the one word fix!
