### PR TITLE
Replace paragraph tags with line breaks in plugin update row

### DIFF
--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -48,18 +48,18 @@ class Admin {
 
 		if ( version_compare("1.0.0", $plugin_data['new_version']) <= 0 ) {
 			//a version of 1.0.0 or greater is availalbe
-			$m .= '<p><b>Warning:</b> Timber 1.0 removed a number of features and methods. Before upgrading please test your theme on a local or staging site to ensure that your theme will work with the newest version.</p>
+			$m .= '<br><b>Warning:</b> Timber 1.0 removed a number of features and methods. Before upgrading please test your theme on a local or staging site to ensure that your theme will work with the newest version.<br>
 
-			<p><strong>Is your theme in active development?</strong> That is, is someone actively in PHP files writing new code? If you answered "no", then <i>do not upgrade</i>. You will not benefit from Timber 1.0</p>';
+			<br><strong>Is your theme in active development?</strong> That is, is someone actively in PHP files writing new code? If you answered "no", then <i>do not upgrade</i>. You will not benefit from Timber 1.0<br>';
 
-			$m .= '<p>Read the <strong><a href="https://github.com/timber/timber/wiki/1.0-Upgrade-Guide">Upgrade Guide</a></strong> for more information</p>';
+			$m .= '<br>Read the <strong><a href="https://github.com/timber/timber/wiki/1.0-Upgrade-Guide">Upgrade Guide</a></strong> for more information<br>';
 
-			$m .= "<p>You can also <b><a href='https://downloads.wordpress.org/plugin/timber-library.0.22.6.zip'>upgrade to version 0.22.6</a></b> if you want to upgrade, but are unsure if you're ready for 1.0";
+			$m .= "<br>You can also <b><a href='https://downloads.wordpress.org/plugin/timber-library.0.22.6.zip'>upgrade to version 0.22.6</a></b> if you want to upgrade, but are unsure if you're ready for 1.0<br>";
 
 		}
 
 		if ( version_compare("1.0.0", $plugin_data['Version']) <= 0 ) {
-			$m .= "<p>Are you seeing errors since upgrading to 1.0? Download <b><a href='https://downloads.wordpress.org/plugin/timber-library.0.22.6.zip'>Version 0.22.6</a></b> to bring things back to stability.";
+			$m .= "<br>Are you seeing errors since upgrading to 1.0? Download <b><a href='https://downloads.wordpress.org/plugin/timber-library.0.22.6.zip'>Version 0.22.6</a></b> to bring things back to stability.";
 		}
 
 		// show message


### PR DESCRIPTION
**Ticket**: #1160

#### Issue
See #1160

#### Solution
Replacing the paragraphs with line breaks bring the update information in line with 4.6 changes to shiny updates

#### Impact
The impact should be minimal. The double line break functions similarly as a paragraph. It's not as "semantic" as before but that's debatable since now the entire update message is wrapped in a single `<p>` tag automatically as of 4.6. Wrapping the different sections in a `<div>` could be ideal since they are block level, but `<div>`s are hoisted out of `<p>` tags in most browsers.

Here is what the proposed change looks like visually in 4.6

![screen shot 2016-08-22 at 11 12 41 pm](https://cloud.githubusercontent.com/assets/4062087/17880303/e8832f8c-68be-11e6-80ac-224e276f6593.png)

Here is what is looks like with the proposed changes on 4.5.3 (and below presumably)

![screen shot 2016-08-22 at 11 25 09 pm](https://cloud.githubusercontent.com/assets/4062087/17880407/0e7d4398-68c0-11e6-9dc5-2def1a9686a2.png)
