### PR TITLE
Fix for Yoast SEO metabox on multisite #1129

### DIFF
--- a/lib/Site.php
+++ b/lib/Site.php
@@ -124,11 +124,15 @@ class Site extends Core implements CoreInterface {
 	/**
 	 * Switches to the blog requested in the request
 	 * @param string|integer|null $site_name_or_id
-	 * @return array with the ID of the old and new blogs
+	 * @return integer with the ID of the new blog
 	 */
 	protected static function switch_to_blog( $site_name_or_id ) {
 		if ( $site_name_or_id === null ) {
-			$site_name_or_id = get_current_blog_id();
+			/* This is necessary for some reason, otherwise it returns 1 all the time */
+			if ( is_multisite() ) {
+				restore_current_blog();
+				$site_name_or_id = get_current_blog_id();
+			}
 		}
 		$info = get_blog_details($site_name_or_id);
 		switch_to_blog($info->blog_id);

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -96,7 +96,7 @@ class Site extends Core implements CoreInterface {
 	public $rss;
 	public $rss2;
 	public $atom;
-	
+
 	/**
 	 * Constructs a TimberSite object
 	 * @example
@@ -111,13 +111,14 @@ class Site extends Core implements CoreInterface {
 	 */
 	public function __construct( $site_name_or_id = null ) {
 		if ( is_multisite() ) {
-			$blog_ids = self::switch_to_blog($site_name_or_id);
+			$blog_id = self::switch_to_blog($site_name_or_id);
 			$this->init();
-			$this->init_as_multisite($blog_ids['new']);
-			return switch_to_blog($blog_ids['old']);
-		} 
-		$this->init();
-		$this->init_as_singlesite();
+			$this->init_as_multisite($blog_id);
+			restore_current_blog();
+		} else {
+			$this->init();
+			$this->init_as_singlesite();
+		}
 	}
 
 	/**
@@ -127,17 +128,11 @@ class Site extends Core implements CoreInterface {
 	 */
 	protected static function switch_to_blog( $site_name_or_id ) {
 		if ( $site_name_or_id === null ) {
-			//this is necessary for some reason, otherwise returns 1 all the time
-			if ( is_multisite() ) {
-				restore_current_blog();
-				$site_name_or_id = get_current_blog_id();
-			}
+			$site_name_or_id = get_current_blog_id();
 		}
-		/* we need to store the current blog, but switch things to the blog id of the Site object requested */
-		$old_id = get_current_blog_id();
 		$info = get_blog_details($site_name_or_id);
 		switch_to_blog($info->blog_id);
-		return array('old' => $old_id, 'new' => $info->blog_id);
+		return $info->blog_id;
 	}
 
 	/**

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -128,11 +128,7 @@ class Site extends Core implements CoreInterface {
 	 */
 	protected static function switch_to_blog( $site_name_or_id ) {
 		if ( $site_name_or_id === null ) {
-			/* This is necessary for some reason, otherwise it returns 1 all the time */
-			if ( is_multisite() ) {
-				restore_current_blog();
-				$site_name_or_id = get_current_blog_id();
-			}
+			$site_name_or_id = get_current_blog_id();
 		}
 		$info = get_blog_details($site_name_or_id);
 		switch_to_blog($info->blog_id);
@@ -216,12 +212,12 @@ class Site extends Core implements CoreInterface {
 
 	protected function icon_multisite( $site_id ) {
 		$image = null;
-		$blog_ids = self::switch_to_blog($site_id);
-		$iid = get_blog_option($blog_ids['new'], 'site_icon');
+		$blog_id = self::switch_to_blog($site_id);
+		$iid = get_blog_option($blog_id, 'site_icon');
 		if ( $iid ) {
 			$image = new Image($iid);
 		}
-		switch_to_blog($blog_ids['old']);
+		restore_current_blog();
 		return $image;
 	}
 


### PR DESCRIPTION
Use Wordpress internal function to restore current blog instead of manually doing it. Solves issue with Yoast SEO metabox on multisites. 

I'm not sure if my changes will break other functionality. But I've done some testing on our site and not encountered any problems at all. We use ACF, WPML and many more plugins and it seems like it hasn't affected them.