### PR TITLE
Add Countable interface to QueryIterator

### DIFF
--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -10,7 +10,7 @@ if ( !defined('ABSPATH') ) {
 	exit;
 }
 
-class QueryIterator implements \Iterator {
+class QueryIterator implements \Iterator, \Countable {
 
 	/**
 	 *
@@ -173,4 +173,21 @@ class QueryIterator implements \Iterator {
 		return $query;
 	}
 
+	/**
+	 * Count elements of an object.
+	 *
+	 * Necessary for some Twig `loop` variable properties.
+	 * @see http://twig.sensiolabs.org/doc/tags/for.html#the-loop-variable
+	 *
+	 * @link  http://php.net/manual/en/countable.count.php
+	 * @return int The custom count as an integer.
+	 * </p>
+	 * <p>
+	 * The return value is cast to an integer.
+	 * @since 5.1.0
+	 */
+	public function count()
+	{
+		return $this->post_count();
+	}
 }

--- a/tests/assets/iterator-loop-test.twig
+++ b/tests/assets/iterator-loop-test.twig
@@ -1,0 +1,3 @@
+{% for post in posts %}
+{{ loop | json_encode }}
+{% endfor %}

--- a/tests/test-timber-iterator.php
+++ b/tests/test-timber-iterator.php
@@ -24,10 +24,40 @@ class TestTimberIterator extends Timber_UnitTestCase {
 
     }
 
+    function testTwigLoopVar() {
+	    $posts = $this->factory->post->create_many( 3 );
+	    $posts = TimberPostGetter::query_posts($posts);
+
+	    $compiled = Timber::compile('assets/iterator-loop-test.twig', array(
+		    'posts' => TimberPostGetter::query_posts( 'post_type=post' )
+	    ) );
+
+	    $loop = array_map('json_decode', explode("\n", trim($compiled)));
+
+	    $this->assertSame(1, $loop[0]->index);
+	    $this->assertSame(2, $loop[0]->revindex0);
+	    $this->assertSame(3, $loop[0]->length);
+	    $this->assertTrue($loop[0]->first);
+	    $this->assertFalse($loop[0]->last);
+
+	    $this->assertSame(2, $loop[1]->index);
+	    $this->assertSame(1, $loop[1]->revindex0);
+	    $this->assertSame(3, $loop[1]->length);
+	    $this->assertFalse($loop[1]->first);
+	    $this->assertFalse($loop[1]->last);
+
+	    $this->assertSame(3, $loop[2]->index);
+	    $this->assertSame(0, $loop[2]->revindex0);
+	    $this->assertSame(3, $loop[2]->length);
+	    $this->assertFalse($loop[2]->first);
+	    $this->assertTrue($loop[2]->last);
+    }
+
     function testPostCount() {
     	$posts = $this->factory->post->create_many( 8 );
         $posts = TimberPostGetter::query_posts('post_type=post');
         $this->assertEquals( 8, $posts->post_count() );
+        $this->assertEquals( 8, count($posts) );
     }
 
 }


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue

The special Twig `loop` variable [requires the `Countable` interface to be implemented](http://twig.sensiolabs.org/doc/tags/for.html#the-loop-variable) when iterating over an object for some loop properties to work as expected (read: exist).

`Timber\QueryIterator` does not implement nor inherit this interface, so when iterating over it in Twig, some properties of the `loop` variable are not there.

#### Solution

The solution is to simply implement the interface on the `QueryIterator` class.  It requires a single `count` method.  The existing `post_count` method remains and is used by the new `count` method.

#### Impact

I have no reason to believe that this would be a backwards-incompatible change.  If anything, it improves the experience of using Timber by filling the gap in expected behavior.

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
Nope.

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
n/a

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Batteries included.
