### PR TITLE
Removed single quotes from $templates.

### DIFF
--- a/timber-starter-theme/index.php
+++ b/timber-starter-theme/index.php
@@ -23,6 +23,6 @@
 	if (is_home()){
 		array_unshift($templates, 'home.twig');
 	}
-	Timber::render('$templates', $context);
+	Timber::render($templates, $context);
 
 


### PR DESCRIPTION
Noticed the last update to the starter templates left quotes around the $templates variable. Removed them so the templates correctly render.
