### PR TITLE
Updated WP.org build script with timber.php file

### DIFF
--- a/bin/deploy-to-wp-org.sh
+++ b/bin/deploy-to-wp-org.sh
@@ -21,7 +21,7 @@ function deploy () {
 	cp ~/Sites/timber/LICENSE.txt tags/$1/LICENSE.txt
 	cp ~/Sites/timber/README.md tags/$1/README.md
 	cp ~/Sites/timber/readme.txt tags/$1/readme.txt
-	cp ~/Sites/timber/timber.php tags/$1/timber.php
+	cp ~/Sites/timber/bin/timber.php tags/$1/timber.php
 	svn add tags/$1
 	cd tags/$1
 	svn commit -m "updating to $1"
@@ -35,7 +35,7 @@ function deploy () {
 	cp ~/Sites/timber/LICENSE.txt ~/Sites/timber-wp/trunk/LICENSE.txt
 	cp ~/Sites/timber/README.md ~/Sites/timber-wp/trunk/README.md
 	cp ~/Sites/timber/readme.txt ~/Sites/timber-wp/trunk/readme.txt
-	cp ~/Sites/timber/timber.php ~/Sites/timber-wp/trunk/timber.php
+	cp ~/Sites/timber/bin/timber.php ~/Sites/timber-wp/trunk/timber.php
 	svn commit -m "updating to $1" readme.txt
 	svn commit -m "updating to $1" timber.php
 }

--- a/bin/timber.php
+++ b/bin/timber.php
@@ -1,0 +1,20 @@
+<?php
+/*
+Plugin Name: Timber
+Description: The WordPress Timber Library allows you to write themes using the power Twig templates.
+Plugin URI: http://timber.upstatement.com
+Author: Jared Novack + Upstatement
+Version: 1.0-rc
+Author URI: http://upstatement.com/
+*/
+// we look for Composer files first in the plugins dir.
+// then in the wp-content dir (site install).
+// and finally in the current themes directories.
+if (   file_exists( $composer_autoload = __DIR__ . '/vendor/autoload.php' ) /* check in self */
+    || file_exists( $composer_autoload = WP_CONTENT_DIR.'/vendor/autoload.php') /* check in wp-content */
+    || file_exists( $composer_autoload = plugin_dir_path( __FILE__ ).'vendor/autoload.php') /* check in plugin directory */
+    || file_exists( $composer_autoload = get_stylesheet_directory().'/vendor/autoload.php') /* check in child theme */
+    || file_exists( $composer_autoload = get_template_directory().'/vendor/autoload.php') /* check in parent theme */
+) {
+    require_once $composer_autoload;
+}


### PR DESCRIPTION
**Ticket**: #911 
**Reviewer**: @connorjburton 
#### Issue
With the new Composer setup, usage as a WordPress plugin is no longer native.

#### Solution
This re-introduces the `timber.php` file (in the `bin` directory) to be used in the build script. When deploying to WP.org, this file is copied into the main directory so that it's read by the WordPress plugin page.

#### Impact
Not really. This will not interfere with the theme-based Composer installation.

#### Considerations
Is it worth adding docs for the edge-edge case of someone installing through non-wp.org but who still want it to use Timber as a plugin versus a theme dependency?

#### Testing
To test, you'll need to manually move `/bin/timber.php` to `/timber.php`