### PR TITLE
Catching acf image array

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -222,10 +222,19 @@ class Image extends Post implements CoreInterface {
 	 * @param int $iid
 	 */
 	function init( $iid = false ) {
+		//Make sure we actually have something to work with
 		if ( !$iid ) { Helper::error_log('Initalized TimberImage without providing first parameter.'); return; }
+		
+		//If passed TimberImage, grab the ID and continue
 		if ( $iid instanceof self ) {
 			$iid = (int) $iid->ID;
 		}
+
+		//If passed ACF image array
+		if(is_array($iid) && isset($iid['ID'])) {
+			$iid = $iid['id'];
+		}
+
 		if ( !is_numeric($iid) && is_string($iid) ) {
 			if ( strstr($iid, '://') ) {
 				$this->init_with_url($iid);

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -232,7 +232,7 @@ class Image extends Post implements CoreInterface {
 
 		//If passed ACF image array
 		if(is_array($iid) && isset($iid['ID'])) {
-			$iid = $iid['id'];
+			$iid = $iid['ID'];
 		}
 
 		if ( !is_numeric($iid) && is_string($iid) ) {

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -199,6 +199,25 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertTrue(TimberImageHelper::is_animated_gif($resized_path));
 	}
 
+	function testImageArray() {
+		$post_id = $this->factory->post->create();
+		$filename = self::copyTestImage('arch.jpg');
+		$wp_filetype = wp_check_filetype( basename( $filename ), null );
+		$attachment = array(
+			'post_mime_type' => $wp_filetype['type'],
+			'post_title' => preg_replace( '/\.[^.]+$/', '', basename( $filename ) ),
+			'post_content' => '',
+			'post_status' => 'inherit'
+		);
+		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
+		$data = array('ID' => $attach_id);
+		$image = new Timber\Image($data);
+		$filename = explode('/', $image->file);
+		$filename = array_pop($filename);
+		$this->assertEquals('arch.jpg', $filename);
+
+	}
+
 	function testResizeTallImage() {
 		$data = array();
 		$data['size'] = array( 'width' => 600 );


### PR DESCRIPTION
**Ticket**: #927
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
Passing an ACF image array would not return a full `Timber\Image` object.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Check if an array has been passed and if that array has an ID property, if it does grab the ID and continue.

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
`Timber\Image` instances initiated with an ACF image array will work properly.

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
`init` method is getting ever larger, it seems to do some logic which should probably be moved out.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None included.
