### PR TITLE
Added time_ago filter translation possibility

### DIFF
--- a/functions/functions-twig.php
+++ b/functions/functions-twig.php
@@ -209,35 +209,16 @@ function wp_resize_letterbox($src, $w, $h, $color = '#000000') {
 	return null;
 }
 
-function twig_time_ago($from, $to = null) {
+function twig_time_ago($from, $to = null, $format_past='%s ago', $format_future='%s from now') {
 	$to = (($to === null) ? (time()) : ($to));
 	$to = ((is_int($to)) ? ($to) : (strtotime($to)));
 	$from = ((is_int($from)) ? ($from) : (strtotime($from)));
 
-	$units = array(
-		"year" => 29030400, // seconds in a year   (12 months)
-		"month" => 2419200, // seconds in a month  (4 weeks)
-		"week" => 604800, // seconds in a week   (7 days)
-		"day" => 86400, // seconds in a day    (24 hours)
-		"hour" => 3600, // seconds in an hour  (60 minutes)
-		"minute" => 60, // seconds in a minute (60 seconds)
-		"second" => 1 // 1 second
-	);
-
-	$diff = abs($from - $to);
-	$suffix = (($from > $to) ? ("from now") : ("ago"));
-	$output = '';
-	foreach ($units as $unit => $mult) {
-		if ($diff >= $mult) {
-			$and = (($mult != 1) ? ("") : ("and "));
-			$output .= ", " . $and . intval($diff / $mult) . " " . $unit . ((intval($diff / $mult) == 1) ? ("") : ("s"));
-			$diff -= intval($diff / $mult) * $mult;
-			break;
-		}
+	if ($from < $to) {
+		return sprintf($format_past, human_time_diff($from, $to));
+	} else {
+		return sprintf($format_future, human_time_diff($to, $from));
 	}
-	$output .= " " . $suffix;
-	$output = substr($output, strlen(", "));
-	return $output;
 }
 
 function twig_body_class($body_classes) {


### PR DESCRIPTION
Wordpress already offers a function for generating a translated time ago string: human_time_diff.
The only downside is, it just generates a string like "20 minutes", so I added some format variables.

For english you can still use {{ time | time_ago }}.
For a translation ( german here for example ):

```
{{ time | time_ago(format_past='vor %s', format_future='in %s') }}
```

This generates  `vor 20 Minuten` which is the german pendant to `20 minutes ago`.

Fixes the issues 2) and 3) mentioned in https://github.com/jarednova/timber/issues/121
