### PR TITLE
Revert a revert for multiste url fix

### DIFF
--- a/bin/phpunit-multisite.xml
+++ b/bin/phpunit-multisite.xml
@@ -1,0 +1,23 @@
+<phpunit
+	bootstrap="../tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+        <const name="WP_TESTS_MULTISITE" value="1" />
+    </php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">../tests/</directory>
+		</testsuite>
+		<!-- The suite below HAS to be last to run,
+		as it includes a test that sets some const and would contaminate
+		the other tests as well. -->
+		<testsuite>
+			<directory prefix="testX-" suffix=".php">../tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -122,7 +122,7 @@ class Site extends Core implements CoreInterface {
 	 * @internal
 	 * @param string|int $site_name_or_id
 	 */
-	protected function init_as_multisite( $site_name_or_id ) {
+	protected function init_as_multisite( $site_name_or_id = null ) {
 		if ( $site_name_or_id === null ) {
 			//this is necessary for some reason, otherwise returns 1 all the time
 			if ( is_multisite() ) {
@@ -130,7 +130,11 @@ class Site extends Core implements CoreInterface {
 				$site_name_or_id = get_current_blog_id();
 			}
 		}
+		/* we need to store the current blog, but switch things to the blog id of the Site object requested */
+		$old_id = get_current_blog_id();
 		$info = get_blog_details($site_name_or_id);
+		switch_to_blog($info->blog_id);
+
 		$this->import($info);
 		$this->ID = $info->blog_id;
 		$this->id = $this->ID;
@@ -142,6 +146,9 @@ class Site extends Core implements CoreInterface {
 		$this->description = get_blog_option($info->blog_id, 'blogdescription');
 		$this->admin_email = get_blog_option($info->blog_id, 'admin_email');
 		$this->multisite = true;
+
+		//switch back to the before time
+		switch_to_blog($old_id);
 	}
 
 	/**

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -136,7 +136,7 @@ class Site extends Core implements CoreInterface {
 		$this->id = $this->ID;
 		$this->name = $this->blogname;
 		$this->title = $this->blogname;
-		$this->url = $this->siteurl;
+		$this->url = get_bloginfo('url');
 		$theme_slug = get_blog_option($info->blog_id, 'stylesheet');
 		$this->theme = new Theme($theme_slug);
 		$this->description = get_blog_option($info->blog_id, 'blogdescription');

--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -22,9 +22,10 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		$bids[] = self::createSubDirectorySite('/bar/', 'My Bar');
 		$bids[] = self::createSubDirectorySite('/bark/', "Barks R Us");
 		$sites = Timber::get_sites();
+		$this->assertEquals('http://example.org/bark', $sites[2]->url);
 		$this->assertEquals('http://example.org/bar', $sites[1]->url);
 		$this->assertEquals("example.org", $sites[2]->domain);
-		$this->assertEquals('http://example.org/bark', $sites[2]->url);
+		
 	}
 
 	public static function createSubDomainSite($domain = 'test.example.org', $title = 'Multisite Test' ) {


### PR DESCRIPTION
**Ticket**: #568
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
A fix was made for the multsite `site.url` property that was reverted at a point afterwards.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Revert the revert as the issues seems to still exist according to the ticket

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Should fix multisite urls

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None included
