### PR TITLE
Added get_scheme URL helper

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -225,7 +225,7 @@ class Timber {
 	 */
 	public static function get_context() {
 		if ( empty(self::$context_cache) ) {
-			self::$context_cache['http_host'] = 'http://'.URLHelper::get_host();
+			self::$context_cache['http_host'] = URLHelper::get_scheme().'://'.URLHelper::get_host();
 			self::$context_cache['wp_title'] = Helper::get_wp_title();
 			self::$context_cache['wp_head'] = Helper::function_wrapper('wp_head');
 			self::$context_cache['wp_footer'] = Helper::function_wrapper('wp_footer');

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -10,10 +10,7 @@ class URLHelper {
 	 * @return string
 	 */
 	public static function get_current_url() {
-		$pageURL = "http://";
-		if ( isset($_SERVER['HTTPS']) && $_SERVER["HTTPS"] == "on" ) {
-			$pageURL = "https://"; ;
-		}
+		$pageURL = self::get_scheme()."://";
 		if ( isset($_SERVER["SERVER_PORT"]) && $_SERVER["SERVER_PORT"] && $_SERVER["SERVER_PORT"] != "80" ) {
 			$pageURL .= self::get_host().":".$_SERVER["SERVER_PORT"].$_SERVER["REQUEST_URI"];
 		} else {
@@ -21,6 +18,17 @@ class URLHelper {
 		}
 		return $pageURL;
 	}
+
+    /**
+     *
+     * Get url scheme
+     * @return string
+     */
+	public static function get_scheme()
+    {
+        return isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+    }
+
 
 	/**
 	 *

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -33,6 +33,31 @@
             $this->assertEquals('http://example.org/', $url);
         }
 
+        function testCurrentURLIsSecure(){
+            if (!isset($_SERVER['SERVER_PORT'])){
+                $_SERVER['SERVER_PORT'] = 443;
+            }
+            if (!isset($_SERVER['SERVER_NAME'])){
+                $_SERVER['SERVER_NAME'] = 'example.org';
+            }
+            $_SERVER['HTTPS'] = 'on';
+            $this->go_to('/');
+            $url = TimberURLHelper::get_current_url();
+            $this->assertEquals('https://example.org/', $url);
+        }
+
+        function testUrlSchemeIsSecure() {
+            $_SERVER['HTTPS'] = 'on';
+            $scheme = TimberURLHelper::get_scheme();
+            $this->assertEquals('https', $scheme);
+        }
+
+        function testUrlSchemeIsNotSecure() {
+            $_SERVER['HTTPS'] = 'off';
+            $scheme = TimberURLHelper::get_scheme();
+            $this->assertEquals('http', $scheme);
+        }
+
         function testIsURL(){
             $url = 'http://example.org';
             $not_url = '/blog/2014/05/whatever';


### PR DESCRIPTION
#### Issue
The url helper was missing the ability to tell what HTTP scheme it was in. 


#### Solution
This fixes that by adding URLHelper::get_scheme() to check if HTTPS is on or off.


#### Impact
This removes the hardcoded HTTP scheme in Timber::get_context()


#### Usage
No special usage


#### Considerations
There's the possibility of adding a check to URLHelper::get_scheme() to see what port is being used, but it's not guaranteed that port 443 will be encrypted.

#### Testing
Test for this method are included.

