### PR TITLE
Apply default ordering of child pages by menu_order, title

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -365,7 +365,7 @@ class TimberPost extends TimberCore {
 		if ($post_type == 'parent') {
 			$post_type = $this->post_type;
 		}
-		$children = get_children('post_parent=' . $this->ID . '&post_type=' . $post_type.'&numberposts=-1');
+		$children = get_children('post_parent=' . $this->ID . '&post_type=' . $post_type . '&numberposts=-1&orderby=menu_order title&order=ASC');
 		foreach ($children as &$child) {
 			$child = new $childPostClass($child->ID);
 		}


### PR DESCRIPTION
Querying child posts does not currently apply any ordering. Perhaps this should be parameterized, but sorting on "menu_order title" is a safe default. [WordPress itself uses this as default to sort hierarchical post listings](https://github.com/WordPress/WordPress/blob/04cb00c9e12bb7e325f76091763986eeac7dd804/wp-admin/includes/post.php#L875).
