### PR TITLE
Add a filter to TimberPostGetter::get_posts

### DIFF
--- a/functions/timber-post-getter.php
+++ b/functions/timber-post-getter.php
@@ -18,7 +18,7 @@ class TimberPostGetter
 
     public static function get_posts( $query = false, $PostClass = 'TimberPost', $return_collection = false ) {
         $posts = self::query_posts( $query, $PostClass );
-        return $posts->get_posts( $return_collection );
+        return apply_filters('timber_post_getter_posts',$posts->get_posts( $return_collection ));
     }
 
 	/**


### PR DESCRIPTION
Makes it easier to add support for plugins that like to mess with the loop (eg. BuddyPress). 

This way you can add support for popular plugins by writing small plugins/extensions like this:
https://github.com/slimndap/TimberBuddyPress

No need to add any hacky code to you theme anymore!
