### PR TITLE
Extending Timber (resolving partial inheritance)

### DIFF
--- a/lib/timber-extendable.php
+++ b/lib/timber-extendable.php
@@ -1,0 +1,116 @@
+<?php
+// Exit if accessed directly
+if ( !defined ( 'ABSPATH' ) )
+    exit;
+
+class TimberExtendable extends TimberCore
+{
+    private $_context;
+
+    public static function extend( $name, $value, $context = false ) {
+
+        if ( !$context ) {
+            $context = self::get_calling_script_dir();
+
+            // All themes share a single context (as there can only be 1 active theme anyway)
+            if ( strpos( $context, get_theme_root() ) === 0 ) {
+                $context = get_theme_root();
+            }
+
+        } elseif ( 'theme' === $context ) {
+            // Allow plugins to extend the theme context
+            $context = get_theme_root();
+
+        }
+
+        if ( !isset( static::$_methods[$name] ) ) {
+            static::$_methods[$name] = array();
+        }
+
+        static::$_methods[$name][$context] = $value;
+    }
+
+    /**
+     * This magic method checks to see if a method has been added to the object,
+     * and calls it.
+     */
+    public function __call( $field, $args ) {
+
+        // First check the current class
+        $class = get_called_class();
+        do {
+
+            // The root TimberExtendable *must* define the static property $_methods.
+            // If a TimberExtendable does not define $_methods, all methods will be
+            // assigned to the first parent TimberExtendable that has $_methods.
+
+            if ( isset( $class::$_methods ) && isset( $class::$_methods[$field] ) ) {
+                foreach( $class::$_methods[$field] as $context => $method ) {
+
+                    // Contexts are a 'root'. So the context ABSPATH . '/wp-content'
+                    // will apply to all code run from plugins or themes. Default
+                    // context is THEME_ROOT.
+
+                    if ( strpos( $this->_context, $context ) === 0 ) {
+                        array_splice( $args, 0, 0, array( $this ) );
+                        return call_user_func_array( $method, $args );
+                    }
+                }
+            }
+        } while( $class = get_parent_class( $class ) );
+
+    }
+
+    /**
+     * @return boolean|string
+     */
+    private static function get_calling_script_dir($offset = 0) {
+        $caller = self::get_calling_script_file($offset);
+        if (!is_null($caller)){
+            $pathinfo = pathinfo($caller);
+            $dir = $pathinfo['dirname'];
+            return $dir;
+        }
+        return null;
+    }
+
+    /**
+     * @param int $offset
+     * @return string|null
+     * @deprecated since 0.20.0
+     */
+    private static function get_calling_script_file($offset = 0) {
+        $caller = null;
+        $backtrace = debug_backtrace();
+        $i = 0;
+        foreach ($backtrace as $trace) {
+            if ( isset( $trace['file'] ) && strpos( $trace['file'], TIMBER_LOC ) !== 0 ) {
+                $caller = $trace['file'];
+                break;
+            }
+            $i++;
+        }
+        if ($offset){
+            $caller = $backtrace[$i + $offset]['file'];
+        }
+        return $caller;
+    }
+
+    protected function __construct( $context = false ) {
+        $this->_init_extendable( $context );
+    }
+
+    protected function _init_extendable( $context = false ) {
+        if ( !$context ) {
+            $context = self::get_calling_script_dir();
+        }
+
+        // When in doubt, assume theme context
+        if ( 'theme' === $context || empty( $context ) ) {
+            $context = get_stylesheet_directory();
+        }
+
+        $this->_context = $context;
+    }
+
+}

--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -29,11 +29,14 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 	 */
 	protected $_wp_attached_file;
 
+    protected static $_methods = array();
+
 	/**
 	 * @param int $iid
 	 */
