### PR TITLE
date wrappers & translation functions

### DIFF
--- a/functions/functions-twig.php
+++ b/functions/functions-twig.php
@@ -101,6 +101,16 @@ class TimberTwig {
 		$twig->addFunction('__', new Twig_SimpleFunction('__', function($text, $domain = 'default'){
 			return __($text, $domain);
 		}));
+        $twig->addFunction('_x', new Twig_SimpleFunction('_x',
+            function($text, $context, $domain = 'default') {
+                return _x($text, $context, $domain);
+            }
+        ));
+        $twig->addFunction('_n', new Twig_SimpleFunction('_n',
+            function($single, $plural, $number, $domain = 'default') {
+                return _n($single, $plural, $number, $domain);
+            }
+        ));
 
 		$twig = apply_filters('get_twig', $twig);
 

--- a/functions/functions-twig.php
+++ b/functions/functions-twig.php
@@ -111,6 +111,11 @@ class TimberTwig {
                 return _n($single, $plural, $number, $domain);
             }
         ));
+        $twig->addFunction('_nx', new Twig_SimpleFunction('_nx',
+            function($single, $plural, $number, $context, $domain = 'default') {
+                return _nx($single, $plural, $number, $context, $domain);
+            }
+        ));
 
 		$twig = apply_filters('get_twig', $twig);
 

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -435,6 +435,16 @@ class TimberPost extends TimberCore {
     }
 
     /**
+     * @param  string $date_format
+     * @return string
+     */
+    function get_modified_date($date_format = '') {
+        $df = $date_format ? $date_format : get_option('date_format');
+        $the_time = $this->get_modified_time($df, null, $this->ID, true)
+        return apply_filters('get_the_modified_date', $the_time, $date_format);
+    }
+
+    /**
      * @param string $time_format
      * @return string
      */
@@ -799,6 +809,13 @@ class TimberPost extends TimberCore {
      */
     public function date($date_format = '') {
         return $this->get_date($date_format);
+    }
+
+    /**
+     * @return string
+     */
+    public function modified_date($date_format = '') {
+        return $this->get_modified_date($date_format);
     }
 
     /**

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -56,11 +56,7 @@ class TimberPost extends TimberCore {
      * @return bool|string
      */
     function get_edit_url() {
-		if ($this->can_edit()) {
-			return get_edit_post_link($this->ID);
-			return '/wp-admin/post.php?post=' . $this->ID . '&action=edit';
-		}
-		return false;
+        return ($this->can_edit() ? get_edit_post_link($this->ID) : false);
 	}
 
 	/**

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -425,6 +425,16 @@ class TimberPost extends TimberCore {
 	}
 
     /**
+     * @param string $time_format
+     * @return string
+     */
+    function get_modified_time($time_format = '') {
+        $time_format = $time_format ? $time_format : get_option('time_format');
+        $the_time = get_post_modified_time($time_format, false, $this->ID, true);
+        return apply_filters('get_the_modified_time', $the_time, $time_format);
+    }
+
+    /**
      * @param string $post_type
      * @param bool $childPostClass
      * @return array

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -439,8 +439,8 @@ class TimberPost extends TimberCore {
      * @return string
      */
     function get_modified_time($time_format = '') {
-        $time_format = $time_format ? $time_format : get_option('time_format');
-        $the_time = get_post_modified_time($time_format, false, $this->ID, true);
+        $tf = $time_format ? $time_format : get_option('time_format');
+        $the_time = get_post_modified_time($tf, false, $this->ID, true);
         return apply_filters('get_the_modified_time', $the_time, $time_format);
     }
 

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -440,7 +440,7 @@ class TimberPost extends TimberCore {
      */
     function get_modified_date($date_format = '') {
         $df = $date_format ? $date_format : get_option('date_format');
-        $the_time = $this->get_modified_time($df, null, $this->ID, true)
+        $the_time = $this->get_modified_time($df, null, $this->ID, true);
         return apply_filters('get_the_modified_date', $the_time, $date_format);
     }
 

--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -425,6 +425,16 @@ class TimberPost extends TimberCore {
 	}
 
     /**
+     * @param  string $date_format
+     * @return string
+     */
+    function get_date($date_format = '') {
+        $df = $date_format ? $date_format : get_option('date_format');
+        $the_date = (string) mysql2date($df, $this->post_date);
+        return apply_filters('get_the_date', $the_date, $date_format);
+    }
+
+    /**
      * @param string $time_format
      * @return string
      */
@@ -783,6 +793,13 @@ class TimberPost extends TimberCore {
     public function display_date(){
 		return date_i18n(get_option('date_format') , strtotime($this->post_date));
 	}
+
+    /**
+     * @return string
+     */
+    public function date($date_format = '') {
+        return $this->get_date($date_format);
+    }
 
     /**
      * @return bool|string


### PR DESCRIPTION
Ran into these while converting underscores.

Date functions reflect wp builtins and run the same filters, but without expecting to be in the loop.

Translation functions are just useful to have as part of the twig environment.
