### PR TITLE
Update timber-helper.php

### DIFF
--- a/functions/timber-helper.php
+++ b/functions/timber-helper.php
@@ -222,6 +222,7 @@ class TimberHelper {
                 unset( $closedtags[array_search( $openedtags[$i], $closedtags )] );
             }
         }
+        $html = str_replace(array('</br>','</hr>','</wbr>'), array('<br />','<hr />','<wbr />'), $html);
         return $html;
     }
 


### PR DESCRIPTION
My Timber-generated pages were failing HTML validation due to some improperly closed standalone tags. This changes those tags to the correct formatting. I left the close slash for backward compatibility with XHTML. There may be other tags, but these were the ones that quickly came to mind.
