### PR TITLE
Preserves custom root URLs - / - in menus, bypassing untrailingslashit c...

### DIFF
--- a/functions/timber-menu-item.php
+++ b/functions/timber-menu-item.php
@@ -30,7 +30,7 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
         $this->add_class( 'menu-item-' . $this->ID );
         $this->menu_object = $data;
         if ( isset( $this->url ) && $this->url ) {
-            $this->url = untrailingslashit( $this->url );
+            $this->url = TimberURLHelper::remove_trailing_slash( $this->url );
         }
     }
 
@@ -94,10 +94,10 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
             if ( isset( $this->_menu_item_type ) && $this->_menu_item_type == 'custom' ) {
                 $this->url = $this->_menu_item_url;
             } else if ( isset( $this->menu_object ) && method_exists( $this->menu_object, 'get_link' ) ) {
-                    $this->url = untrailingslashit( $this->menu_object->get_link() );
+                    $this->url = $this->menu_object->get_link();
                 }
         }
-        return untrailingslashit( $this->url );
+        return TimberURLHelper::remove_trailing_slash( $this->url );
     }
 
     /**
@@ -106,7 +106,7 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
      * @return string
      */
     function get_path() {
-        return untrailingslashit( TimberURLHelper::get_rel_url( $this->get_link() ) );
+        return TimberURLHelper::remove_trailing_slash( TimberURLHelper::get_rel_url( $this->get_link() ) );
     }
 
     /**
@@ -204,7 +204,7 @@ class TimberMenuItem extends TimberCore implements TimberCoreInterface {
      * @return string
      */
     public function path() {
-        return untrailingslashit( $this->get_path() );
+        return $this->get_path();
     }
 
     /**

--- a/functions/timber-url-helper.php
+++ b/functions/timber-url-helper.php
@@ -161,6 +161,18 @@ class TimberURLHelper
     }
 
     /**
+     * Pass links through untrailingslashit unless they are a single /
+     *
+     * @param  string $link
+     * @return string
+     */
+    public static function remove_trailing_slash($link) {
+        if ( $link != "/")
+            $link = untrailingslashit( $link );
+        return $link;
+    }
+
+    /**
      * @param string $url
      * @param int $timeout
      * @return string|WP_Error

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -11,7 +11,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$this->_createTestMenu();
 		$menu = new TimberMenu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
-		$this->assertEquals( 2, count( $menu->get_items() ) );
+		$this->assertEquals( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[0];
 		$this->assertEquals( 'home', $item->slug() );
@@ -36,7 +36,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$context['menu'] = new TimberMenu();
 		$str = Timber::compile( 'assets/child-menu.twig', $context );
 		$str = preg_replace('/\s+/', '', $str);
-		$this->assertEquals('<ulclass="navnavbar-nav"><li><ahref="http://example.org/home"class="has-children">Home</a><ulclass="dropdown-menu"role="menu"><li><ahref="http://example.org/child-page">ChildPage</a></li></ul><li><ahref="http://upstatement.com"class="no-children">Upstatement</a></ul>', $str);
+		$this->assertEquals('<ulclass="navnavbar-nav"><li><ahref="http://example.org/home"class="has-children">Home</a><ulclass="dropdown-menu"role="menu"><li><ahref="http://example.org/child-page">ChildPage</a></li></ul><li><ahref="http://upstatement.com"class="no-children">Upstatement</a><li><ahref="/"class="no-children">RootHome</a></ul>', $str);
 	}
 
 	function testMenuTwigWithClasses(){
@@ -67,7 +67,7 @@ class TimberMenuTest extends WP_UnitTestCase {
 		$this->_createTestMenu();
 		$menu = new TimberMenu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
-		$this->assertEquals( 2, count( $menu->get_items() ) );
+		$this->assertEquals( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[1];
 		$this->assertTrue( $item->is_external() );
@@ -152,6 +152,21 @@ class TimberMenuTest extends WP_UnitTestCase {
 		update_post_meta( $child_menu_item, '_menu_item_url', '' );
 		$post = new TimberPost($child_menu_item);
 		$menu_items[] = $child_menu_item;
+		$root_url_link_id = wp_insert_post(
+			array(
+				'post_title' => 'Root Home',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 4
+			)
+		);
+
+		$menu_items[] = $root_url_link_id;
+		update_post_meta( $root_url_link_id, '_menu_item_type', 'custom' );
+		update_post_meta( $root_url_link_id, '_menu_item_object_id', $root_url_link_id );
+		update_post_meta( $root_url_link_id, '_menu_item_url', '/' );
+		update_post_meta( $root_url_link_id, '_menu_item_xfn', '' );
+		update_post_meta( $root_url_link_id, '_menu_item_menu_item_parent', 0 );
 		foreach ( $menu_items as $object_id ) {
 			$query = "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id, term_order) VALUES ($object_id, $menu_id, 0);";
 			$wpdb->query( $query );

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -43,11 +43,18 @@
             $local = 'http://example.org/directory';
             $subdomain = 'http://cdn.example.org/directory';
             $external = 'http://upstatement.com';
-            $rel_url = '/directory';
+            $rel_url = '/directory/';
             $this->assertEquals('/directory', TimberURLHelper::get_rel_url($local));
             $this->assertEquals($subdomain, TimberURLHelper::get_rel_url($subdomain));
             $this->assertEquals($external, TimberURLHelper::get_rel_url($external));
             $this->assertEquals($rel_url, TimberURLHelper::get_rel_url($rel_url));
+        }
+
+        function testRemoveTrailingSlash(){
+            $url_with_trailing_slash = 'http://example.org/directory/';
+            $root_url = "/";
+            $this->assertEquals('http://example.org/directory', TimberURLHelper::remove_trailing_slash($url_with_trailing_slash));
+            $this->assertEquals('/', TimberURLHelper::remove_trailing_slash($root_url));
         }
 
         function testDownloadURL(){


### PR DESCRIPTION
This addresses #308.

It adds a URL helper method that selectively applies untrailingslashit on URLs unless they = '/'

FYI, I added another menu item to TimberMenuTest to test this.

I'm still not sure if there is a better way [to set a menu link to "home"](https://github.com/jarednova/timber/issues/308#issuecomment-50341251) that works across different environments but this (setting a custom menu item of /) is often a use case for me, so hopefully this looks OK! 
