### PR TITLE
65 post preview

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -126,7 +126,7 @@ class Post extends Core implements CoreInterface {
 	public $post_date;
 
 	/**
-	 * @var string 	$post_exceprt 	the raw text of a manual post exceprt as stored in the database
+	 * @var string 	$post_excerpt 	the raw text of a manual post excerpt as stored in the database
 	 */
 	public $post_excerpt;
 
@@ -356,6 +356,10 @@ class Post extends Core implements CoreInterface {
 			return null;
 		}
 		return $result->ID;
+	}
+
+	public function preview() {
+		return new PostPreview( $this );
 	}
 
 	/**

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Timber;
+
+/**
+ * Wrapper for the post_type object provided by WordPress
+ * @since 1.0.4
+*/
+class PostPreview {
+
+	protected $post;
+	protected $end = '&hellip;';
+	protected $force = false;
+	protected $lenth = 50;
+	protected $readmore = 'Read More';
+	protected $strip = true;
+
+	function __construct( $post ) {
+		$this->post = $post;
+	}
+
+	public function __toString() {
+		return $this->run();
+	}
+
+	public function length( $len = 50 ) {
+		$this->length = $len;
+		return $this;
+	}
+
+	protected function run() {
+		$end = $this->end;
+		$force = $this->force;
+		$len = $this->length;
+		$readmore = $this->readmore;
+		$strip = $this->strip;
+		
+
+		$text = '';
+		$trimmed = false;
+		if ( isset($this->post->post_excerpt) && strlen($this->post->post_excerpt) ) {
+			if ( $this->force ) {
+				$text = Helper::trim_words($this->post->post_excerpt, $len, false);
+				$trimmed = true;
+			} else {
+				$text = $this->post->post_excerpt;
+			}
+		}
+		if ( !strlen($text) && preg_match('/<!--\s?more(.*?)?-->/', $this->post->post_content, $readmore_matches) ) {
+			$pieces = explode($readmore_matches[0], $this->post->post_content);
+			$text = $pieces[0];
+			if ( $force ) {
+				$text = Helper::trim_words($text, $len, false);
+				$trimmed = true;
+			}
+			$text = do_shortcode($text);
+		}
+		if ( !strlen($text) ) {
+			$text = Helper::trim_words($this->post->content(), $len, false);
+			$trimmed = true;
+		}
+		if ( !strlen(trim($text)) ) {
+			return trim($text);
+		}
+		if ( $strip ) {
+			$allowable_tags = (is_string($strip)) ? $strip : null;
+			$text = trim(strip_tags($text, $allowable_tags));
+		}
+		if ( strlen($text) ) {
+			$text = trim($text);
+			$last = $text[strlen($text) - 1];
+			if ( $last != '.' && $trimmed ) {
+				$text .= $end;
+			}
+			if ( !$strip ) {
+				$last_p_tag = strrpos($text, '</p>');
+				if ( $last_p_tag !== false ) {
+					$text = substr($text, 0, $last_p_tag);
+				}
+				if ( $last != '.' && $trimmed ) {
+					$text .= $end.' ';
+				}
+			}
+			$read_more_class = apply_filters('timber/post/get_preview/read_more_class', "read-more");
+			if ( $readmore && isset($readmore_matches) && !empty($readmore_matches[1]) ) {
+				$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
+			} elseif ( $readmore ) {
+				$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($readmore).'</a>';
+			}
+			if ( !$strip && $last_p_tag && (strpos($text, '<p>') || strpos($text, '<p ')) ) {
+				$text .= '</p>';
+			}
+		}
+		return trim($text);
+	}
+
+}

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -44,6 +44,11 @@ class PostPreview {
 		return $this;
 	}
 
