### PR TITLE
Add extra contextual parameters to render filters

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -67,7 +67,7 @@ class Loader {
 				do_action('timber_loader_render_file', $result);
 			}
 			$data = apply_filters('timber_loader_render_data', $data);
-			$data = apply_filters('timber/loader/render_data', $data);
+			$data = apply_filters( 'timber/loader/render_data', $data, $file );
 			$output = $twig->render($file, $data);
 		}
 
@@ -75,7 +75,7 @@ class Loader {
 			$this->set_cache($key, $output, self::CACHEGROUP, $expires, $cache_mode);
 		}
 		$output = apply_filters('timber_output', $output);
-		return apply_filters('timber/output', $output);
+		return apply_filters( 'timber/output', $output, $file, $data );
 	}
 
 	/**


### PR DESCRIPTION
This change adds extra parameters to the `timber/loader/render_data` and `timber/output` filters so more context is available when using the filters.