### PR TITLE
Use home_url() instead of site_url() in resize() (#102)

### DIFF
--- a/functions/timber-image-helper.php
+++ b/functions/timber-image-helper.php
@@ -88,7 +88,7 @@
 			if (empty($src)){
 				return '';
 			}
-			if (strstr($src, 'http') && !strstr($src, site_url())) {
+			if (strstr($src, 'http') && !strstr($src, home_url())) {
 				$src = self::sideload_image($src);
 			}
 			$abs = false;


### PR DESCRIPTION
As per the discussion in #102, this pull request changes the resize filter to use home_url() instead of site_url().
