### PR TITLE
Force non-404 headers as soon as possible

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -489,11 +489,11 @@ class Timber {
                     if ($query->is_main_query()){
                         $query->is_404 = false;
                     }
-                });
+                },1);
                 add_action('template_redirect', function(){
                     global $wp_query;
                     $wp_query->is_404 = false;
-                });
+                },1);
             }
         }
 


### PR DESCRIPTION
A small fix. If force_header is set in `Timber::load_template` and it's not 404, make sure it happens as early as possible. The overrides used to be called at normal priority (10), but plugins that do stuff with 404s may use the same hook at default priority.

Permalink Finder (for example) does its redirects at `template_redirect`/10. If you're unlucky, this may be loaded before Timber forces non-404.
