### PR TITLE
Improving TimberPost::get_prev to reduce complexity

### DIFF
--- a/functions/timber-post.php
+++ b/functions/timber-post.php
@@ -382,7 +382,6 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
           return $this->_prev[$taxonomy];
         }
         global $post;
-        $this->_prev = array();
         $old_global = $post;
         $post = $this;
         $within_taxonomy = ($taxonomy) ? $taxonomy : 'category';


### PR DESCRIPTION
I've addressed some of the issues I fixed earlier in #357 that got rejected.

I've opted to set some defaults and only call get_adjacent_post and set $this->_prev[$taxonomy] in one place each.
