### PR TITLE
Handle trailing slashes properly

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -513,9 +513,14 @@ class Helper {
 					}
 					$link = str_replace(' ', '+', $link);
 					$link = untrailingslashit($link);
+
+					$link = esc_url(apply_filters('paginate_links', $link));
+
+					$link = user_trailingslashit($link);
+
 					$page_links[] = array(
 						'class' => 'page-number page-numbers',
-						'link' => esc_url(apply_filters('paginate_links', $link)),
+						'link' => $link,
 						'title' => $n_display,
 						'name' => $n_display,
 						'current' => $args['current'] == $n
@@ -530,6 +535,7 @@ class Helper {
 				}
 			}
 		}
+
 		return $page_links;
 	}
 

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -141,5 +141,51 @@
 			$this->assertEquals(1984, $people[1]->year);
 		}
 
+		function testPaginateLinksWithTrailingSlash() {
+
+			$args = array('total' => 20);
+
+			$this->setPermalink('/%year%/%post_id%/');
+
+			$pagination = \Timber\Helper::paginate_links($args);
+
+			foreach($pagination as $page) {
+				if(array_key_exists('link', $page) && !empty($page['link'])) {
+					$this->assertStringEndsWith('/', $page['link']);
+				}
+			}
+
+			resetPermalinks();
+		}
+
+		function testPaginateLinksWithOutTrailingSlash() {
+
+			$args = array('total' => 20);
+
+			$this->setPermalink('/%year%/%post_id%');
+
+			$pagination = \Timber\Helper::paginate_links($args);
+
+			foreach($pagination as $page) {
+				if(array_key_exists('link', $page) && !empty($page['link'])) {
+					$this->assertFalse( '/', substr( $page['link'], - 1 ) );
+				}
+			}
+
+			resetPermalinks();
+		}
+
+		function setPermalink($pattern) {
+			global $wp_rewrite;
+			$wp_rewrite->init();
+			$wp_rewrite->set_permalink_structure( $pattern );
+			$wp_rewrite->flush_rules();
+		}
+
+		function resetPermalinks() {
+			global $wp_rewrite;
+			$wp_rewrite->init();
+			$wp_rewrite->flush_rules();
+		}
 
 	}

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -79,7 +79,18 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( 'http://example.org/page/5/?s=post', $pagination['pages'][4]['link'] );
 	}
 
-	function testPaginationHomePretty( $struc = '/%postname%/' ) {
+	function testPaginationHomePrettyTrailingSlash( $struc = '/%postname%/' ) {
+		global $wp_rewrite;
+		$wp_rewrite->permalink_structure = $struc;
+		update_option( 'permalink_structure', $struc );
+		$posts = $this->factory->post->create_many( 55 );
+		$this->go_to( home_url( '/' ) );
+		$pagination = Timber::get_pagination();
+		$this->assertEquals( 'http://example.org/page/3/', $pagination['pages'][2]['link'] );
+		$this->assertEquals( 'http://example.org/page/2/', $pagination['next']['link'] );
+	}
+
+	function testPaginationHomePrettyNonTrailingSlash( $struc = '/%postname%' ) {
 		global $wp_rewrite;
 		$wp_rewrite->permalink_structure = $struc;
 		update_option( 'permalink_structure', $struc );
@@ -135,9 +146,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$posts = $this->factory->post->create_many( 150 );
 		$this->go_to( home_url( '/page/13' ) );
 		$pagination = Timber::get_pagination();
-		$this->assertEquals( 'http://example.org/page/14', $pagination['next']['link'] );
+		$this->assertEquals( 'http://example.org/page/14/', $pagination['next']['link'] );
 	}
-
-
-
 }


### PR DESCRIPTION
**Ticket**: # https://github.com/timber/timber/issues/1109
**Reviewer**: @jarednova 

#### Issue
Trailing slash is not set appropriately for paginated links


#### Solution
Use `user_trailingslashit`


#### Impact
Pagination links may be affected.


#### Considerations
Code works with my install, generating the paginated links appropriately, but a bunch of tests are failing and I have no idea why/how to fix them.


#### Testing
Tests are included, but they are failing!

