### PR TITLE
Changed hook to initialize 'ACFTimber' to 'init'

### DIFF
--- a/functions/integrations/acf-timber.php
+++ b/functions/integrations/acf-timber.php
@@ -47,7 +47,7 @@
 			return get_field($field, 'user_'.$uid);
 		}
 	}
-	add_action( 'plugins_loaded', function(){
+	add_action( 'init', function(){
 		if (class_exists('ACF')){
 			new ACFTimber();
 		}


### PR DESCRIPTION
This fixes an issue where ACFTimber is not created when Advanced Custom Fields is included within a theme.
