### PR TITLE
Fix usage of old classnames

### DIFF
--- a/lib/Cache/KeyGenerator.php
+++ b/lib/Cache/KeyGenerator.php
@@ -11,7 +11,7 @@ class KeyGenerator implements KeyGeneratorInterface {
 	 * @return string
 	 */
 	public function generateKey($value) {
-		if (is_a($value, 'TimberKeyGeneratorInterface')) {
+		if (is_a($value, 'Timber\Cache\TimberKeyGeneratorInterface')) {
 			return $value->_get_cache_key();
 		}
 

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -484,7 +484,7 @@ class ImageHelper {
 		}
 		// otherwise generate result file
 		if ( $op->run($old_server_path, $new_server_path) ) {
-			if ( get_class($op) === 'TimberImageOperationResize' && $external ) {
+			if ( get_class($op) === 'Timber\Image\Operation\Resize' && $external ) {
 				$new_url = strtolower($new_url);
 			}
 			return $new_url;

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -17,7 +17,7 @@ class MenuItem extends Core implements CoreInterface {
 	public $post_name;
 	public $url;
 
-	public $PostClass = 'TimberPost';
+	public $PostClass = 'Timber\Post';
 
 	protected $_name;
 	protected $_menu_item_object_id;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -848,7 +848,7 @@ class Post extends Core implements CoreInterface {
 	 * ```
 	 * @return bool|array
 	 */
-	public function comments( $count = 0, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'TimberComment' ) {
+	public function comments( $count = 0, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'Timber\Comment' ) {
 		global $overridden_cpage, $user_ID;
 		$overridden_cpage = false;
 
@@ -1594,7 +1594,7 @@ class Post extends Core implements CoreInterface {
 	 * @param string $CommentClass
 	 * @return array|mixed
 	 */
-	public function get_comments( $count = 0, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'TimberComment' ) {
+	public function get_comments( $count = 0, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'Timber\Comment' ) {
 		return $this->comments($count, $order, $type, $status, $CommentClass);
 	}
 

--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -17,9 +17,9 @@ class QueryIterator implements \Iterator {
 	 * @var WP_Query
 	 */
 	private $_query = null;
-	private $_posts_class = 'TimberPost';
+	private $_posts_class = 'Timber\Post';
 
-	public function __construct( $query = false, $posts_class = 'TimberPost' ) {
+	public function __construct( $query = false, $posts_class = 'Timber\Post' ) {
 		add_action('pre_get_posts', array($this, 'fix_number_posts_wp_quirk'));
 		if ( $posts_class )
 			$this->_posts_class = $posts_class;

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -120,7 +120,7 @@ class Timber {
 	 * @param string  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function get_post( $query = false, $PostClass = 'TimberPost' ) {
+	public static function get_post( $query = false, $PostClass = 'Timber\Post' ) {
 		return PostGetter::get_post($query, $PostClass);
 	}
 
@@ -137,7 +137,7 @@ class Timber {
 	 * @param string|array  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function get_posts( $query = false, $PostClass = 'TimberPost', $return_collection = false ) {
+	public static function get_posts( $query = false, $PostClass = 'Timber\Post', $return_collection = false ) {
 		return PostGetter::get_posts($query, $PostClass, $return_collection);
 	}
 
@@ -148,7 +148,7 @@ class Timber {
 	 * @param string  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function query_post( $query = false, $PostClass = 'TimberPost' ) {
+	public static function query_post( $query = false, $PostClass = 'Timber\Post' ) {
 		return PostGetter::query_post($query, $PostClass);
 	}
 
@@ -159,7 +159,7 @@ class Timber {
 	 * @param string  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function query_posts( $query = false, $PostClass = 'TimberPost' ) {
+	public static function query_posts( $query = false, $PostClass = 'Timber\Post' ) {
 		return PostGetter::query_posts($query, $PostClass);
 	}
 
@@ -174,7 +174,7 @@ class Timber {
 	 * @param string  $TermClass
 	 * @return mixed
 	 */
-	public static function get_terms( $args = null, $maybe_args = array(), $TermClass = 'TimberTerm' ) {
+	public static function get_terms( $args = null, $maybe_args = array(), $TermClass = 'Timber\Term' ) {
 		return TermGetter::get_terms($args, $maybe_args, $TermClass);
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,7 @@ function _manually_load_plugin() {
 	global $timber;
 
 	require dirname( __FILE__ ) . '/../vendor/autoload.php';
-	$timber = new Timber();
+	$timber = new \Timber\Timber();
 	require dirname( __FILE__ ) . '/../wp-content/plugins/advanced-custom-fields/acf.php';
 }
 


### PR DESCRIPTION
**Reviewer**: @jarednova 

#### Issue
The code is still relying on the old classnames without namespaces.

#### Solution
Changing oldclassnames to new namespaces names.

#### Impact
None.

#### Usage
No changes.

#### Considerations
I'm quite sure I still missed some.

#### Testing
No changes. Everything is still passing.
