### PR TITLE
ref #979 -- is_admin() lives in \is_admin();

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -58,10 +58,10 @@ class Timber {
 	 * @return
 	 */
 	protected function test_compatibility() {
-		if ( is_admin() || $_SERVER['PHP_SELF'] == '/wp-login.php' ) {
+		if ( \is_admin() || $_SERVER['PHP_SELF'] == '/wp-login.php' ) {
 			return;
 		}
-		if ( version_compare(phpversion(), '5.3.0', '<') && !is_admin() ) {
+		if ( version_compare(phpversion(), '5.3.0', '<') && !\is_admin() ) {
 			trigger_error('Timber requires PHP 5.3.0 or greater. You have '.phpversion(), E_USER_ERROR);
 		}
 		if ( !class_exists('Twig_Autoloader') ) {


### PR DESCRIPTION
**Ticket**: #979
**Reviewer**: @connorjburton 

#### Issue
User @chrisgherbert is getting an error of `[05-May-2016 18:31:42 Europe/Berlin] PHP Fatal error:  Call to undefined function Timber\is_admin() in /Users/cherbert/web/bedrock-timber-test/vendor/timber/timber/lib/Timber.php on line 61`


#### Solution
`is_admin` is a WP function in the global namespace so it should be referred to as `\is_admin()` so PHP doesn't look for `Timber\is_admin()`

#### Considerations
This doesn't quite make sense. From what I read here:

http://php.net/manual/en/language.namespaces.fallback.php

PHP should always look in the global namespace when a function is not found in the current namespace; thus this PR shouldn't be necessary. Could there be a setting that this user has on in their PHP or WP settings?


#### Testing
All tests pass locally. I tested both `is_admin` and `\is_admin()` on a test site and they both work.
