### PR TITLE
Fix function_wrapper docs

### DIFF
--- a/docs/wiki/wp-integration.md
+++ b/docs/wiki/wp-integration.md
@@ -114,10 +114,10 @@ Classes (including namespaced) are also supported for `function_wrapper`:
 
 ```php
 # Namespaced has to be a string
-TimberHelper::function_wrapper('Example\Class', 'function_in_class');
+TimberHelper::function_wrapper(array('Example\Class', 'function_in_class'));
 
 # Otherwise, you can pass the object of the class
-TimberHelper::function_wrapper($this, 'function_in_class');
+TimberHelper::function_wrapper(array($this, 'function_in_class'));
 ```
 
 You can then call the function like so `{{function_in_class}}`

--- a/lib/timber-helper.php
+++ b/lib/timber-helper.php
@@ -162,12 +162,10 @@ class TimberHelper {
 	}
 
 	/**
-	 *
-	 *
-	 * @param string  $function_name
-	 * @param integer[]   $defaults
-	 * @param bool    $return_output_buffer
-	 * @return TimberFunctionWrapper
+	 * @param mixed $function_name or array( $class( string|object ), $function_name )
+	 * @param array (optional) $defaults
+	 * @param bool (optional) $return_output_buffer Return function output instead of return value (default: false)
+	 * @return \TimberFunctionWrapper
 	 */
 	public static function function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false ) {
 		return new TimberFunctionWrapper( $function_name, $defaults, $return_output_buffer );


### PR DESCRIPTION
#### Issue
<!-- Description of the problem that this code change is solving -->
The Wiki documentation of `TimberHelper::function_wrapper` contains an error regarding the new possibility to pass in Classes or Objects. They have to be passed in as an Array. Also the DocBlock of `TimberHelper::function_wrapper` does not reflect that change.


#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Updated the DocBlock (with the updated DocBlock that is shown in the wiki documentation) and added the `array()` part in the wiki documentation.