### PR TITLE
Fix #242: Refactor Timber::load_template to use filter 'template_include...

### DIFF
--- a/timber.php
+++ b/timber.php
@@ -687,12 +687,9 @@ class Timber {
             });
         }
         if ($template) {
-            add_action('wp_loaded', function() use ($template) {
-                wp();
-                do_action('template_redirect');
-                load_template($template);
-                die;
-            });
+        	add_filter('template_include', function($t) use ($template) {
+        		return $template;
+        	});
             return true;
         }
         return false;


### PR DESCRIPTION
- Timber::load_template now uses the 'template_include' filter rather than do_action('template_redirect').
- See http://codex.wordpress.org/Plugin_API/Action_Reference/template_redirect

See #242
