### PR TITLE
ref #217 #285 -- added PW support for post content, but not by default

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -910,6 +910,7 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * If the Password form is to be shown, show it!
+	 * @return string|void
 	 */
 	protected function maybe_show_password_form(){
 		if ( $this->password_required() ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -909,6 +909,19 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * If the Password form is to be shown, show it!
+	 */
+	protected function maybe_show_password_form(){
+		if ( $this->password_required() ) {
+			$show_pw = false;
+			$show_pw = apply_filters('timber/post/content/show_password_form_for_protected', $show_pw);
+			if ($show_pw) {
+				return apply_filters('timber/post/content/password_form', get_the_password_form($this->ID), $this);
+			}
+		}
+	}
+
+	/**
 	 * Gets the actual content of a WP Post, as opposed to post_content this will run the hooks/filters attached to the_content. \This guy will return your posts content with WordPress filters run on it (like for shortcodes and wpautop).
 	 * @api
 	 * @example
@@ -922,6 +935,9 @@ class Post extends Core implements CoreInterface {
 	 * @return string
 	 */
 	public function content( $page = 0, $len = -1 ) {
+		if ( $form = $this->maybe_show_password_form() ) {
+			return $form;
+		}
 		if ( $len == -1 && $page == 0 && $this->_content ) {
 			return $this->_content;
 		}

--- a/tests/assets/password-form.twig
+++ b/tests/assets/password-form.twig
@@ -1,0 +1,1 @@
+<form>Enter password to see {{post.title}}</form>

--- a/tests/test-timber-post-password.php
+++ b/tests/test-timber-post-password.php
@@ -1,0 +1,50 @@
+<?php
+
+	class TestTimberPostPassword extends Timber_UnitTestCase {
+
+		function testPasswordedContentDefault(){
+			$quote = 'The way to do well is to do well.';
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$post->post_content = $quote;
+			$post->post_password = 'burrito';
+			wp_update_post($post);
+			$password_form = get_the_password_form($post->ID);
+			$this->assertEquals(wpautop($quote), $post->content());
+			$this->assertEquals(wpautop($quote), $post->get_content());
+		}
+
+		function testPasswordedContentWhenEnabled(){
+			add_filter('timber/post/content/show_password_form_for_protected', function($maybe_show) {
+				return true;
+			});
+			$quote = 'The way to do well is to do well.';
+			$post_id = $this->factory->post->create();
+			$post = new TimberPost($post_id);
+			$post->post_content = $quote;
+			$post->post_password = 'burrito';
+			wp_update_post($post);
+			$password_form = get_the_password_form($post->ID);
+			$this->assertEquals($password_form, $post->content());
+			$this->assertEquals($password_form, $post->get_content());
+		}
+
+		function testPasswordedContentWhenEnabledWithCustomForm(){
+			add_filter('timber/post/content/show_password_form_for_protected', function($maybe_show) {
+				return true;
+			});
+			add_filter('timber/post/content/password_form', function($form, $post){
+				return Timber::compile('assets/password-form.twig', array('post' => $post));
+			}, 10, 2);
+			$quote = 'The way to do well is to do well.';
+			$post_id = $this->factory->post->create(array('post_title' => 'Secrets!'));
+			$post = new TimberPost($post_id);
+			$post->post_content = $quote;
+			$post->post_password = 'burrito';
+			wp_update_post($post);
+			$password_form = '<form>Enter password to see Secrets!</form>';
+			$this->assertEquals($password_form, $post->content());
+			$this->assertEquals($password_form, $post->get_content());
+		}
+
+	}


### PR DESCRIPTION
**Ticket**: #217 

Usage....

New filter for `functions.php`

### Enable the PW prompt for private posts...
```php
add_filter('timber/post/content/show_password_form_for_protected', function($maybe_show) {
    return true;
});
```

### Modify the form....

```php
add_filter('timber/post/content/password_form', function($form, $post){
    return Timber::compile('assets/password-form.twig', array('post' => $post));
 }, 10, 2);
```