### PR TITLE
Trying to fix init at root wp level

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -91,12 +91,11 @@ class Timber {
 	 * @codeCoverageIgnore
 	 */
 	protected function init() {
-		if(class_exists('\WP') && !defined('TIMBER_LOADED')) {
+		if( class_exists('\WP') && !defined('TIMBER_LOADED') ) {
 			Twig::init();
 			ImageHelper::init();
 			Admin::init();
 			Integrations::init();
-
 			define('TIMBER_LOADED', true);
 		}
 	}
@@ -234,7 +233,9 @@ class Timber {
 	 * @return bool|string
 	 */
 	public static function compile( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT, $via_render = false ) {
-		if(!defined('TIMBER_LOADED')) self::init();
+		if( !defined('TIMBER_LOADED') ) {
+			self::init();
+		}
 		$caller = self::get_calling_script_dir();
 		$caller_file = self::get_calling_script_file();
 		$caller_file = apply_filters('timber_calling_php_file', $caller_file);

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -91,10 +91,14 @@ class Timber {
 	 * @codeCoverageIgnore
 	 */
 	protected function init() {
-		Twig::init();
-		ImageHelper::init();
-		Admin::init();
-		Integrations::init();
+		if(class_exists('\WP') && !defined('TIMBER_LOADED')) {
+			Twig::init();
+			ImageHelper::init();
+			Admin::init();
+			Integrations::init();
+
+			defined('TIMBER_LOADED', true);
+		}
 	}
 
 	/* Post Retrieval Routine
@@ -230,6 +234,7 @@ class Timber {
 	 * @return bool|string
 	 */
 	public static function compile( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT, $via_render = false ) {
+		if(!defined('TIMBER_LOADED')) self::init();
 		$caller = self::get_calling_script_dir();
 		$caller_file = self::get_calling_script_file();
 		$caller_file = apply_filters('timber_calling_php_file', $caller_file);

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -97,7 +97,7 @@ class Timber {
 			Admin::init();
 			Integrations::init();
 
-			defined('TIMBER_LOADED', true);
+			define('TIMBER_LOADED', true);
 		}
 	}
 


### PR DESCRIPTION
**Ticket**: #991 and #979 
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
If you include Timber at root level it will throw a fatal error as wordpress is not available at that point and we make use of wordpress functions.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Defer setup until `WP` is available, we defer by calling the `init` function on each `compile` method, if the new constant `TIMBER_LOADED` is not defined.

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
We will see, early days on this one.

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
I tried to make this as small of a change as possible to achieve the desired result and we should keep that in mind if we need to develop it further.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
No tests included