### PR TITLE
Simplyfing config in TimberHelper::transient

### DIFF
--- a/functions/timber-helper.php
+++ b/functions/timber-helper.php
@@ -13,10 +13,9 @@ class TimberHelper {
      * @return mixed
      */
     public static function transient( $slug, $callback, $transient_time = 0, $lock_timeout = 5, $force = false ) {
+        $enable_transients = true;
         if ( $transient_time === false || ( defined( 'WP_DISABLE_TRANSIENTS' ) && WP_DISABLE_TRANSIENTS ) ) {
             $enable_transients = false;
-        } else {
-            $enable_transients = true;
         }
 
         $data = $enable_transients ? get_transient( $slug ) : false;


### PR DESCRIPTION
I've simplified the config for `$enable_transients` by setting a default value instead of relying on an else clause.
