### PR TITLE
ACF posts now return as TimberPosts

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1026,7 +1026,7 @@ class Post extends Core implements CoreInterface {
 			}
 		}
 		$value = apply_filters('timber_post_get_meta_field', $value, $this->ID, $field_name, $this);
-		$value = $this->convert( $value );
+		$value = $this->convert( $value, __CLASS__ );
 		return $value;
 	}
 
@@ -1034,13 +1034,12 @@ class Post extends Core implements CoreInterface {
 	 * Finds any WP_Post objects and converts them to Timber\Posts
 	 * @param array $data
 	 */
-	public function convert( $data ) {
+	public function convert( $data, $class ) {
 		if( is_array( $data ) ) {
-			$class = __CLASS__;
 			$func = __FUNCTION__;
 			foreach( $data as &$ele ) {
 				if( gettype( $ele ) === 'array' ) {
-					$ele = $this->$func( $ele );
+					$ele = $this->$func( $ele, $class );
 				} else {
 					if( $ele instanceof WP_Post ) {
 						$ele = new $class( $ele );

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1026,7 +1026,7 @@ class Post extends Core implements CoreInterface {
 			}
 		}
 		$value = apply_filters('timber_post_get_meta_field', $value, $this->ID, $field_name, $this);
-		$value = $this->convert($value);
+		$value = $this->convert( $value );
 		return $value;
 	}
 
@@ -1034,16 +1034,16 @@ class Post extends Core implements CoreInterface {
 	 * Finds any WP_Post objects and converts them to Timber\Posts
 	 * @param array $data
 	 */
-	public function convert($data) {
-		if(is_array($data)) {
+	public function convert( $data ) {
+		if( is_array( $data ) ) {
 			$class = __CLASS__;
 			$func = __FUNCTION__;
-			foreach($data as &$ele) {
-				if(gettype($ele) === 'array') {
-					$ele = $this->$func($ele);
+			foreach( $data as &$ele ) {
+				if( gettype( $ele ) === 'array' ) {
+					$ele = $this->$func( $ele );
 				} else {
-					if($ele instanceof WP_Post) {
-						$ele = new $class($ele);
+					if( $ele instanceof WP_Post ) {
+						$ele = new $class( $ele );
 					}
 				}
 			}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1026,7 +1026,30 @@ class Post extends Core implements CoreInterface {
 			}
 		}
 		$value = apply_filters('timber_post_get_meta_field', $value, $this->ID, $field_name, $this);
+		$value = $this->convert($value);
 		return $value;
+	}
+
+	/**
+	 * Finds any WP_Post objects and converts them to Timber\Posts
+	 * @param array $data
+	 */
+	public function convert($data) {
+		if(is_array($data)) {
+			$class = __CLASS__;
+			$func = __FUNCTION__;
+			foreach($data as &$ele) {
+				if(gettype($ele) === 'array') {
+					$ele = $this->$func($ele);
+				} else {
+					if($ele instanceof WP_Post) {
+						$ele = new $class($ele);
+					}
+				}
+			}
+		}
+
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: #944 
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
ACF fields that container a post would return as `WP_Post`, not `Timber\Post`

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
If `get_field` returns an array, we run through each array element to see if it's either an array(1) or is an instance of `WP_Post`(2)

1. We run `$this->convert` again recursively till `$ele` is no longer an array
2. We pass the `WP_Post` into `Timber\Post`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
None that I know of, if someone already has done this manually, it will just end up passing `Timber\Post` into `Timber\Post`

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
There is less usage as you won't have to cast `WP_Post` to `TimberPost` anymore

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
Performance I think should be good, I don't think `instanceof` or `gettype` are expensive?

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
No tests added, may add some after namespacing is merged.