### PR TITLE
Added functionality to get direct children of a term excluding grandc…

### DIFF
--- a/lib/Term.php
+++ b/lib/Term.php
@@ -49,6 +49,7 @@ class Term extends Core implements CoreInterface {
 	public static $representation = 'term';
 
 	public $_children;
+	public $_directChildren;
 	/**
 	 * @api
 	 * @var string the human-friendly name of the term (ex: French Cuisine)
@@ -310,6 +311,21 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @internal
+	 * @return array
+	 */
+	public function get_direct_children() {
+		if ( !isset($this->_directChildren) ) {
+			$children = get_terms($this->taxonomy, array('parent' => $this->ID, 'hide_empty' => false));
+			foreach ( $children as &$child ) {
+				$child = new Term($child);
+			}
+			$this->_directChildren = $children;
+		}
+		return $this->_directChildren;
+	}
+
+	/**
 	 *
 	 *
 	 * @param string  $key
@@ -329,6 +345,14 @@ class Term extends Core implements CoreInterface {
 	 */
 	public function children() {
 		return $this->get_children();
+	}
+
+	/**
+	 * @api
+	 * @return array
+	 */
+	public function direct_children() {
+		return $this->get_direct_children();
 	}
 
 	/**


### PR DESCRIPTION
#### Issue

Trying to loop through each level of a taxonomy but with existing functionality of get_children, after the first level the function would return all children (get_term_children) even the grandchildren. I needed to apply different styles and functionality to each level of the taxonomy.
#### Solution

Added a function named get_direct_children to return only terms directly related to the term parent. Essentially return terms one level deep.
#### Testing

Only tested within current project.

…hildren, useful for working with mutli leveled taxonomies.
