### PR TITLE
Exposing all translation functions

### DIFF
--- a/lib/timber-twig.php
+++ b/lib/timber-twig.php
@@ -185,6 +185,33 @@ class TimberTwig {
 		$twig->addFunction( '__', new Twig_SimpleFunction( '__', function ( $text, $domain = 'default' ) {
 					return __( $text, $domain );
 				} ) );
+		$twig->addFunction( 'translate', new Twig_SimpleFunction( 'translate', function ( $text, $domain = 'default' ) {
+					return translate( $text, $domain );
+				} ) );
+		$twig->addFunction( '_e', new Twig_SimpleFunction( '_e', function ( $text, $domain = 'default' ) {
+					return _e( $text, $domain );
+				} ) );
+		$twig->addFunction( '_n', new Twig_SimpleFunction( '_n', function ( $single, $plural, $number, $domain = 'default' ) {
+					return _n( $single, $plural, $number, $domain );
+				} ) );
+		$twig->addFunction( '_x', new Twig_SimpleFunction( '_x', function ( $text, $context, $domain = 'default' ) {
+					return _x( $text, $context, $domain );
+				} ) );
+		$twig->addFunction( '_ex', new Twig_SimpleFunction( '_ex', function ( $text, $context, $domain = 'default' ) {
+					return _ex( $text, $context, $domain );
+				} ) );
+		$twig->addFunction( '_nx', new Twig_SimpleFunction( '_nx', function ( $single, $plural, $number, $context, $domain = 'default' ) {
+					return _nx( $single, $plural, $number, $context, $domain );
+				} ) );
+		$twig->addFunction( '_n_noop', new Twig_SimpleFunction( '_n_noop', function ( $singular, $plural, $domain = 'default' ) {
+					return _n_noop( $singular, $plural, $domain );
+				} ) );
+		$twig->addFunction( '_nx_noop', new Twig_SimpleFunction( '_nx_noop', function ( $singular, $plural, $context, $domain = 'default' ) {
+					return _nx_noop( $singular, $plural, $context, $domain );
+				} ) );
+		$twig->addFunction( 'translate_nooped_plural', new Twig_SimpleFunction( 'translate_nooped_plural', function ( $nooped_plural, $count, $domain = 'default' ) {
+					return translate_nooped_plural( $nooped_plural, $count, $domain );
+				} ) );
 		/* get_twig is deprecated, use timber/twig */
 		$twig = apply_filters( 'get_twig', $twig );
 		$twig = apply_filters( 'timber/twig', $twig );


### PR DESCRIPTION
**Ticket**: #412 
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
Full range of translation functions aren't exposed to context

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Expose rull range

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Some users may already have added `translate` or other functions to their context, I assume this will override those functions?

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
All translation functions are exposed to context, e.g`{{translate()}}`

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
I don't think they are necessary, we would just be testing Wordpress' functions.