### PR TITLE
Return password form if content requires password

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -672,6 +672,9 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
      * @return string
      */
     function get_content($len = 0, $page = 0) {
+        if (post_password_required($this)) {
+            return get_the_password_form($this);
+        }
         if ($len == 0 && $page == 0 && $this->_content) {
             return $this->_content;
         }

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -224,6 +224,20 @@
 			$this->assertEquals($page2, trim(strip_tags($post->get_paged_content())));
 		}
 
+		function testPasswordedContent(){
+			$quote = 'The way to do well is to do well.';
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$post->post_content = $quote;
+			$post->post_password = 'burrito';
+			wp_update_post($post);
+			ob_start();
+			get_the_password_form($post);
+			$password_form = ob_end_clean();
+			$this->assertEquals($password_form, $post->content());
+			$this->assertEquals($password_form, $post->get_content());
+		}
+
 		function testMetaCustomArrayFilter(){
 			add_filter('timber_post_get_meta', function($customs){
 				foreach($customs as $key=>$value){

--- a/timber-starter-theme/single.php
+++ b/timber-starter-theme/single.php
@@ -15,10 +15,4 @@ $context['post'] = $post;
 $context['wp_title'] .= ' - ' . $post->title();
 $context['comment_form'] = TimberHelper::get_comment_form();
 
-if (post_password_required($post->ID)){
-	Timber::render('single-password.twig', $context);
-} else {
-	Timber::render(array('single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig'), $context);
-}
-
-
+Timber::render(array('single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig'), $context);

--- a/timber-starter-theme/views/single-password.twig
+++ b/timber-starter-theme/views/single-password.twig
@@ -1,8 +1,0 @@
-{% extends "base.twig" %}
-{% block content %}
-	<form class="password-form" action="/wp-login.php?action=postpass" method="post">
-    	<label for="pwbox-{{post.ID}}">Password:</label>
-    	<input class="password-box" name="post_password" id="pwbox-{{post.ID}}" type="password" placeholder="Password" size="20" maxlength="20" />
-    	<input class="password-btn" type="submit" name="Submit" value="Submit" />
-   	</form>
-{% endblock %}


### PR DESCRIPTION
Mirroring the [default WordPress `get_the_content` behavior](https://core.trac.wordpress.org/browser/tags/3.9.1/src/wp-includes/post-template.php#L216), Timber's `get_content` and `content` should return the password form for unauthenticated users. There is more discussion about how this is currently handled in #217. I'd argue that it would be ideal for the developer to not concern themselves with conditionally handling password authentication in each template.

I had some issues getting VVV running in an attempt to verify the included unit test, so please verify on my behalf.