### PR TITLE
ref #1070 -- ref #1057 -- resolve errors with {{ post.type }} fallout

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -163,7 +163,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * @var PostType $_type stores the PostType object for the Post
 	 */
-	private $_type;
+	protected $__type;
 
 	/**
 	 * If you send the constructor nothing it will try to figure out the current post id based on being inside The_Loop
@@ -1018,10 +1018,13 @@ class Post extends Core implements CoreInterface {
 	 * @return PostType
 	 */
 	public function type() {
-		if ( !$this->_type instanceof PostType ) {
-			$this->_type = new PostType($this->post_type);
+		if ( isset($this->custom['type']) ) {
+			return $this->custom['type'];
 		}
-		return $this->_type;
+		if ( !$this->__type instanceof PostType ) {
+			$this->__type = new PostType($this->post_type);
+		}
+		return $this->__type;
 	}
 
 	/**

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -37,4 +37,22 @@
 			$this->assertEquals('Posts', $str);
 		}
 
+		function testLegacyTypeCustomField() {
+			$post_id = $this->factory->post->create();
+			update_post_meta($post_id, 'type', 'numberwang');
+			$post = new TimberPost($post_id);
+			$template = '{{post.type}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('numberwang', $str);
+		}
+
+		function testUnderscoreTypeCustomField() {
+			$post_id = $this->factory->post->create();
+			update_post_meta($post_id, '_type', 'numberwang');
+			$post = new TimberPost($post_id);
+			$template = '{{post._type}}';
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('numberwang', $str);
+		}
+
 	}


### PR DESCRIPTION
**Ticket**: #1070 and #1057 
**Reviewer**: @connorjburton 

#### Issue
Some errors were caused by #1003. This should resolve them:
- If a post had a custom field named "type", you would get the `PostType` object instead of the value
- If a post had a custom field named "_type" all hell broke loose

#### Solution
Return a custom field value if set for `post.type`

#### Impact
Version `1.0.5` can restore expected functionality, we can plan for how to do things best in `1.1.x`

#### Usage
None

#### Considerations
We should consider if/how to disallow the names of certain custom fields

#### Testing
You betcha
