### PR TITLE
Allow usage of classmap in get_post

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -9,12 +9,14 @@ class PostGetter {
 
 	/**
 	 * @param mixed $query
-	 * @param string $PostClass
+	 * @param string|array $PostClass
 	 * @return array|bool|null
 	 */
 	public static function get_post( $query = false, $PostClass = '\Timber\Post' ) {
 		// if a post id is passed, grab the post directly
 		if ( is_numeric($query) ) {
+			$post_type      = get_post_type($query);
+			$PostClass = PostGetter::get_post_class($post_type, $PostClass);
 			$post = new $PostClass($query);
 			// get the latest revision if we're dealing with a preview
 			$posts = PostsCollection::maybe_set_preview(array($post));
@@ -43,7 +45,7 @@ class PostGetter {
 
 	/**
 	 * @param mixed $query
-	 * @param string $PostClass
+	 * @param string|array $PostClass
 	 * @return array|bool|null
 	 */
 	public static function query_posts( $query = false, $PostClass = '\Timber\Post' ) {
@@ -92,6 +94,37 @@ class PostGetter {
 	public static function wp_query_has_posts() {
 		global $wp_query;
 		return ($wp_query && property_exists($wp_query, 'posts') && $wp_query->posts);
+	}
+
+	/**
+	 * @param string $post_type
+	 * @param string|array $post_class
+	 *
+	 * @return string
+	 */
+	public static function get_post_class( $post_type, $post_class = '\Timber\Post' )
+	{
+		$post_class = apply_filters( 'Timber\PostClassMap', $post_class );
+		$post_class_use = '\Timber\Post';
+
+		if ( is_array( $post_class ))  {
+			if (isset( $post_class[$post_type] )) {
+				$post_class_use = $post_class[$post_type];
+			}
+			else {
+				Helper::error_log( $post_type . ' not found in ' . print_r( $post_class, true ) );
+			}
+		} elseif ( is_string($post_class) ) {
+			$post_class_use = $post_class;
+		} else {
+			Helper::error_log( 'Unexpeted value for PostClass: ' . print_r( $post_class, true ) );
+		}
+
+		if ( !class_exists( $post_class_use ) || !( is_subclass_of( $post_class_use, '\Timber\Post' ) || is_a( $post_class_use, '\Timber\Post', true ) ) ) {
+			Helper::error_log( 'Class ' . $post_class_use . ' either does not exist or implement \Timber\Post' );
+		}
+
+		return $post_class_use;
 	}
 
 	/**

--- a/lib/PostsCollection.php
+++ b/lib/PostsCollection.php
@@ -18,22 +18,9 @@ class PostsCollection extends \ArrayObject {
 			$posts = array();
 		}
 		foreach ( $posts as $post_object ) {
-			$post_class_use = $post_class;
-			if ( is_array($post_class) ) {
-				$post_type      = get_post_type($post_object);
-				$post_class_use = '\Timber\Post';
+			$post_type      = get_post_type($post_object);
+			$post_class_use = PostGetter::get_post_class($post_type, $post_class);
 
-				if ( isset($post_class[$post_type]) ) {
-					$post_class_use = $post_class[$post_type];
-
-				} else {
-					if ( is_array($post_class) ) {
-						Helper::error_log($post_type.' of '.$post_object->ID.' not found in '.print_r($post_class, true));
-					} else {
-						Helper::error_log($post_type.' not found in '.$post_class);
-					}
-				}
-			}
 			// Don't create yet another object if $post_object is already of the right type
 			if ( is_a($post_object, $post_class_use) ) {
 				$post = $post_object;

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -120,7 +120,7 @@ class Timber {
 	 * Get post.
 	 * @api
 	 * @param mixed   $query
-	 * @param string  $PostClass
+	 * @param string|array  $PostClass
 	 * @return array|bool|null
 	 */
 	public static function get_post( $query = false, $PostClass = 'Timber\Post' ) {

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -26,6 +26,18 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$this->assertEquals( 'TimberPortfolio', get_class($posts[1]) );
 	}
 
+	function testGetPostWithClassMap() {
+		register_post_type('portfolio', array('public' => true));
+		$post_id_portfolio = $this->factory->post->create(array('post_type' => 'portfolio', 'post_title' => 'A portfolio item', 'post_date' => '2015-04-23 15:13:52'));
+		$post_id_alert = $this->factory->post->create(array('post_type' => 'alert', 'post_title' => 'An alert', 'post_date' => '2015-06-23 15:13:52'));
+		$post_portfolio = Timber::get_post($post_id_portfolio, array('portfolio' => 'TimberPortfolio', 'alert' => 'TimberAlert'));
+		$post_alert = Timber::get_post($post_id_alert, array('portfolio' => 'TimberPortfolio', 'alert' => 'TimberAlert'));
+		$this->assertEquals( 'TimberPortfolio', get_class($post_portfolio) );
+		$this->assertEquals( $post_id_portfolio, $post_portfolio->ID );
+		$this->assertEquals( 'TimberAlert', get_class($post_alert) );
+		$this->assertEquals( $post_id_alert, $post_alert->ID );
+	}
+
 	function test587() {
 		register_post_type('product');
 		$pids = $this->factory->post->create_many(6, array('post_type' => 'product'));
@@ -202,18 +214,18 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 
 }
 
-class job extends TimberPost {
+class job extends \Timber\Post {
 
 }
 
-class Person extends TimberPost {
+class Person extends \Timber\Post {
 
 }
 
-class TimberAlert extends TimberPost {
+class TimberAlert extends \Timber\Post {
 
 }
 
-class TimberPortfolio extends TimberPost {
+class TimberPortfolio extends \Timber\Post {
 
 }


### PR DESCRIPTION
**Ticket**: #1149

#### Issue
In Timber 1.1.2 you can't use classmap array when retrieving single post.

#### Solution
Get post_type and figure out the class to be used before instantiating it. This is handled by static method `get_post_class` which is also used in `PostCollection`. Added possibility to set classmap by filter `Timber\PostClassMap`.

#### Impact
Backward compatible.

#### Usage
`get_post` usage is now the same than prior 1.1.2 version.

#### Considerations
There is need to investigate if `get_post_class` method could be used for example in method `get_posts()` of `\Timber\Term\`

#### Testing
Tests included and passed