### PR TITLE
Added get_category_link method to TimberPost

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -411,8 +411,9 @@ class TimberPost extends TimberCore {
 		$cats = $this->get_categories();
 		if (count($cats) && isset($cats[0])) {
 			return $cats[0];
+		} else {
+			return null;
 		}
-		return null;
 	}
 
 	function get_category_link() {


### PR DESCRIPTION
I added a new method to TimberPost to create the category url of a TimberPost object.
