### PR TITLE
Pass taxonomy to term class in Timber::handle_term_query

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -301,7 +301,7 @@ class Timber {
         }
         $terms = get_terms($taxonomies, $args);
         foreach($terms as &$term){
-            $term = new $TermClass($term->term_id);
+            $term = new $TermClass($term->term_id, $term->taxonomy);
         }
         return $terms;
     }


### PR DESCRIPTION
Hi Jared!
Simple fix this time: if two terms are defined with the same taxonomy, WP reuses the term (and term ID). TimberTerm will use the first one found, if it's not explicitly given. In handle_term_query, the full term object is available, so we can just tell TimberTerm what tax we're looking for.
