### PR TITLE
Comment form redux1

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -444,6 +444,18 @@ class Helper {
 
 	/**
 	 *
+	 * Gets the comment form for use on a single article page
+	 * @deprecated 0.21.8 use `{{ function('comment_form') }}` instead
+	 * @param int     $post_id which post_id should the form be tied to?
+	 * @param array   $args this $args thing is a fucking mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
+	 * @return string
+	 */
+	public static function get_comment_form( $post_id = null, $args = array() ) {
+		return self::ob_function( 'comment_form', array( $args, $post_id ) );
+	}
+
+	/**
+	 *
 	 *
 	 * @param string  $args
 	 * @return array

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -506,6 +506,16 @@ class Post extends Core implements CoreInterface {
 		return $post;
 	}
 
+	/**
+	 *
+	 * Gets the comment form for use on a single article page
+	 * @param array   $args this $args thing is a fucking mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
+	 * @return string of HTML for the form
+	 */
+	public function comment_form( $args = array() ) {
+		return Helper::get_comment_form( $this->ID, $args );
+	}
+
 
 	/**
 	 * Get the terms associated with the post

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -2,6 +2,13 @@
 
 	class TestTimberHelper extends Timber_UnitTestCase {
 
+		function testCommentFormPHP() {
+			$post_id = $this->factory->post->create();
+			$form = TimberHelper::get_comment_form($post_id);
+			$form = trim($form);
+			$this->assertStringStartsWith('<div id="respond"', $form);
+		}
+
 		function testCloseTagsWithSelfClosingTags(){
 			$p = '<p>My thing is this <hr>Whatever';
 			$html = TimberHelper::close_tags($p);

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -589,6 +589,13 @@
 			$this->assertEquals('My Page', $post->title());
 		}
 
+		function testCommentFormOnPost() {
+			$post_id = $this->factory->post->create();
+			$post = new Timber\Post($post_id);
+			$form = $post->comment_form();
+			$this->assertStringStartsWith('<div id="respond"', trim($form));
+		}
+
 		/**
 		 * @group failing
 		 */


### PR DESCRIPTION
**Reviewer**: @connorjburton 

#### Issue
Many people (especially on the WordPress.org forums) have reported problems with the deprecated `TimberHelper::get_comment_form` function. Well of course they have, it was removed!

https://wordpress.org/support/topic/fatal-error-class-not-found-in-101?replies=2
https://wordpress.org/support/topic/get_comment_form-returns-empty?replies=4

... that said, the problem they're running into isn't entirely of their making. The `single.php` file in the Starter Theme had a call to `TimberHelper::get_comment_form` that I'm sure many developers left in w/o realizing what it was doing. I'd like to reduce 1.0 pain as much as possible

#### Solution
Restore the `Helper::get_comment_form` method (for now). But introduce a better method through `{{ post.comment_form }}` for folks to use.

#### Impact
A little extra code

#### Usage
We should update elements of the Starter Theme to use `{{ post.comment_form }}`

#### Considerations
I don't like the idea of a Timber object method returning HTML. But I also sympathize that hand-building a comment form's HTML is no one's idea of a good time.

#### Testing
Unit tests included!