### PR TITLE
Adding more descriptive errors for initing TimberImage without src

### DIFF
--- a/lib/timber-image.php
+++ b/lib/timber-image.php
@@ -203,6 +203,8 @@ class TimberImage extends TimberPost implements TimberCoreInterface {
 	 * @param int $iid
 	 */
 	function init( $iid = false ) {
+		if(!$iid) { TimberHelper::error_log('Initalized TimberImage without providing first parameter.'); return; }
+		
 		if ( !is_numeric( $iid ) && is_string( $iid ) ) {
 			if (strstr($iid, '://')) {
 				$this->init_with_url($iid);

--- a/lib/timber-twig.php
+++ b/lib/timber-twig.php
@@ -112,7 +112,7 @@ class TimberTwig {
 					}
 					return new $PostClass( $pid );
 				} ) );
-		$twig->addFunction( new Twig_SimpleFunction( 'TimberImage', function ( $pid, $ImageClass = 'TimberImage' ) {
+		$twig->addFunction( new Twig_SimpleFunction( 'TimberImage', function ( $pid = false, $ImageClass = 'TimberImage' ) {
 					if ( is_array( $pid ) && !TimberHelper::is_array_assoc( $pid ) ) {
 						foreach ( $pid as &$p ) {
 							$p = new $ImageClass( $p );


### PR DESCRIPTION
**Ticket**: #496 
**Reviewer**: @jarednova 

#### Issue
Users are experiencing an error `Not able to init in TimberImage with iid=` - this leads me to believe `TimberImage` is being initialised with an empty parameter, as `iid` is false.

#### Solution
Adds another error for if a user hasn't entered anything for the first parameter.


#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Extra error

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
Nope

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
This may solve the issue, or just expose a larger issue.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Not sure tests are necessary here.