### PR TITLE
Feature/interfaced object factories

### DIFF
--- a/lib/Factory/Factory.php
+++ b/lib/Factory/Factory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class Factory
+ * @package Timber\Factory
+ */
+abstract class Factory implements FactoryInterface {
+
+	protected $object_class = null;
+
+	/**
+	 * Factory constructor.
+	 *
+	 * @param string $object_class
+	 */
+	function __construct( $object_class = '' ) {
+		if ( $object_class && class_exists( $object_class ) ) {
+			$this->object_class = $object_class;
+		}
+	}
+
+}

--- a/lib/Factory/FactoryInterface.php
+++ b/lib/Factory/FactoryInterface.php
@@ -9,11 +9,9 @@ namespace Timber\Factory;
 interface FactoryInterface {
 
 	/**
-	 * @param $object_class string The class to use to instantiate the retrieved object
-	 *
 	 * @return object
 	 */
-	public static function get( $object_class = '' );
+	public static function get();
 
 	/**
 	 * @return object

--- a/lib/Factory/FactoryInterface.php
+++ b/lib/Factory/FactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Interface FactoryInterface
+ * @package Timber\Factory
+ */
+interface FactoryInterface {
+
+	/**
+	 * @param $object_class string The class to use to instantiate the retrieved object
+	 *
+	 * @return object
+	 */
+	public static function get( $object_class = '' );
+
+	/**
+	 * @return object
+	 */
+	public function get_object();
+
+}

--- a/lib/Factory/ObjectClassFactory.php
+++ b/lib/Factory/ObjectClassFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Timber\Factory;
+use Timber\Helper;
+
+/**
+ * Class ObjectFactoryClass
+ * @package Timber
+ */
+class ObjectClassFactory {
+
+	public static $TermClass = '\Timber\Term';
+	public static $PostClass = '\Timber\Post';
+
+	/**
+	 * @param string $type The object type–"post" or "term"
+	 * @param string|null $object_type The object's internal type–a post type or taxonomy
+	 * @param object|null $object The object for which the class is being retrieved
+	 * @param string|null $class The desired "default" class
+	 *
+	 * @return mixed|string
+	 */
+	public static function get_class( $type, $object_type = null, $object = null, $class = null ) {
+
+		$type = ucwords( $type );
+
+		$class_to_use = $default_class = static::${"{$type}Class"};
+
+		if ( ! $class ) {
+			$class = $default_class;
+		}
+
+		$class = apply_filters( "Timber\\${type}ClassMap", $class, $object_type, $object, $default_class );
+
+		if ( is_array( $class ) && is_string( $object_type ) ) {
+			if ( isset( $class[ $object_type ] ) ) {
+				$class_to_use = $class[ $object_type ];
+			} else {
+				Helper::error_log( $object_type . ' not found in ' . print_r( $class, true ) );
+			}
+		} elseif ( is_string( $class ) ) {
+			$class_to_use = $class;
+		} else {
+			Helper::error_log( "Unexpected value for {$type}Class: " . print_r( $class, true ) );
+		}
+
+		if ( ! class_exists( $class_to_use ) || ! ( is_subclass_of( $class_to_use, $default_class ) || is_a( $class_to_use, $default_class, true ) ) ) {
+			Helper::error_log( 'Class ' . $class_to_use . " either does not exist or implement $default_class" );
+		}
+
+		return $class_to_use;
+	}
+
+}

--- a/lib/Factory/ObjectClassFactory.php
+++ b/lib/Factory/ObjectClassFactory.php
@@ -24,20 +24,26 @@ class ObjectClassFactory {
 
 		$type = ucwords( $type );
 
-		$class_to_use = $default_class = static::${"{$type}Class"};
+		$default_class = static::${"{$type}Class"};
+		$class_to_use = $class;
 
-		$class = apply_filters( "Timber\\${type}ClassMap", $class, $object_type, $object, $default_class );
+		if ( ! $class_to_use || $class_to_use && ! class_exists( $class_to_use ) ) {
 
-		if ( is_string( $class ) ) {
-			$class_to_use = $class;
-		} else if ( is_array( $class ) && is_string( $object_type ) ) {
-			if ( isset( $class[ $object_type ] ) ) {
-				$class_to_use = $class[ $object_type ];
+			$class_to_use = $default_class;
+			$class = apply_filters( "Timber\\${type}ClassMap", $class, $object_type, $object, $default_class );
+
+			if ( is_string( $class ) ) {
+				$class_to_use = $class;
+			} else if ( is_array( $class ) && is_string( $object_type ) ) {
+				if ( isset( $class[ $object_type ] ) ) {
+					$class_to_use = $class[ $object_type ];
+				} else {
+					Helper::error_log( $object_type . ' not found in ' . print_r( $class, true ) );
+				}
 			} else {
-				Helper::error_log( $object_type . ' not found in ' . print_r( $class, true ) );
+				Helper::error_log( "Unexpected value for {$type}Class: " . print_r( $class, true ) );
 			}
-		} else {
-			Helper::error_log( "Unexpected value for {$type}Class: " . print_r( $class, true ) );
+
 		}
 
 		if ( ! class_exists( $class_to_use ) || ! ( is_subclass_of( $class_to_use, $default_class ) || is_a( $class_to_use, $default_class, true ) ) ) {

--- a/lib/Factory/ObjectClassFactory.php
+++ b/lib/Factory/ObjectClassFactory.php
@@ -44,7 +44,7 @@ class ObjectClassFactory {
 			Helper::error_log( 'Class ' . $class_to_use . " either does not exist or implement $default_class" );
 		}
 
-		return apply_filters( 'Timber\PostClass', $class_to_use, $object_type, $object_type, $default_class );
+		return apply_filters( "Timber\\${type}Class", $class_to_use, $object_type, $object_type, $default_class );
 	}
 
 }

--- a/lib/Factory/ObjectClassFactory.php
+++ b/lib/Factory/ObjectClassFactory.php
@@ -16,7 +16,7 @@ class ObjectClassFactory {
 	 * @param string $type The object type–"post" or "term"
 	 * @param string|null $object_type The object's internal type–a post type or taxonomy
 	 * @param object|null $object The object for which the class is being retrieved
-	 * @param string|null $class The desired "default" class
+	 * @param string|null $class The desired class; overrides results of Timber\${type}ClassMap filter
 	 *
 	 * @return mixed|string
 	 */
@@ -26,20 +26,16 @@ class ObjectClassFactory {
 
 		$class_to_use = $default_class = static::${"{$type}Class"};
 
-		if ( ! $class ) {
-			$class = $default_class;
-		}
-
 		$class = apply_filters( "Timber\\${type}ClassMap", $class, $object_type, $object, $default_class );
 
-		if ( is_array( $class ) && is_string( $object_type ) ) {
+		if ( is_string( $class ) ) {
+			$class_to_use = $class;
+		} else if ( is_array( $class ) && is_string( $object_type ) ) {
 			if ( isset( $class[ $object_type ] ) ) {
 				$class_to_use = $class[ $object_type ];
 			} else {
 				Helper::error_log( $object_type . ' not found in ' . print_r( $class, true ) );
 			}
-		} elseif ( is_string( $class ) ) {
-			$class_to_use = $class;
 		} else {
 			Helper::error_log( "Unexpected value for {$type}Class: " . print_r( $class, true ) );
 		}
@@ -48,7 +44,7 @@ class ObjectClassFactory {
 			Helper::error_log( 'Class ' . $class_to_use . " either does not exist or implement $default_class" );
 		}
 
-		return $class_to_use;
+		return apply_filters( 'Timber\PostClass', $class_to_use, $object_type, $object_type, $default_class );
 	}
 
 }

--- a/lib/Factory/ObjectGetterInterface.php
+++ b/lib/Factory/ObjectGetterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Interface ObjectGetterInterface
+ * @package Timber\Factory
+ */
+interface ObjectGetterInterface {
+
+	/**
+	 * @param null $identifier
+	 *
+	 * @return mixed
+	 */
+	static function get_object( $identifier );
+}

--- a/lib/Factory/PostFactory.php
+++ b/lib/Factory/PostFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class PostFactory
+ * @package Timber
+ */
+class PostFactory extends Factory implements FactoryInterface {
+
+	/**
+	 * @param \WP_Post|int|string|null $post_identifier
+	 *
+	 * @return \Timber\Post|null
+	 */
+	public static function get( $post_identifier = null ) {
+		return ( new self() )->get_object();
+	}
+
+	/**
+	 * @param \WP_Post|int|null $post_identifier
+	 *
+	 * @return \Timber\Post|null
+	 */
+	public function get_object( $post_identifier = null ) {
+		$post = PostGetter::get_object( $post_identifier );
+
+		$class = ObjectClassFactory::get_class( 'post', get_post_type( $post ), $post, $this->object_class );
+
+		return $post ? new $class( $post ) : null;
+	}
+}

--- a/lib/Factory/PostFactory.php
+++ b/lib/Factory/PostFactory.php
@@ -14,7 +14,7 @@ class PostFactory extends Factory implements FactoryInterface {
 	 * @return \Timber\Post|null
 	 */
 	public static function get( $post_identifier = null ) {
-		return ( new self() )->get_object();
+		return ( new self() )->get_object( $post_identifier );
 	}
 
 	/**

--- a/lib/Factory/PostGetter.php
+++ b/lib/Factory/PostGetter.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class Post
+ * @package Timber\Factory
+ */
+class PostGetter implements ObjectGetterInterface {
+
+	/**
+	 * @param null $identifier
+	 *
+	 * @return \WP_Post|null
+	 */
+	static function get_object( $identifier = null ) {
+		$identifier = static::determine_id( $identifier );
+
+		return $identifier ? static::get_post_from_identifier( $identifier ) : null;
+	}
+
+	/**
+	 * @param $identifier
+	 *
+	 * @return false|int
+	 */
+	static function determine_id( $identifier ) {
+		if ( null === $identifier ) {
+			return static::determine_id_from_query();
+		}
+
+		return $identifier;
+	}
+
+	/**
+	 * Grabs the global post, from:
+	 * \WP_Query::queried_object_id
+	 *
+	 *
+	 *
+	 * @return false|int
+	 */
+	static function determine_id_from_query() {
+		global $wp_query;
+		$identifier = null;
+
+		if ( isset( $wp_query->queried_object_id )
+		     && $wp_query->queried_object_id
+		     && isset( $wp_query->queried_object )
+		     && is_object( $wp_query->queried_object )
+		     && get_class( $wp_query->queried_object ) == 'WP_Post'
+		) {
+			if ( isset( $_GET[ 'preview' ] ) && isset( $_GET[ 'preview_nonce' ] ) && wp_verify_nonce( $_GET[ 'preview_nonce' ], 'post_preview_' . $wp_query->queried_object_id ) ) {
+				$identifier = static::get_post_preview_id( $wp_query );
+			} else if ( ! $identifier ) {
+				$identifier = $wp_query->queried_object_id;
+			}
+		} else if ( $wp_query->is_home && isset( $wp_query->queried_object_id ) && $wp_query->queried_object_id ) {
+			//hack for static page as home page
+			$identifier = $wp_query->queried_object_id;
+		} else {
+			$identifier = get_the_ID();
+			if ( ! $identifier ) {
+				global $wp_query;
+				if ( isset( $wp_query->query[ 'p' ] ) ) {
+					$identifier = $wp_query->query[ 'p' ];
+				}
+			}
+		}
+
+		if ( $identifier === null && ( $identifier_from_loop = PostGetter::loop_to_id() ) ) {
+			$identifier = $identifier_from_loop;
+		}
+
+		return $identifier;
+	}
+
+	/**
+	 * @param $query
+	 *
+	 * @return bool|void
+	 */
+	protected static function get_post_preview_id( $query ) {
+		$can = array(
+			'edit_' . $query->queried_object->post_type . 's',
+		);
+
+		if ( $query->queried_object->author_id !== get_current_user_id() ) {
+			$can[] = 'edit_others_' . $query->queried_object->post_type . 's';
+		}
+
+		$can_preview = array();
+
+		foreach ( $can as $type ) {
+			if ( current_user_can( $type ) ) {
+				$can_preview[] = true;
+			}
+		}
+
+		if ( count( $can_preview ) !== count( $can ) ) {
+			return false;
+		}
+
+		$revisions = wp_get_post_revisions( $query->queried_object_id );
+
+		if ( ! empty( $revisions ) ) {
+			$revision = reset( $revisions );
+
+			return $revision->ID;
+		}
+
+		return false;
+	}
+
+	/**
+	 * takes a mix of integer (post ID), string (post slug),
+	 * or object to return a WordPress post object from WP's built-in get_post() function
+	 * @internal
+	 *
+	 * @param integer|string|object|\WP_Post $identifier
+	 *
+	 * @return \WP_Post|null
+	 */
+	protected static function get_post_from_identifier( $identifier = 0 ) {
+		if ( is_string( $identifier ) || is_numeric( $identifier ) || ( is_object( $identifier ) && ! isset( $identifier->post_title ) ) || $identifier === 0 ) {
+			$pid  = self::check_post_id( $identifier );
+			$post = get_post( $pid );
+			return $post;
+		}
+
+		//we can skip if already is WP_Post
+		return $identifier;
+	}
+
+	/**
+	 * helps you find the post id regardless of whether you send a string or whatever
+	 *
+	 * @param integer $pid ;
+	 *
+	 * @internal
+	 * @return integer|null ID number of a post
+	 */
+	protected static function check_post_id( $pid ) {
+		if ( is_numeric( $pid ) && $pid === 0 ) {
+			$pid = get_the_ID();
+
+			return $pid;
+		}
+		if ( ! is_numeric( $pid ) && is_string( $pid ) ) {
+			$pid = self::get_post_id_by_name( $pid );
+
+			return $pid;
+		}
+		if ( ! $pid ) {
+			return null;
+		}
+
+		return $pid;
+	}
+
+	/**
+	 * get_post_id_by_name($post_name)
+	 * @internal
+	 *
+	 * @param string $post_name
+	 *
+	 * @return int
+	 */
+	public static function get_post_id_by_name( $post_name ) {
+		global $wpdb;
+		$query  = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_name = %s LIMIT 1", $post_name );
+		$result = $wpdb->get_row( $query );
+		if ( ! $result ) {
+			return null;
+		}
+
+		return $result->ID;
+	}
+
+
+}

--- a/lib/Factory/TermFactory.php
+++ b/lib/Factory/TermFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class Term
+ * @package Timber\Factory
+ */
+class TermFactory extends Factory implements FactoryInterface {
+
+
+	/**
+	 * @param \WP_Term|int|string|null $term $term
+	 * @param string $taxonomy
+	 * @param string $field
+	 *
+	 * @return \Timber\Term
+	 */
+	public static function get( $term = null, $taxonomy = 'category', $field = 'term_taxonomy_id' ) {
+		return ( new self() )->get_object( $term, $taxonomy, $field );
+	}
+
+	/**
+	 * @param \WP_Term|int|string|null $term
+	 *
+	 *
+	 * @return \Timber\Term
+	 */
+	public function get_object( $term = null, $taxonomy = 'category', $field = 'term_taxonomy_id' ) {
+		$term = TermGetter::get_object( $term, $taxonomy, $field );
+
+		$class = ObjectClassFactory::get_class( 'term', $term->taxonomy, $term, $this->object_class );
+
+		return $term ? new $class( $term ) : null;
+	}
+
+}

--- a/lib/Factory/TermGetter.php
+++ b/lib/Factory/TermGetter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Timber\Factory;
+
+/**
+ * Class TermGetter
+ * @package Timber\Factory
+ */
+class TermGetter implements ObjectGetterInterface {
+
+	/**
+	 * @param int|string $identifier
+	 * @param string $taxonomy
+	 *
+	 * @return \WP_Term|null
+	 */
+	public static function get_object( $identifier = null, $taxonomy = 'category', $field = 'term_taxonomy_id' ) {
+
+		if ( is_object( $identifier ) ) {
+			return get_term( $identifier );
+		}
+
+		if ( $identifier === null ) {
+			$identifier = static::get_term_from_query();
+		}
+
+		if ( ! is_numeric( $identifier ) && 'term_taxonomy_id' === $field ) {
+			$field = 'slug';
+		}
+
+		return get_term_by( $field, $identifier, $taxonomy ) ?: null;
+	}
+
+	/**
+	 * @internal
+	 * @return integer
+	 */
+	protected static function get_term_from_query() {
+		global $wp_query;
+		if ( isset( $wp_query->queried_object ) ) {
+			$qo = $wp_query->queried_object;
+			if ( isset( $qo->term_id ) ) {
+				return $qo->term_id;
+			}
+		}
+		if ( isset( $wp_query->tax_query->queries[ 0 ][ 'terms' ][ 0 ] ) ) {
+			return $wp_query->tax_query->queries[ 0 ][ 'terms' ][ 0 ];
+		}
+
+		return null;
+	}
+
+}

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -399,17 +399,6 @@ class Image extends Post implements CoreInterface {
 
 	/**
 	 * @api
-	 * @return bool|TimberPost
-	 */
-	public function parent() {
-		if ( !$this->post_parent ) {
-			return false;
-		}
-		return new $this->PostClass($this->post_parent);
-	}
-
-	/**
-	 * @api
 	 * @example
 	 * ```twig
 	 * <img src="{{ image.path }}" />

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -3,6 +3,7 @@
 namespace Timber;
 
 use Timber\Core;
+use Timber\Factory\PostFactory;
 use Timber\Post;
 
 /**
@@ -48,7 +49,6 @@ use Timber\Post;
 class Menu extends Core {
 
 	public $MenuItemClass = 'Timber\MenuItem';
-	public $PostClass = 'Timber\Post';
 
 	/**
 	 * @api
@@ -209,7 +209,7 @@ class Menu extends Core {
 			if ( isset($item->ID) ) {
 				if ( is_object($item) && get_class($item) == 'WP_Post' ) {
 					$old_menu_item = $item;
-					$item = new $this->PostClass($item);
+					$item = PostFactory::get( $item );
 				}
 				$menu_item = new $this->MenuItemClass($item);
 				if ( isset($old_menu_item) ) {

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -5,6 +5,8 @@ namespace Timber;
 use Timber\Core;
 use Timber\CoreInterface;
 
+use Timber\Factory\PostFactory;
+use Timber\Factory\TermFactory;
 use Timber\URLHelper;
 
 class MenuItem extends Core implements CoreInterface {
@@ -16,8 +18,6 @@ class MenuItem extends Core implements CoreInterface {
 	public $level = 0;
 	public $post_name;
 	public $url;
-
-	public $PostClass = 'Timber\Post';
 
 	protected $_name;
 	protected $_menu_item_object_id;
@@ -40,6 +40,7 @@ class MenuItem extends Core implements CoreInterface {
 		$this->name = $this->name();
 		$this->add_class('menu-item-'.$this->ID);
 		$this->menu_object = $data;
+		$this->master_object = $this->get_master_object();
 	}
 
 	/**
@@ -47,6 +48,27 @@ class MenuItem extends Core implements CoreInterface {
 	 */
 	public function __toString() {
 		return $this->name();
+	}
+
+	/**
+	 * Magic getter
+	 *
+	 * Checks to see if this object has the property/method, via Core::__get
+	 * Falls back to ::__get of the master object of this menu item
+	 *
+	 * @param $field
+	 *
+	 * @return mixed
+	 */
+	public function __get( $field ) {
+		$self = parent::__get( $field );
+		if ( $self ) {
+			return $self;
+		}
+		return (
+			is_object( $this->master_object)
+			&& is_subclass_of( $this->master_object, '\Timber\Core' )
+		) ? $this->master_object->__get( $field ) : null;
 	}
 
 	/**
@@ -102,9 +124,19 @@ class MenuItem extends Core implements CoreInterface {
 	 * @return mixed whatever object (Post, Term, etc.) the menu item represents
 	 */
 	protected function get_master_object() {
-		if ( isset($this->_menu_item_object_id) ) {
-			return new $this->PostClass($this->_menu_item_object_id);
+		if ( isset( $this->_menu_item_type ) ) {
+			switch ( $this->_menu_item_type ) {
+				case 'taxonomy':
+					return TermFactory::get( $this->object_id );
+					break;
+				default:
+					return PostFactory::get( $this->object_id );
+					break;
+			}
 		}
+
+		return null;
+
 	}
 
 	/**

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -56,16 +56,6 @@ class Post extends Core implements CoreInterface {
 	public $ImageClass = 'Timber\Image';
 
 	/**
-	 * @var string $PostClass the name of the class to handle posts by default
-	 */
-	public $PostClass = 'Timber\Post';
-
-	/**
-	 * @var string $TermClass the name of the class to handle terms by default
-	 */
-	public $TermClass = 'Timber\Term';
-
-	/**
 	 * @var string $object_type what does this class represent in WordPress terms?
 	 */
 	public $object_type = 'post';
@@ -418,7 +408,6 @@ class Post extends Core implements CoreInterface {
 	 */
 	public function terms( $tax = '', $merge = true, $TermClass = '' ) {
 		$taxonomies = array();
-		$TermClass = $TermClass ?: $this->TermClass;
 
 		if ( is_string($merge) && class_exists($merge) ) {
 			$TermClass = $merge;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -177,8 +177,8 @@ class Post extends Core implements CoreInterface {
 	 */
 	public function __construct( $post ) {
 
-		if ( ! $post instanceof \WP_Post ) {
-			_doing_it_wrong( 'Timber\Term::__construct', 'Please use Timber\Factory\PostFactory::get() to instantiate Timber Posts', '2.0.0' );
+		if ( ! $post instanceof \WP_Post && ! $post instanceof Post ) {
+			_doing_it_wrong( 'Timber\Post::__construct', 'Please use Timber\Factory\PostFactory::get() to instantiate Timber Posts', '2.0.0' );
 			$post = PostFactory::get( $post );
 		}
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -5,6 +5,8 @@ namespace Timber;
 use Timber\Core;
 use Timber\CoreInterface;
 
+use Timber\Factory\PostFactory;
+use Timber\Factory\TermFactory;
 use Timber\Term;
 use Timber\User;
 use Timber\Image;
@@ -173,54 +175,18 @@ class Post extends Core implements CoreInterface {
 	 * ```
 	 * @param mixed $pid
 	 */
-	public function __construct( $pid = null ) {
-		$pid = $this->determine_id($pid);
-		$this->init($pid);
-	}
+	public function __construct( $post ) {
 
-	/**
-	 * tries to figure out what post you want to get if not explictly defined (or if it is, allows it to be passed through)
-	 * @internal
-	 * @param mixed a value to test against
-	 * @return int the numberic id we should be using for this post object
-	 */
-	protected function determine_id( $pid ) {
-		global $wp_query;
-		if ( $pid === null &&
-			isset($wp_query->queried_object_id)
-			&& $wp_query->queried_object_id
-			&& isset($wp_query->queried_object)
-			&& is_object($wp_query->queried_object)
-			&& get_class($wp_query->queried_object) == 'WP_Post'
-			) {
-				if ( isset($_GET['preview']) && isset($_GET['preview_nonce']) && wp_verify_nonce($_GET['preview_nonce'], 'post_preview_'.$wp_query->queried_object_id) ) {
-					$pid = $this->get_post_preview_id($wp_query);
-				} else if ( !$pid ) {
-					$pid = $wp_query->queried_object_id;
-				}
-		} else if ( $pid === null && $wp_query->is_home && isset($wp_query->queried_object_id) && $wp_query->queried_object_id ) {
-			//hack for static page as home page
-			$pid = $wp_query->queried_object_id;
-		} else if ( $pid === null ) {
-			$gtid = false;
-			$maybe_post = get_post();
-			if ( isset($maybe_post->ID) ) {
-				$gtid = true;
-			}
-			if ( $gtid ) {
-				$pid = get_the_ID();
-			}
-			if ( !$pid ) {
-				global $wp_query;
-				if ( isset($wp_query->query['p']) ) {
-					$pid = $wp_query->query['p'];
-				}
-			}
+		if ( ! $post instanceof \WP_Post ) {
+			_doing_it_wrong( 'Timber\Term::__construct', 'Please use Timber\Factory\PostFactory::get() to instantiate Timber Posts', '2.0.0' );
+			$post = PostFactory::get( $post );
 		}
-		if ( $pid === null && ($pid_from_loop = PostGetter::loop_to_id()) ) {
-			$pid = $pid_from_loop;
-		}
-		return $pid;
+
+		$post_info = $this->get_info( $post );
+		$this->import( $post_info );
+		//cant have a function, so gots to do it this way
+		$post_class  = $this->post_class();
+		$this->class = $post_class;
 	}
 
 	/**
@@ -229,56 +195,6 @@ class Post extends Core implements CoreInterface {
 	 */
 	public function __toString() {
 		return $this->title();
-	}
-
-	protected function get_post_preview_id( $query ) {
-		$can = array(
-	 		'edit_'.$query->queried_object->post_type.'s',
-	 	);
-
-	 	if ( $query->queried_object->author_id !== get_current_user_id() ) {
-	 		$can[] = 'edit_others_'.$query->queried_object->post_type.'s';
-	 	}
-
-	 	$can_preview = array();
-
-		foreach ( $can as $type ) {
-			 if ( current_user_can($type) ) {
-				$can_preview[] = true;
-			 }
-		}
-
-		if ( count($can_preview) !== count($can) ) {
-			 return;
-		}
-
-		$revisions = wp_get_post_revisions($query->queried_object_id);
-
-		if ( !empty($revisions) ) {
-			$revision = reset($revisions);
-			return $revision->ID;
-		}
-
-		return false;
-	}
-
-	/**
-	 * Initializes a Post
-	 * @internal
-	 * @param integer $pid
-	 */
-	protected function init( $pid = false ) {
-		if ( $pid === false ) {
-			$pid = get_the_ID();
-		}
-		if ( is_numeric($pid) ) {
-			$this->ID = $pid;
-		}
-		$post_info = $this->get_info($pid);
-		$this->import($post_info);
-		//cant have a function, so gots to do it this way
-		$post_class = $this->post_class();
-		$this->class = $post_class;
 	}
 
 	/**
@@ -303,65 +219,6 @@ class Post extends Core implements CoreInterface {
 			update_post_meta($this->ID, $field, $value);
 			$this->$field = $value;
 		}
-	}
-
-
-	/**
-	 * takes a mix of integer (post ID), string (post slug),
-	 * or object to return a WordPress post object from WP's built-in get_post() function
-	 * @internal
-	 * @param integer $pid
-	 * @return WP_Post on success
-	 */
-	protected function prepare_post_info( $pid = 0 ) {
-		if ( is_string($pid) || is_numeric($pid) || (is_object($pid) && !isset($pid->post_title)) || $pid === 0 ) {
-			$pid = self::check_post_id($pid);
-			$post = get_post($pid);
-			if ( $post ) {
-				return $post;
-			}
-		}
-		//we can skip if already is WP_Post
-		return $pid;
-	}
-
-
-	/**
-	 * helps you find the post id regardless of whether you send a string or whatever
-	 * @param integer $pid ;
-	 * @internal
-	 * @return integer ID number of a post
-	 */
-	protected function check_post_id( $pid ) {
-		if ( is_numeric($pid) && $pid === 0 ) {
-			$pid = get_the_ID();
-			return $pid;
-		}
-		if ( !is_numeric($pid) && is_string($pid) ) {
-			$pid = self::get_post_id_by_name($pid);
-			return $pid;
-		}
-		if ( !$pid ) {
-			return null;
-		}
-		return $pid;
-	}
-
-
-	/**
-	 * get_post_id_by_name($post_name)
-	 * @internal
-	 * @param string $post_name
-	 * @return int
-	 */
-	public static function get_post_id_by_name( $post_name ) {
-		global $wpdb;
-		$query = $wpdb->prepare("SELECT ID FROM $wpdb->posts WHERE post_name = %s LIMIT 1", $post_name);
-		$result = $wpdb->get_row($query);
-		if ( !$result ) {
-			return null;
-		}
-		return $result->ID;
 	}
 
 	/**
@@ -498,11 +355,10 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Used internally by init, etc. to build TimberPost object
 	 * @internal
-	 * @param  int $pid
+	 * @param \WP_Post $post
 	 * @return null|object|WP_Post
 	 */
-	protected function get_info( $pid ) {
-		$post = $this->prepare_post_info($pid);
+	protected function get_info( $post ) {
 		if ( !isset($post->post_status) ) {
 			return null;
 		}
@@ -601,7 +457,7 @@ class Post extends Core implements CoreInterface {
 
 			// map over array of wordpress terms, and transform them into instances of the TermClass
 			$terms = array_map(function( $term ) use ($TermClass, $taxonomy) {
-				return call_user_func(array($TermClass, 'from'), $term->term_id, $taxonomy);
+				return ( new TermFactory( $TermClass ) )->get_object( $term, $taxonomy );
 			}, $terms);
 
 			if ( $merge && is_array($terms) ) {
@@ -852,7 +708,7 @@ class Post extends Core implements CoreInterface {
 		$query = 'post_parent='.$this->ID.'&post_type[]='.$post_type.'&numberposts=-1&orderby=menu_order title&order=ASC&post_status=publish';
 		$children = get_children($query);
 		foreach ( $children as &$child ) {
-			$child = new $childPostClass($child->ID);
+			$child = ( new PostFactory( $childPostClass ) )->get_object( $child );
 		}
 		$children = array_values($children);
 		return $children;
@@ -1174,7 +1030,7 @@ class Post extends Core implements CoreInterface {
 			}
 
 			if ( $adjacent ) {
-				$this->_next[$in_same_term] = new $this->PostClass($adjacent);
+				$this->_next[$in_same_term] = PostFactory::get( $adjacent );
 			} else {
 				$this->_next[$in_same_term] = false;
 			}
@@ -1228,7 +1084,7 @@ class Post extends Core implements CoreInterface {
 					$ele = $this->$func($ele, $class);
 				} else {
 					if ( $ele instanceof WP_Post ) {
-						$ele = new $class($ele);
+						$ele = ( new PostFactory( $class ) )->get_object( $ele );
 					}
 				}
 			}
@@ -1245,13 +1101,13 @@ class Post extends Core implements CoreInterface {
 	 * ```twig
 	 * Parent page: <a href="{{ post.parent.link }}">{{ post.parent.title }}</a>
 	 * ```
-	 * @return bool|Timber\Post
+	 * @return bool|\Timber\Post
 	 */
 	public function parent() {
 		if ( !$this->post_parent ) {
 			return false;
 		}
-		return new $this->PostClass($this->post_parent);
+		return PostFactory::get( $this->post_parent );
 	}
 
 
@@ -1293,7 +1149,7 @@ class Post extends Core implements CoreInterface {
 		$adjacent = get_adjacent_post(($in_same_term), '', true, $within_taxonomy);
 		$prev_in_taxonomy = false;
 		if ( $adjacent ) {
-			$prev_in_taxonomy = new $this->PostClass($adjacent);
+			$prev_in_taxonomy = PostFactory::get( $adjacent );
 		}
 		$this->_prev[$in_same_term] = $prev_in_taxonomy;
 		$post = $old_global;

--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\PostFactory;
 use Timber\Helper;
 use Timber\Post;
 
@@ -26,15 +27,8 @@ class PostCollection extends \ArrayObject {
 			$posts = array();
 		}
 		foreach ( $posts as $post_object ) {
-			$post_type      = get_post_type($post_object);
-			$post_class_use = PostGetter::get_post_class($post_type, $post_class);
 
-			// Don't create yet another object if $post_object is already of the right type
-			if ( is_a($post_object, $post_class_use) ) {
-				$post = $post_object;
-			} else {
-				$post = new $post_class_use($post_object);
-			}
+			$post = ( new PostFactory( $post_class ) )->get_object( $post_object );
 
 			if ( isset($post->ID) ) {
 				$returned_posts[] = $post;

--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -16,7 +16,7 @@ if ( !defined('ABSPATH') ) {
  */
 class PostCollection extends \ArrayObject {
 
-	public function __construct( $posts = array(), $post_class = '\Timber\Post' ) {
+	public function __construct( $posts = array(), $post_class = '' ) {
 		$returned_posts = self::init($posts, $post_class);
 		parent::__construct($returned_posts, $flags = 0, 'Timber\PostsIterator');
 	}

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -13,7 +13,7 @@ class PostGetter {
 	 * @param string|array $PostClass
 	 * @return array|bool|null
 	 */
-	public static function get_post( $query = false, $PostClass = '\Timber\Post' ) {
+	public static function get_post( $query = false, $PostClass = '' ) {
 		// if a post id is passed, grab the post directly
 		if ( is_numeric($query) ) {
 			$post = ( new PostFactory( $PostClass ) )->get_object( $query );
@@ -30,12 +30,12 @@ class PostGetter {
 		}
 	}
 
-	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
+	public static function get_posts( $query = false, $PostClass = '', $return_collection = false ) {
 		$posts = self::query_posts($query, $PostClass);
 		return apply_filters('timber_post_getter_get_posts', $posts->get_posts($return_collection));
 	}
 
-	public static function query_post( $query = false, $PostClass = '\Timber\Post' ) {
+	public static function query_post( $query = false, $PostClass = '' ) {
 		$posts = self::query_posts($query, $PostClass);
 		if ( method_exists($posts, 'current') && $post = $posts->current() ) {
 			return $post;
@@ -47,7 +47,7 @@ class PostGetter {
 	 * @param string|array $PostClass
 	 * @return PostCollection | QueryIterator
 	 */
-	public static function query_posts( $query = false, $PostClass = '\Timber\Post' ) {
+	public static function query_posts( $query = false, $PostClass = '' ) {
 		if ( $type = self::get_class_for_use_as_timber_post($query) ) {
 			$PostClass = $type;
 			if ( self::is_post_class_or_class_map($query) ) {
@@ -101,9 +101,9 @@ class PostGetter {
 	 *
 	 * @return string
 	 */
-	public static function get_post_class( $post_type, $post_class = '\Timber\Post' ) {
+	public static function get_post_class( $post_type, $post_class = '' ) {
 		$post_class = apply_filters( 'Timber\PostClassMap', $post_class );
-		$post_class_use = '\Timber\Post';
+		$post_class_use = '';
 
 		if ( is_array($post_class) )  {
 			if ( isset( $post_class[$post_type]) ) {
@@ -117,7 +117,7 @@ class PostGetter {
 			Helper::error_log('Unexpeted value for PostClass: ' . print_r( $post_class, true));
 		}
 
-		if ( !class_exists( $post_class_use ) || !( is_subclass_of($post_class_use, '\Timber\Post') || is_a($post_class_use, '\Timber\Post', true) ) ) {
+		if ( !class_exists( $post_class_use ) || !( is_subclass_of($post_class_use, '') || is_a($post_class_use, '', true) ) ) {
 			Helper::error_log('Class ' . $post_class_use . ' either does not exist or implement \Timber\Post');
 		}
 
@@ -157,7 +157,7 @@ class PostGetter {
 			return false;
 		}
 
-		if ( !is_array($type) && class_exists($type) && is_subclass_of($type, '\Timber\Post') ) {
+		if ( !is_array($type) && class_exists($type) && is_subclass_of($type, '') ) {
 			return $type;
 		}
 	}

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\PostFactory;
 use Timber\PostCollection;
 use Timber\QueryIterator;
 
@@ -15,9 +16,7 @@ class PostGetter {
 	public static function get_post( $query = false, $PostClass = '\Timber\Post' ) {
 		// if a post id is passed, grab the post directly
 		if ( is_numeric($query) ) {
-			$post_type      = get_post_type($query);
-			$PostClass = PostGetter::get_post_class($post_type, $PostClass);
-			$post = new $PostClass($query);
+			$post = ( new PostFactory( $PostClass ) )->get_object( $query );
 			// get the latest revision if we're dealing with a preview
 			$posts = PostCollection::maybe_set_preview(array($post));
 			if ( $post = reset($posts) ) {

--- a/lib/PostQuery.php
+++ b/lib/PostQuery.php
@@ -25,7 +25,7 @@ class PostQuery extends PostCollection {
 	protected $queryIterator;
 	protected $pagination = null;
 
-	public function __construct( $query = false, $post_class = '\Timber\Post' ) {
+	public function __construct( $query = false, $post_class = '' ) {
 		$this->userQuery = $query;
 		$this->queryIterator = PostGetter::query_posts($query, $post_class);
 

--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -19,9 +19,9 @@ class QueryIterator implements \Iterator, \Countable {
 	 * @var WP_Query
 	 */
 	private $_query = null;
-	private $_posts_class = 'Timber\Post';
+	private $_posts_class;
 
-	public function __construct( $query = false, $posts_class = 'Timber\Post' ) {
+	public function __construct( $query = false, $posts_class = '' ) {
 		add_action('pre_get_posts', array($this, 'fix_number_posts_wp_quirk'));
 		add_action('pre_get_posts', array($this, 'fix_cat_wp_quirk'));
 		if ( $posts_class ) {

--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+use Timber\Factory\PostFactory;
 use Timber\Helper;
 use Timber\PostCollection;
 
@@ -128,7 +129,7 @@ class QueryIterator implements \Iterator, \Countable {
 
 		// Sets up the global post, but also return the post, for use in Twig template
 		$posts_class = $this->_posts_class;
-		return new $posts_class($post);
+		return ( new PostFactory( $posts_class ) )->get_object( $post );
 	}
 
 	/**

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -64,7 +64,7 @@ class Term extends Core implements CoreInterface {
 	 */
 	public function __construct( $term, $tax = 'category' ) {
 
-		if ( ! $term instanceof \WP_Term ) {
+		if ( ! $term instanceof \WP_Term && ! $term instanceof Term ) {
 			_doing_it_wrong( 'Timber\Term::__construct', 'Please use Timber\Factory\TermFactory::get() to instantiate Timber Terms', '2.0.0' );
 			$term = TermFactory::get( $term, $tax );
 		}

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -43,9 +43,6 @@ use Timber\URLHelper;
  */
 class Term extends Core implements CoreInterface {
 
-	public $PostClass = 'Timber\Post';
-	public $TermClass = 'Term';
-
 	public $object_type = 'term';
 	public static $representation = 'term';
 
@@ -172,9 +169,7 @@ class Term extends Core implements CoreInterface {
 	 * @return array|bool|null
 	 */
 	public function get_posts( $numberposts = 10, $post_type = 'any', $PostClass = '' ) {
-		if ( !strlen($PostClass) ) {
-			$PostClass = $this->PostClass;
-		}
+
 		$default_tax_query = array(array(
 			'field' => 'id',
 			'terms' => $this->ID,
@@ -189,17 +184,11 @@ class Term extends Core implements CoreInterface {
 			if ( !isset($args['post_type']) ) {
 				$args['post_type'] = 'any';
 			}
-			if ( class_exists($post_type) ) {
-				$PostClass = $post_type;
-			}
 		} else if ( is_array($numberposts) ) {
 			//they sent us an array already baked
 			$args = $numberposts;
 			if ( !isset($args['tax_query']) ) {
 				$args['tax_query'] = $default_tax_query;
-			}
-			if ( class_exists($post_type) ) {
-				$PostClass = $post_type;
 			}
 			if ( !isset($args['post_type']) ) {
 				$args['post_type'] = 'any';
@@ -320,8 +309,8 @@ class Term extends Core implements CoreInterface {
 	 * ```
 	 * @return array|bool|null
 	 */
-	public function posts( $numberposts_or_args = 10, $post_type_or_class = 'any', $post_class = '' ) {
-		return $this->get_posts($numberposts_or_args, $post_type_or_class, $post_class);
+	public function posts( $numberposts_or_args = 10, $post_type = 'any', $post_class = '' ) {
+		return $this->get_posts($numberposts_or_args, $post_type, $post_class);
 	}
 
 	/**

--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -16,7 +16,7 @@ class TermGetter {
 	 * @param string $taxonomy
 	 * @return Timber\Term|WP_Error|null
 	 */
-	public static function get_term( $term, $taxonomy, $TermClass = '\Timber\Term' ) {
+	public static function get_term( $term, $taxonomy, $TermClass = '' ) {
 		return TermFactory::get( $term, $taxonomy, null, $TermClass );
 	}
 
@@ -26,7 +26,7 @@ class TermGetter {
 	 * @param string $TermClass
 	 * @return mixed
 	 */
-	public static function get_terms( $args = null, $maybe_args = array(), $TermClass = '\Timber\Term' ) {
+	public static function get_terms( $args = null, $maybe_args = array(), $TermClass = '' ) {
 		if ( is_string($maybe_args) && !strstr($maybe_args, '=') ) {
 			//the user is sending the $TermClass in the second argument
 			$TermClass = $maybe_args;
@@ -71,7 +71,7 @@ class TermGetter {
 	 * @param string $TermClass
 	 * @return mixed
 	 */
-	public static function handle_term_query( $taxonomies, $args, $TermClass ) {
+	public static function handle_term_query( $taxonomies, $args, $TermClass = '' ) {
 		if ( !isset($args['hide_empty']) ) {
 			$args['hide_empty'] = false;
 		}

--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -2,9 +2,14 @@
 
 namespace Timber;
 
+use Timber\Factory\TermFactory;
 use Timber\Term;
 use Timber\Helper;
 
+/**
+ * Class TermGetter
+ * @package Timber
+ */
 class TermGetter {
 	/**
 	 * @param int|WP_Term|object $term
@@ -12,8 +17,7 @@ class TermGetter {
 	 * @return Timber\Term|WP_Error|null
 	 */
 	public static function get_term( $term, $taxonomy, $TermClass = '\Timber\Term' ) {
-		$term = get_term($term, $taxonomy);
-		return new $TermClass($term->term_id, $term->taxonomy);
+		return TermFactory::get( $term, $taxonomy, null, $TermClass );
 	}
 
 	/**
@@ -79,7 +83,7 @@ class TermGetter {
 		}
 		$terms = get_terms($taxonomies, $args);
 		foreach ( $terms as &$term ) {
-			$term = new $TermClass($term->term_id, $term->taxonomy);
+			$term = ( new TermFactory( $TermClass ) )->get_object( $term );
 		}
 		return $terms;
 	}

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -123,7 +123,7 @@ class Timber {
 	 * @param string|array  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function get_post( $query = false, $PostClass = 'Timber\Post' ) {
+	public static function get_post( $query = false, $PostClass = '' ) {
 		return PostGetter::get_post($query, $PostClass);
 	}
 
@@ -141,7 +141,7 @@ class Timber {
 	 * @param string|array  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function get_posts( $query = false, $PostClass = 'Timber\Post', $return_collection = false ) {
+	public static function get_posts( $query = false, $PostClass = '', $return_collection = false ) {
 		return PostGetter::get_posts($query, $PostClass, $return_collection);
 	}
 
@@ -152,7 +152,7 @@ class Timber {
 	 * @param string  $PostClass
 	 * @return array|bool|null
 	 */
-	public static function query_post( $query = false, $PostClass = 'Timber\Post' ) {
+	public static function query_post( $query = false, $PostClass = '' ) {
 		return PostGetter::query_post($query, $PostClass);
 	}
 
@@ -163,7 +163,7 @@ class Timber {
 	 * @param string  $PostClass
 	 * @return PostCollection
 	 */
-	public static function query_posts( $query = false, $PostClass = 'Timber\Post' ) {
+	public static function query_posts( $query = false, $PostClass = '' ) {
 		return PostGetter::query_posts($query, $PostClass);
 	}
 
@@ -178,7 +178,7 @@ class Timber {
 	 * @param string  $TermClass
 	 * @return mixed
 	 */
-	public static function get_terms( $args = null, $maybe_args = array(), $TermClass = 'Timber\Term' ) {
+	public static function get_terms( $args = null, $maybe_args = array(), $TermClass = '' ) {
 		return TermGetter::get_terms($args, $maybe_args, $TermClass);
 	}
 
@@ -189,7 +189,7 @@ class Timber {
 	 * @param string     $taxonomy
 	 * @return Timber\Term|WP_Error|null
 	 */
-	public static function get_term( $term, $taxonomy = 'post_tag', $TermClass = 'Timber\Term' ) {
+	public static function get_term( $term, $taxonomy = 'post_tag', $TermClass = '' ) {
 		return TermGetter::get_term($term, $taxonomy, $TermClass);
 	}
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -2,6 +2,8 @@
 
 namespace Timber;
 
+use Timber\Factory\PostFactory;
+use Timber\Factory\TermFactory;
 use Timber\URLHelper;
 use Timber\Helper;
 
@@ -97,11 +99,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('TimberPost', function( $pid, $PostClass = 'Timber\Post' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $PostClass($p);
+							$p = ( new PostFactory( $PostClass ) )->get_object( $p );
 						}
 						return $pid;
 					}
-					return new $PostClass($pid);
+					return ( new PostFactory( $PostClass ) )->get_object( $pid );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('TimberImage', function( $pid = false, $ImageClass = 'Timber\Image' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
@@ -116,11 +118,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('TimberTerm', function( $pid, $TermClass = 'Timber\Term' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $TermClass($p);
+							$p = ( new TermFactory( $TermClass ) )->get_object( $p );
 						}
 						return $pid;
 					}
-					return new $TermClass($pid);
+					return ( new TermFactory( $TermClass ) )->get_object( $pid );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('TimberUser', function( $pid, $UserClass = 'Timber\User' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
@@ -136,11 +138,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('Post', function( $pid, $PostClass = 'Timber\Post' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $PostClass($p);
+							$p = ( new PostFactory( $PostClass ) )->get_object( $p );
 						}
 						return $pid;
 					}
-					return new $PostClass($pid);
+					return ( new PostFactory( $PostClass ) )->get_object( $pid );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('Image', function( $pid, $ImageClass = 'Timber\Image' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
@@ -154,11 +156,11 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('Term', function( $pid, $TermClass = 'Timber\Term' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
-							$p = new $TermClass($p);
+							$p = ( new TermFactory( $TermClass ) )->get_object( $p );
 						}
 						return $pid;
 					}
-					return new $TermClass($pid);
+					return ( new TermFactory( $TermClass ) )->get_object( $pid );
 				} ));
 		$twig->addFunction(new \Twig_SimpleFunction('User', function( $pid, $UserClass = 'Timber\User' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -96,7 +96,7 @@ class Twig {
 		$twig->addFunction(new \Twig_SimpleFunction('shortcode', 'do_shortcode'));
 
 		/* TimberObjects */
-		$twig->addFunction(new \Twig_SimpleFunction('TimberPost', function( $pid, $PostClass = 'Timber\Post' ) {
+		$twig->addFunction(new \Twig_SimpleFunction('TimberPost', function( $pid, $PostClass = '' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
 							$p = ( new PostFactory( $PostClass ) )->get_object( $p );
@@ -115,7 +115,7 @@ class Twig {
 					return new $ImageClass($pid);
 				} ));
 
-		$twig->addFunction(new \Twig_SimpleFunction('TimberTerm', function( $pid, $TermClass = 'Timber\Term' ) {
+		$twig->addFunction(new \Twig_SimpleFunction('TimberTerm', function( $pid, $TermClass = '' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
 							$p = ( new TermFactory( $TermClass ) )->get_object( $p );
@@ -135,7 +135,7 @@ class Twig {
 				} ));
 
 		/* TimberObjects Alias */
-		$twig->addFunction(new \Twig_SimpleFunction('Post', function( $pid, $PostClass = 'Timber\Post' ) {
+		$twig->addFunction(new \Twig_SimpleFunction('Post', function( $pid, $PostClass = '' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
 							$p = ( new PostFactory( $PostClass ) )->get_object( $p );
@@ -153,7 +153,7 @@ class Twig {
 					}
 					return new $ImageClass($pid);
 				} ));
-		$twig->addFunction(new \Twig_SimpleFunction('Term', function( $pid, $TermClass = 'Timber\Term' ) {
+		$twig->addFunction(new \Twig_SimpleFunction('Term', function( $pid, $TermClass = '' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
 							$p = ( new TermFactory( $TermClass ) )->get_object( $p );


### PR DESCRIPTION
This builds on #1218 and #1219 to provide interfaced object factories, separate for each object type.
This pattern allows developers to instantiate their own Factory instances, with which they can specify the "default" class to be used.
This PR also updates Timber to use these factories; there are several instances where the factories are directly instantiated over using the static `get` method for instantiation & object retrieval in one go.
