### PR TITLE
992 post type labels

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -42,7 +42,7 @@ class Comment extends Core implements CoreInterface {
 	public $post_id;
 	public $comment_author;
 
-	public $children = array();
+	protected $children = array();
 
 	/**
 	 * @param int $cid
@@ -149,6 +149,23 @@ class Comment extends Core implements CoreInterface {
 	 */
 	public function content() {
 		return apply_filters('get_comment_text ', $this->comment_content);
+	}
+
+	/**
+	 * @api
+	 * @return array Comments
+	 */
+	public function children() {
+		return $this->children;
+	}
+
+	/**
+	 */
+	public function add_child( Comment $child_comment ) {
+		if ( !is_array($this->children) ) {
+			$this->children = array();
+		}
+		return $this->children[] = $child_comment;
 	}
 
 	/**

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -39,6 +39,7 @@ class Comment extends Core implements CoreInterface {
 	public $comment_date;
 	public $comment_ID;
 	public $user_id;
+	public $post_id;
 	public $comment_author;
 
 	public $children = array();
@@ -163,7 +164,7 @@ class Comment extends Core implements CoreInterface {
 	 * @return boolean
 	 */
 	public function approved() {
-		return $this->comment_approved;
+		return Helper::is_true($this->comment_approved);		
 	}
 
 	/**

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -33,14 +33,14 @@ abstract class Core {
 	 * @return mixed
 	 */
 	function __get( $field ) {
-		if ( method_exists($this, $field) ) {
-			return $this->$field = $this->$field();
-		}
 		if ( property_exists($this, $field) ) {
 			return $this->$field;
 		}
 		if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
 			return $this->$field = $meta_value;
+		}
+		if ( method_exists($this, $field) ) {
+			return $this->$field = $this->$field();
 		}
 		return $this->$field = false;
 	}
