### PR TITLE
Fix issue where timestamps could be erroneously converted by strtotime

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -271,7 +271,7 @@ class Twig {
 
 		if ( $date instanceof \DateTime ) {
 			$timestamp = $date->getTimestamp() + $date->getOffset();
-		} else if ( is_numeric($date) && strtotime($date) === false ) {
+		} else if ( is_numeric($date) && (strtotime($date) === false || strlen($date) !== 8) ) {
 			$timestamp = intval($date);
 		} else {
 			$timestamp = strtotime($date);

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -101,4 +101,10 @@
 			$this->assertEquals('Thing is on Oct 29, 2015', $str);
 		}
 
+		function testUnixDateEdgeCase() {
+			$twig = "Thing is on {{'1457395200'|date('M j, Y')}}";
+			$str = Timber::compile_string($twig);
+			$this->assertEquals('Thing is on Mar 8, 2016', $str);
+		}
+
 	}


### PR DESCRIPTION
**Ticket**: #1085 
Reviewer: @jarednova

#### Issue
Bug in the date filter where some timestamps were being dubiously evaluated with `strtotime()` instead of their actual value because some timestamps can be interpreted as differing dates by strtotime, such as strtotime('1457395200') => 101944277859.

#### Solution
Only use `strtotime` on numeric values that are 8 characters in length (assuming they will be in format YYYYMMDD). 

#### Impact
Timestamps that are 8 chars in length will suffer, but this is preferable to previous behaviour. Most dates in WordPress will probably not be timestamps

#### Testing
Added a test with a timestamp that `strtotime` will interpret as a valid, different date.