### PR TITLE
Object factory usage

### DIFF
--- a/lib/Factory/Factory.php
+++ b/lib/Factory/Factory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class ObjectFactory
+ * @package Timber
+ *
+ * The ObjectFactory is a developer's way of converting WordPress objects into Timber ones!
+ * Passed a WordPress object or identifier, it will return Timber's core, corresponding object class by default.
+ * However, the ObjectFactory allows a developer to override this default with their own extension of the Timber objects.
+ *
+ */
+class Factory {
+
+	/**
+	 * @param \WP_Post|int|null $post_identifier
+	 *
+	 * @return \Timber\Post|null
+	 */
+	public static function get_post( $post_identifier = null, $class_default = null ) {
+		$post = Post::get_object( $post_identifier );
+
+		$class = ObjectClassFactory::get_class( 'post', get_post_type( $post ), $post, $class_default );
+
+		return $post ? new $class( $post ) : null;
+	}
+
+
+	/**
+	 * @param \WP_Term|int|string|null $term
+	 *
+	 *
+	 * @return \Timber\Term
+	 */
+	public static function get_term( $term = null, $taxonomy = 'category', $field = 'term_taxonomy_id', $class_default = null ) {
+		$term = Term::get_object( $term, $taxonomy, $field );
+
+		$class = ObjectClassFactory::get_class( 'term', $term->taxonomy, $term, $class_default );
+
+		return $term ? new $class( $term ) : null;
+	}
+}

--- a/lib/Factory/ObjectClassFactory.php
+++ b/lib/Factory/ObjectClassFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Timber\Factory;
+use Timber\Helper;
+
+/**
+ * Class ObjectFactoryClass
+ * @package Timber
+ */
+class ObjectClassFactory {
+
+	public static $PostClass = '\Timber\Post';
+	public static $TermClass = '\Timber\Term';
+
+	/**
+	 * @param string $type The object type–"post" or "term"
+	 * @param string|null $object_type The object's internal type–a post type or taxonomy
+	 * @param object|null $object The object for which the class is being retrieved
+	 * @param string|null $class The desired "default" class
+	 *
+	 * @return mixed|string
+	 */
+	public static function get_class( $type, $object_type = null, $object = null, $class = null ) {
+
+		$type = ucwords( $type );
+
+		$class_to_use = $default_class = static::${"{$type}Class"};
+
+		if ( ! $class ) {
+			$class = $default_class;
+		}
+
+		$class = apply_filters( "Timber\\${type}ClassMap", $class, $object_type, $object, $default_class );
+
+		if ( is_array( $class ) && is_string( $object_type ) ) {
+			if ( isset( $class[ $object_type ] ) ) {
+				$class_to_use = $class[ $object_type ];
+			} else {
+				Helper::error_log( $object_type . ' not found in ' . print_r( $class, true ) );
+			}
+		} elseif ( is_string( $class ) ) {
+			$class_to_use = $class;
+		} else {
+			Helper::error_log( "Unexpected value for {$type}Class: " . print_r( $class, true ) );
+		}
+
+		if ( ! class_exists( $class_to_use ) || ! ( is_subclass_of( $class_to_use, $default_class ) || is_a( $class_to_use, $default_class, true ) ) ) {
+			Helper::error_log( 'Class ' . $class_to_use . " either does not exist or implement $default_class" );
+		}
+
+		return $class_to_use;
+	}
+
+}

--- a/lib/Factory/ObjectFactoryInterface.php
+++ b/lib/Factory/ObjectFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Interface ObjectFactoryInterface
+ * @package Timber\Factory
+ */
+interface ObjectFactoryInterface {
+
+	/**
+	 * @param null $identifier
+	 *
+	 * @return mixed
+	 */
+	static function get_object( $identifier );
+}