+	public function strip( $strip = true ) {
+		$this->strip = $strip;
+		return $this;
+	}
+
 	protected function run() {
 		$end = $this->end;
 		$force = $this->force;

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -3,7 +3,8 @@
 namespace Timber;
 
 /**
- * Wrapper for the post_type object provided by WordPress
+ * An object that lets a user easily modify the post preview to their
+ * liking
  * @since 1.0.4
 */
 class PostPreview {
@@ -11,7 +12,7 @@ class PostPreview {
 	protected $post;
 	protected $end = '&hellip;';
 	protected $force = false;
-	protected $lenth = 50;
+	protected $length = 50;
 	protected $readmore = 'Read More';
 	protected $strip = true;
 
@@ -28,13 +29,27 @@ class PostPreview {
 		return $this;
 	}
 
+	public function end( $end = '&hellip;' ) {
+		$this->end = $end;
+		return $this;
+	}
+
+	public function force( $force = true ) {
+		$this->force = $force;
+		return $this;
+	}
+
+	public function read_more( $readmore = 'Read More' ) {
+		$this->readmore = $readmore;
+		return $this;
+	}
+
 	protected function run() {
 		$end = $this->end;
 		$force = $this->force;
 		$len = $this->length;
 		$readmore = $this->readmore;
 		$strip = $this->strip;
-		
 
 		$text = '';
 		$trimmed = false;

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -2,6 +2,14 @@
 
 	class TestTimberPostPreviewObject extends Timber_UnitTestCase {
 
+		function testPreviewTags() {
+			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
+			$post = new TimberPost($post_id);
+			$template = '{{post.preview.length(3).read_more(false).strip(false)}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertNotContains('</p>', $str);
+		}
+
 		function testPostPreviewObjectWithLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(4) }}';
@@ -61,6 +69,14 @@
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = new TimberPost( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
+		}
+
+		function testPreviewWithSpaceInMoreTag() {
+			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
+			$post = new TimberPost( $pid );
+			$template = '{{post.preview.length(3).force}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $str);
 		}
 
 

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -2,12 +2,37 @@
 
 	class TestTimberPostPreviewObject extends Timber_UnitTestCase {
 
-		function testPostPreviewObjectWtihLength() {
+		function testPostPreviewObjectWithLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
-			$template = '{{ post.preview.length(3) }}';
+			$template = '{{ post.preview.length(4) }}';
 			$post = new TimberPost($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
-			echo $str;
+			$this->assertEquals('Lauren is a duck&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
+
+		function testPostPreviewObjectWithForcedLength() {
+			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
+			$template = '{{ post.preview.force.length(3) }}';
+			$post = new TimberPost($pid);
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('In my younger&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
+		}
+
+		function testPostPreviewObjectWithReadMore() {
+			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
+			$template = '{{ post.preview.read_more("Keep Reading") }}';
+			$post = new TimberPost($pid);
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
+		}
+
+		function testPostPreviewObjectWithEverything() {
+			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
+			$template = '{{ post.preview.length(6).force.end("-->").read_more("Keep Reading") }}';
+			$post = new TimberPost($pid);
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('In my younger and more vulnerable--> <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
+		}
+
 
 	}

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -50,5 +50,18 @@
 			$this->assertEquals('In my younger and more vulnerable--> <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
 
+		function testPreviewWithMoreTagAndForcedLength() {
+			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
+			$post = new TimberPost( $pid );
+
+			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
+		}
+
+		function testPreviewWithCustomMoreTag() {
+			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
+			$post = new TimberPost( $pid );
+			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
+		}
+
 
 	}

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -18,6 +18,22 @@
 			$this->assertEquals('In my younger&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
+		function testPostPreviewObject() {
+			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
+			$template = '{{ post.preview }}';
+			$post = new TimberPost($pid);
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
+		}
+
+		function testPostPreviewObjectStrip() {
+			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
+			$template = '{{ post.preview.strip(false) }}';
+			$post = new TimberPost($pid);
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
+		}
+
 		function testPostPreviewObjectWithReadMore() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.read_more("Keep Reading") }}';

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -19,7 +19,7 @@
 		}
 
 		function testPostPreviewObject() {
-			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
+			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview }}';
 			$post = new TimberPost($pid);
 			$str = Timber::compile_string($template, array('post' => $post));

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -1,0 +1,13 @@
+<?php
+
+	class TestTimberPostPreviewObject extends Timber_UnitTestCase {
+
+		function testPostPreviewObjectWtihLength() {
+			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
+			$template = '{{ post.preview.length(3) }}';
+			$post = new TimberPost($pid);
+			$str = Timber::compile_string($template, array('post' => $post));
+			echo $str;
+		}
+
+	}


### PR DESCRIPTION
**Ticket**: #65
**Reviewer**: @connorjburton 

#### Issue
`{{ post.get_preview }}` is a hodge-podge of arguments. Too many arguments. And in an order that makes no particular sense.

#### Solution
Create an object to manage post previews!

#### Impact
`{{ post.get_preview}}` is unaffected. The `PostPreview` object should make it easier to add customizations down the line

#### Usage
It's easy and fun: `{{ post.preview.length(20) }}` or `{{ post.preview.length(20).force.read_more("Keep Reading") }}` or `{{ post.preview.length(25).end('...') }}`

#### Considerations
`{{ post.get_preview }}` could be refactored to use the processing in the `PostPreview` object, but now as I think about it, it might just be best to leave it so that that the Preview object can evolve w/o backwards compatibility concerns.

#### Testing
Tests included!
