### PR TITLE
You can now re-initialize a Timber Image with a Timber Image

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -155,6 +155,17 @@ class Image extends Post implements CoreInterface {
 	}
 
 	/**
+	 * @return array
+	 */
+	protected function get_post_custom($iid) {
+		$pc = get_post_custom($iid);
+		if ( is_bool($pc) ) {
+			return array();
+		}
+		return $pc;
+	}
+
+	/**
 	 * @internal
 	 * @param  int $iid the id number of the image in the WP database
 	 */
@@ -165,7 +176,7 @@ class Image extends Post implements CoreInterface {
 			if ( !is_array($image_info) ) {
 				$image_info = array();
 			}
-			$image_custom = get_post_custom($iid);
+			$image_custom = self::get_post_custom($iid);
 			$basic = get_post($iid);
 			if ( $basic ) {
 				if ( isset($basic->post_excerpt) ) {
@@ -212,7 +223,9 @@ class Image extends Post implements CoreInterface {
 	 */
 	function init( $iid = false ) {
 		if ( !$iid ) { Helper::error_log('Initalized TimberImage without providing first parameter.'); return; }
-		
+		if ( $iid instanceof Image ) {
+			$iid = (int) $iid->ID;
+		}
 		if ( !is_numeric($iid) && is_string($iid) ) {
 			if ( strstr($iid, '://') ) {
 				$this->init_with_url($iid);
@@ -263,7 +276,7 @@ class Image extends Post implements CoreInterface {
 			$this->ID = $iid;
 		}
 		if ( isset($this->ID) ) {
-			$custom = get_post_custom($this->ID);
+			$custom = self::get_post_custom($this->ID);
 			foreach ( $custom as $key => $value ) {
 				$this->$key = $value[0];
 			}

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -223,7 +223,7 @@ class Image extends Post implements CoreInterface {
 	 */
 	function init( $iid = false ) {
 		if ( !$iid ) { Helper::error_log('Initalized TimberImage without providing first parameter.'); return; }
-		if ( $iid instanceof Image ) {
+		if ( $iid instanceof self ) {
 			$iid = (int) $iid->ID;
 		}
 		if ( !is_numeric($iid) && is_string($iid) ) {

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -796,6 +796,33 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals($image->src(), $result);
 	}
 
+	function testTimberImageFromTimberImage() {
+		$post = $this->get_post_with_image();
+		$image = $post->thumbnail();
+		$post = new TimberImage($image);
+		$str = '{{ TimberImage(post).src }}';
+		$result = Timber::compile_string( $str, array('post' => $post) );
+		$this->assertEquals($image->src(), $result);
+	}
+
+	function testTimberImageFromTimberImageID() {
+		$post = $this->get_post_with_image();
+		$image = $post->thumbnail();
+		$post = new TimberImage($image->ID);
+		$str = '{{ TimberImage(post).src }}';
+		$result = Timber::compile_string( $str, array('post' => $post) );
+		$this->assertEquals($image->src(), $result);
+	}
+
+	function testTimberImageFromImageID() {
+		$post = $this->get_post_with_image();
+		$image = $post->thumbnail();
+		$post = $image->ID;
+		$str = '{{ TimberImage(post).src }}';
+		$result = Timber::compile_string( $str, array('post' => $post) );
+		$this->assertEquals($image->src(), $result);
+	}
+
 	function testTimberImageFromAttachment() {
 		$iid = self::get_image_attachment();
 		$image = new TimberImage($iid);


### PR DESCRIPTION
**Reviewer**: @connorjburton 

#### Issue
If the `TimberImage` or `Image` function in twig was passed a `\Timber\Image` object it would cause a compile error.

#### Solution
If passed an `Image` object, the `\Timber\Image::init` function will now grab the ID and re-initialize

#### Impact
It would be bad practice to do this, but it's worse to have a silent error. 

#### Usage
No.

#### Considerations
Rather than re-initialize, the `Image` object should be able to grab the public assignments of properties so that no new queries need to be run.

#### Testing
New Unit tests included demonstrating failing behavior and passing behavior
