### PR TITLE
Include wordpress install directory as routing base path #139

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -450,7 +450,7 @@ class Timber {
                 if (strpos($route, $base_path) === 0) {
                     $base_path = '/';
                 } else {
-                    $base_path = '/' . $base_path;
+                    $base_path = '/' . $base_path . '/';
                 }
                 $timber->router->setBasePath($base_path);
             }


### PR DESCRIPTION
Also checks if the directory is included in the route already so it shouldn't break any pre-existing routes
