### PR TITLE
Adding get term

### DIFF
--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -7,6 +7,11 @@ use Timber\Helper;
 
 class TermGetter {
 
+	public static function get_term( $term, $taxonomy, $output = OBJECT, $filter = 'raw', $TermClass = 'Term' ) {
+		$term = get_term($term, $taxonomy, $output, $filter);
+		return new $TermClass($term->term_id, $term->taxonomy);
+	}
+
 	/**
 	 * @param string|array $args
 	 * @param array $maybe_args

--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -6,10 +6,14 @@ use Timber\Term;
 use Timber\Helper;
 
 class TermGetter {
-
-	public static function get_term( $term, $taxonomy, $output = OBJECT, $filter = 'raw', $TermClass = 'Term' ) {
-		$term = get_term($term, $taxonomy, $output, $filter);
-		return new $TermClass($term->term_id, $term->taxonomy);
+	/**
+	 * @param int|WP_Term|object $term
+	 * @param string $taxonomy
+	 * @return Timber\Term|WP_Error|null
+	 */
+	public static function get_term( $term, $taxonomy, $TermClass = 'Term' ) {
+		$term = get_term( $term, $taxonomy );
+		return new $TermClass( $term->term_id, $term->taxonomy );
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -178,6 +178,19 @@ class Timber {
 		return TermGetter::get_terms($args, $maybe_args, $TermClass);
 	}
 
+	/**
+	 * Get term.
+	 *
+	 * @param int|WP_Term|object $term
+	 * @param string     $taxonomy
+	 * @param string     $output
+	 * @param string     $filter
+	 * @return Timber\Term|WP_Error|null
+	 */
+	public static function get_term( $term, $taxonomy, $output = OBJECT, $filter = 'raw', $TermClass = 'Timber\Term' ) {
+		return TermGetter::get_term( $term, $taxonomy, $output, $filter, $TermClass );
+	}
+
 	/* Site Retrieval
 	================================ */
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -183,12 +183,10 @@ class Timber {
 	 *
 	 * @param int|WP_Term|object $term
 	 * @param string     $taxonomy
-	 * @param string     $output
-	 * @param string     $filter
 	 * @return Timber\Term|WP_Error|null
 	 */
-	public static function get_term( $term, $taxonomy, $output = OBJECT, $filter = 'raw', $TermClass = 'Timber\Term' ) {
-		return TermGetter::get_term( $term, $taxonomy, $output, $filter, $TermClass );
+	public static function get_term( $term, $taxonomy, $TermClass = 'Timber\Term' ) {
+		return TermGetter::get_term( $term, $taxonomy, $TermClass );
 	}
 
 	/* Site Retrieval

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -185,7 +185,7 @@ class Timber {
 	 * @param string     $taxonomy
 	 * @return Timber\Term|WP_Error|null
 	 */
-	public static function get_term( $term, $taxonomy, $TermClass = 'Timber\Term' ) {
+	public static function get_term( $term, $taxonomy = 'post_tag', $TermClass = 'Timber\Term' ) {
 		return TermGetter::get_term( $term, $taxonomy, $TermClass );
 	}
 

--- a/tests/test-timber-term-getter.php
+++ b/tests/test-timber-term-getter.php
@@ -2,6 +2,19 @@
 
 	class TestTimberTermGetter extends Timber_UnitTestCase {
 
+		function testGetSingleTerm() {
+			$term_id = $this->factory->term->create( array('name' => 'Toyota') );
+			$term = Timber::get_term($term_id);
+			$this->assertEquals($term_id, $term->ID);
+		}
+
+		function testGetSingleTermInTaxonomy() {
+			register_taxonomy('cars', 'post');
+			$term_id = $this->factory->term->create( array('name' => 'Toyota', 'taxonomy' => 'cars') );
+			$term = Timber::get_term($term_id, 'cars');
+			$this->assertEquals($term_id, $term->ID);
+		}
+
 		function testGetArrayOfTerms(){
 			$term_ids = array();
 			$term_ids[] = $this->factory->term->create();


### PR DESCRIPTION
**Ticket**: #386 
**Reviewer**: @jarednova @ste93cry

#### Issue
<!-- Description of the problem that this code change is solving -->
There was no wrapper for `get_term`

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Adds wrapper

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
None

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
`Timber::get_term(params)`

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
This needs testing, I literally just added a wrapper, `get_terms` seems to do a lot more.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Needs a test
