### PR TITLE
add escaping for esc_url and wp_kses_post

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -246,6 +246,7 @@ class Loader {
 
 		$twig = apply_filters('twig_apply_filters', $twig);
 		$twig = apply_filters('timber/twig/filters', $twig);
+		$twig = apply_filters('timber/twig/escapers', $twig);
 		$twig = apply_filters('timber/loader/twig', $twig);
 		return $twig;
 	}

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -26,6 +26,7 @@ class Twig {
 	 */
 	public function __construct() {
 		add_action('timber/twig/filters', array($this, 'add_timber_filters'));
+		add_action('timber/twig/escapers', array($this, 'add_timber_escapers'));
 	}
 
 	/**
@@ -206,6 +207,25 @@ class Twig {
 		 */
 		$twig = apply_filters('get_twig', $twig);
 		return $twig;
+	}
+
+	/**
+	 *
+	 *
+	 * @param Twig_Environment $twig
+	 * @return Twig_Environment
+	 */
+	public function add_timber_escapers( $twig ) {
+
+		$twig->getExtension( 'core' )->setEscaper( 'esc_url', function( \Twig_Environment $env, $string, $charset ) {
+			return esc_url( $string );
+		} );
+		$twig->getExtension( 'core' )->setEscaper( 'wp_kses_post', function( \Twig_Environment $env, $string, $charset ) {
+			return wp_kses_post( $string );
+		} );
+
+		return $twig;
+
 	}
 
 	/**

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -217,10 +217,10 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension( 'core' )->setEscaper( 'esc_url', function( \Twig_Environment $env, $string, $charset ) {
+		$twig->getExtension( 'core' )->setEscaper( 'esc_url', function( \Twig_Environment $env, $string ) {
 			return esc_url( $string );
 		} );
-		$twig->getExtension( 'core' )->setEscaper( 'wp_kses_post', function( \Twig_Environment $env, $string, $charset ) {
+		$twig->getExtension( 'core' )->setEscaper( 'wp_kses_post', function( \Twig_Environment $env, $string ) {
 			return wp_kses_post( $string );
 		} );
 

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -184,6 +184,20 @@
 			$this->assertEquals('jiggy', trim($result));
 		}
 
+		function testEscUrl(){
+			$url = 'http://example.com/Mr WordPress';
+			$str = Timber::compile_string( "{{the_url | e('esc_url')}}", array( 'the_url' => $url ) );
+			$this->assertEquals( 'http://example.com/Mr%20WordPress', $str );
+
+		}
+
+		function testWpKsesPost(){
+
+			$evil_script = '<div foo="bar" src="bum">Foo</div><script>DoEvilThing();</script>';
+			$str         = Timber::compile_string( "{{ evil_script | e('wp_kses_post') }}", array( 'evil_script' => $evil_script ) );
+			$this->assertEquals( '<div>Foo</div>DoEvilThing();', $str );
+		}
+
 		/**
      	* @expectedException Twig_Error_Syntax
      	*/


### PR DESCRIPTION
**Reviewer**: @jarednova

#### Issue
There was no escaping for `esc_url` or `wp_kses_post` natively in Twig (or Timber)


#### Solution
I added escapers as described in the [Twig Docs](http://twig.sensiolabs.org/doc/filters/escape.html#custom-escapers)

I'm not sure if `wp_kses_post` should be an escaper or if it should be it's own filter a la `wpautop` what are your thoughts?

I added the code in `Timber\Twig` and it acts as an analog to the filters, seems like the logical place for this to live.

I also added an extra filter `timber/twig/escapers` which is pretty much an analog to `timber/twig/filters`


#### Impact
Should be minimal impact.


#### Usage
```twig
<a href="{{ post.get_field('custom_link')|e('esc_url') }}">My Link</a>
```

```twig
<p>{{ post.get_field('wysiwyg_field')|e('wp_kses_post') }}</p>
```


#### Considerations
This is pretty straightforward, we may want to move wp_kses_post into a filter - that's all.


#### Testing
included unit tests -- can make them more robust if needed

