### PR TITLE
initialize  variable in Timber::get_pagination that throws a notice because it's not set

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -445,7 +445,7 @@ class Timber {
 		$data['current'] = $args['current'];
 		$data['total'] = $args['total'];
 		$data['pages'] = Helper::paginate_links($args);
-
+		$current = null;
 		if ( $data['total'] <= count($data['pages']) ) {
 			// decrement current so that it matches up with the 0 based index used by the pages array
 			$current = $data['current'] - 1;


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
when running `Timber::get_pagination` if the following is false:

```
( $data['total'] <= count($data['pages']) ) 
```
and the following, within the `foreach ( $data['pages'] as $key => $page ) {`, are all empty
```
$page['current']
```

the `$current` variable is not defined, resulting in a notice being thrown:

```
Notice: Undefined variable: current in /home/vagrant/Sites/xxx/web/wp-content/plugins/timber-library/lib/Timber.php on line 467
```




#### Solution
adding in an initialization of the `$current` variable before `$current` would even be set for the first time would prevent this from being thrown.

You could also bail after the `else` clause that contains `foreach ( $data['pages'] as $key => $page ) {` _if_ `$current` is still null.


#### Impact
None


#### Usage
N/A

#### Considerations
N/A

#### Testing
You could run a test if you're on page 1, there's a call to pagination however because of lack of data there are no subsequent pages
