### PR TITLE
Workaround against error caused by importing protected/private object properties in PHP 7

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -62,6 +62,9 @@ abstract class Core {
 		}
 		if ( is_array($info) ) {
 			foreach ( $info as $key => $value ) {
+				if ( $key === '' || ord( $key[0] ) === 0 ) {
+					continue;
+				}
 				if ( !empty($key) && $force ) {
 					$this->$key = $value;
 				} else if ( !empty($key) && !method_exists($this, $key) ) {

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -20,6 +20,9 @@ class PostType {
 	protected function init( $post_type ) {
 		$obj = get_post_type_object($post_type);
 		foreach (get_object_vars($obj) as $key => $value) {
+			if ( $key === '' || ord( $key[0] ) === 0 ) {
+				continue;
+			}
 			$this->$key = $value;
 		}
 	}


### PR DESCRIPTION
#### Issue
[import()](https://github.com/timber/timber/blob/master/lib/Core.php#L59) method in `\Timber\Core` may cause fatal error in PHP 7 in a case if it receives object containing protected / private properties as input. I've prepared [gist](https://gist.github.com/FlyingDR/72dea267a3e313a31b374932df226a0c) that demonstrates problem.

Problem arises when several factors are came together:
1. [get_object_vars()](https://secure.php.net/get_object_vars) function, used into method returns object property names for protected / private properties prefixed with `\0` character (see [comment](https://secure.php.net/manual/en/function.get-object-vars.php#47075))
2. Previous point by itself is not a problem without `(object)(array)$var` type casting used into [`\Timber\Post::get_info()`](https://github.com/timber/timber/blob/master/lib/Post.php#L519) method. This type cast (actually cast from object to array) causes protected / private object properties to be stored into resulted variable.

#### Solution
Provided fix ensures that no special chars are used into key names that eliminates issue.

#### Testing
Since problem is affected only PHP 7 and causes fatal error - it is not obvious that tests needs to be written, instead problem should be avoided in its entire.