### PR TITLE
Adding has field + tests

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -636,6 +636,13 @@ class Post extends Core implements CoreInterface {
 		return get_comments_number($this->ID);
 	}
 
+	/**
+	 * @param string $field_name
+	 * @return boolean
+	 */
+	public function has_field( $fied_name ) {
+		return (!$this->get_field( $field_name )) ? false : true;
+	}
 
 	/**
 	 * @param string $field_name

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -640,7 +640,7 @@ class Post extends Core implements CoreInterface {
 	 * @param string $field_name
 	 * @return boolean
 	 */
-	public function has_field( $fied_name ) {
+	public function has_field( $field_name ) {
 		return (!$this->get_field( $field_name )) ? false : true;
 	}
 

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -14,6 +14,14 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$this->assertEquals( 'foobar', $str );
 	}
 
+	function testACFHasFieldPost() {
+		$pid = $this->factory->post->create();
+		$str = '{{post.has_field("heythisdoesntexist")}}';
+		$post = new TimberPost( $pid );
+		$str = Timber::compile_string( $str, array( 'post' => $post ) );
+		$this->assertFalse($str);
+	}
+
 	function testACFGetFieldTermCategory() {
 		update_field( 'color', 'blue', 'category_1' );
 		$cat = new TimberTerm( 1 );

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -14,12 +14,21 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$this->assertEquals( 'foobar', $str );
 	}
 
-	function testACFHasFieldPost() {
+	function testACFHasFieldPostFalse() {
 		$pid = $this->factory->post->create();
-		$str = '{{post.has_field("heythisdoesntexist")}}';
+		$str = '{% if post.has_field("heythisdoesntexist") %}FAILED{% else %}WORKS{% endif %}';
 		$post = new TimberPost( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
-		$this->assertFalse($str);
+		$this->assertEquals('WORKS', $str);
+	}
+
+	function testACFHasFieldPostTrue() {
+		$pid = $this->factory->post->create();
+		update_post_meta($pid, 'best_radiohead_album', 'in_rainbows');
+		$str = '{% if post.has_field("best_radiohead_album") %}In Rainbows{% else %}OK Computer{% endif %}';
+		$post = new TimberPost( $pid );
+		$str = Timber::compile_string( $str, array( 'post' => $post ) );
+		$this->assertEquals('In Rainbows', $str);
 	}
 
 	function testACFGetFieldTermCategory() {


### PR DESCRIPTION
**Ticket**: #942
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
`post.has_field(fieldname)` doesn't exist

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Add an alias to the `get_field` method that returns a `boolean` rather than `mixed`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
None, new method

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
`post.has_field('field')` => `boolean`

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
There isn't any real benefit to this, it's mostly syntax sugar, but it is more inline with ACF itself.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Tests included, I hope they run...
