### PR TITLE
Post->get_terms() return class

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1459,8 +1459,8 @@ class Post extends Core implements CoreInterface {
 	 * @param bool $merge Should the resulting array be one big one (true)? Or should it be an array of sub-arrays for each taxonomy (false)?
 	 * @return array
 	 */
-	public function get_terms( $tax = '', $merge = true ) {
-		return $this->terms($tax, $merge);
+	public function get_terms( $tax = '', $merge = true, $TermClass = '' ) {
+		return $this->terms($tax, $merge, $TermClass);
 	}
 
 	/**

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -642,6 +642,10 @@
 			// test return class
 			$terms = $post->terms('post_tag', true, $class_name);
 			$this->assertEquals($class_name, get_class($terms[0]));
+
+			// test return class for deprecated $post->get_terms
+			$get_terms = $post->get_terms('post_tag', true, $class_name);
+			$this->assertEquals($class_name, get_class($get_terms[0]));
 		}
 
 		function testPostContentLength() {

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -627,6 +627,23 @@
 			$this->assertEquals(count($post_tag_terms) + count($post_team_terms), count($post_tag_and_team_terms));
 		}
 
+		function testPostTermClass() {
+			$class_name = 'TimberTermSubclass';
+			require_once('php/timber-term-subclass.php');
+
+			// create new post
+			$pid = $this->factory->post->create();
+			$post = new TimberPost($pid);
+
+			// create a new tag, associate with post
+			$dummy_tag = wp_insert_term('whatever', 'post_tag');
+			wp_set_object_terms($pid, $dummy_tag['term_id'], 'post_tag', true);
+
+			// test return class
+			$terms = $post->terms('post_tag', true, $class_name);
+			$this->assertEquals($class_name, get_class($terms[0]));
+		}
+
 		function testPostContentLength() {
 			$crawl = "The evil leaders of Planet Spaceball having foolishly spuandered their precious atmosphere, have devised a secret plan to take every breath of air away from their peace-loving neighbor, Planet Druidia. Today is Princess Vespa's wedding day. Unbeknownest to the princess, but knowest to us, danger lurks in the stars above...";
 			$pid = $this->factory->post->create(array('post_content' => $crawl));


### PR DESCRIPTION
**Ticket**: #1221
**Reviewer**: @jarednova / @connorjburton?
#### Issue

See #1221.
#### Solution
- Test for `Post->terms()` return class
- Test for `Post->get_terms()` return class
- Receive parameter for `Post->get_terms()` and pass it
#### Impact

More backwards compatibility with pre-1.0 versions.
#### Usage

No changes.
#### Considerations

The `$TermClass` parameter could be better documented (this is missing right now), but that's probably better as a separate issue.
#### Testing

Tests are included.
