### PR TITLE
Correctly test date filter support for DateTime objects

### DIFF
--- a/tests/test-timber-twig-filters.php
+++ b/tests/test-timber-twig-filters.php
@@ -25,7 +25,7 @@
 			$data['bday'] = $date;
 			$str = Timber::compile_string("{{bday|date('M j, Y')}}", $data);
 			$this->assertEquals('Sep 28, 1983', trim($str));
-			$date = new DateTime($date);
+			$data['bday'] = new DateTime($date);
 			$str = Timber::compile_string("{{bday|date('M j, Y')}}", $data);
 			$this->assertEquals('Sep 28, 1983', trim($str));
 		}


### PR DESCRIPTION
As is, the intended testing for DateTime date filter test is only testing the pre-existing string date value.

See original commit 7536b09
