### PR TITLE
Add alt property to TimberImage

### DIFF
--- a/functions/timber-image.php
+++ b/functions/timber-image.php
@@ -93,6 +93,11 @@ class TimberImage extends TimberCore {
 		return new $this->PostClass($this->post_parent);
 	}
 
+	function get_alt() {
+		$alt = trim(strip_tags(get_post_meta($this->ID, '_wp_attachment_image_alt', true)));
+		return $alt;
+	}
+
 	function init($iid) {
 		if (!is_numeric($iid) && is_string($iid)) {
 			if (strstr($iid, '://')) {
@@ -114,14 +119,6 @@ class TimberImage extends TimberCore {
 				if (isset($basic->post_excerpt)){
 					$this->caption = $basic->post_excerpt;
 				}
-				$alt = trim(strip_tags(get_post_meta($iid, '_wp_attachment_image_alt', true)));
-				if (empty($alt)){
-					$alt = $this->caption;
-				}
-				if (empty($alt)){
-					$alt = $basic->post_title;
-				}
-				$this->alt = $alt;
 				$image_custom = array_merge($image_custom, get_object_vars($basic));
 			}
 			$image_info = array_merge($image_info, $image_custom);
@@ -190,5 +187,9 @@ class TimberImage extends TimberCore {
 
 	public function width(){
 		return $this->get_width();
+	}
+
+	public function alt(){
+		return $this->get_alt();
 	}
 }

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -115,46 +115,14 @@ class TimberImageTest extends WP_UnitTestCase {
 
 	function testImageAltText(){
 		$upload_dir = wp_upload_dir();
-		$thumb_title = 'Thumb title';
-		$thumb_caption = 'Thumb caption';
 		$thumb_alt = 'Thumb alt';
 		$filename = $this->copyTestImage('flag.png');
 		$wp_filetype = wp_check_filetype(basename($filename), null );
-
-		// if only title isset, alt = title
 		$post_id = $this->factory->post->create();
 		$attachment = array(
 			'post_mime_type' => $wp_filetype['type'],
-			'post_title' => $thumb_title,
+			'post_title' => preg_replace('/\.[^.]+$/', '', basename($filename)),
 			'post_excerpt' => '',
-			'post_status' => 'inherit'
-		);
-		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
-		add_post_meta($post_id, '_thumbnail_id', $attach_id, true);
-		$data = array();
-		$data['post'] = new TimberPost($post_id);
-		$this->assertEquals($data['post']->thumbnail()->alt, $thumb_title);
-
-		// if excerpt (i.e. caption) isset, alt = caption
-		$post_id = $this->factory->post->create();
-		$attachment = array(
-			'post_mime_type' => $wp_filetype['type'],
-			'post_title' => $thumb_title,
-			'post_excerpt' => $thumb_caption,
-			'post_status' => 'inherit'
-		);
-		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
-		add_post_meta($post_id, '_thumbnail_id', $attach_id, true);
-		$data = array();
-		$data['post'] = new TimberPost($post_id);
-		$this->assertEquals($data['post']->thumbnail()->alt, $thumb_caption);
-
-		// if Alternative Text isset, alt = Alternative Text
-		$post_id = $this->factory->post->create();
-		$attachment = array(
-			'post_mime_type' => $wp_filetype['type'],
-			'post_title' => $thumb_title,
-			'post_excerpt' => $thumb_caption,
 			'post_status' => 'inherit'
 		);
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
@@ -162,7 +130,7 @@ class TimberImageTest extends WP_UnitTestCase {
 		add_post_meta($attach_id, '_wp_attachment_image_alt', $thumb_alt, true);
 		$data = array();
 		$data['post'] = new TimberPost($post_id);
-		$this->assertEquals($data['post']->thumbnail()->alt, $thumb_alt);
+		$this->assertEquals($data['post']->thumbnail()->alt(), $thumb_alt);
 	}
 
 	public static function is_connected() {


### PR DESCRIPTION
This adds an alt property to TimberImage that follows Wordpress' logic for determining the alt text of an image. In order of precedence, alt text is determined by: Alternative Text field, Caption field (post_excerpt), Title (post_title).

This would add another query for each TimberImage, however, because Wordpress stores the Alternative Text value in wp_postmeta.

But it would be nice to easily reference the alt text value for an image as, e.g.  post.thumbnail.alt

(This is just my third pull request and first time writing a phpunit test; it's possible I overlooked something.)

Thanks for considering!
