### PR TITLE
Fixing post getter array bug

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -124,7 +124,7 @@ class PostGetter {
 			return false;
 		}
 
-		if ( class_exists($type) && is_subclass_of($type, '\Timber\Post') ) {
+		if ( !is_array($type) && class_exists($type) && is_subclass_of($type, '\Timber\Post') ) {
 			return $type;
 		}
 	}


### PR DESCRIPTION
**Ticket**: #935 
**Reviewer**: @

#### Issue
<!-- Description of the problem that this code change is solving -->
Passing an array for `post_type` causes a warning.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Checks if it's an array before doing `class_exists`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
None

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
None

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
None

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None
