### PR TITLE
pass default twig date filter through wordpress date_i18n function

### DIFF
--- a/functions/functions-twig.php
+++ b/functions/functions-twig.php
@@ -238,7 +238,7 @@ function twig_body_class($body_classes) {
 
 /**
  * @param string $date
- * @param string format (optional)
+ * @param string $format (optional)
  * @return string
  */
 function twig_intl_date($date, $format = null) {


### PR DESCRIPTION
In response to https://github.com/jarednova/timber/pull/154
