### PR TITLE
Fixing uppercase extension

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -104,8 +104,8 @@ class Image extends Post implements CoreInterface {
 	 * @return string the src of the file
 	 */
 	public function __toString() {
-		if ( $this->src() ) {
-			return $this->src();
+		if ( $src = $this->src() ) {
+			return $src;
 		}
 		return '';
 	}

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -365,7 +365,7 @@ class ImageHelper {
 		$parts = pathinfo($tmp);
 		$result['subdir'] = ($parts['dirname'] === '/') ? '' : $parts['dirname'];
 		$result['filename'] = $parts['filename'];
-		$result['extension'] = $parts['extension'];
+		$result['extension'] = strtolower($parts['extension']);
 		$result['basename'] = $parts['basename'];
 		// todo filename
 		return $result;


### PR DESCRIPTION
**Ticket**: #1043 
**Reviewer**: @jarednova 

#### Issue
<!-- Description of the problem that this code change is solving -->
If you tried to resize an image with an uppercase extension it would return the URL with the uppercase extension, which would be fine if we didn't `strtolower` the extension when saving the resized image.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
`strtolower` the extension that we get back from `pathinfo`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
None

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No change

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->

