### PR TITLE
836 preview page fix

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -256,8 +256,8 @@ class Post extends Core implements CoreInterface {
 		$revisions = wp_get_post_revisions($query->queried_object_id);
 
 		if ( !empty($revisions) ) {
-			$last = reset($revisions);
-			return $last->ID;
+			$revision = reset($revisions);
+			return $revision->ID;
 		}
 
 		return false;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -256,7 +256,7 @@ class Post extends Core implements CoreInterface {
 		$revisions = wp_get_post_revisions($query->queried_object_id);
 
 		if ( !empty($revisions) ) {
-			$last = end($revisions);
+			$last = reset($revisions);
 			return $last->ID;
 		}
 


### PR DESCRIPTION
**Ticket**: #836 

#### Issue
The "Preview Changes" button in a WordPress post on the admin side was grabbing the last or oldest revision, not the newest revision, meaning the preview changes button would not show your latest changes, but the oldest revision of the post or page.  

#### Solution
instead of grabbing the post id from last element of the $revisions array, I am grabbing it from the first element. 


…last revison from a list of revisons sorted in desc order, meaning it was always showing you the first revision ever made, and not the latest change