### PR TITLE
405 wpml image url fix

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -187,7 +187,7 @@ class ImageHelper {
 	 */
 	protected static function add_constants() {
 		if ( !defined('WP_CONTENT_SUBDIR') ) {
-			$wp_content_path = str_replace(home_url(), '', WP_CONTENT_URL);
+			$wp_content_path = str_replace(site_url(), '', WP_CONTENT_URL);
 			define('WP_CONTENT_SUBDIR', $wp_content_path);
 		}
 	}
@@ -199,7 +199,7 @@ class ImageHelper {
 	 */
 	static function add_filters() {
 		add_filter('upload_dir', function( $arr ) {
-			$arr['relative'] = str_replace(home_url(), '', $arr['baseurl']);
+			$arr['relative'] = str_replace(site_url(), '', $arr['baseurl']);
 			return $arr;
 		} );
 	}
@@ -351,7 +351,7 @@ class ImageHelper {
 			}
 		} else {
 			if ( !$result['absolute'] ) {
-				$tmp = home_url().$tmp;
+				$tmp = site_url().$tmp;
 			}
 			if ( 0 === strpos($tmp, $upload_dir['baseurl']) ) {
 				$result['base'] = self::BASE_UPLOADS; // upload based

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -114,8 +114,12 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 	}
 
 	function testWPMLurls() {
-		// this could be used to test the url issue caused by the WPML language identifier in the url
-		// However, WPML can't be installed with composer so this test doesn't accomplish much
+		// this test replicates the url issue caused by the WPML language identifier in the url
+		// However, WPML can't be installed with composer so this test mocks the WPML plugin
+
+		// WPML uses a filter to alter the home_url
+		$home_url_filter = function($url){ return $url.'/en'; };
+		add_filter( 'home_url', $home_url_filter, -10, 4 );
 
 		// test with a local and external file
 		foreach ([
@@ -127,10 +131,14 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 			if (strpos($img, '://') === false) {
 				$img = TestTimberImage::copyTestImage($img);
 			}
+
 			$resized = TimberImageHelper::resize($img, 50, 50);
 
 			// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
 			$this->assertLessThanOrEqual( 1, substr_count($resized, 'example.org') );
+			// make sure the image has been resized
+			$resized = TimberUrlHelper::url_to_file_system( $resized );
+			$this->assertTrue( TestTimberImage::checkSize($resized, 50, 50), 'image should be resized' );
 		}
 	}
 

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -113,4 +113,13 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$this->assertTrue( $is_sized );
 	}
 
+	function testWPMLurls() {
+		// this could be used to test the url issue caused by the WPML language identifier in the url
+		// However, WPML can't be installed with composer so this test doesn't accomplish much
+		$arch = TestTimberImage::copyTestImage('arch.jpg');
+		$resized = TimberImageHelper::resize($arch, 50, 50);
+		// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
+		$this->assertEquals( substr_count($resized, 'example.org'), 1 );
+	}
+
 }

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -118,17 +118,17 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		// However, WPML can't be installed with composer so this test mocks the WPML plugin
 
 		// WPML uses a filter to alter the home_url
-		$home_url_filter = function($url){ return $url.'/en'; };
+		$home_url_filter = function( $url ) { return $url.'/en'; };
 		add_filter( 'home_url', $home_url_filter, -10, 4 );
 
 		// test with a local and external file
-		foreach ([
+		foreach ( [
 					'arch.jpg',
 					'https://raw.githubusercontent.com/timber/timber/master/tests/assets/arch-2night.jpg'
-				] as $img) {
+				] as $img ) {
 
 			// copy image if it's local
-			if (strpos($img, '://') === false) {
+			if ( strpos($img, '://') === false ) {
 				$img = TestTimberImage::copyTestImage($img);
 			}
 

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -116,10 +116,22 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 	function testWPMLurls() {
 		// this could be used to test the url issue caused by the WPML language identifier in the url
 		// However, WPML can't be installed with composer so this test doesn't accomplish much
-		$arch = TestTimberImage::copyTestImage('arch.jpg');
-		$resized = TimberImageHelper::resize($arch, 50, 50);
-		// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
-		$this->assertEquals( substr_count($resized, 'example.org'), 1 );
+
+		// test with a local and external file
+		foreach ([
+					'arch.jpg',
+					'https://raw.githubusercontent.com/timber/timber/master/tests/assets/arch-2night.jpg'
+				] as $img) {
+
+			// copy image if it's local
+			if (strpos($img, '://') === false) {
+				$img = TestTimberImage::copyTestImage($img);
+			}
+			$resized = TimberImageHelper::resize($img, 50, 50);
+
+			// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
+			$this->assertLessThanOrEqual( 1, substr_count($resized, 'example.org') );
+		}
 	}
 
 }


### PR DESCRIPTION
#### Issue
WPML language identifier breaks the ImageHelper
https://github.com/timber/timber/issues/405


#### Solution
Use site_url() instead of home_url()


#### Impact
This might break some things that the current tests don't cover.


#### Testing
The test mocks the filter added by WPML since WPML is not a free plugin one could easily install using composer. Without the home_url() -> site_url() change the test fails.
