### PR TITLE
Set user password to be hidden by default

### DIFF
--- a/lib/User.php
+++ b/lib/User.php
@@ -67,9 +67,10 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * @param int|bool $uid
+	 * @param bool $include_pass Whether to include the user's hashed password
 	 */
-	public function __construct( $uid = false ) {
-		$this->init($uid);
+	public function __construct( $uid = false, $include_pass = false ) {
+		$this->init($uid, $include_pass);
 	}
 
 	/**
@@ -118,8 +119,9 @@ class User extends Core implements CoreInterface {
 	/**
 	 * @internal
 	 * @param int|bool $uid The user ID to use
+	 * @param bool $include_pass Whether to include the user's hashed password
 	 */
-	protected function init( $uid = false ) {
+	protected function init( $uid = false, $include_pass = false ) {
 		if ( $uid === false ) {
 			$uid = get_current_user_id();
 		}
@@ -141,6 +143,9 @@ class User extends Core implements CoreInterface {
 			} else {
 				$this->import($data);
 			}
+		}
+		if ( ! $include_pass ) {
+			unset( $this->user_pass );
 		}
 		$this->id = $this->ID;
 		$this->name = $this->name();

--- a/lib/User.php
+++ b/lib/User.php
@@ -67,10 +67,9 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * @param int|bool $uid
-	 * @param bool $include_pass Whether to include the user's hashed password
 	 */
-	public function __construct( $uid = false, $include_pass = false ) {
-		$this->init($uid, $include_pass);
+	public function __construct( $uid = false ) {
+		$this->init($uid);
 	}
 
 	/**
@@ -119,9 +118,8 @@ class User extends Core implements CoreInterface {
 	/**
 	 * @internal
 	 * @param int|bool $uid The user ID to use
-	 * @param bool $include_pass Whether to include the user's hashed password
 	 */
-	protected function init( $uid = false, $include_pass = false ) {
+	protected function init( $uid = false ) {
 		if ( $uid === false ) {
 			$uid = get_current_user_id();
 		}
@@ -144,9 +142,7 @@ class User extends Core implements CoreInterface {
 				$this->import($data);
 			}
 		}
-		if ( ! $include_pass ) {
-			unset( $this->user_pass );
-		}
+		unset($this->user_pass);
 		$this->id = $this->ID;
 		$this->name = $this->name();
 		$this->avatar = new Image(get_avatar_url($this->id));

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -27,6 +27,18 @@
 			$this->assertEquals('Sixteenth President', $str);
 		}
 
+		function testInitWithoutPasswordFlag() {
+			$uid = $this->factory->user->create(array('display_name' => 'Tom Riddle'));
+			$user = new TimberUser($uid );
+			$this->assertFalse(property_exists( $user, 'user_pass'));
+		}
+
+		function testInitWithPasswordFlag() {
+			$uid = $this->factory->user->create(array('display_name' => 'Serius Black'));
+			$user = new TimberUser($uid, true);
+			$this->assertTrue(property_exists($user, 'user_pass'));
+		}
+
 		function testInitWithObject(){
 			$uid = $this->factory->user->create(array('display_name' => 'Baberaham Lincoln'));
 			$uid = get_user_by('id', $uid);

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -27,16 +27,10 @@
 			$this->assertEquals('Sixteenth President', $str);
 		}
 
-		function testInitWithoutPasswordFlag() {
+		function testInitShouldUnsetPassword() {
 			$uid = $this->factory->user->create(array('display_name' => 'Tom Riddle'));
 			$user = new TimberUser($uid );
 			$this->assertFalse(property_exists( $user, 'user_pass'));
-		}
-
-		function testInitWithPasswordFlag() {
-			$uid = $this->factory->user->create(array('display_name' => 'Serius Black'));
-			$user = new TimberUser($uid, true);
-			$this->assertTrue(property_exists($user, 'user_pass'));
 		}
 
 		function testInitWithObject(){


### PR DESCRIPTION
**Ticket**: #1073 
**Reviewer**: @jarednova 

#### Issue
As described in #1073, the user's hashed password exposed is in the TimberUser object.

#### Solution
Added an `include_pass` flag to the constructor and init functions, which is set to false by default.  Unless the flag is set to true, the user password will not be exposed in the user object.   

#### Impact
Would only affect users that are using that hashed password somewhere, which seems like an edge case.

#### Usage
The TimberUser constructor now accepts an optional second param, the `include_pass` flag.  

#### Considerations
-

#### Testing
Tests are included!

