### PR TITLE
Sort menu items by order instead of title

### DIFF
--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -122,7 +122,7 @@ class Menu extends Core {
 	/**
 	 * @internal
 	 */
-	protected function init_as_page_menu() {
+	protected function init_as_page_menu(array('sort_column' => 'menu_order')) {
 		$menu = get_pages();
 		if ( $menu ) {
 			foreach ( $menu as $mi ) {


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
<!-- Description of the problem that this code change is solving -->
	TwigMenu menu.items and menu.get_items() returns menu sorted by the title and not menu_order
#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
 
Use init_as_page_menu() with parameter array('sort_column' => 'menu_order')

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
May impact sites that relied on menu items sorted alphabetically 

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
No

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->

Current test has passed because menu title with menu_order was Bar Page, should probably be renamed.