### PR TITLE
ref #934 -- added upgrade warning for WP.org

### DIFF
--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -5,8 +5,11 @@ namespace Timber;
 class Admin {
 	
     public static function init() {
-        add_filter('plugin_row_meta', array( __CLASS__, 'meta_links' ), 10, 2);
-        add_action('in_plugin_update_message-timber-library/timber.php', array('Timber\Admin', 'in_plugin_update_message'), 10, 2);
+        $filter = add_filter('plugin_row_meta', array( __CLASS__, 'meta_links' ), 10, 2);
+        $action = add_action('in_plugin_update_message-timber-library/timber.php', array('Timber\Admin', 'in_plugin_update_message'), 10, 2);
+        if ($filter && $action) {
+        	return true;
+        }
     }
 
 	/**

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -5,7 +5,8 @@ namespace Timber;
 class Admin {
 	
     public static function init() {
-        return add_filter( 'plugin_row_meta', array( __CLASS__, 'meta_links' ), 10, 2 );
+        add_filter('plugin_row_meta', array( __CLASS__, 'meta_links' ), 10, 2);
+        add_action('in_plugin_update_message-timber-library/timber.php', array('Timber\Admin', 'in_plugin_update_message'), 10, 2);
     }
 
 	/**
@@ -23,6 +24,33 @@ class Admin {
 			return $links;
 		}
 		return $links;
+	}
+
+    /**
+	 *  in_plugin_update_message
+	 *
+	 *  Displays an update message for plugin list screens.
+	 *  Shows only the version updates from the current until the newest version
+	 *
+	 *  @type	function
+	 *  @date	4/22/16
+	 *
+	 *  @param	{array}		$plugin_data
+	 *  @param	{object}	$r
+	 */
+	function in_plugin_update_message( $plugin_data, $r ) {
+		
+		// vars
+		$m = __('<p><b>Warning:</b> Timber 1.0 removed a number of features and methods. Before upgrading please test your theme on a local or staging site to ensure that your theme will work with the newest version.</p> 
+
+			<p><strong>Is your theme in active development?</strong> That is, is someone actively in PHP files writing new code? If you answered "no", then <i>do not upgrade</i>. You will not benefit from Timber 1.0</p>
+
+			<p>Read the <strong><a href="https://github.com/timber/timber/wiki/1.0-Upgrade-Guide">Upgrade Guide</a></strong> for more information</p>', 'acf');
+		
+		
+		// show message
+		echo '<br />' . sprintf( $m, admin_url('edit.php?post_type=acf-field-group&page=acf-settings-updates'), 'http://www.advancedcustomfields.com/pro');
+	
 	}
 
 }


### PR DESCRIPTION
**Reviewer**: @connorjburton 

#### Issue
Because of the methods removed in #934 — people could be surprised when elements of their theme doesn't work.

#### Solution
Add an upgrade warning so people with a perfectly-fine WordPress theme don't upgrade for the sake of upgrading. The warning urges people who have a legacy site to not upgrade and directs others to an [Upgrade Guide](https://github.com/timber/timber/wiki/1.0-Upgrade-Guide)

#### Impact
None

#### Considerations
In the future, we'll need a bit of code to NOT show this when going from 1.0 to 1.1 and the best way to manage messages for different version bumps.

#### Testing
No automated tests included; but tested locally to ensure it shows up when it's supposed to show up
