### PR TITLE
Use WP_SITEURL in 'Timber not activated' error message

### DIFF
--- a/timber-starter-theme/functions.php
+++ b/timber-starter-theme/functions.php
@@ -2,7 +2,7 @@
 
 	if (!class_exists('Timber')){
 		add_action( 'admin_notices', function(){
-			echo '<div class="error"><p>Timber not activated. Make sure you activate the plugin in <a href="/wp-admin/plugins.php#timber">/wp-admin/plugins.php</a></p></div>';
+			echo '<div class="error"><p>Timber not activated. Make sure you activate the plugin in <a href="' . _config_wp_siteurl() . '/wp-admin/plugins.php#timber">' . _config_wp_siteurl() . '/wp-admin/plugins.php</a></p></div>';
 		});
 		return;
 	}


### PR DESCRIPTION
This should help if you don't install WP in the default path (and if you've defined the WP_SITEURL constant). Not sure if this is the best way to approach this, but this can at least be a conversation starter.