@@ -56,18 +56,17 @@ abstract class Core {
 	 * ```
 	 * @param array|object $info an object or array you want to grab data from to attach to the Timber object
 	 */
-	function import( $info, $force = true ) {
+	function import( $info, $force = false ) {
 		if ( is_object($info) ) {
 			$info = get_object_vars($info);
 		}
 		if ( is_array($info) ) {
 			foreach ( $info as $key => $value ) {
-				$this->$key = $value;
-				// if ( !empty($key) && $force ) {
-				// 	$this->$key = $value;
-				// } else if ( !empty($key) && !method_exists($this, $key) ) {
-				// 	$this->$key = $value;
-				// }
+				if ( !empty($key) && $force ) {
+					$this->$key = $value;
+				} else if ( !empty($key) && !method_exists($this, $key) ) {
+					$this->$key = $value;
+				}
 			}
 		}
 	}

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -62,11 +62,12 @@ abstract class Core {
 		}
 		if ( is_array($info) ) {
 			foreach ( $info as $key => $value ) {
-				if ( !empty($key) && $force ) {
-					$this->$key = $value;
-				} else if ( !empty($key) && !method_exists($this, $key) ) {
-					$this->$key = $value;
-				}
+				$this->$key = $value;
+				// if ( !empty($key) && $force ) {
+				// 	$this->$key = $value;
+				// } else if ( !empty($key) && !method_exists($this, $key) ) {
+				// 	$this->$key = $value;
+				// }
 			}
 		}
 	}

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -23,27 +23,27 @@ abstract class Core {
 	 * This is helpful for twig to return properties and methods see: https://github.com/fabpot/Twig/issues/2
 	 * @return mixed
 	 */
-	function __call( $field, $args ) {
-		return $this->__get($field);
-	}
+	// function __call( $field, $args ) {
+	// 	return $this->__get($field);
+	// }
 
 	/**
 	 * This is helpful for twig to return properties and methods see: https://github.com/fabpot/Twig/issues/2
 	 *
 	 * @return mixed
 	 */
-	function __get( $field ) {
-		if ( property_exists($this, $field) ) {
-			return $this->$field;
-		}
-		if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
-			return $this->$field = $meta_value;
-		}
-		if ( method_exists($this, $field) ) {
-			return $this->$field = $this->$field();
-		}
-		return $this->$field = false;
-	}
+	// function __get( $field ) {
+	// 	if ( method_exists($this, $field) ) {
+	// 		return $this->$field = $this->$field();
+	// 	}
+	// 	if ( property_exists($this, $field) ) {
+	// 		return $this->$field;
+	// 	}
+	// 	if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
+	// 		return $this->$field = $meta_value;
+	// 	}
+	// 	return $this->$field = false;
+	// }
 
 	/**
 	 * Takes an array or object and adds the properties to the parent object
@@ -56,7 +56,7 @@ abstract class Core {
 	 * ```
 	 * @param array|object $info an object or array you want to grab data from to attach to the Timber object
 	 */
-	function import( $info, $force = false ) {
+	function import( $info, $force = true ) {
 		if ( is_object($info) ) {
 			$info = get_object_vars($info);
 		}

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -23,27 +23,27 @@ abstract class Core {
 	 * This is helpful for twig to return properties and methods see: https://github.com/fabpot/Twig/issues/2
 	 * @return mixed
 	 */
-	// function __call( $field, $args ) {
-	// 	return $this->__get($field);
-	// }
+	function __call( $field, $args ) {
+		return $this->__get($field);
+	}
 
 	/**
 	 * This is helpful for twig to return properties and methods see: https://github.com/fabpot/Twig/issues/2
 	 *
 	 * @return mixed
 	 */
-	// function __get( $field ) {
-	// 	if ( method_exists($this, $field) ) {
-	// 		return $this->$field = $this->$field();
-	// 	}
-	// 	if ( property_exists($this, $field) ) {
-	// 		return $this->$field;
-	// 	}
-	// 	if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
-	// 		return $this->$field = $meta_value;
-	// 	}
-	// 	return $this->$field = false;
-	// }
+	function __get( $field ) {
+		if ( method_exists($this, $field) ) {
+			return $this->$field = $this->$field();
+		}
+		if ( property_exists($this, $field) ) {
+			return $this->$field;
+		}
+		if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
+			return $this->$field = $meta_value;
+		}
+		return $this->$field = false;
+	}
 
 	/**
 	 * Takes an array or object and adds the properties to the parent object

--- a/lib/CoreInterface.php
+++ b/lib/CoreInterface.php
@@ -4,14 +4,14 @@ namespace Timber;
 
 interface CoreInterface {
 
-	// public function __call( $field, $args );
+	public function __call( $field, $args );
 
-	// public function __get( $field );
+	public function __get( $field );
 
 	/**
 	 * @return boolean
 	 */
-	// public function __isset( $field );
+	public function __isset( $field );
 
 	public function meta( $key );
 

--- a/lib/CoreInterface.php
+++ b/lib/CoreInterface.php
@@ -4,9 +4,9 @@ namespace Timber;
 
 interface CoreInterface {
 
-	public function __call( $field, $args );
+	// public function __call( $field, $args );
 
-	public function __get( $field );
+	// public function __get( $field );
 
 	/**
 	 * @return boolean

--- a/lib/CoreInterface.php
+++ b/lib/CoreInterface.php
@@ -11,7 +11,7 @@ interface CoreInterface {
 	/**
 	 * @return boolean
 	 */
-	public function __isset( $field );
+	// public function __isset( $field );
 
 	public function meta( $key );
 

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -15,7 +15,6 @@ class MenuItem extends Core implements CoreInterface {
 	public $class = '';
 	public $level = 0;
 	public $post_name;
-	public $type;
 	public $url;
 
 	public $PostClass = 'TimberPost';
@@ -200,10 +199,19 @@ class MenuItem extends Core implements CoreInterface {
 	 * @return bool
 	 */
 	function is_external() {
-		if ( $this->type != 'custom' ) {
+		if ( $this->type() != 'custom' ) {
 			return false;
 		}
 		return URLHelper::is_external($this->url);
+	}
+
+	/**
+	 * Return the type of the menu item
+	 * @since 1.0.4
+	 * @return string
+	 */
+	public function type() {
+		return $this->_menu_item_type;
 	}
 
 	/**

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -150,7 +150,7 @@ class Post extends Core implements CoreInterface {
 	 * @api
 	 * @var string 	$post_type 		the name of the post type, this is the machine name (so "my_custom_post_type" as opposed to "My Custom Post Type")
 	 */
-	protected $post_type;
+	public $post_type;
 
 	/**
 	 * @api
@@ -603,9 +603,11 @@ class Post extends Core implements CoreInterface {
 	function get_paged_content() {
 		return $this->paged_content();
 	}
+
+
 	/**
-	 *
-	 * Here is my summary
+	 * Returns the post_type object with labels and other info
+	 * 
 	 * @deprecated since 1.0.3
 	 * @example
 	 * 
@@ -616,15 +618,12 @@ class Post extends Core implements CoreInterface {
 	 * ```html
 	 * This post is from <span>Recipes</span>
 	 * ```
-	 * @return mixed
+	 * @return PostType
 	 */
 	public function get_post_type() {
 		return $this->type();
 	}
 
-	public function post_type() {
-		return $this->type();
-	}
 
 	/**
 	 * @return int the number of comments on a post
@@ -632,6 +631,7 @@ class Post extends Core implements CoreInterface {
 	public function get_comment_count() {
 		return get_comments_number($this->ID);
 	}
+
 
 	/**
 	 * @param string $field_name
@@ -977,11 +977,27 @@ class Post extends Core implements CoreInterface {
 	 	return apply_filters('get_the_time', $the_time, $tf);
 	}
 
+
+	/**
+	 * Returns the post_type object with labels and other info
+	 * 
+	 * @deprecated since 1.0.3
+	 * @example
+	 * 
+	 * ```twig
+	 * This post is from <span>{{ post.type.labels.name }}</span>
+	 * ```
+	 *
+	 * ```html
+	 * This post is from <span>Recipes</span>
+	 * ```
+	 * @return PostType
+	 */
 	public function type() {
-		if ( !$this->post_type instanceof PostType ) {
-			$this->post_type = new PostType($this->post_type);
+		if ( !$this->_type instanceof PostType ) {
+			$this->_type = new PostType($this->post_type);
 		}
-		return $this->post_type;
+		return $this->_type;
 	}
 
 	/**

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -150,7 +150,7 @@ class Post extends Core implements CoreInterface {
 	 * @api
 	 * @var string 	$post_type 		the name of the post type, this is the machine name (so "my_custom_post_type" as opposed to "My Custom Post Type")
 	 */
-	public $post_type;
+	protected $post_type;
 
 	/**
 	 * @api
@@ -1115,7 +1115,6 @@ class Post extends Core implements CoreInterface {
 	}
 
 
-
 	/**
 	 * Finds any WP_Post objects and converts them to Timber\Posts
 	 * @param array $data
@@ -1137,6 +1136,7 @@ class Post extends Core implements CoreInterface {
 		return $data;
 	}
 
+
 	/**
 	 * Gets the parent (if one exists) from a post as a Timber\Post object (or whatever is set in Timber\Post::$PostClass)
 	 * @api
@@ -1154,6 +1154,7 @@ class Post extends Core implements CoreInterface {
 		return new $this->PostClass($this->post_parent);
 	}
 
+
 	/**
 	 * Gets the relative path of a WP Post, so while link() will return http://example.org/2015/07/my-cool-post
 	 * this will return just /2015/07/my-cool-post
@@ -1167,6 +1168,7 @@ class Post extends Core implements CoreInterface {
 	public function path() {
 		return URLHelper::get_rel_url($this->get_link());
 	}
+
 
 	/**
 	 * Get the previous post in a set
@@ -1226,6 +1228,7 @@ class Post extends Core implements CoreInterface {
 		}
 	}
 
+
 	/**
 	 * Returns the processed title to be used in templates. This returns the title of the post after WP's filters have run. This is analogous to `the_title()` in standard WP template tags.
 	 * @api
@@ -1236,9 +1239,9 @@ class Post extends Core implements CoreInterface {
 	 * @return string
 	 */
 	public function title() {
-		error_log('calling title()');
 		return apply_filters('the_title', $this->post_title, $this->ID);
 	}
+
 
 	/** 
 	 *

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -11,6 +11,7 @@ use Timber\Image;
 use Timber\Helper;
 use Timber\URLHelper;
 use Timber\PostGetter;
+use Timber\PostType;
 
 /**
  * This is the object you use to access or extend WordPress posts. Think of it as Timber's (more accessible) version of WP_Post. This is used throughout Timber to represent posts retrieved from WordPress making them available to Twig templates. See the PHP and Twig examples for an example of what it's like to work with this object in your code.
@@ -167,8 +168,6 @@ class Post extends Core implements CoreInterface {
 	 * @param mixed $pid
 	 */
 	public function __construct( $pid = null ) {
-		$this->namespacing();
-
 		$pid = $this->determine_id($pid);
 		$this->init($pid);
 	}
@@ -597,7 +596,9 @@ class Post extends Core implements CoreInterface {
 	/**
 	 *
 	 * Here is my summary
+	 * @deprecated since 1.0.3
 	 * @example
+	 * 
 	 * ```twig
 	 * This post is from <span>{{ post.get_post_type.labels.plural }}</span>
 	 * ```
@@ -608,7 +609,11 @@ class Post extends Core implements CoreInterface {
 	 * @return mixed
 	 */
 	public function get_post_type() {
-		return get_post_type_object($this->post_type);
+		return $this->type();
+	}
+
+	public function post_type() {
+		return $this->type();
 	}
 
 	/**
@@ -962,6 +967,13 @@ class Post extends Core implements CoreInterface {
 	 	return apply_filters('get_the_time', $the_time, $tf);
 	}
 
+	public function type() {
+		if ( !$this->post_type instanceof PostType ) {
+			$this->post_type = new PostType($this->post_type);
+		}
+		return $this->post_type;
+	}
+
 	/**
 	 * Returns the edit URL of a post if the user has access to it
 	 * @return bool|string the edit URL of a post in the WordPress admin 
@@ -1214,6 +1226,7 @@ class Post extends Core implements CoreInterface {
 	 * @return string
 	 */
 	public function title() {
+		error_log('calling title()');
 		return apply_filters('the_title', $this->post_title, $this->ID);
 	}
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -876,7 +876,7 @@ class Post extends Core implements CoreInterface {
 		// Add child comments to the relative "super parents"
 		foreach ( $comments_tree as $comment_parent => $comment_children ) {
 			foreach ( $comment_children as $comment_child ) {
-				$timber_comments[$comment_parent]->children[] = $timber_comments[$comment_child];
+				$timber_comments[$comment_parent]->add_child( $timber_comments[$comment_child] );
 				unset($timber_comments[$comment_child]);
 			}
 		}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -608,7 +608,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Returns the post_type object with labels and other info
 	 * 
-	 * @deprecated since 1.0.3
+	 * @deprecated since 1.0.4
 	 * @example
 	 * 
 	 * ```twig
@@ -981,7 +981,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Returns the post_type object with labels and other info
 	 * 
-	 * @deprecated since 1.0.3
+	 * @since 1.0.4
 	 * @example
 	 * 
 	 * ```twig

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -2,15 +2,19 @@
 
 namespace Timber;
 
+/**
+ * Wrapper for the post_type object provided by WordPress
+ * @since 1.0.4
+*/
 class PostType {
 
 	function __construct( $post_type ) {
-		$this->name = $post_type;
+		$this->slug = $post_type;
 		$this->init( $post_type );
 	}
 
 	public function __toString() {
-		return $this->name;
+		return $this->slug;
 	}
 
 	protected function init( $post_type ) {

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Timber;
+
+class PostType {
+
+	function __construct( $post_type ) {
+		$this->name = $post_type;
+		$this->init( $post_type );
+	}
+
+	public function __toString() {
+		return $this->name;
+	}
+
+	protected function init( $post_type ) {
+		$obj = get_post_type_object($post_type);
+		print_r($obj);
+		foreach (get_object_vars($obj) as $key => $value) {
+			$this->$key = $value;
+		}
+	}
+
+}

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -15,7 +15,6 @@ class PostType {
 
 	protected function init( $post_type ) {
 		$obj = get_post_type_object($post_type);
-		print_r($obj);
 		foreach (get_object_vars($obj) as $key => $value) {
 			$this->$key = $value;
 		}

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -41,11 +41,11 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $kramer_quote));
 		$comment = new TimberComment($comment_id);
-		$comment->assertTrue($comment->approved());
+		$this->assertTrue($comment->approved());
 
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'You ever dream in 3-D? It’s like the Boogie Man is coming RIGHT AT YOU.', 'comment_approved' => false));
 		$comment = new TimberComment($comment_id);
-		$comment->assertFalse($comment->approved());
+		$this->assertFalse($comment->approved());
 	}
 
 	function testCommentDate(){
@@ -53,7 +53,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote, 'comment_date' => '2015-08-21 03:24:07'));
 		$comment = new TimberComment($comment_id);
-		$comment->assertEquals('August 21, 2015', $comment->date());
+		$this->assertEquals('August 21, 2015', $comment->date());
 	}
 
 	function testCommentTime(){
@@ -61,7 +61,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote, 'comment_date' => '2015-08-21 03:24:07'));
 		$comment = new TimberComment($comment_id);
-		$comment->assertEquals('3:24 am', $comment->time());
+		$this->assertEquals('3:24 am', $comment->time());
 	}
 
 	function testCommentReplyLink() {

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -101,7 +101,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$post = new TimberPost($post_id);
 		$comments = $post->get_comments();
 		$this->assertEquals(2, count($comments));
-		$this->assertEquals(1, count($comments[1]->children));
+		$this->assertEquals(1, count($comments[1]->children()));
 		$twig_string = '{{comment.author.name}}';
 		$result = Timber::compile_string($twig_string, array('comment' => $comments[0]));
 		$this->assertEquals('Cosmo Kramer', $result);

--- a/tests/test-timber-core.php
+++ b/tests/test-timber-core.php
@@ -16,7 +16,7 @@ class TestTimberCore extends Timber_UnitTestCase {
 		$object->foo = 'Dark Helmet';
 		$tc->import($object);
 		$this->assertEquals('Drebin', $tc->frank);
-		$this->assertEquals('Dark Helmet', $tc->foo);
+		$this->assertEquals('bar', $tc->foo);
 		$tc->import($object, true);
 		$this->assertEquals('Dark Helmet', $tc->foo);
 		$this->assertEquals('Drebin', $tc->frank);

--- a/tests/test-timber-core.php
+++ b/tests/test-timber-core.php
@@ -16,7 +16,7 @@ class TestTimberCore extends Timber_UnitTestCase {
 		$object->foo = 'Dark Helmet';
 		$tc->import($object);
 		$this->assertEquals('Drebin', $tc->frank);
-		$this->assertEquals('bar', $tc->foo);
+		$this->assertEquals('Dark Helmet', $tc->foo);
 		$tc->import($object, true);
 		$this->assertEquals('Dark Helmet', $tc->foo);
 		$this->assertEquals('Drebin', $tc->frank);

--- a/tests/test-timber-custom-fields.php
+++ b/tests/test-timber-custom-fields.php
@@ -17,14 +17,14 @@ class TestTimberCustomFields extends Timber_UnitTestCase {
 		$result = Timber::compile_string($str, array('post' => $post));
 		$this->assertEquals('foo', $result);
 		//
-		// $str = '{{post.post_title}}';
-		// update_post_meta($post_id, 'post_title', 'jiggypoof');
-		// $post = new TimberPost($post_id);
-		// $result = Timber::compile_string($str, array('post' => $post));
-		// $this->assertEquals('foo', $result);
-		// $str = '{{post.custom.post_title}}';
-		// $result = Timber::compile_string($str, array('post' => $post));
-		// $this->assertEquals('jiggypoof', $result);
+		$str = '{{post.post_title}}';
+		update_post_meta($post_id, 'post_title', 'jiggypoof');
+		$post = new TimberPost($post_id);
+		$result = Timber::compile_string($str, array('post' => $post));
+		$this->assertEquals('foo', $result);
+		$str = '{{post.custom.post_title}}';
+		$result = Timber::compile_string($str, array('post' => $post));
+		$this->assertEquals('jiggypoof', $result);
 	}
 
 	function testPostCustomFieldPropertyConflict(){

--- a/tests/test-timber-custom-fields.php
+++ b/tests/test-timber-custom-fields.php
@@ -17,14 +17,14 @@ class TestTimberCustomFields extends Timber_UnitTestCase {
 		$result = Timber::compile_string($str, array('post' => $post));
 		$this->assertEquals('foo', $result);
 		//
-		$str = '{{post.post_title}}';
-		update_post_meta($post_id, 'post_title', 'jiggypoof');
-		$post = new TimberPost($post_id);
-		$result = Timber::compile_string($str, array('post' => $post));
-		$this->assertEquals('foo', $result);
-		$str = '{{post.custom.post_title}}';
-		$result = Timber::compile_string($str, array('post' => $post));
-		$this->assertEquals('jiggypoof', $result);
+		// $str = '{{post.post_title}}';
+		// update_post_meta($post_id, 'post_title', 'jiggypoof');
+		// $post = new TimberPost($post_id);
+		// $result = Timber::compile_string($str, array('post' => $post));
+		// $this->assertEquals('foo', $result);
+		// $str = '{{post.custom.post_title}}';
+		// $result = Timber::compile_string($str, array('post' => $post));
+		// $this->assertEquals('jiggypoof', $result);
 	}
 
 	function testPostCustomFieldPropertyConflict(){

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -99,6 +99,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[1];
+		print_r($item);
 		$this->assertTrue( $item->external() );
 		$struc = get_option( 'permalink_structure' );
 		$this->assertEquals( 'http://upstatement.com', $item->url );

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -99,7 +99,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[1];
-		print_r($item);
 		$this->assertTrue( $item->external() );
 		$struc = get_option( 'permalink_structure' );
 		$this->assertEquals( 'http://upstatement.com', $item->url );

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -1,0 +1,31 @@
+<?php
+
+	class TestTimberPostType extends Timber_UnitTestCase {
+
+		function testPostTypeObject() {
+			$obj = get_post_type_object('post');
+		}
+
+		function testPostTypeProperty(){
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$this->assertEquals('post', $post->post_type);
+		}
+
+		// function testPostTypeMethodInTwig() {
+		// 	$post_id = $this->factory->post->create();
+		// 	$post = new TimberPost($post_id);
+		// 	$template = '{{post.post_type}}';
+		// 	$str = Timber::compile_string($template, array('post' => $post));
+		// 	$this->assertEquals('post', $str);
+		// }
+
+		// function testTypeMethodInTwig() {
+		// 	$post_id = $this->factory->post->create();
+		// 	$post = new TimberPost($post_id);
+		// 	$template = '{{post.type}}';
+		// 	$str = Timber::compile_string($template, array('post' => $post));
+		// 	$this->assertEquals('post', $str);
+		// }
+
+	}

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -12,20 +12,36 @@
 			$this->assertEquals('post', $post->post_type);
 		}
 
-		// function testPostTypeMethodInTwig() {
-		// 	$post_id = $this->factory->post->create();
-		// 	$post = new TimberPost($post_id);
-		// 	$template = '{{post.post_type}}';
-		// 	$str = Timber::compile_string($template, array('post' => $post));
-		// 	$this->assertEquals('post', $str);
-		// }
+		function testPostTypeMethodInTwig() {
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$template = '{{post.post_type}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('post', $str);
+		}
 
-		// function testTypeMethodInTwig() {
-		// 	$post_id = $this->factory->post->create();
-		// 	$post = new TimberPost($post_id);
-		// 	$template = '{{post.type}}';
-		// 	$str = Timber::compile_string($template, array('post' => $post));
-		// 	$this->assertEquals('post', $str);
-		// }
+		function testTypeMethodInTwig() {
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$template = '{{post.type}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('post', $str);
+		}
+
+		function testPostTypeMethodInTwigLabels() {
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$template = '{{post.post_type.labels.name}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('Posts', $str);
+		}
+
+		function testTypeMethodInTwigLabels() {
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$template = '{{post.type.labels.name}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('Posts', $str);
+		}
 
 	}

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -4,12 +4,13 @@
 
 		function testPostTypeObject() {
 			$obj = get_post_type_object('post');
+			$this->assertEquals('Posts', $obj->labels->name);
 		}
 
 		function testPostTypeProperty(){
 			$post_id = $this->factory->post->create();
 			$post = new TimberPost($post_id);
-			$this->assertEquals('post', $post->post_type());
+			$this->assertEquals('post', $post->post_type);
 		}
 
 		function testPostTypeMethodInTwig() {
@@ -26,14 +27,6 @@
 			$template = '{{post.type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('post', $str);
-		}
-
-		function testPostTypeMethodInTwigLabels() {
-			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
-			$template = '{{post.post_type.labels.name}}';
-			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertEquals('Posts', $str);
 		}
 
 		function testTypeMethodInTwigLabels() {

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -9,7 +9,7 @@
 		function testPostTypeProperty(){
 			$post_id = $this->factory->post->create();
 			$post = new TimberPost($post_id);
-			$this->assertEquals('post', $post->post_type);
+			$this->assertEquals('post', $post->post_type());
 		}
 
 		function testPostTypeMethodInTwig() {

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -88,7 +88,10 @@
 		function testNonexistentMethod(){
 			$post_id = $this->factory->post->create();
 			$post = new TimberPost( $post_id );
-			$this->assertFalse( $post->donkey() );
+			$template = '{{post.donkey}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('', $str);
+			//$this->assertFalse( $post->donkey() );
 		}
 
 		function testNext(){


### PR DESCRIPTION
**Ticket**: #992 
**Reviewer**: @connorjburton 

#### Issue
Need an API to access post type information that matches other methods on Post


#### Solution
`{{ post.type }}` can store and return this data

#### Impact
If a user has a custom field named "type" they're gonna have a bad time

#### Usage
`{{ post.type }}` and the old method `{{ post.get_post_type }}` still work

#### Considerations
Should `{{ post.post_type }}` return this data too? At first I thought so, but then I changed my mind. Thoughts?

#### Testing
Tests included!