### PR TITLE
Added an action to TimberPost::init()

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -56,6 +56,8 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 		//cant have a function, so gots to do it this way
 		$post_class = $this->post_class();
 		$this->class = $post_class;
+
+		do_action('timber_post_init',$this);
 	}
 
     /**


### PR DESCRIPTION
This action replaces the filter in TimberPostGetter::get_posts(), which should be removed again.
This way Timber::get_post() and new TimberPost() are analogues again.

It also made it much simpler for me to achieve the same results with the BuddyPress plugin. 

To see it in action:
1. Merge this pull request.
2. Install the BuddyPress plugin.
3. Activate the Timber starter theme.
4. Enable pretty permalinks.
5. View one of the BuddyPress pages (eg. example.com/groups).
