### PR TITLE
Force the query to not have is_404 true if force_header is other than 404

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -463,16 +463,12 @@ class Timber {
                 $header_string = "$protocol $force_header $text";
                 return $header_string;
             }, 10, 4 );
-            add_filter('body_class', function($classes) use ($force_header) {
-                if (isset($classes) && is_array($classes) && $force_header != 404){
-                    foreach($classes as &$class){
-                        if (strstr($class, '404')){
-                            $class = '';
-                        }
-                    }
-                }
-                return $classes;
-            });
+            if (404 != $force_header) {
+                add_action('parse_query', function($query) {
+                    if ($query->is_main_query())
+                        $query->is_404 = false;
+                });
+            }
         }
 
         if ($query) {


### PR DESCRIPTION
Hi Jared!

I had this fix sitting around in my local branch for a while. When I just finally got around to pushing I saw that you already fixed this. Nonetheless, this is a slight improvement, as it fixes the root of the problem (WP Query thinking it's a 404) rather than the symptom (the body getting the 404 class).

Cheers,
Mike
