### PR TITLE
Delete generate files for image when metadata generated

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -166,7 +166,7 @@ class ImageHelper {
 	}
 
 	/**
-	 * Deletes all resized versions of an image when the source is deleted
+	 * Deletes all resized versions of an image when the source is deleted or its meta data is regenerated
 	 */
 	protected static function add_actions() {
 		add_action('delete_attachment', function( $post_id ) {
@@ -178,6 +178,17 @@ class ImageHelper {
 					ImageHelper::delete_generated_files($attachment->file_loc);
 				}
 			}
+		} );
+		add_filter('wp_generate_attachment_metadata', function( $metadata, $post_id ) {
+			$post = get_post($post_id);
+			$image_types = array('image/jpeg', 'image/png', 'image/gif', 'image/jpg');
+			if ( in_array($post->post_mime_type, $image_types) ) {
+				$attachment = new Image($post_id);
+				if ( $attachment->file_loc ) {
+					ImageHelper::delete_generated_files($attachment->file_loc);
+				}
+			}
+			return $metadata;
 		} );
 	}
 

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -170,24 +170,10 @@ class ImageHelper {
 	 */
 	protected static function add_actions() {
 		add_action('delete_attachment', function( $post_id ) {
-			$post = get_post($post_id);
-			$image_types = array('image/jpeg', 'image/png', 'image/gif', 'image/jpg');
-			if ( in_array($post->post_mime_type, $image_types) ) {
-				$attachment = new Image($post_id);
-				if ( $attachment->file_loc ) {
-					ImageHelper::delete_generated_files($attachment->file_loc);
-				}
-			}
+			ImageHelper::delete_generated_if_image($post_id);
 		} );
 		add_filter('wp_generate_attachment_metadata', function( $metadata, $post_id ) {
-			$post = get_post($post_id);
-			$image_types = array('image/jpeg', 'image/png', 'image/gif', 'image/jpg');
-			if ( in_array($post->post_mime_type, $image_types) ) {
-				$attachment = new Image($post_id);
-				if ( $attachment->file_loc ) {
-					ImageHelper::delete_generated_files($attachment->file_loc);
-				}
-			}
+			ImageHelper::delete_generated_if_image($post_id);
 			return $metadata;
 		} );
 	}
@@ -216,6 +202,24 @@ class ImageHelper {
 	}
 
 	//-- end of public methods --//
+
+	
+	/**
+	 * Checks if attachment is an image before deleting generated files
+	 *
+	 * @param  int  $post_id   an attachment post id
+	 *
+	 */
+	static function delete_generated_if_image( $post_id ) {
+		if ( wp_attachment_is_image( $post_id ) ) {
+			$attachment = new Image($post_id);
+			if ( $attachment->file_loc ) {
+				ImageHelper::delete_generated_files($attachment->file_loc);
+			}
+		}
+	}
+	
+	
 	/**
 	 * Deletes the auto-generated files for resize and letterboxing created by Timber
 	 * @param string  $local_file   ex: /var/www/wp-content/uploads/2015/my-pic.jpg


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
Generates files not affected when Wordpress regenerates thumbnails


#### Solution
Delete generated files for an image/attachment when Wordpress is called to regenerate thumbnails so that images generated by Timber can be regenerated when next called


#### Impact
All generated images for an attachment would be deleted and would be recreated when first accessed.
Backward compatible.


#### Usage
Just for folks to know that if they regenerate Wordpress thumbnails that any resized images created by Timber will be deleted and will only be regenerated when first accessed.


#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
No tests.
Without the code, generated images remain.
With the code, generated images are deleted for an image/attachment.

