### PR TITLE
allow passing an array of post_types to Post->children()

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -835,7 +835,7 @@ class Post extends Core implements CoreInterface {
 	 *     {% endfor %}
 	 * {% endif %}
 	 * ```
-	 * @param string $post_type _optional_ use to find children of a particular post type (attachment vs. page for example). You might want to restrict to certain types of children in case other stuff gets all mucked in there. You can use 'parent' to use the parent's post type
+	 * @param string|array $post_type _optional_ use to find children of a particular post type (attachment vs. page for example). You might want to restrict to certain types of children in case other stuff gets all mucked in there. You can use 'parent' to use the parent's post type or you can pass an array of post types.
 	 * @param string|bool $childPostClass _optional_ a custom post class (ex: 'MyTimber\Post') to return the objects as. By default (false) it will use Timber\Post::$post_class value.
 	 * @return array
 	 */
@@ -846,7 +846,10 @@ class Post extends Core implements CoreInterface {
 		if ( $post_type == 'parent' ) {
 			$post_type = $this->post_type;
 		}
-		$children = get_children('post_parent='.$this->ID.'&post_type='.$post_type.'&numberposts=-1&orderby=menu_order title&order=ASC&post_status=publish');
+		if (is_array($post_type)) {
+			$post_type = implode('&post_type[]=', $post_type);
+		}
+		$children = get_children('post_parent='.$this->ID.'&post_type[]='.$post_type.'&numberposts=-1&orderby=menu_order title&order=ASC&post_status=publish');
 		foreach ( $children as &$child ) {
 			$child = new $childPostClass($child->ID);
 		}


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
<!-- Description of the problem that this code change is solving -->
At the moment you can't pass an array of post types to the children function of the Post class.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Allow passing arrays.

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Should not affect backwards compatibility. Wordpress already supports querying for multiple post types.


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
You can pass an array to children()

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
I have only done some brief testing which seemed to work fine.

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
If needed I can help by adding a test.
