### PR TITLE
fixes #230 scope issue in TimberImageHelper

### DIFF
--- a/functions/timber-image-helper.php
+++ b/functions/timber-image-helper.php
@@ -7,8 +7,8 @@
 				$post = get_post($post_id);
 				$image_types = array('image/jpeg', 'image/png', 'image/gif', 'image/jpg');
 				if ($post->post_type == 'attachment' && in_array($post->post_mime_type, $image_types)){
-					self::delete_resized_files_from_url($post->guid);
-					self::delete_letterboxed_files_from_url($post->guid);
+					TimberImageHelper::delete_resized_files_from_url($post->guid);
+					TimberImageHelper::delete_letterboxed_files_from_url($post->guid);
 				}
 			});
 		}
@@ -28,12 +28,12 @@
 		    return array("red" => 0xFF & ($int >> 0x10), "green" => 0xFF & ($int >> 0x8), "blue" => 0xFF & $int);
 		}
 
-		private static function delete_resized_files_from_url($src){
+		public static function delete_resized_files_from_url($src){
 			$local = TimberURLHelper::url_to_file_system($src);
 			self::delete_resized_files($local);
 		}
 
-		private static function delete_letterboxed_files_from_url($src){
+		public static function delete_letterboxed_files_from_url($src){
 			$local = TimberURLHelper::url_to_file_system($src);
 			self::delete_letterboxed_files($local);
 		}


### PR DESCRIPTION
After upgrading Timber to Version 0.18.1 (hosted on WPEngine), ran in to this error when trying to delete photos from the media library (the same issue as in #230):

> PHP Fatal error: Cannot access self:: when no class scope is active in /nas/wp/www/cluster-1088/ups/wp-content/plugins/timber-library/functions/timber-image-helper.php on line 10, referer: http://ups.wpengine.com/wp-admin/upload.php?post_mime_type=image

With the help of @jarednova solved with these changes (it was a scoping issue, hooked actions are not in the class context so 'self' is not available, or at least doesn't refer to TimberImageHelper)
