### PR TITLE
Fixing double image object issue

### DIFF
--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -205,7 +205,11 @@ class Resize extends ImageOperation {
 			// @codeCoverageIgnoreStart
 			Helper::error_log( 'Error loading ' . $image->error_data['error_loading_image'] );
 		} else {
-			Helper::error_log( $image );
+			if(!extension_loaded('gd')) {
+				Helper::error_log( 'Can not resize image, please installed php-gd' );
+			} else {
+				Helper::error_log( $image );
+			}
 			// @codeCoverageIgnoreEnd
 		}
 	}

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -60,8 +60,8 @@ class Resize extends ImageOperation {
 	 * @param string $load_filename
 	 * @param string $save_filename
 	 */
-	protected function run_animated_gif( $load_filename, $save_filename ) {
-		$current_size = $image->get_size();
+	protected function run_animated_gif( $load_filename, $save_filename, $editor ) {
+		$current_size = $editor->get_size();
 		$src_w = $current_size['width'];
 		$src_h = $current_size['height'];
 		$w = $this->w;
@@ -173,12 +173,12 @@ class Resize extends ImageOperation {
 		$image = wp_get_image_editor( $load_filename );
 		if ( !is_wp_error( $image ) ) {
 			//should be resized by gif resizer
-			if ( ImageHelper::is_animated_gif($load_filename) ) {
+			if ( ImageHelper::is_animated_gif( $load_filename ) ) {
 				//attempt to resize
 				//return if successful
 				//proceed if not
-				$gif = self::run_animated_gif($image, $save_filename);
-				if ($gif) {
+				$gif = self::run_animated_gif( $load_filename, $save_filename, $editor );
+				if ( $gif ) {
 					return true;
 				}
 			}

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -3,6 +3,7 @@
 namespace Timber\Image\Operation;
 
 use Timber\Helper;
+use Timber\ImageHelper;
 use Timber\Image\Operation as ImageOperation;
 
 /**
@@ -82,9 +83,9 @@ class Resize extends ImageOperation {
 			return $image->writeImages($save_filename, true);
 		} else if ( isset( $image->error_data['error_loading_image'] ) ) {
 			// @codeCoverageIgnoreStart
-			TimberHelper::error_log( 'Error loading ' . $image->error_data['error_loading_image'] );
+			Helper::error_log( 'Error loading ' . $image->error_data['error_loading_image'] );
 		} else {
-			TimberHelper::error_log( $image );
+			Helper::error_log( $image );
 			// @codeCoverageIgnoreEnd
 		}
 	}
@@ -181,7 +182,7 @@ class Resize extends ImageOperation {
 		$image = wp_get_image_editor( $load_filename );
 		if ( !is_wp_error( $image ) ) {
 			//should be resized by gif resizer
-			if ( TimberImageHelper::is_animated_gif($image) ) {
+			if ( ImageHelper::is_animated_gif($image) ) {
 				//attempt to resize
 				//return if successful
 				//proceed if not
@@ -202,8 +203,8 @@ class Resize extends ImageOperation {
 			$result = $image->save( $save_filename );
 			if ( is_wp_error( $result ) ) {
 				// @codeCoverageIgnoreStart
-				TimberHelper::error_log( 'Error resizing image' );
-				TimberHelper::error_log( $result );
+				Helper::error_log( 'Error resizing image' );
+				Helper::error_log( $result );
 				return false;
 				// @codeCoverageIgnoreEnd
 			} else {
@@ -211,9 +212,9 @@ class Resize extends ImageOperation {
 			}
 		} else if ( isset( $image->error_data['error_loading_image'] ) ) {
 			// @codeCoverageIgnoreStart
-			TimberHelper::error_log( 'Error loading ' . $image->error_data['error_loading_image'] );
+			Helper::error_log( 'Error loading ' . $image->error_data['error_loading_image'] );
 		} else {
-			TimberHelper::error_log( $image );
+			Helper::error_log( $image );
 			// @codeCoverageIgnoreEnd
 		}
 	}

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -182,7 +182,7 @@ class Resize extends ImageOperation {
 		$image = wp_get_image_editor( $load_filename );
 		if ( !is_wp_error( $image ) ) {
 			//should be resized by gif resizer
-			if ( ImageHelper::is_animated_gif($image) ) {
+			if ( ImageHelper::is_animated_gif($load_filename) ) {
 				//attempt to resize
 				//return if successful
 				//proceed if not

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -71,7 +71,7 @@ class Resize extends ImageOperation {
 		}
 		$image = new \Imagick($load_filename);
 		$image = $image->coalesceImages();
-		$crop = self::get_target_sizes($load_filename);
+		$crop = self::get_target_sizes($editor);
 		foreach ( $image as $frame ) {
 			$frame->cropImage($crop['src_w'], $crop['src_h'], $crop['x'], $crop['y']);
 			$frame->thumbnailImage($w, $h);
@@ -82,9 +82,9 @@ class Resize extends ImageOperation {
 	}
 
 	/**
-	 * @param string $image
+	 * @param WP_Image_Editor $image
 	 */
-	protected function get_target_sizes( $image ) {
+	protected function get_target_sizes( \WP_Image_Editor $image ) {
 		$w = $this->w;
 		$h = $this->h;
 		$crop = $this->crop;
@@ -177,7 +177,7 @@ class Resize extends ImageOperation {
 				//attempt to resize
 				//return if successful
 				//proceed if not
-				$gif = self::run_animated_gif( $load_filename, $save_filename, $editor );
+				$gif = self::run_animated_gif( $load_filename, $save_filename, $image );
 				if ( $gif ) {
 					return true;
 				}

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -61,33 +61,24 @@ class Resize extends ImageOperation {
 	 * @param string $save_filename
 	 */
 	protected function run_animated_gif( $load_filename, $save_filename ) {
-		$image = wp_get_image_editor( $load_filename );
-		if ( !is_wp_error( $image ) ) {
-			$current_size = $image->get_size();
-			$src_w = $current_size['width'];
-			$src_h = $current_size['height'];
-			$w = $this->w;
-			$h = $this->h;
-			if ( !class_exists('Imagick') ) {
-				return false;
-			}
-			$image = new \Imagick($load_filename);
-			$image = $image->coalesceImages();
-			$crop = self::get_target_sizes($load_filename);
-			foreach ( $image as $frame ) {
-				$frame->cropImage($crop['src_w'], $crop['src_h'], $crop['x'], $crop['y']);
-				$frame->thumbnailImage($w, $h);
-				$frame->setImagePage($w, $h, 0, 0);
-			}
-			$image = $image->deconstructImages();
-			return $image->writeImages($save_filename, true);
-		} else if ( isset( $image->error_data['error_loading_image'] ) ) {
-			// @codeCoverageIgnoreStart
-			Helper::error_log( 'Error loading ' . $image->error_data['error_loading_image'] );
-		} else {
-			Helper::error_log( $image );
-			// @codeCoverageIgnoreEnd
+		$current_size = $image->get_size();
+		$src_w = $current_size['width'];
+		$src_h = $current_size['height'];
+		$w = $this->w;
+		$h = $this->h;
+		if ( !class_exists('Imagick') ) {
+			Helper::error_log( 'Can not resize GIF, Imagick is not installed' );
 		}
+		$image = new \Imagick($load_filename);
+		$image = $image->coalesceImages();
+		$crop = self::get_target_sizes($load_filename);
+		foreach ( $image as $frame ) {
+			$frame->cropImage($crop['src_w'], $crop['src_h'], $crop['x'], $crop['y']);
+			$frame->thumbnailImage($w, $h);
+			$frame->setImagePage($w, $h, 0, 0);
+		}
+		$image = $image->deconstructImages();
+		return $image->writeImages($save_filename, true);
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: None
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
I discovered a bug that I haven't seem reported anywhere, I got a fatal error when trying to resize an image.

If you look at the code before/after, you will see that we run `wp_get_image_editor` in both `run_animated_gif` and `run`, the result of that then gets passed into `get_target_sizes` which will then run `wp_get_image_editor` once again, and pass in the result of the previous `wp_get_image_editor`

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Firstly I moved the errors further up the method so we catch any errors without throwing fatal errors on production sites.

Then I passed the result of `wp_get_image_editor` into `get_target_sizes` and didn't run that method again once we were in there.

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Should fix this bug

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
I couldn't find any other mention of this, so maybe it's my setup, but the code didn't look right to me.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None included