### PR TITLE
Refactor: Needs better error_log handling

### DIFF
--- a/lib/image/timber-image-operation-resize.php
+++ b/lib/image/timber-image-operation-resize.php
@@ -103,8 +103,8 @@ class TimberImageOperationResize extends TimberImageOperation {
             }
             $result = $image->save( $save_filename );
             if ( is_wp_error( $result ) ) {
-                error_log( 'Error resizing image' );
-                error_log( print_r( $result, true ) );
+                TimberHelper::error_log( 'Error resizing image' );
+                TimberHelper::error_log( print_r( $result, true ) );
                 return false;
             } else {
                 return true;

--- a/lib/image/timber-image-operation-retina.php
+++ b/lib/image/timber-image-operation-retina.php
@@ -56,8 +56,8 @@ class TimberImageOperationRetina extends TimberImageOperation {
             $image->crop( 0, 0, $src_w, $src_h, $w, $h );
             $result = $image->save( $save_filename );
             if ( is_wp_error( $result ) ) {
-                error_log( 'Error resizing image' );
-                error_log( print_r( $result, true ) );
+                TimberHelper::error_log( 'Error resizing image' );
+                TimberHelper::error_log( print_r( $result, true ) );
                 return false;
             } else {
                 return true;

--- a/lib/timber-helper.php
+++ b/lib/timber-helper.php
@@ -133,10 +133,9 @@ class TimberHelper {
 	}
 
 	/**
-	 *
+	 * Adds an error_log to your server log or to a configured folder defined with Timber::$log_dir
 	 *
 	 * @param mixed $arg that you want to error_log
-	 * @return void
 	 */
 	public static function error_log( $arg ) {
 		if ( !WP_DEBUG ) {
@@ -145,7 +144,12 @@ class TimberHelper {
 		if ( is_object( $arg ) || is_array( $arg ) ) {
 			$arg = print_r( $arg, true );
 		}
-		return error_log( $arg );
+		if ( !empty(Timber::$log_dir) ) {
+			error_log( $arg, 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
+		} else {
+			error_log( $arg );
+		}
+		return;
 	}
 
 	/**

--- a/lib/timber-helper.php
+++ b/lib/timber-helper.php
@@ -146,9 +146,9 @@ class TimberHelper {
 		}
 		$backtrace = debug_backtrace();
 		if ( !empty(Timber::$log_dir) ) {
-			error_log( $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg, 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
+			error_log( '[' . date('Y-m-d H:i:s') . ']' . $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg, 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
 		} else {
-			error_log( $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg );
+			error_log( '[' . date('Y-m-d H:i:s') . ']' . $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg );
 		}
 		return;
 	}

--- a/lib/timber-helper.php
+++ b/lib/timber-helper.php
@@ -144,10 +144,11 @@ class TimberHelper {
 		if ( is_object( $arg ) || is_array( $arg ) ) {
 			$arg = print_r( $arg, true );
 		}
+		$backtrace = debug_backtrace();
 		if ( !empty(Timber::$log_dir) ) {
-			error_log( $arg, 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
+			error_log( $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg, 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
 		} else {
-			error_log( $arg );
+			error_log( $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg );
 		}
 		return;
 	}

--- a/lib/timber-helper.php
+++ b/lib/timber-helper.php
@@ -146,7 +146,7 @@ class TimberHelper {
 		}
 		$backtrace = debug_backtrace();
 		if ( !empty(Timber::$log_dir) ) {
-			error_log( '[' . date('Y-m-d H:i:s') . ']' . $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg, 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
+			error_log( '[' . date('Y-m-d H:i:s') . ']' . $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg . '\r\n', 3, Timber::$log_dir . 'timber-' . date('Y-m-d') . '.log' );
 		} else {
 			error_log( '[' . date('Y-m-d H:i:s') . ']' . $backtrace[1]['class'] . '::' . $backtrace[1]['function'] . '() - ' . $arg );
 		}

--- a/lib/timber-loader.php
+++ b/lib/timber-loader.php
@@ -214,7 +214,7 @@ class TimberLoader {
                 $loc = realpath($loc);
                 $paths[] = $loc;
             } else {
-                //error_log($loc.' is not a directory');
+                //TimberHelper::error_log($loc.' is not a directory');
             }
         }
         if (!ini_get('open_basedir')) {

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -641,7 +641,7 @@ class TimberImageTest extends WP_UnitTestCase {
 		$_FILES['tester'] = $data;
 		$file_id = WP_Overrides::media_handle_upload('tester', 0, array(), array( 'test_form' => false));
 		if (!is_int($file_id)) {
-			error_log(print_r($file_id, true));
+			TimberHelper::error_log(print_r($file_id, true));
 		}
 		$image = new TimberImage($file_id);
 		$str = '<img src="{{image.src(\'medium\')}}" />';
@@ -659,7 +659,7 @@ class TimberImageTest extends WP_UnitTestCase {
 		$_FILES['tester'] = $data;
 		$file_id = WP_Overrides::media_handle_upload('tester', 0, array(), array( 'test_form' => false));
 		if (!is_int($file_id)) {
-			error_log(print_r($file_id, true));
+			TimberHelper::error_log(print_r($file_id, true));
 		}
 		$image = new TimberImage($file_id);
 		$str = '<img src="{{image.src(\'medium\')}}" />';

--- a/timber.php
+++ b/timber.php
@@ -41,6 +41,7 @@ class Timber {
 
 	public static $locations;
 	public static $dirname;
+	public static $log_dir;
 	public static $twig_cache = false;
 	public static $cache = false;
 	public static $auto_meta = true;


### PR DESCRIPTION
Refactor the basic error_logs with the one created in TimberHelper, also add backtrace and logtime to get better logs. For an additional feature the "user" could define a directory where the library will put it's logs instead of the system log.
