### PR TITLE
Fix Notice: Trying to get property of non-object

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -125,6 +125,9 @@ class TimberPost extends TimberCore {
 		global $wpdb;
 		$query = $wpdb->prepare("SELECT ID FROM $wpdb->posts WHERE post_name = %s LIMIT 1", $post_name);
 		$result = $wpdb->get_row($query);
+		if (!$result) {
+			return null;
+		}
 		return $result->ID;
 	}
 


### PR DESCRIPTION
Was getting this notice on a single post page. This got rid of the warning for me.
