### PR TITLE
Avoid test to break if no image processing extensions are installed

### DIFF
--- a/tests/test-timber-image-letterbox.php
+++ b/tests/test-timber-image-letterbox.php
@@ -2,6 +2,13 @@
 
 class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 
+	function setUp() {
+		parent::setUp();
+		if ( ! extension_loaded( 'gd' ) ) {
+			self::markTestSkipped( 'Letterbox image operation tests requires GD extension' );
+		}
+	}
+
 	function testLetterbox() {
 		$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -2,6 +2,13 @@
 
 class TestTimberImageResize extends Timber_UnitTestCase {
 
+	function setUp() {
+		parent::setUp();
+		if ( ! extension_loaded( 'gd' ) ) {
+			self::markTestSkipped( 'Image resizing tests requires GD extension' );
+		}
+	}
+
 	function testCropCenter() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
 		$resized = TimberImageHelper::resize($cropper, 100, 300, 'center');

--- a/tests/test-timber-image-tojpg.php
+++ b/tests/test-timber-image-tojpg.php
@@ -2,6 +2,13 @@
 
 	class TestTimberImageToJPG extends Timber_UnitTestCase {
 
+		function setUp() {
+			parent::setUp();
+			if ( ! extension_loaded( 'gd' ) ) {
+				self::markTestSkipped( 'JPEG conversion tests requires GD extension' );
+			}
+		}
+
 		/**
      	 * @expectedException Twig_Error_Runtime
      	 */

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -232,6 +232,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertTrue( $exists );
 		//make sure it's the width it's supposed to be
 		$image = wp_get_image_editor( $resized_path );
+		if ( $image instanceof WP_Error ) {
+			self::markTestSkipped( 'Tall image resizing test is skipped because no image editor is provided by WordPress, make sure that either GD or Imagick extension is installed' );
+		}
 		$current_size = $image->get_size();
 		$w = $current_size['width'];
 		$this->assertEquals( $w, 600 );
@@ -424,6 +427,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testPNGtoJPG() {
+		if ( ! extension_loaded( 'gd' ) ) {
+			self::markTestSkipped( 'PNG to JPEG conversion test requires GD extension' );
+		}
 		$file_loc = self::copyTestImage( 'eastern-trans.png' );
 		$upload_dir = wp_upload_dir();
 		$new_file = TimberImageHelper::img_to_jpg( $upload_dir['url'].'/eastern-trans.png', '#FFFF00' );
@@ -586,6 +592,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testLetterboxImageDeletion() {
+		if ( ! extension_loaded( 'gd' ) ) {
+			self::markTestSkipped( 'Letterbox image test requires GD extension' );
+		}
 		$data = array();
 		$file = self::copyTestImage( 'city-museum.jpg' );
 		$upload_dir = wp_upload_dir();
@@ -617,6 +626,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testThemeImageLetterbox() {
+		if ( ! extension_loaded( 'gd' ) ) {
+			self::markTestSkipped( 'Letterbox image test requires GD extension' );
+		}
 		$dest = get_template_directory().'/images/cardinals.jpg';
 		copy( __DIR__.'/assets/cardinals.jpg', $dest );
 		$image = get_template_directory_uri().'/images/cardinals.jpg';
@@ -763,6 +775,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testGifToJpg() {
+		if ( ! extension_loaded( 'gd' ) ) {
+			self::markTestSkipped( 'JPEG conversion test requires GD extension' );
+		}
 		$filename = self::copyTestImage('loading.gif');
 		$gif_url = str_replace(ABSPATH, 'http://'.$_SERVER['HTTP_HOST'].'/', $filename);
 		$str = '<img src="{{'."'$gif_url'".'|tojpg}}" />';

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -186,6 +186,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testAnimatedGifResize() {
+		if ( ! extension_loaded( 'imagick' ) ) {
+			self::markTestSkipped( 'Animated GIF resizing test requires Imagick extension' );
+		}
 		$image = self::copyTestImage('robocop.gif');
 		$data = array('crop' => 'default');
 		$data['size'] = array('width' => 90, 'height' => 90);
@@ -792,6 +795,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testResizeGif() {
+		if ( ! extension_loaded( 'imagick' ) ) {
+			self::markTestSkipped( 'Animated GIF resizing test requires Imagick extension' );
+		}
 		$filename = self::copyTestImage('loading.gif');
 		$gif_url = str_replace(ABSPATH, 'http://'.$_SERVER['HTTP_HOST'].'/', $filename);
 		$str = '<img src="{{'."'$gif_url'".'|resize(200)}}" />';


### PR DESCRIPTION
#### Issue
Currently tests run can cause fatal errors in a case if they're running on PHP with no image processing extensions (GD, Imagick).

#### Solution
This pull request marks affected tests as skipped in a case if no such extensions are loaded.

#### Impact
Raise of chance on success tests run in more environments.