### PR TITLE
1128 cache transients

### DIFF
--- a/lib/Cache/Cleaner.php
+++ b/lib/Cache/Cleaner.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Timber\Cache;
+
+class Cleaner {
+
+	protected static function delete_transients_single_site() {
+		global $wpdb;
+		$sql = "
+				DELETE
+					a, b
+				FROM
+					{$wpdb->options} a, {$wpdb->options} b
+				WHERE
+					a.option_name LIKE '%_transient_%' AND
+					a.option_name NOT LIKE '%_transient_timeout_%' AND
+					b.option_name = CONCAT(
+						'_transient_timeout_',
+						SUBSTRING(
+							a.option_name,
+							CHAR_LENGTH('_transient_') + 1
+						)
+					)
+				AND b.option_value < UNIX_TIMESTAMP()
+			";
+		return $wpdb -> query( $sql );
+	}
+
+	protected static function delete_transients_multisite() {
+		global $wpdb;
+		$sql = "DELETE
+						a, b
+					FROM
+						{$wpdb->sitemeta} a, {$wpdb->sitemeta} b
+					WHERE
+						a.meta_key LIKE '_site_transient_timberloader_%' AND
+						a.meta_key NOT LIKE '_site_transient_timeout_timberloader_%' AND
+						b.meta_key = CONCAT(
+							'_site_transient_timeout_timberloader_',
+							SUBSTRING(
+								a.meta_key,
+								CHAR_LENGTH('_site_transient_') + 1
+							)
+						)
+					AND b.meta_value < UNIX_TIMESTAMP()
+				";
+
+				$clean = $wpdb -> query( $sql );
+		return $clean;
+	}
+
+	public static function delete_transients( ) {
+		global $_wp_using_ext_object_cache;
+
+		if ( $_wp_using_ext_object_cache ) {
+			return 0;
+		}
+
+		global $wpdb;
+		$records = 0;
+
+		// Delete transients from options table
+		$records .= self::delete_transients_single_site();
+
+		// Delete transients from multisite, if configured as such
+
+		if ( is_multisite() && is_main_network() ) {
+
+			$records .= self::delete_transients_multisite();
+		}
+		return $records;
+
+	}
+
+
+}

--- a/lib/Cache/Cleaner.php
+++ b/lib/Cache/Cleaner.php
@@ -23,7 +23,7 @@ class Cleaner {
 					)
 				AND b.option_value < UNIX_TIMESTAMP()
 			";
