### PR TITLE
remove strtotime check from dates

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -271,7 +271,7 @@ class Twig {
 
 		if ( $date instanceof \DateTime ) {
 			$timestamp = $date->getTimestamp() + $date->getOffset();
-		} else if ( is_numeric($date) && strtotime($date) === false ) {
+		} else if ( is_numeric($date) ) {
 			$timestamp = intval($date);
 		} else {
 			$timestamp = strtotime($date);


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1085

#### Issue
Bug in the date filter where some timestamps were being dubiously evaluated with `strtotime()` instead of their actual value 

#### Solution
Remove the check for `strtotime($date) === false` when deciding to use intval()


#### Impact
I believe the impact is only positive. I'm trying to think what purpose that check had in the first place... couldn't find anything in the commit history. I'm worried perhaps this was covering a different edge case, but I'm confident the current behaviour is not idea

#### Testing
Testing the date filter with '1457395200' could snag this.

some timestamps can be interpreted as differing dates by strtotime, such as strtotime('1457395200') => 101944277859. 
So strings like this should be treated with `intval()`.
I cannot think of an example where a date that would satisfy `is_numeric()` should be translated with `strtotime()`