### PR TITLE
load children inheriting published status

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -849,7 +849,10 @@ class Post extends Core implements CoreInterface {
 		if ( is_array($post_type) ) {
 			$post_type = implode('&post_type[]=', $post_type);
 		}
-		$query = 'post_parent='.$this->ID.'&post_type[]='.$post_type.'&numberposts=-1&orderby=menu_order title&order=ASC&post_status=publish';
+		$query = 'post_parent='.$this->ID.'&post_type[]='.$post_type.'&numberposts=-1&orderby=menu_order title&order=ASC&post_status[]=publish';
+		if ($this->post_status == 'publish' ) {
+			$query .= '&post_status[]=inherit';
+		}
 		$children = get_children($query);
 		foreach ( $children as &$child ) {
 			$child = new $childPostClass($child->ID);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -850,7 +850,7 @@ class Post extends Core implements CoreInterface {
 			$post_type = implode('&post_type[]=', $post_type);
 		}
 		$query = 'post_parent='.$this->ID.'&post_type[]='.$post_type.'&numberposts=-1&orderby=menu_order title&order=ASC&post_status[]=publish';
-		if ($this->post_status == 'publish' ) {
+		if ( $this->post_status == 'publish' ) {
 			$query .= '&post_status[]=inherit';
 		}
 		$children = get_children($query);

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -495,6 +495,15 @@
 			$this->assertEquals(8, count($parent->children()));
 		}
 
+		function testPostChildrenOfInheritStatus(){
+			$parent_id = $this->factory->post->create();
+			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id));
+			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id,
+			                                                       'post_status' => 'inherit'));
+			$parent = new TimberPost($parent_id);
+			$this->assertEquals(8, count($parent->children()));
+		}
+
 		function testPostChildrenOfParentType(){
 			$parent_id = $this->factory->post->create(array('post_type' => 'foo'));
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id));


### PR DESCRIPTION
#### Issue
Child posts with inherit status are not loaded with post.children

#### Solution
Add ```post_status=inherit``` to get_children query.

#### Impact
None

#### Usage
Attachments with post.number are now correctly loaded

#### Considerations
```post.children``` returns also the thumbnail making ```post.children``` cumbersome it in twig templates. So, what do you think about excluding it from the method it self?

#### Testing
Done