--- a/lib/Factory/Post.php
+++ b/lib/Factory/Post.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Timber\Factory;
+
+use Timber\PostGetter;
+
+/**
+ * Class Post
+ * @package Timber\Factory
+ */
+class Post implements ObjectFactoryInterface {
+
+	/**
+	 * @param null $identifier
+	 *
+	 * @return \WP_Post|null
+	 */
+	static function get_object( $identifier = null ) {
+		$identifier = static::determine_id( $identifier );
+
+		return $identifier ? static::get_post_from_identifier( $identifier ) : null;
+	}
+
+	/**
+	 * @param $identifier
+	 *
+	 * @return false|int
+	 */
+	static function determine_id( $identifier ) {
+		if ( null === $identifier ) {
+			return static::determine_id_from_query();
+		}
+
+		return $identifier;
+	}
+
+	/**
+	 * Grabs the global post, from:
+	 * \WP_Query::queried_object_id
+	 *
+	 *
+	 *
+	 * @return false|int
+	 */
+	static function determine_id_from_query() {
+		global $wp_query;
+		$identifier = null;
+
+		if ( isset( $wp_query->queried_object_id )
+		     && $wp_query->queried_object_id
+		     && isset( $wp_query->queried_object )
+		     && is_object( $wp_query->queried_object )
+		     && get_class( $wp_query->queried_object ) == 'WP_Post'
+		) {
+			if ( isset( $_GET[ 'preview' ] ) && isset( $_GET[ 'preview_nonce' ] ) && wp_verify_nonce( $_GET[ 'preview_nonce' ], 'post_preview_' . $wp_query->queried_object_id ) ) {
+				$identifier = static::get_post_preview_id( $wp_query );
+			} else if ( ! $identifier ) {
+				$identifier = $wp_query->queried_object_id;
+			}
+		} else if ( $wp_query->is_home && isset( $wp_query->queried_object_id ) && $wp_query->queried_object_id ) {
+			//hack for static page as home page
+			$identifier = $wp_query->queried_object_id;
+		} else {
+			$identifier = get_the_ID();
+			if ( ! $identifier ) {
+				global $wp_query;
+				if ( isset( $wp_query->query[ 'p' ] ) ) {
+					$identifier = $wp_query->query[ 'p' ];
+				}
+			}
+		}
+
+		if ( $identifier === null && ( $identifier_from_loop = PostGetter::loop_to_id() ) ) {
+			$identifier = $identifier_from_loop;
+		}
+
+		return $identifier;
+	}
+
+	/**
+	 * @param $query
+	 *
+	 * @return bool|void
+	 */
+	protected static function get_post_preview_id( $query ) {
+		$can = array(
+			'edit_' . $query->queried_object->post_type . 's',
+		);
+
+		if ( $query->queried_object->author_id !== get_current_user_id() ) {
+			$can[] = 'edit_others_' . $query->queried_object->post_type . 's';
+		}
+
+		$can_preview = array();
+
+		foreach ( $can as $type ) {
+			if ( current_user_can( $type ) ) {
+				$can_preview[] = true;
+			}
+		}
+
+		if ( count( $can_preview ) !== count( $can ) ) {
+			return false;
+		}
+
+		$revisions = wp_get_post_revisions( $query->queried_object_id );
+
+		if ( ! empty( $revisions ) ) {
+			$revision = reset( $revisions );
+
+			return $revision->ID;
+		}
+
+		return false;
+	}
+
+	/**
+	 * takes a mix of integer (post ID), string (post slug),
+	 * or object to return a WordPress post object from WP's built-in get_post() function
+	 * @internal
+	 *
+	 * @param integer|string|object|\WP_Post $identifier
+	 *
+	 * @return \WP_Post|null
+	 */
+	protected static function get_post_from_identifier( $identifier = 0 ) {
+		if ( is_string( $identifier ) || is_numeric( $identifier ) || ( is_object( $identifier ) && ! isset( $identifier->post_title ) ) || $identifier === 0 ) {
+			$pid  = self::check_post_id( $identifier );
+			$post = get_post( $pid );
+			if ( $post ) {
+				return $post;
+			}
+		}
+
+		//we can skip if already is WP_Post
+		return $identifier;
+	}
+
+	/**
+	 * helps you find the post id regardless of whether you send a string or whatever
+	 *
+	 * @param integer $pid ;
+	 *
+	 * @internal
+	 * @return integer|null ID number of a post
+	 */
+	protected static function check_post_id( $pid ) {
+		if ( is_numeric( $pid ) && $pid === 0 ) {
+			$pid = get_the_ID();
+
+			return $pid;
+		}
+		if ( ! is_numeric( $pid ) && is_string( $pid ) ) {
+			$pid = self::get_post_id_by_name( $pid );
+
+			return $pid;
+		}
+		if ( ! $pid ) {
+			return null;
+		}
+
+		return $pid;
+	}
+
+	/**
+	 * get_post_id_by_name($post_name)
+	 * @internal
+	 *
+	 * @param string $post_name
+	 *
+	 * @return int
+	 */
+	public static function get_post_id_by_name( $post_name ) {
+		global $wpdb;
+		$query  = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_name = %s LIMIT 1", $post_name );
+		$result = $wpdb->get_row( $query );
+		if ( ! $result ) {
+			return null;
+		}
+
+		return $result->ID;
+	}
+
+
+}