-	public function __construct($iid) {
+	public function __construct( $iid, $context = false ) {
 		$this->init($iid);
+        $this->_init_extendable( $context );
 	}
 
 	/**

--- a/lib/timber-post.php
+++ b/lib/timber-post.php
@@ -23,7 +23,7 @@
  *
  * @package Timber
  */
-class TimberPost extends TimberCore implements TimberCoreInterface {
+class TimberPost extends TimberExtendable implements TimberCoreInterface {
 
 	/**
 	 * @var string $ImageClass the name of the class to handle images by default
@@ -143,6 +143,11 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 */
 	public $slug;
 
+    /**
+     * @var array Contains the methods extended using TimberPost::extend
+     */
+    protected static $_methods = array();
+
 	/**
 	 * If you send the constructor nothing it will try to figure out the current post id based on being inside The_Loop
 	 * @example
@@ -151,10 +156,13 @@ class TimberPost extends TimberCore implements TimberCoreInterface {
 	 * $other_post = new TimberPost($random_post_id);
 	 * ```
 	 * @param mixed $pid
+	 * @param string $context
 	 */
-	public function __construct($pid = null) {
+	public function __construct( $pid = null, $context = false ) {
 		$pid = $this->determine_id( $pid );
 		$this->init($pid);
+
+        parent::__construct( $context );
 	}
 
 	/**


### PR DESCRIPTION
In the 1.0 plan (#161) the roadmap (#259) we discussed partial inheritance. This is a proposed solution to the problem, that I have worked with successfully. Let me explain!

This issue is that if you want to extend an object in Timber, you generally have to extend all the WP objects (`TimberImage`, `TimberPost`, etc.) to not run into surprises, because of inheritance and factory methods. 

To show the problem: if you extend `TimberPost` OOP style (`MyTimberPost extends TimberPost`), then the only way to get `TimberImages` (which also extend `TimberPosts`) to have access to the same methods is by creating your own `MyTimberImage`, which extends `TimberImage`. This class then has to contain (hardcoded) _the same methods as `MyTimberPost`_. That's not very DRY. 

A mixins system would be a solution to this, even though it means verbosely extending everything. But, to make things more complicated, whenever Timber returns another object, you run the risk of ending up with a vanilla Timber object again.

For example: `TimberPost::get_thumbnail()` returns a `TimberImage` object. If you want to extend `TimberImage`, you also need to extend `TimberPost` to always return `MyTimberImages` in factory methods.

Some solutions have been suggested in #161 . Using WordPress filters to set the 'default' object type is nice, but makes for a lot of scaffolding - especially if you just want to 'quickly' add a single method to Timber objects.

My usual fallback is to twig filters and functions. As an example, let's try to display all attached images to a post:

``` twig
{# 1. The normal way: #}
{% for image in post.children( 'attachment', 'TimberImage' ) %}
    <img src="{{image}}" />
{% endfor %}

{# 2. The usual quick fix - write a filter #}
{% for image in post|get_attached_images %}
    <img src="{{image}}" />
{% endfor %}

{# 3. What I would ideally do, by extending TimberPost #}
{% for image in post.attached_images %}
    <img src="{{image}}" />
{% endfor %}
```

I have toyed with a few ways of making option 3 easier to implement and `TimberExtendable` is the result of that.

The basic idea is this: themes and plugins can add arbitrary methods to Timber objects that will be available from a certain context. Here's a practical example:

``` php
TimberPost::extend( "get_attached_images", function( $post ) {

    // Only apply this method to posts and pages
    if ( !in_array( $post->post_type, array( "post", "page" ) ) ) {
        return;
    }

    return $post->get_children( "attachment", "TimberImage" );

} );
```

Now every `TimberPost` and child of `TimberPost` (that means `TimberImage` as well as `MyTimberPost` and `MyTimberImage`) will have the `get_attached_images` method available to it.

Because ideally Timber can be used by plugins as well as the active theme independently, `TimberExtendable` allows for a context in which the methods are available. If no context is explicitly given, the context is the calling script dir in the case of plugins, and the theme root dir for themes.

So, if both a plugin and a theme (coincidentally) add the same method with `TimberPost::extend`, they will not conflict. Plugins can however explicitly add methods to the theme context, by passing `theme` as the `$context` argument.

I haven't tested this multi-context functionality a lot, so some work still has to be done there. But the basic idea has been working great on my latest Timber project.

If we want to pursue this further, I think the best way to go is to make this a bigger refactor and merge it with #486 to clean up the internal inheritance in Timber too!

Sorry for the long story! Let me know what you think.

Cheers,
Mike
