### PR TITLE
Add image size param to TimberImage::get_src

### DIFF
--- a/functions/timber-image.php
+++ b/functions/timber-image.php
@@ -23,20 +23,26 @@ class TimberImage extends TimberCore {
 		return pathinfo($this->file);
 	}
 
-	function get_src() {
+	function get_src( $size = '' ) {
 		if (isset($this->abs_url)) {
 			return $this->abs_url;
 		}
-		if (!isset($this->file) && isset($this->_wp_attached_file)) {
+
+        if ($size && is_string($size) && isset($this->sizes[$size])) {
+            return reset(image_downsize($this->ID, $size));
+        }
+
+        if (!isset($this->file) && isset($this->_wp_attached_file)) {
 			$this->file = $this->_wp_attached_file;
 		}
-		if (isset($this->file)) {
-			//return $this->file;
-			$dir = wp_upload_dir();
-			$base = ($dir["baseurl"]);
-			return trailingslashit($base) . $this->file;
-		}
-    	return false;
+
+		if (!isset($this->file))
+            return false;
+
+        $dir = wp_upload_dir();
+        $base = ($dir["baseurl"]);
+        return trailingslashit($base) . $this->file;
+
   	}
 
 	function get_path() {
@@ -107,7 +113,7 @@ class TimberImage extends TimberCore {
 
 	/* Alias */
 
-	function src() {
-		return $this->get_src();
+	function src($size = '') {
+		return $this->get_src($size);
 	}
 }


### PR DESCRIPTION
Hi again! I am using [this](http://wordpress.org/plugins/manual-image-crop/) plugin to manually adjust the crop on WP image sizes, but `TimberImage::get_src` only retrieves the full size image. Using the resize filter works nicely in most other situations, but not this one. (Nb. all image sizes are loaded into `TimberImage::$sizes`, but these are unfiltered.. plugins like Manual Image Crop filter into image_downsize)

I propose to add an image size param to `TimberImage::get_src`, so one can optionally retrieve a specific image size.

As an added bonus, you can then combine the WP size with the resize filter, for extra fine grained control over cropping! I now use my WP image size as a large cropping ratio for a manual crop, and then use  the resize filter to downsize the image where necessary. Example:

``` php
add_image_size( 'squared', 1000, 1000, true );
```

```
{# view.twig #}
<img src="{{TimberImage(image_id).get_src('squared')|resize(150,150)}}" />
```
