### PR TITLE
Add excerpt chars filter

### DIFF
--- a/lib/Filter.php
+++ b/lib/Filter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Timber;
+
+/**
+ * Class provides different commonly used in Wordpress development
+ */
+class Filter
+{
+    /**
+     * Trims text to a certain number of characters.
+     * This function can be useful for excerpt of the post
+     * As opposed to wp_trim_words trims characters that makes text to
+     * take the same amount of space in each post for example
+     *
+     * @param string $text      Text to trim.
+     * @param int    $num_chars Number of characters. Default is 60.
+     * @param string|null $more      Optional. What to append if $text needs to be trimmed. Default '&hellip;'.
+     * @return string trimmed text.
+     */
+    public static function trim_characters($text, $num_chars = 60, $more = null)
+    {
+        if ($more === null) {
+            $more = __('&hellip;');
+        }
+        $text = wp_strip_all_tags($text);
+        $text = mb_strimwidth($text, 0, $num_chars, $more);
+        return $text;
+    }
+}

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -53,6 +53,7 @@ class Twig {
 		$twig->addFilter(new \Twig_SimpleFilter('stripshortcodes', 'strip_shortcodes'));
 		$twig->addFilter(new \Twig_SimpleFilter('array', array($this, 'to_array')));
 		$twig->addFilter(new \Twig_SimpleFilter('excerpt', 'wp_trim_words'));
+		$twig->addFilter(new \Twig_SimpleFilter('excerpt_chars', array('Timber\Filter','trim_characters')));
 		$twig->addFilter(new \Twig_SimpleFilter('function', array($this, 'exec_function')));
 		$twig->addFilter(new \Twig_SimpleFilter('pretags', array($this, 'twig_pretags')));
 		$twig->addFilter(new \Twig_SimpleFilter('sanitize', 'sanitize_title'));

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -40,6 +40,12 @@
 			$this->assertStringStartsWith('<div id="respond"', $form);
 		}
 
+		function testTrimCharacters() {
+			$text    = "Sometimes you need to do such weird things like remove all comments from your project.";
+			$trimmed = \Timber\Filter::trim_characters( $text, 20 );
+			$this->assertEquals( "Sometimes yo&hellip;", $trimmed );
+		}
+
 		function testCloseTagsWithSelfClosingTags(){
 			$p = '<p>My thing is this <hr>Whatever';
 			$html = TimberHelper::close_tags($p);

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -179,6 +179,12 @@
 			$this->assertEquals('Four score and seven years ago&hellip;', $str);
 		}
 
+		function testFilterTrimCharacters() {
+			$gettysburg = 'Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men are created equal.';
+			$str = Timber::compile_string("{{content | excerpt_chars(100)}}", array('content' => $gettysburg));
+			$this->assertEquals('Four score and seven years ago our fathers brought forth on this continent, a new nation, co&hellip;', $str);
+		}
+
 		function testSetSimple() {
 			$result = Timber::compile('assets/set-simple.twig', array('foo' => 'bar'));
 			$this->assertEquals('jiggy', trim($result));


### PR DESCRIPTION
#### Issue
<!-- Description of the problem that this code change is solving -->

Add separate `Filter` class for commonly used filters. In this case add useful filter for trimming text
string to a certain amount of characters.
Decouple `Twig` class. Move all filter methods like `add_list_separators` , `time_ago`. (Not included in this pull request).

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

Create new class `Filter`. Add `trim_characters` method. Modify `Twig` class, add new `Twig_SimpleFilter`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->

Uses `mb_strimwidth` (PHP 4 >= 4.0.6, PHP 5, PHP 7) , wordpress functions `__()` for localization and
`wp_strip_all_tags` for striping all tags from input text.

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->

By default string is trimmed to 60 characters. 

```
   <p class="post-content__text">
                    {{ post.post_content|excerpt_chars }}
    </p>
```
You can specify desired characters amount 

```
   <p class="post-content__text">
                    {{ post.post_content|excerpt_chars(130) }}
    </p>
```

It is possible to specify custom excerpt (more text). By default `&hellip;` is used

```
   <p class="post-content__text">
                    {{ post.post_content|excerpt_chars(130,'[...]') }}
    </p>
```
#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

I would suggest to decouple `Twig` class and move all filters to the `Filter` class.