-		return $wpdb -> query( $sql );
+		return $wpdb->query($sql);
 	}
 
 	protected static function delete_transients_multisite() {
@@ -46,7 +46,7 @@ class Cleaner {
 					AND b.meta_value < UNIX_TIMESTAMP()
 				";
 
-				$clean = $wpdb -> query( $sql );
+				$clean = $wpdb->query($sql);
 		return $clean;
 	}
 

--- a/lib/Cache/Cleaner.php
+++ b/lib/Cache/Cleaner.php
@@ -28,15 +28,16 @@ class Cleaner {
 
 	protected static function delete_transients_multisite() {
 		global $wpdb;
-		$sql = "DELETE
+		$sql = "
+					DELETE
 						a, b
 					FROM
 						{$wpdb->sitemeta} a, {$wpdb->sitemeta} b
 					WHERE
-						a.meta_key LIKE '_site_transient_timberloader_%' AND
-						a.meta_key NOT LIKE '_site_transient_timeout_timberloader_%' AND
+						a.meta_key LIKE '_site_transient_%' AND
+						a.meta_key NOT LIKE '_site_transient_timeout_%' AND
 						b.meta_key = CONCAT(
-							'_site_transient_timeout_timberloader_',
+							'_site_transient_timeout_',
 							SUBSTRING(
 								a.meta_key,
 								CHAR_LENGTH('_site_transient_') + 1

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -2,6 +2,8 @@
 
 namespace Timber;
 
+use Timber\Cache\Cleaner;
+
 class Loader {
 
 	const CACHEGROUP = 'timberloader';
@@ -73,10 +75,15 @@ class Loader {
 		}
 
 		if ( false !== $output && false !== $expires && null !== $key ) {
+			$this->delete_cache();
 			$this->set_cache($key, $output, self::CACHEGROUP, $expires, $cache_mode);
 		}
 		$output = apply_filters('timber_output', $output);
 		return apply_filters('timber/output', $output, $data, $file);
+	}
+
+	protected function delete_cache() {
+		Cleaner::delete_transients();
 	}
 
 	/**
@@ -244,11 +251,11 @@ class Loader {
 
 		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
 		if ( self::CACHE_TRANSIENT === $cache_mode ) {
-					$value = get_transient($trans_key);
+			$value = get_transient($trans_key);
 		} elseif ( self::CACHE_SITE_TRANSIENT === $cache_mode ) {
-					$value = get_site_transient($trans_key);
+			$value = get_site_transient($trans_key);
 		} elseif ( self::CACHE_OBJECT === $cache_mode && $object_cache ) {
-					$value = wp_cache_get($key, $group);
+			$value = wp_cache_get($key, $group);
 		}
 
 		return $value;
@@ -270,18 +277,18 @@ class Loader {
 		}
 
 		if ( (int) $expires < 1 ) {
-					$expires = 0;
+			$expires = 0;
 		}
 
 		$cache_mode = self::_get_cache_mode($cache_mode);
 		$trans_key = substr($group.'_'.$key, 0, self::TRANS_KEY_LEN);
 
 		if ( self::CACHE_TRANSIENT === $cache_mode ) {
-					set_transient($trans_key, $value, $expires);
+			set_transient($trans_key, $value, $expires);
 		} elseif ( self::CACHE_SITE_TRANSIENT === $cache_mode ) {
-					set_site_transient($trans_key, $value, $expires);
+			set_site_transient($trans_key, $value, $expires);
 		} elseif ( self::CACHE_OBJECT === $cache_mode && $object_cache ) {
-					wp_cache_set($key, $value, $group, $expires);
+			wp_cache_set($key, $value, $group, $expires);
 		}
 
 		return $value;

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -24,11 +24,6 @@
 			$wp_rewrite->flush_rules();
 			update_option( 'permalink_structure', $struc );
 			flush_rewrite_rules( true );
-
-		// 	$struc = '/%postname%/';
-		// global $wp_rewrite;
-		// $wp_rewrite->permalink_structure = $struc;
-		// update_option( 'permalink_structure', $struc );
 		}
 
 		function tearDown() {

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -231,6 +231,7 @@
             $pid = $this->factory->post->create();
             $post = new TimberPost($pid);
             set_transient( 'random_600', 'foo', 600 );
+            $random_post = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), 600);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
             sleep($time + 2);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
@@ -238,7 +239,7 @@
             global $wpdb;
             $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
             $data = $wpdb->get_results( $query );
-            $this->assertEquals(1, $wpdb->num_rows);
+            $this->assertEquals(2, $wpdb->num_rows);
             $this->assertEquals('foo', get_transient('random_600'));
         }
 

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -11,6 +11,7 @@
         }
 
         function testTransientLock() {
+
             $transient = $this->_generate_transient_name();
             TimberHelper::_lock_transient( $transient, 5 );
             $this->assertTrue( TimberHelper::_is_transient_locked( $transient ) );
@@ -209,7 +210,36 @@
             $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
             $wpdb->query( $query );
             $this->assertEquals(0, $wpdb->num_rows);
+        }
 
+        function testTimberLoaderCacheTransients() {
+            $time = 2;
+            $pid = $this->factory->post->create();
+            $post = new TimberPost($pid);
+            $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
+            sleep($time + 2);
+            $str_new = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
+            $this->assertEquals($str_old, $str_new);
+            global $wpdb;
+            $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
+            $data = $wpdb->get_results( $query );
+            $this->assertEquals(1, $wpdb->num_rows);
+        }
+
+        function testTimberLoaderCacheTransientsButKeepOtherTransients() {
+            $time = 2;
+            $pid = $this->factory->post->create();
+            $post = new TimberPost($pid);
+            set_transient( 'random_600', 'foo', 600 );
+            $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
+            sleep($time + 2);
+            $str_new = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
+            $this->assertEquals($str_old, $str_new);
+            global $wpdb;
+            $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
+            $data = $wpdb->get_results( $query );
+            $this->assertEquals(1, $wpdb->num_rows);
+            $this->assertEquals('foo', get_transient('random_600'));
         }
 
 	}

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -226,6 +226,23 @@
             $this->assertEquals(1, $wpdb->num_rows);
         }
 
+        function testTimberLoaderCacheTransientsWithExtObjectCache() {
+            global $_wp_using_ext_object_cache;
+            $_wp_using_ext_object_cache = true;
+            $time = 2;
+            $pid = $this->factory->post->create();
+            $post = new TimberPost($pid);
+            $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
+            sleep($time + 2);
+            $str_new = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
+            $this->assertEquals($str_old, $str_new);
+            global $wpdb;
+            $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
+            $data = $wpdb->get_results( $query );
+            $this->assertEquals(0, $wpdb->num_rows);
+            $_wp_using_ext_object_cache = false;
+        }
+
         function testTimberLoaderCacheTransientsButKeepOtherTransients() {
             $time = 2;
             $pid = $this->factory->post->create();


### PR DESCRIPTION
**Ticket**: #1128 
## What this does

When new items are set in the cache, the new `Timber\Cache\Cleaner` cache will wipe any expired ones
## Background

This overrides WP's default behavior of leaving expired transients to rot. This is explained here....

http://www.staze.org/wordpress-_transient-buildup/
https://wordpress.org/plugins/artiss-transient-cleaner/
## Considerations

There's a slight performance drag, as a new query is now run to wipe old transients. But it's only done when _setting_ a new one, so we're expecting that to be a slow-load anyway. This will not affect the site experience for a user visiting the cached version of a page (other than to speed it up since the DB will be so much smoother).

It's worth considering whether this belongs in Timber or not. [This solution](http://www.staze.org/wordpress-_transient-buildup/) shows how to do it for non-Timber situations where transients build up. My belief is that even though this is an underlying WP problem, it's felt so intensely with Timber that it behooves the platform to build-in a solution
