### PR TITLE
Try to fix #322 - Not showing more than 5 images in galleries.

### DIFF
--- a/functions/timber-query-iterator.php
+++ b/functions/timber-query-iterator.php
@@ -131,7 +131,8 @@ class TimberQueryIterator implements Iterator {
 
     //get_posts users numberposts
     static function fix_number_posts_wp_quirk( $query ) {
-        if (isset($query->query) && isset($query->query['numberposts'])) {
+        if (isset($query->query) && isset($query->query['numberposts'])
+                && !isset($query->query['posts_per_page'])) {
             $query->set( 'posts_per_page', $query->query['numberposts'] );
         }
         return $query;


### PR DESCRIPTION
The problem start when using the `[gallery]` shortcode. The gallery shortcode is defined in `media.php, line 702`. Specifying ids in the shortcode sets the `include` parameter (`line 712`) for the `get_posts()` call (`line 746`).

``` php
    $attr['include'] = $attr['ids'];
```

`get_posts()` is defined in `post.php, line 1676`. At the top of the function defaults are given and the `numberposts` option is set to `5`. `posts_per_page` is not mentioned.

``` php
    function get_posts($args = null) {
        $defaults = array(
            'numberposts' => 5, 'offset' => 0,
            'category' => 0, 'orderby' => 'date',
            'order' => 'DESC', 'include' => array(),
            'exclude' => array(), 'meta_key' => '',
            'meta_value' =>'', 'post_type' => 'post',
            'suppress_filters' => true
        );
```

`get_posts()` then sets posts_per_page based on `numberpages`. `line 1689`:

``` php
    if ( ! empty($r['numberposts']) && empty($r['posts_per_page']) )
        $r['posts_per_page'] = $r['numberposts'];
```

Additionally it also sets `posts_per_page` based on the number of ids in the `include` parameter. Note it does not also set `numberposts`. `line 1693`:

``` php
    if ( ! empty($r['include']) ) {
        $incposts = wp_parse_id_list( $r['include'] );
        $r['posts_per_page'] = count($incposts);  // only the number of posts included
```

It then passes the arguments to a new `WP_Query` object and calls `query()` on it. `query()` calls `WP_Query->get_posts()` (defined in `query.php, line 2152`).

At the top of `get_posts()` it calls the `pre_get_posts` action:

``` php
    do_action_ref_array('pre_get_posts', array(&$this));
```

This is when Timber's quirk function is called. It sets `posts_per_page` from `number_posts` (which always has a value at this point).

``` php
    add_action( 'pre_get_posts', array($this, 'fix_number_posts_wp_quirk' ));
    static function fix_number_posts_wp_quirk( $query ) {
```

`get_posts()` has absolutely no mention of `numberposts`. It uses `posts_per_page` to construct its SQL, possibly getting the value from a database option. `line 2222`:

``` php
    if ( !isset($q['posts_per_page']) || $q['posts_per_page'] == 0 )
        $q['posts_per_page'] = get_option('posts_per_page');
```

The problem is that Timber tries to support the `numberposts` parameter even in situations where WP doesn't respect it. [Function Reference get_posts](http://codex.wordpress.org/Function_Reference/get_posts) claims:

> Note: 'numberposts' and 'posts_per_page' can be used interchangeably.

However the Timber fix from commit dc42a63b1b235597d3fcf427adc73dc4469d63c5 trusts the `numberposts` parameter over `posts_per_page`. I think the precedence of these two should be reversed as it seems `posts_per_page` is used more, particularly in documentation and the shortcodes etc.

This commit only sets `posts_per_page` if it has not already been set.

Ideally however, this is a WordPress issue which needs fixing.
