### PR TITLE
Use default wp rewrite base for pagination

### DIFF
--- a/lib/timber.php
+++ b/lib/timber.php
@@ -412,7 +412,7 @@ class Timber {
 				parse_str( $url[1], $query );
 				$args['add_args'] = $query;
 			}
-			$args['format'] = 'page/%#%';
+			$args['format'] = $wp_rewrite->pagination_base . '/%#%';
 			$args['base'] = trailingslashit( $url[0] ).'%_%';
 		} else {
 			$big = 999999999;


### PR DESCRIPTION
#### Issue
`Timber::get_pagination` ignores WP's default pagination base in `$wp_rewrite` and just uses `'page'`.


#### Solution
Replace `'page'` in `Timber::get_pagination`'s format with `$wp_rewrite->pagination_base`.


#### Impact
The codebase would only improve because it now uses WP's rewrite settings.