### PR TITLE
Add a 'timber_output' filter

### DIFF
--- a/functions/timber-loader.php
+++ b/functions/timber-loader.php
@@ -71,7 +71,7 @@ class TimberLoader {
             $this->set_cache($key, $output, self::CACHEGROUP, $expires, $cache_mode);
         }
 
-        return $output;
+        return apply_filters('timber_output', $output);
     }
 
     /**


### PR DESCRIPTION
This will allow us to filter the output anyway we like, further controlling our markup.
For example this function will add `data-pjax` to all internal links using this filter:

``` php
function add_pjax_internal_links( $output ) {

    // convert to array so we can skip the <head>
    $output_array = explode( '</head>', $output );

    // Add pjax-data to internal links
    $output_array[1] = str_replace( 'href="/', 'data-pjax href="/', $output_array[1] );
    $output_array[1] = str_replace( 'href="' . get_home_url(), 'data-pjax href="' . get_home_url(), $output_array[1] );

    // convert array back to string
    $output = implode( '', $output_array);

    return $output;

}
add_filter( 'timber_output', 'add_pjax_internal_links' );
```
