### PR TITLE
fix resize for urls when upload directory is not in default location

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -367,9 +367,11 @@ class ImageHelper {
 			}
 		} else {
 			if ( !$result['absolute'] ) {
-				$pos = strpos(content_url(), CONTENT_DIR);
+				$pos = strpos($upload_dir['baseurl'], $upload_dir['relative']);
 				if ($pos !== false) {
-					$tmp = substr_replace(content_url(), '', $pos, strlen(CONTENT_DIR)) . $tmp;
+					$tmp = substr_replace($upload_dir['baseurl'], '', $pos, strlen($upload_dir['relative'])) . $tmp;
+				} else {
+					$tmp = site_url().$tmp;
 				}
 			}
 			if ( 0 === strpos($tmp, $upload_dir['baseurl']) ) {

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -367,7 +367,10 @@ class ImageHelper {
 			}
 		} else {
 			if ( !$result['absolute'] ) {
-				$tmp = site_url().$tmp;
+				$pos = strpos(content_url(), CONTENT_DIR);
+				if ($pos !== false) {
+					$tmp = substr_replace(content_url(), '', $pos, strlen(CONTENT_DIR)) . $tmp;
+				}
 			}
 			if ( 0 === strpos($tmp, $upload_dir['baseurl']) ) {
 				$result['base'] = self::BASE_UPLOADS; // upload based

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -312,7 +312,7 @@ class ImageHelper {
 	public static function sideload_image( $file ) {
 		$loc = self::get_sideloaded_file_loc($file);
 		if ( file_exists($loc) ) {
-			return URLHelper::preslashit(URLHelper::get_rel_path($loc));
+			return URLHelper::file_system_to_url($loc);
 		}
 		// Download file to temp location
 		if ( !function_exists('download_url') ) {
@@ -367,12 +367,7 @@ class ImageHelper {
 			}
 		} else {
 			if ( !$result['absolute'] ) {
-				$pos = strpos($upload_dir['baseurl'], $upload_dir['relative']);
-				if ($pos !== false) {
-					$tmp = substr_replace($upload_dir['baseurl'], '', $pos, strlen($upload_dir['relative'])) . $tmp;
-				} else {
-					$tmp = site_url().$tmp;
-				}
+				$tmp = site_url().$tmp;
 			}
 			if ( 0 === strpos($tmp, $upload_dir['baseurl']) ) {
 				$result['base'] = self::BASE_UPLOADS; // upload based


### PR DESCRIPTION
Unfortunately the reverting in #1229 has caused issues with resizes when uploads is not in a standard location. This attempts to fix it again, and not break WPML.