### PR TITLE
Possibility to change "Read More..." link using filters

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -389,6 +389,7 @@ class Post extends Core implements CoreInterface {
 	 */
 	public function get_preview( $len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = '&hellip;' ) {
 		$text = '';
+		$link = '';
 		$trimmed = false;
 		$last_p_tag = null;
 		if ( isset($this->post_excerpt) && strlen($this->post_excerpt) ) {
@@ -436,11 +437,11 @@ class Post extends Core implements CoreInterface {
 			}
 			$read_more_class = apply_filters('timber/post/get_preview/read_more_class', "read-more");
 			if ( $readmore && isset($readmore_matches) && !empty($readmore_matches[1]) ) {
-				$readmorelink = ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
+				$link = ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
 			} elseif ( $readmore ) {
-				$readmorelink = ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore).'</a>';
+				$link = ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore).'</a>';
 			}
-			$text .= apply_filters( 'timber/post/get_preview/read_more_link', $readmorelink );
+			$text .= apply_filters( 'timber/post/get_preview/read_more_link', $link );
 			if ( !$strip && $last_p_tag && (strpos($text, '<p>') || strpos($text, '<p ')) ) {
 				$text .= '</p>';
 			}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -436,10 +436,11 @@ class Post extends Core implements CoreInterface {
 			}
 			$read_more_class = apply_filters('timber/post/get_preview/read_more_class', "read-more");
 			if ( $readmore && isset($readmore_matches) && !empty($readmore_matches[1]) ) {
-				$text .= ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
+				$readmorelink = ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
 			} elseif ( $readmore ) {
-				$text .= ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore).'</a>';
+				$readmorelink = ' <a href="'.$this->link().'" class="'.$read_more_class.'">'.trim($readmore).'</a>';
 			}
+			$text .= apply_filters( 'timber/post/get_preview/read_more_link', $readmorelink );
 			if ( !$strip && $last_p_tag && (strpos($text, '<p>') || strpos($text, '<p ')) ) {
 				$text .= '</p>';
 			}

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -88,7 +88,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 
 	function testReadMoreLinkFilter() {
 		$link = "Foobar"
-		add_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ) );
+		add_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ), 10, 1 );
 		$this->assertEquals( 'Foobar', apply_filters( 'timber/post/get_preview/read_more_link', $link ) );
 		remove_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ) );
 	}

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -86,4 +86,15 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		return $file . $data['number'];
 	}
 
+	function testReadMoreLinkFilter() {
+		$link = "Foobar"
+		add_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ) );
+		$this->assertEquals( 'Foobar', apply_filters( 'timber/post/get_preview/read_more_link', $link ) );
+		remove_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ) );
+	}
+
+	function filter_timber_post_get_preview_read_more_link( $link ) {
+		return $link;
+	}
+
 }


### PR DESCRIPTION
#### Issue
Unable to edit the "Read more" link in full, e.g. to add extra elements (div, li, etc)


#### Solution
Using the wordpress filters it's possible to create a filter that we can then use in our functions.php to customize the link in full


#### Usage
```
function read_more_link( $link ){
	$post = get_post();
	$link = '<div><a class="read-more" href="'. get_permalink($post->ID) . '">Read more...</a></div>';
	return $link;
}
add_filter( 'timber/post/get_preview/read_more_link', array($this, 'read_more_link') );
```

