### PR TITLE
Fixed term loading with multiple taxonomies

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -375,7 +375,7 @@ class TimberPost extends TimberCore {
 
 			} else {
 				foreach ($terms as &$term) {
-					$term = new $TermClass($term->term_id);
+					$term = new $TermClass($term->term_id, $tax);
 				}
 				if ($merge && is_array($terms)) {
 					$ret = array_merge($ret, $terms);

--- a/functions/timber-term.php
+++ b/functions/timber-term.php
@@ -10,10 +10,12 @@ class TimberTerm extends TimberCore {
 
 	public static $representation = 'term';
 
-	function __construct($tid = null) {
+	function __construct($tid = null, $tax='') {
 		if ($tid === null) {
 			$tid = $this->get_term_from_query();
 		}
+		if(strlen($tax))
+			$this->taxonomy = $tax;
 		$this->init($tid);
 	}
 
@@ -61,12 +63,17 @@ class TimberTerm extends TimberCore {
 			return $tid;
 		}
 		$tid = self::get_tid($tid);
-		global $wpdb;
-		$query = $wpdb->prepare("SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $tid);
-		$tax = $wpdb->get_var($query);
-		if (isset($tax) && strlen($tax)) {
-			$term = get_term($tid, $tax);
-			return $term;
+		
+		if(isset($this->taxonomy) && strlen($this->taxonomy)) {
+			return get_term($tid, $this->taxonomy);
+		} else {
+			global $wpdb;
+			$query = $wpdb->prepare("SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $tid);
+			$tax = $wpdb->get_var($query);
+			if (isset($tax) && strlen($tax)) {
+				$term = get_term($tid, $tax);
+				return $term;
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
## The problem

When using equally named terms in different taxonomies, TimberPost::get_terms returns the the terms for **some** taxonomy, but not always the right one. Using it in a template for linking to a term archive could link to the wrong term archive.
This was due to the TimberTerm::get_post function, which just selected one taxonomy using the term ( ignoring the others ):

```
$query = $wpdb->prepare("SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $tid);
```
## The solution

Since TimberPost::get_terms accepts a taxonomy name, it can be passed further to the TimberTerm and no guessing is needed.
With this fix, you can use

```
{% for term in post.terms %}
    <a href="{{ term.link }}">{{ term.name }}</a>
{% endfor %}
```

in your template and get the link to the right term.
