### PR TITLE
Refactoring Twig_Loader_String existing Twig environment

### DIFF
--- a/lib/timber.php
+++ b/lib/timber.php
@@ -232,12 +232,9 @@ class Timber {
 	 */
 	public static function compile_string( $string, $data = array() ) {
 		$dummy_loader = new TimberLoader();
-		$dummy_loader->get_twig();
-		$loader = new Twig_Loader_String();
-		$twig = new Twig_Environment( $loader );
-		$twig = apply_filters( 'timber/twig/filters', $twig );
-		$twig = apply_filters( 'twig_apply_filters', $twig );
-		return $twig->render( $string, $data );
+		$twig = $dummy_loader->get_twig();
+		$template = $twig->createTemplate($string);
+		return $template->render( $data );
 	}
 
 	/**

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -176,7 +176,7 @@
 		function testFilterTruncate() {
 			$gettysburg = 'Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.';
 			$str = Timber::compile_string("{{address | truncate(6)}}", array('address' => $gettysburg));
-			$this->assertEquals('Four score and seven years ago&amp;hellip;', $str);
+			$this->assertEquals('Four score and seven years ago&hellip;', $str);
 		}
 
 		function testSetSimple() {


### PR DESCRIPTION
Fixes #863 

#### Issue
Tests (and possibly existing code in themes) using `compile_string` currently use `Twig_Loader_String` which is not recommended and deprecated since `1.18.1`

#### Solution
Hooks into the existing Twig environment and loads the template via that.

#### Impact
None

#### Usage
No change

#### Considerations
None