### PR TITLE
Fix a typo in the starter theme

### DIFF
--- a/timber-starter-theme/views/base.twig
+++ b/timber-starter-theme/views/base.twig
@@ -46,6 +46,6 @@
                 {% include 'footer.twig' %}
             </footer>
             {{ function('wp_footer') }}
-        {% endblock }
+        {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
Super pedantic but just starting out with timber and noticed this when activating the base theme!
