### PR TITLE
Update timber-helper.php

### DIFF
--- a/functions/timber-helper.php
+++ b/functions/timber-helper.php
@@ -241,7 +241,7 @@ class TimberHelper {
         $pattern .= '[a-wyz][a-z](fo|g|l|m|mes|o|op|pa|ro|seum|t|u|v|z)?)#i';
         $ret = preg_replace( $pattern, '<a href="mailto:\\1">\\1</a>', $ret );
         $ret = preg_replace( "/\B@(\w+)/", " <a href=\"http://www.twitter.com/\\1\" target=\"_blank\">@\\1</a>", $ret );
-        $ret = preg_replace( "/\B#(\w+)/", " <a href=\"http://search.twitter.com/search?q=\\1\" target=\"_blank\">#\\1</a>", $ret );
+        $ret = preg_replace( "/\B#(\w+)/", " <a href=\"http://twitter.com/search?q=\\1\" target=\"_blank\">#\\1</a>", $ret );
         return $ret;
     }
 


### PR DESCRIPTION
Linking to 
http://search.twitter.com/search?q=winners
gets you
The Twitter REST API v1 is no longer active. Please migrate to API v1.1. https://dev.twitter.com/docs/api/1.1/overview.

it's just a link, we don't need no api?
