### PR TITLE
Fix images when wordpress is not installed in default location

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -167,18 +167,16 @@ class ImageHelper {
 
 	/**
 	 * Deletes all resized versions of an image when the source is deleted
+	 * or its meta data is regenerated
 	 */
 	protected static function add_actions() {
 		add_action('delete_attachment', function( $post_id ) {
-			$post = get_post($post_id);
-			$image_types = array('image/jpeg', 'image/png', 'image/gif', 'image/jpg');
-			if ( in_array($post->post_mime_type, $image_types) ) {
-				$attachment = new Image($post_id);
-				if ( $attachment->file_loc ) {
-					ImageHelper::delete_generated_files($attachment->file_loc);
-				}
-			}
+			\Timber\ImageHelper::_delete_generated_if_image($post_id);
 		} );
+		add_filter('wp_generate_attachment_metadata', function( $metadata, $post_id ) {
+			\Timber\ImageHelper::_delete_generated_if_image($post_id);
+			return $metadata;
+		}, 10, 2);
 	}
 
 	/**
@@ -205,6 +203,24 @@ class ImageHelper {
 	}
 
 	//-- end of public methods --//
+
+
+	/**
+	 * Checks if attachment is an image before deleting generated files
+	 *
+	 * @param  int  $post_id   an attachment post id
+	 *
+	 */
+	public static function _delete_generated_if_image( $post_id ) {
+		if ( wp_attachment_is_image($post_id) ) {
+			$attachment = new Image($post_id);
+			if ( $attachment->file_loc ) {
+				ImageHelper::delete_generated_files($attachment->file_loc);
+			}
+		}
+	}
+
+
 	/**
 	 * Deletes the auto-generated files for resize and letterboxing created by Timber
 	 * @param string  $local_file   ex: /var/www/wp-content/uploads/2015/my-pic.jpg
@@ -458,32 +474,32 @@ class ImageHelper {
 			$op->filename($au['filename'], $au['extension']),
 			$au['absolute']
 		);
-		$new_server_path = self::_get_file_path(
+		$destination_path = self::_get_file_path(
 			$au['base'],
 			$au['subdir'],
 			$op->filename($au['filename'], $au['extension'])
 		);
-		$old_server_path = self::_get_file_path(
+		$source_path = self::_get_file_path(
 			$au['base'],
 			$au['subdir'],
 			$au['basename']
 		);
 
 		$new_url = apply_filters('timber/image/new_url', $new_url);
-		$new_server_path = apply_filters('timber/image/new_path', $new_server_path);
+		$destination_path = apply_filters('timber/image/new_path', $destination_path);
 
 		// if already exists...
-		if ( file_exists($new_server_path) ) {
-			if ( $force ) {
+		if ( file_exists($destination_path) ) {
+			if ( $force || filemtime($source_path) > filemtime($destination_path) ) {
 				// Force operation - warning: will regenerate the image on every pageload, use for testing purposes only!
-				unlink($new_server_path);
+				unlink($destination_path);
 			} else {
 				// return existing file (caching)
 				return $new_url;
 			}
 		}
 		// otherwise generate result file
-		if ( $op->run($old_server_path, $new_server_path) ) {
+		if ( $op->run($source_path, $destination_path) ) {
 			if ( get_class($op) === 'Timber\Image\Operation\Resize' && $external ) {
 				$new_url = strtolower($new_url);
 			}

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -167,16 +167,18 @@ class ImageHelper {
 
 	/**
 	 * Deletes all resized versions of an image when the source is deleted
-	 * or its meta data is regenerated
 	 */
 	protected static function add_actions() {
 		add_action('delete_attachment', function( $post_id ) {
-			\Timber\ImageHelper::_delete_generated_if_image($post_id);
+			$post = get_post($post_id);
+			$image_types = array('image/jpeg', 'image/png', 'image/gif', 'image/jpg');
+			if ( in_array($post->post_mime_type, $image_types) ) {
+				$attachment = new Image($post_id);
+				if ( $attachment->file_loc ) {
+					ImageHelper::delete_generated_files($attachment->file_loc);
+				}
+			}
 		} );
-		add_filter('wp_generate_attachment_metadata', function( $metadata, $post_id ) {
-			\Timber\ImageHelper::_delete_generated_if_image($post_id);
-			return $metadata;
-		}, 10, 2);
 	}
 
 	/**
@@ -185,7 +187,7 @@ class ImageHelper {
 	 */
 	protected static function add_constants() {
 		if ( !defined('WP_CONTENT_SUBDIR') ) {
-			$wp_content_path = str_replace(site_url(), '', WP_CONTENT_URL);
+			$wp_content_path = str_replace(get_home_url(), '', WP_CONTENT_URL);
 			define('WP_CONTENT_SUBDIR', $wp_content_path);
 		}
 	}
@@ -197,30 +199,12 @@ class ImageHelper {
 	 */
 	static function add_filters() {
 		add_filter('upload_dir', function( $arr ) {
-			$arr['relative'] = str_replace(site_url(), '', $arr['baseurl']);
+			$arr['relative'] = str_replace(get_home_url(), '', $arr['baseurl']);
 			return $arr;
 		} );
 	}
 
 	//-- end of public methods --//
-
-	
-	/**
-	 * Checks if attachment is an image before deleting generated files
-	 *
-	 * @param  int  $post_id   an attachment post id
-	 *
-	 */
-	public static function _delete_generated_if_image( $post_id ) {
-		if ( wp_attachment_is_image($post_id) ) {
-			$attachment = new Image($post_id);
-			if ( $attachment->file_loc ) {
-				ImageHelper::delete_generated_files($attachment->file_loc);
-			}
-		}
-	}
-	
-	
 	/**
 	 * Deletes the auto-generated files for resize and letterboxing created by Timber
 	 * @param string  $local_file   ex: /var/www/wp-content/uploads/2015/my-pic.jpg
@@ -367,7 +351,7 @@ class ImageHelper {
 			}
 		} else {
 			if ( !$result['absolute'] ) {
-				$tmp = site_url().$tmp;
+				$tmp = get_home_url().$tmp;
 			}
 			if ( 0 === strpos($tmp, $upload_dir['baseurl']) ) {
 				$result['base'] = self::BASE_UPLOADS; // upload based
@@ -474,32 +458,32 @@ class ImageHelper {
 			$op->filename($au['filename'], $au['extension']),
 			$au['absolute']
 		);
-		$destination_path = self::_get_file_path(
+		$new_server_path = self::_get_file_path(
 			$au['base'],
 			$au['subdir'],
 			$op->filename($au['filename'], $au['extension'])
 		);
-		$source_path = self::_get_file_path(
+		$old_server_path = self::_get_file_path(
 			$au['base'],
 			$au['subdir'],
 			$au['basename']
 		);
-		
+
 		$new_url = apply_filters('timber/image/new_url', $new_url);
-		$destination_path = apply_filters('timber/image/new_path', $destination_path);
-		
+		$new_server_path = apply_filters('timber/image/new_path', $new_server_path);
+
 		// if already exists...
-		if ( file_exists($destination_path) ) {
-			if ( $force || filemtime($source_path) > filemtime($destination_path) ) {
+		if ( file_exists($new_server_path) ) {
+			if ( $force ) {
 				// Force operation - warning: will regenerate the image on every pageload, use for testing purposes only!
-				unlink($destination_path);
+				unlink($new_server_path);
 			} else {
 				// return existing file (caching)
 				return $new_url;
 			}
 		}
 		// otherwise generate result file
-		if ( $op->run($source_path, $destination_path) ) {
+		if ( $op->run($old_server_path, $new_server_path) ) {
 			if ( get_class($op) === 'Timber\Image\Operation\Resize' && $external ) {
 				$new_url = strtolower($new_url);
 			}


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
When Wordpress is in a different directory other than the default, (for example when using [Bedrock](https://github.com/roots/bedrock), images are not found by the ImageHelper class.


#### Solution
Replace uses of site_url() with get_home_url()


#### Impact
The change is designed to have no impact.


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->


#### Considerations
Will need to make sure this has no unintended side effects on multisite installs.

#### Testing
Tests are already in place.
