### PR TITLE
Display_date didn't respect the international dates.

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -482,7 +482,7 @@ class TimberPost extends TimberCore {
 	}
 
 	public function display_date(){
-		return date(get_option('date_format'), strtotime($this->post_date));
+		return date_i18n(get_option('date_format') , strtotime($this->post_date));
 	}
 
 	public function edit_link(){


### PR DESCRIPTION
Followed instructions from Worpdress Codex: http://codex.wordpress.org/Function_Reference/date_i18n
