### PR TITLE
Changing home_url to site_url to keep subdirectories

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -394,7 +394,7 @@ class ImageHelper {
 		}
 		$url .= '/'.$filename;
 		if ( !$absolute ) {
-			$url = str_replace(home_url(), '', $url);
+			$url = str_replace(site_url(), '', $url);
 		}
 		// $url = TimberURLHelper::remove_double_slashes( $url);
 		return $url;


### PR DESCRIPTION
**Ticket**: #598 
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
If WP is in a sub-directory `TimberImage` will incorrectly strip out `home_url` (includes sub directory) instead of `site_url` (just includes protocol:host).

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Change `home_url` to `site_url`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
This needs testing properly by people who have the issue

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None included