### PR TITLE
User avatar is now a TimberImage

### DIFF
--- a/lib/User.php
+++ b/lib/User.php
@@ -7,6 +7,8 @@ use Timber\CoreInterface;
 
 use Timber\URLHelper;
 
+use Timber\Image;
+
 /**
  * This is used in Timber to represent users retrived from WordPress. You can call `$my_user = new TimberUser(123);` directly, or access it through the `{{ post.author }}` method.
  * @example
@@ -142,7 +144,7 @@ class User extends Core implements CoreInterface {
 		}
 		$this->id = $this->ID;
 		$this->name = $this->name();
-		$this->avatar = get_avatar_url($this->id);
+		$this->avatar = new Image(get_avatar_url($this->id));
 		$custom = $this->get_custom();
 		$this->import($custom);
 	}

--- a/lib/User.php
+++ b/lib/User.php
@@ -42,7 +42,7 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * @api
-	 * @var string The URL of the author's avatar
+	 * @var string|Image The URL of the author's avatar
 	 */
 	public $avatar;
 


### PR DESCRIPTION
**Ticket**: #983
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
User avatar just returned a URL.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Now returns a `Timber\Image`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
If someone has already done `TimberImage(user.avatar)` it will just return the same `TimberImage`

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
`TimberImage(user.avatar)`

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
I am not sure the benefit of improving this any further, unless we have reason to.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None included