### PR TITLE
Loader locations normalization

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -115,23 +115,18 @@ class Loader {
 	 */
 	private function get_locations_theme() {
 		$theme_locs = array();
-		$child_loc  = realpath( get_stylesheet_directory() );
-		$parent_loc = realpath( get_template_directory() );
-		if ( is_dir( $child_loc ) ) {
-			$theme_locs[] = $child_loc;
-			$child_loc    = trailingslashit( $child_loc );
-			foreach ( $this->get_locations_theme_dir() as $dirname ) {
-				$tloc = realpath( $child_loc . $dirname );
-				if ( is_dir( $tloc ) ) {
-					$theme_locs[] = $tloc;
-				}
+		$theme_dirs = $this->get_locations_theme_dir();
+		$roots      = array( get_stylesheet_directory(), get_template_directory() );
+		$roots      = array_map( 'realpath', $roots );
+		$roots      = array_unique( $roots );
+		foreach ( $roots as $root ) {
+			if ( !is_dir( $root ) ) {
+				continue;
 			}
-		}
-		if ( $child_loc !== $parent_loc && is_dir( $parent_loc ) ) {
-			$theme_locs[] = $parent_loc;
-			$parent_loc   = trailingslashit( $parent_loc );
-			foreach ( $this->get_locations_theme_dir() as $dirname ) {
-				$tloc = realpath( $parent_loc . $dirname );
+			$theme_locs[] = $root;
+			$root         = trailingslashit( $root );
+			foreach ( $theme_dirs as $dirname ) {
+				$tloc = realpath( $root . $dirname );
 				if ( is_dir( $tloc ) ) {
 					$theme_locs[] = $tloc;
 				}

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -23,7 +23,7 @@ class Loader {
 
 	protected $cache_mode = self::CACHE_TRANSIENT;
 
-	public $locations;
+	private $locations;
 
 	/**
 	 * @param bool|string   $caller the calling directory or false
@@ -101,8 +101,8 @@ class Loader {
 	 */
 	protected function template_exists( $file ) {
 		foreach ( $this->locations as $dir ) {
-			$look_for = trailingslashit($dir).$file;
-			if ( file_exists($look_for) ) {
+			$look_for = $dir . $file;
+			if ( file_exists( $look_for ) ) {
 				return true;
 			}
 		}
@@ -112,7 +112,7 @@ class Loader {
 	/**
 	 * @return array
 	 */
-	public function get_locations_theme() {
+	private function get_locations_theme() {
 		$theme_locs = array();
 		$child_loc  = realpath( get_stylesheet_directory() );
 		$parent_loc = realpath( get_template_directory() );
@@ -155,7 +155,7 @@ class Loader {
 	 *
 	 * @return array
 	 */
-	public function get_locations_user() {
+	private function get_locations_user() {
 		$locs = array();
 		if ( isset(Timber::$locations) ) {
 			if ( is_string(Timber::$locations) ) {
@@ -175,7 +175,7 @@ class Loader {
 	 * @param bool|string   $caller the calling directory
 	 * @return array
 	 */
-	public function get_locations_caller( $caller = false ) {
+	private function get_locations_caller( $caller = false ) {
 		$locs = array();
 		if ( $caller && is_string($caller) ) {
 			$caller = realpath( $caller );
@@ -218,24 +218,9 @@ class Loader {
 	 * @return \Twig_Loader_Filesystem
 	 */
 	public function get_loader() {
-		$paths = array();
-		foreach ( $this->locations as $loc ) {
-			$loc = realpath($loc);
-			if ( is_dir($loc) ) {
-				$loc = realpath($loc);
-				$paths[] = $loc;
-			} else {
-				//error_log($loc.' is not a directory');
-			}
-		}
-		if ( !ini_get('open_basedir') ) {
-			$paths[] = '/';
-		} else {
-			$paths[] = ABSPATH;
-		}
+		$paths = array_merge( $this->locations, array( ini_get( 'open_basedir' ) ? ABSPATH : '/' ) );
 		$paths = apply_filters('timber/loader/paths', $paths);
-		$loader = new \Twig_Loader_Filesystem($paths);
-		return $loader;
+		return new \Twig_Loader_Filesystem($paths);
 	}
 
 	/**

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -37,13 +37,14 @@ class Loader {
 	/**
 	 * @param string        $file
 	 * @param array         $data
-	 * @param bool          $expires
+	 * @param array|bool    $expires
 	 * @param string        $cache_mode
 	 * @return bool|string
 	 */
 	public function render( $file, $data = null, $expires = false, $cache_mode = self::CACHE_USE_DEFAULT ) {
 		// Different $expires if user is anonymous or logged in
 		if ( is_array($expires) ) {
+			/** @var array $expires */
 			if ( is_user_logged_in() && isset($expires[1]) ) {
 				$expires = $expires[1];
 			} else {
@@ -224,7 +225,7 @@ class Loader {
 	}
 
 	/**
-	 * @return Twig_Environment
+	 * @return \Twig_Environment
 	 */
 	public function get_twig() {
 		$loader = $this->get_loader();


### PR DESCRIPTION
#### Issue
Currently `Timber\Loader` class collects location information from several methods and their checks and normalization is inconsistent. It results into duplicates into resulted set of paths in some cases, e.g. when using paths containing symlinks. Moreover prepared paths are re-normalized upon use ([twice](https://github.com/timber/timber/blob/master/lib/Loader.php#L215)) while it can be safely omitted if locations storage itself will be not accessible directly from outer code.

#### Solution
Provided patch unifies paths checks and normalization across information gathering methods and removes methods mean for internal use from being publicly accessed.

#### Impact
Minor performance gain and slightly better stability
