### PR TITLE
Cleans up composer.json formatting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,50 +1,57 @@
 {
-	"name"       : "jarednova/timber",
-	"type"       : "wordpress-plugin",
-	"description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
-	"keywords"   : ["timber", "twig", "themes", "templating"],
-	"homepage"   : "http://timber.upstatement.com",
-	"license"    : "MIT",
-	"authors"    : [
-		{
-			"name"    : "Jared Novack",
-			"email"   : "jared@upstatement.com",
-			"homepage": "http://upstatement.com"
-		}
-	],
-	"support"    : {
-		"issues": "https://github.com/jarednova/timber/issues",
-		"wiki"  : "https://github.com/jarednova/timber/wiki",
-		"source": "https://github.com/jarednova/timber"
-	},
-	"require"    : {
-		"php"                		: ">=5.3.0",
-		"twig/twig"			 		: "~1.15",
-		"dannyvankooten/php-router"	: "dev-master#e9a479820b871ae4493fec30d5e433456767a505",
-		"composer/installers"		: "~1.0",
-		"asm89/twig-cache-extension": "~0.1"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "3.7.*",
-        "satooshi/php-coveralls": "dev-master",
-        "AdvancedCustomFields/acf5-beta" : "5.0",
-        "wp-cli/wp-cli" : "*"
-	},
-	"repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "AdvancedCustomFields/acf5-beta",
-                "version": "5.0",
-                "dist": {
-                    "url": "https://www.dropbox.com/s/763lrwuvonk0prb/advanced-custom-fields-pro.zip?dl=1",
-                    "type": "zip"
-                },
-                "autoload": {
-                    "psr-0": { "acf\\advanced-custom-fields-pro": "" }
-                },
-                "target-dir": "acf/advanced-custom-fields-pro"
-            }
-        }
-    ]
+  "name": "jarednova/timber",
+  "type": "wordpress-plugin",
+  "description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
+  "keywords": [
+    "timber",
+    "twig",
+    "themes",
+    "templating"
+  ],
+  "homepage": "http://timber.upstatement.com",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Jared Novack",
+      "email": "jared@upstatement.com",
+      "homepage": "http://upstatement.com"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/jarednova/timber/issues",
+    "wiki": "https://github.com/jarednova/timber/wiki",
+    "source": "https://github.com/jarednova/timber"
+  },
+  "require": {
+    "php": ">=5.3.0",
+    "twig/twig": "~1.15",
+    "dannyvankooten/php-router": "dev-master#e9a479820b871ae4493fec30d5e433456767a505",
+    "composer/installers": "~1.0",
+    "asm89/twig-cache-extension": "~0.1"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "3.7.*",
+    "satooshi/php-coveralls": "dev-master",
+    "AdvancedCustomFields/acf5-beta": "5.0",
+    "wp-cli/wp-cli": "*"
+  },
+  "repositories": [
+    {
+      "type": "package",
+      "package": {
+        "name": "AdvancedCustomFields/acf5-beta",
+        "version": "5.0",
+        "dist": {
+          "url": "https://www.dropbox.com/s/763lrwuvonk0prb/advanced-custom-fields-pro.zip?dl=1",
+          "type": "zip"
+        },
+        "autoload": {
+          "psr-0": {
+            "acfadvanced-custom-fields-pro": ""
+          }
+        },
+        "target-dir": "acf/advanced-custom-fields-pro"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
The previous formatting was a mess:

![screenshot 2014-12-11 19 25 58](https://cloud.githubusercontent.com/assets/2192970/5405541/cf78347e-816b-11e4-841f-d477103c23bb.png)

Converts to 2 space indention
Fixes broken indention
