### PR TITLE
get_preview uses for <!--more--> tag

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -149,6 +149,14 @@ class TimberPost extends TimberCore {
 				$text = $this->post_excerpt;
 			}
 		}
+		if (!strlen($text) && strpos($this->post_content, '<!--more-->') !== false) {
+			$pieces = explode('<!--more-->',$this->post_content);
+			$text = $pieces[0];
+			if ($force) {
+				$text = TimberHelper::trim_words($text, $len, false);
+				$trimmed = true;
+			}
+		}
 		if (!strlen($text)) {
 			$text = TimberHelper::trim_words($this->get_content(), $len, false);
 			$trimmed = true;

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -134,6 +134,11 @@
 			$post->post_excerpt = '';
 			$prev = $post->get_preview(3,false,'Custom more');
 			$this->assertRegExp('/this is super &hellip;  <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/',$prev);
+
+			// content with <!--more--> tag, force false
+			$post->post_content = 'this is super dooper<!--more--> trooper long words';
+			$prev = $post->get_preview(3,false,'');
+			$this->assertEquals($prev, 'this is super dooper');
 		}
 
 		function testTitle(){


### PR DESCRIPTION
get_preview() checks post content for a <!--more--> tag and uses that to generate the preview if the _force_ param is false. If an excerpt is set in addition to the <!--more--> tag being present in the post content, the excerpt takes precedence. (Addresses #127)