--- a/lib/Factory/Post.php
+++ b/lib/Factory/Post.php
@@ -127,9 +127,7 @@ class Post implements ObjectFactoryInterface {
 		if ( is_string( $identifier ) || is_numeric( $identifier ) || ( is_object( $identifier ) && ! isset( $identifier->post_title ) ) || $identifier === 0 ) {
 			$pid  = self::check_post_id( $identifier );
 			$post = get_post( $pid );
-			if ( $post ) {
-				return $post;
-			}
+			return $post;
 		}
 
 		//we can skip if already is WP_Post

--- a/lib/Factory/Term.php
+++ b/lib/Factory/Term.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class Term
+ * @package Timber\Factory
+ */
+class Term implements ObjectFactoryInterface {
+
+	/**
+	 * @param int|string $identifier
+	 * @param string $taxonomy
+	 *
+	 * @return \WP_Term|null
+	 */
+	public static function get_object( $identifier = null, $taxonomy = 'category', $field = 'term_taxonomy_id' ) {
+
+		if ( is_object( $identifier ) ) {
+			return get_term( $identifier );
+		}
+
+		if ( $identifier === null ) {
+			$identifier = static::get_term_from_query();
+		}
+
+		if ( ! is_numeric( $identifier ) && 'term_taxonomy_id' === $field ) {
+			$field = 'slug';
+		}
+
+		return get_term_by( $field, $identifier, $taxonomy ) ?: null;
+	}
+
+	/**
+	 * @internal
+	 * @return integer
+	 */
+	protected static function get_term_from_query() {
+		global $wp_query;
+		if ( isset( $wp_query->queried_object ) ) {
+			$qo = $wp_query->queried_object;
+			if ( isset( $qo->term_id ) ) {
+				return $qo->term_id;
+			}
+		}
+		if ( isset( $wp_query->tax_query->queries[ 0 ][ 'terms' ][ 0 ] ) ) {
+			return $wp_query->tax_query->queries[ 0 ][ 'terms' ][ 0 ];
+		}
+
+		return null;
+	}
+
+}

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -3,6 +3,7 @@
 namespace Timber;
 
 use Timber\Core;
+use Timber\Factory\Factory;
 use Timber\Post;
 
 /**
@@ -209,7 +210,7 @@ class Menu extends Core {
 			if ( isset($item->ID) ) {
 				if ( is_object($item) && get_class($item) == 'WP_Post' ) {
 					$old_menu_item = $item;
-					$item = new $this->PostClass($item);
+					$item = Factory::get_post( $item, $this->PostClass );
 				}
 				$menu_item = new $this->MenuItemClass($item);
 				if ( isset($old_menu_item) ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -175,6 +175,12 @@ class Post extends Core implements CoreInterface {
 	 * @param mixed $pid
 	 */
 	public function __construct( $post ) {
+
+		if ( ! $post instanceof \WP_Post ) {
+			_doing_it_wrong( 'Timber\Term::__construct', 'Please use Timber\Factory\Factory::get_post() to instantiate Timber Posts', '2.0.0' );
+			$post = Factory::get_post( $post );
+		}
+
 		$post_info = $this->get_info( $post );
 		$this->import( $post_info );
 		//cant have a function, so gots to do it this way

--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\Factory;
 use Timber\Helper;
 use Timber\Post;
 
@@ -26,15 +27,8 @@ class PostCollection extends \ArrayObject {
 			$posts = array();
 		}
 		foreach ( $posts as $post_object ) {
-			$post_type      = get_post_type($post_object);
-			$post_class_use = PostGetter::get_post_class($post_type, $post_class);
 
-			// Don't create yet another object if $post_object is already of the right type
-			if ( is_a($post_object, $post_class_use) ) {
-				$post = $post_object;
-			} else {
-				$post = new $post_class_use($post_object);
-			}
+			$post = Factory::get_post( $post_object, $post_class );
 
 			if ( isset($post->ID) ) {
 				$returned_posts[] = $post;

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\Factory;
 use Timber\PostCollection;
 use Timber\QueryIterator;
 
@@ -17,7 +18,7 @@ class PostGetter {
 		if ( is_numeric($query) ) {
 			$post_type      = get_post_type($query);
 			$PostClass = PostGetter::get_post_class($post_type, $PostClass);
-			$post = new $PostClass($query);
+			$post = Factory::get_post( $query, $PostClass );
 			// get the latest revision if we're dealing with a preview
 			$posts = PostCollection::maybe_set_preview(array($post));
 			if ( $post = reset($posts) ) {

--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\Factory;
 use Timber\Helper;
 use Timber\PostCollection;
 
@@ -128,7 +129,7 @@ class QueryIterator implements \Iterator, \Countable {
 
 		// Sets up the global post, but also return the post, for use in Twig template
 		$posts_class = $this->_posts_class;
-		return new $posts_class($post);
+		return Factory::get_post( $post, $posts_class );
 	}
 
 	/**

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -5,6 +5,7 @@ namespace Timber;
 use Timber\Core;
 use Timber\CoreInterface;
 
+use Timber\Factory\Factory;
 use Timber\Post;
 use Timber\Helper;
 use Timber\URLHelper;
@@ -61,17 +62,23 @@ class Term extends Core implements CoreInterface {
 	public $taxonomy;
 
 	/**
-	 * @param int $tid
-	 * @param string $tax
+	 * @param \WP_Term $term
 	 */
-	public function __construct( $tid = null, $tax = '' ) {
-		if ( $tid === null ) {
-			$tid = $this->get_term_from_query();
+	public function __construct( $term ) {
+		if ( isset( $term->id ) ) {
+			$term->ID = $term->id;
+		} else if ( isset( $term->term_id ) ) {
+			$term->ID = $term->term_id;
 		}
-		if ( strlen($tax) ) {
-			$this->taxonomy = $tax;
+
+		if ( isset( $term->ID ) ) {
+			$term->id = $term->ID;
+			$this->import( $term );
+			if ( isset( $term->term_id ) ) {
+				$custom = $this->get_term_meta( $term->term_id );
+				$this->import( $custom );
+			}
 		}
-		$this->init($tid);
 	}
 
 	/**
@@ -91,51 +98,6 @@ class Term extends Core implements CoreInterface {
 		return new static($tid, $taxonomy);
 	}
 
-
-	/* Setup
-	===================== */
-
-	/**
-	 * @internal
-	 * @return integer
-	 */
-	protected function get_term_from_query() {
-		global $wp_query;
-		if ( isset($wp_query->queried_object) ) {
-			$qo = $wp_query->queried_object;
-			if ( isset($qo->term_id) ) {
-				return $qo->term_id;
-			}
-		}
-		if ( isset($wp_query->tax_query->queries[0]['terms'][0]) ) {
-			return $wp_query->tax_query->queries[0]['terms'][0];
-		}
-	}
-
-	/**
-	 * @internal
-	 * @param int $tid
-	 */
-	protected function init( $tid ) {
-		$term = $this->get_term($tid);
-		if ( isset($term->id) ) {
-			$term->ID = $term->id;
-		} else if ( isset($term->term_id) ) {
-			$term->ID = $term->term_id;
-		} else if ( is_string($tid) ) {
-			//echo 'bad call using '.$tid;
-			//Helper::error_log(debug_backtrace());
-		}
-		if ( isset($term->ID) ) {
-			$term->id = $term->ID;
-			$this->import($term);
-			if ( isset($term->term_id) ) {
-				$custom = $this->get_term_meta($term->term_id);
-				$this->import($custom);
-			}
-		}
-	}
-
 	/**
 	 * @internal
 	 * @param int $tid
@@ -145,58 +107,6 @@ class Term extends Core implements CoreInterface {
 		$customs = array();
 		$customs = apply_filters('timber_term_get_meta', $customs, $tid, $this);
 		return apply_filters('timber/term/meta', $customs, $tid, $this);
-	}
-
-	/**
-	 * @internal
-	 * @param int $tid
-	 * @return mixed
-	 */
-	protected function get_term( $tid ) {
-		if ( is_object($tid) || is_array($tid) ) {
-			return $tid;
-		}
-		$tid = self::get_tid($tid);
-
-		if ( isset($this->taxonomy) && strlen($this->taxonomy) ) {
-			return get_term($tid, $this->taxonomy);
-		} else {
-			global $wpdb;
-			$query = $wpdb->prepare("SELECT taxonomy FROM $wpdb->term_taxonomy WHERE term_id = %d LIMIT 1", $tid);
-			$tax = $wpdb->get_var($query);
-			if ( isset($tax) && strlen($tax) ) {
-				$this->taxonomy = $tax;
-				return get_term($tid, $tax);
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * @internal
-	 * @param int $tid
-	 * @return int
-	 */
-	protected function get_tid( $tid ) {
-		global $wpdb;
-		if ( is_numeric($tid) ) {
-			return $tid;
-		}
-		if ( gettype($tid) == 'object' ) {
-			$tid = $tid->term_id;
-		}
-		if ( is_numeric($tid) ) {
-			$query = $wpdb->prepare("SELECT * FROM $wpdb->terms WHERE term_id = %d", $tid);
-		} else {
-			$query = $wpdb->prepare("SELECT * FROM $wpdb->terms WHERE slug = %s", $tid);
-		}
-		$result = $wpdb->get_row($query);
-		if ( isset($result->term_id) ) {
-			$result->ID = $result->term_id;
-			$result->id = $result->term_id;
-			return $result->ID;
-		}
-		return 0;
 	}
 
 	/* Public methods
@@ -302,7 +212,7 @@ class Term extends Core implements CoreInterface {
 		if ( !isset($this->_children) ) {
 			$children = get_term_children($this->ID, $this->taxonomy);
 			foreach ( $children as &$child ) {
-				$child = new Term($child);
+				$child = Factory::get_term( $child );
 			}
 			$this->_children = $children;
 		}

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -62,9 +62,16 @@ class Term extends Core implements CoreInterface {
 	public $taxonomy;
 
 	/**
-	 * @param \WP_Term $term
+	 * @param \WP_Term|mixed $term
+	 * @param string $tax Deprecated as of v2.0.0
 	 */
-	public function __construct( $term ) {
+	public function __construct( $term, $tax = 'category' ) {
+
+		if ( ! $term instanceof \WP_Term ) {
+			_doing_it_wrong( 'Timber\Term::__construct', 'Please use Timber\Factory\Factory::get_term() to instantiate Timber Terms', '2.0.0' );
+			$term = Factory::get_term( $term, $tax );
+		}
+
 		if ( isset( $term->id ) ) {
 			$term->ID = $term->id;
 		} else if ( isset( $term->term_id ) ) {
@@ -89,13 +96,16 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
+	 *
+	 * @deprecated Use Factory::get_term()
+	 *
 	 * @param $tid
 	 * @param $taxonomy
 	 *
-	 * @return static
+	 * @return Term
 	 */
 	public static function from( $tid, $taxonomy ) {
-		return new static($tid, $taxonomy);
+		return Factory::get_term( $tid, $taxonomy );
 	}
 
 	/**

--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\Factory;
 use Timber\Term;
 use Timber\Helper;
 
@@ -12,8 +13,7 @@ class TermGetter {
 	 * @return Timber\Term|WP_Error|null
 	 */
 	public static function get_term( $term, $taxonomy, $TermClass = '\Timber\Term' ) {
-		$term = get_term($term, $taxonomy);
-		return new $TermClass($term->term_id, $term->taxonomy);
+		return Factory::get_term( $term, $taxonomy, null, $TermClass );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class TermGetter {
 		}
 		$terms = get_terms($taxonomies, $args);
 		foreach ( $terms as &$term ) {
-			$term = new $TermClass($term->term_id, $term->taxonomy);
+			$term = Factory::get_term( $term, null, null, $TermClass );
 		}
 		return $terms;
 	}

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\Factory;
 use Timber\URLHelper;
 use Timber\Helper;
 
@@ -97,11 +98,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('TimberPost', function( $pid, $PostClass = 'Timber\Post' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $PostClass($p);
+							$p = Factory::get_post( $p, $PostClass );
 						}
 						return $pid;
 					}
-					return new $PostClass($pid);
+					return Factory::get_post( $pid, $PostClass );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('TimberImage', function( $pid = false, $ImageClass = 'Timber\Image' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
@@ -136,11 +137,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('Post', function( $pid, $PostClass = 'Timber\Post' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $PostClass($p);
+							$p = Factory::get_post( $p, $PostClass );
 						}
 						return $pid;
 					}
-					return new $PostClass($pid);
+					return Factory::get_post( $pid, $PostClass );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('Image', function( $pid, $ImageClass = 'Timber\Image' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -117,11 +117,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('TimberTerm', function( $pid, $TermClass = 'Timber\Term' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $TermClass($p);
+							$p = Factory::get_term( $p, $TermClass );
 						}
 						return $pid;
 					}
-					return new $TermClass($pid);
+					return Factory::get_term( $pid, $TermClass );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('TimberUser', function( $pid, $UserClass = 'Timber\User' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
@@ -155,11 +155,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('Term', function( $pid, $TermClass = 'Timber\Term' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $TermClass($p);
+							$p = Factory::get_term( $p, $TermClass );
 						}
 						return $pid;
 					}
-					return new $TermClass($pid);
+					return Factory::get_term( $pid, $TermClass );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('User', function( $pid, $UserClass = 'Timber\User' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {


### PR DESCRIPTION
Note that #1218 should be reviewed first! This builds off of that PR.
#### Issue

Timber directly instantiates objects of its own classes. Factories allow abstraction of this process.
#### Solution

This builds off of the introduction of the WP Object Factory to showcase how the factory could be implemented.
#### Impact

BC was maintained by allowing direct instantiation of the objects, passing through to the factory in the constructor.
#### Usage

Classes should not be directly instantiated; they should be passed through the new factory.
#### Considerations

I don't have extensive Timber experience, so it's possible I missed a use-case or instantiation type to cover in the factory.
#### Testing

Yet to be done!
