### PR TITLE
Edited get_post method to get posts directly by id

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -13,6 +13,16 @@ class PostGetter {
 	 * @return array|bool|null
 	 */
 	public static function get_post( $query = false, $PostClass = '\Timber\Post' ) {
+		// if a post id is passed, grab the post directly
+		if ( is_numeric($query) ) {
+			$post = new $PostClass($query);
+			// get the latest revision if we're dealing with a preview
+			$posts = PostsCollection::maybe_set_preview(array($post));
+			if ( $post = reset($posts) ) {
+				return $post;
+			}
+		}
+
 		$posts = self::get_posts($query, $PostClass);
 		if ( $post = reset($posts) ) {
 			return $post;

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -25,6 +25,29 @@ class TestTimber extends Timber_UnitTestCase {
 		$this->assertEquals('kill-bill', $post->post_name);
 	}
 
+	function testGetPostByPostObject() {
+		$pid = $this->factory->post->create();
+		$wp_post = get_post($pid);
+		$post = Timber::get_post($wp_post, 'TimberAlert');
+		$this->assertEquals('TimberAlert', get_class($post));
+		$this->assertEquals($pid, $post->ID);
+	}
+
+	function testGetPostByQueryArray() {
+		$pid = $this->factory->post->create();
+		$post = Timber::get_post(array('post_type' => 'post'), 'TimberAlert');
+		$this->assertEquals('TimberAlert', get_class($post));
+		$this->assertEquals($pid, $post->ID);
+	}
+
+	function testGetPostWithCustomPostType() {
+		register_post_type('event');
+		$pid = $this->factory->post->create(array('post_type' => 'event'));
+		$post = Timber::get_post($pid, 'TimberAlert');
+		$this->assertEquals('TimberAlert', get_class($post));
+		$this->assertEquals($pid, $post->ID);
+	}
+
 	function testGetPostsQueryString(){
 		$this->factory->post->create();
 		$this->factory->post->create();

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -41,7 +41,15 @@ class TestTimber extends Timber_UnitTestCase {
 	}
 
 	function testGetPostWithCustomPostType() {
-		register_post_type('event');
+		register_post_type('event', array('public' => true));
+		$pid = $this->factory->post->create(array('post_type' => 'event'));
+		$post = Timber::get_post($pid, 'TimberAlert');
+		$this->assertEquals('TimberAlert', get_class($post));
+		$this->assertEquals($pid, $post->ID);
+	}
+
+	function testGetPostWithCustomPostTypeNotPublic() {
+		register_post_type('event', array('public' => false));
 		$pid = $this->factory->post->create(array('post_type' => 'event'));
 		$post = Timber::get_post($pid, 'TimberAlert');
 		$this->assertEquals('TimberAlert', get_class($post));


### PR DESCRIPTION
**Ticket**: #819
**Reviewer**: @jarednova 

#### Issue
As described in the ticket, Timber::get_post using an ID may not return anything when a post with a custom type is requested, in contrast to the WP `get_post` function.

#### Solution
Instead of using the `get_posts`  method, which will only get post types with `exclude from search` set to true, just get posts directly using `new $PostClass()`.  The new post constructor uses Wordpress' `get_post`, which is pretty much a direct database hit to get a post based on ID and circumvents a lot of the logic applied to `get_posts`.  There's also a conditional in there to handle post previews.

#### Impact
- 


#### Usage
nope!


#### Considerations
This use of the `maybe_get_preview` function here is a little funky -- it's intended to accept and return an array, which makes sense in the context of a `PostsCollection` but isn't super clean here.  We could potentially set the method to accept either an object or an array, and in that instance I think it might make sense to move it to the `Helper` or `Timber` class.  Let me know what you think.

#### Testing
Tests included!

