### PR TITLE
Adding count property to queryiterator

### DIFF
--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -60,6 +60,10 @@ class QueryIterator implements \Iterator {
 
 	}
 
+	public function post_count() {
+	    return $this->_query->post_count;
+	}
+
 	public function get_posts( $return_collection = false ) {
 		if ( isset($this->_query->posts) ) {
 			$posts = new PostsCollection($this->_query->posts, $this->_posts_class);

--- a/tests/test-timber-iterator.php
+++ b/tests/test-timber-iterator.php
@@ -24,4 +24,10 @@ class TestTimberIterator extends Timber_UnitTestCase {
 
     }
 
+    function testPostCount() {
+    	$posts = $this->factory->post->create_many( 8 );
+        $posts = TimberPostGetter::query_posts('post_type=post');
+        $this->assertEquals( 8, $posts->post_count() );
+    }
+
 }


### PR DESCRIPTION
**Ticket**: #837
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
If you have a `Timber\QueryIterator` object, there is no way to get the total posts returned, for example of a search results page with the default `posts` object in context.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Add a method to return the private `_query.post_count` property

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
No impact

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
` {{ QueryIteratorObject.post_count }}`

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
There may be other properties that would be useful to expose. Also I am not sure on the reason behind returning a `QueryIterator` rather than a collection of `Timber\Post`s, you could then do `{{ posts | length }}` to get the total posts

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
None
