### PR TITLE
Adding memoization to get_context

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -194,24 +194,28 @@ class Timber {
 	 * @return array
 	 */
 	public static function get_context() {
-		$data = array();
-		$data['http_host'] = 'http://'.URLHelper::get_host();
-		$data['wp_title'] = Helper::get_wp_title();
-		$data['wp_head'] = Helper::function_wrapper('wp_head');
-		$data['wp_footer'] = Helper::function_wrapper('wp_footer');
-		$data['body_class'] = implode(' ', get_body_class());
+		static $cache = [];
+		
+		if(empty($cache)) {
+			$cache['http_host'] = 'http://'.URLHelper::get_host();
+			$cache['wp_title'] = Helper::get_wp_title();
+			$cache['wp_head'] = Helper::function_wrapper('wp_head');
+			$cache['wp_footer'] = Helper::function_wrapper('wp_footer');
+			$cache['body_class'] = implode(' ', get_body_class());
+			
+			$cache['site'] = new Site();
+			$cache['request'] = new Request();
+			$user = new User();
+			$cache['user'] = ($user->ID) ? $user : false;
+			$cache['theme'] = $cache['site']->theme;
+			
+			$cache['posts'] = Timber::query_posts();
 
-		$data['site'] = new Site();
-		$data['request'] = new Request();
-		$user = new User();
-		$data['user'] = ($user->ID) ? $user : false;
-		$data['theme'] = $data['site']->theme;
+			$cache = apply_filters('timber_context', $cache);
+			$cache = apply_filters('timber/context', $cache);
+		}
 
-		$data['posts'] = Timber::query_posts();
-
-		$data = apply_filters('timber_context', $data);
-		$data = apply_filters('timber/context', $data);
-		return $data;
+		return $cache;
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -39,6 +39,8 @@ class Timber {
 	public static $auto_meta = true;
 	public static $autoescape = false;
 
+	public static $context_cache = [];
+
 	/**
 	 * @codeCoverageIgnore
 	 */
@@ -194,28 +196,27 @@ class Timber {
 	 * @return array
 	 */
 	public static function get_context() {
-		static $cache = [];
-		
-		if(empty($cache)) {
-			$cache['http_host'] = 'http://'.URLHelper::get_host();
-			$cache['wp_title'] = Helper::get_wp_title();
-			$cache['wp_head'] = Helper::function_wrapper('wp_head');
-			$cache['wp_footer'] = Helper::function_wrapper('wp_footer');
-			$cache['body_class'] = implode(' ', get_body_class());
+		if( empty(self::$context_cache) ) {
+			self::$context_cache['http_host'] = 'http://'.URLHelper::get_host();
+			self::$context_cache['wp_title'] = Helper::get_wp_title();
+			self::$context_cache['wp_head'] = Helper::function_wrapper('wp_head');
+			self::$context_cache['wp_footer'] = Helper::function_wrapper('wp_footer');
+			self::$context_cache['body_class'] = implode(' ', get_body_class());
 			
-			$cache['site'] = new Site();
-			$cache['request'] = new Request();
+			self::$context_cache['site'] = new Site();
+			self::$context_cache['request'] = new Request();
 			$user = new User();
-			$cache['user'] = ($user->ID) ? $user : false;
-			$cache['theme'] = $cache['site']->theme;
+			self::$context_cache['user'] = ($user->ID) ? $user : false;
+			self::$context_cache['theme'] = self::$context_cache['site']->theme;
 			
-			$cache['posts'] = Timber::query_posts();
+			self::$context_cache['posts'] = Timber::query_posts();
 
-			$cache = apply_filters('timber_context', $cache);
-			$cache = apply_filters('timber/context', $cache);
+			self::$context_cache = apply_filters('timber_context', self::$context_cache);
+			self::$context_cache = apply_filters('timber/context', self::$context_cache);
 		}
 
-		return $cache;
+		
+		return self::$context_cache;
 	}
 
 	/**

--- a/tests/TimberImage_UnitTestCase.php
+++ b/tests/TimberImage_UnitTestCase.php
@@ -13,6 +13,7 @@
 		}
 
 		function tearDown() {
+			parent::tearDown();
 			if (isset($this->_files) && is_array($this->_files)) {
 				foreach($this->_files as $file) {
 					if (file_exists($file)) {

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -21,4 +21,9 @@
 			flush_rewrite_rules( true );
 		}
 
+		function tearDown() {
+			parent::tearDown();
+			Timber::$context_cache = [];
+		}
+
 	}

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -2,6 +2,9 @@
 
 class TestTimberContext extends Timber_UnitTestCase {
 
+	/**
+	 * This throws an infite loop if memorization isn't working
+	 */
 	function testContextLoop() {
 		add_filter('timber_context', function($context) {
 			$context = Timber::get_context();
@@ -9,7 +12,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 			return $context;
 		});
 		$context = Timber::get_context();
-
+		$this->assertEquals('http://example.org', $context['http_host']);
 	}
 
 


### PR DESCRIPTION
**Ticket**: #977
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
Calling `get_context` inside the `timber_context` filter is common, and at the moment causes an infinite loop.

This would also not cache any data so is unnecessarily slow

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Adds memoization to the `get_context` function so it will only run the filters once (Fixes infinite loop) and also is faster when using `get_context` multiple times.

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Faster, fixes issue with infinite loop.

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
This needs some real world testing, will get the guys on the ticket to give it a go.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
No tests included.