### PR TITLE
Merge ACF fields into post custom fields

### DIFF
--- a/functions/integrations/acf-timber.php
+++ b/functions/integrations/acf-timber.php
@@ -10,7 +10,7 @@
 		}
 
 		function post_get_meta($customs, $post_id){
-			return $customs;
+			return array_merge($customs, get_fields());
 		}
 
 		function post_get_meta_field($value, $post_id, $field_name){


### PR DESCRIPTION
Ideally, I would like to be able to use ACF custom fields directly in my page via `{{ post.my_custom_field }}` syntax ([which I've interpreted from the docs to be possible](https://github.com/jarednova/timber/wiki/TimberPost#wiki-properties)). This change automatically merges all ACF fields with a page's custom fields, making it possible to use fields as direct properties (replacing the current `{{ post.get_field('my_custom_field') }}` syntax). Please advise if there are reasons unknown to me as to why this may be undesirable.
