### PR TITLE
Deprecated Twig getExtension argument

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -220,18 +220,18 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension('core')->setEscaper('esc_url', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig_Extension_Core')->setEscaper('esc_url', function( \Twig_Environment $env, $string ) {
 			return esc_url( $string );
 		});
-		$twig->getExtension('core')->setEscaper('wp_kses_post', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig_Extension_Core')->setEscaper('wp_kses_post', function( \Twig_Environment $env, $string ) {
 			return wp_kses_post( $string );
 		});
 
-		$twig->getExtension('core')->setEscaper('esc_html', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig_Extension_Core')->setEscaper('esc_html', function( \Twig_Environment $env, $string ) {
 			return esc_html( $string );
 		});
 
-		$twig->getExtension('core')->setEscaper('esc_js', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig_Extension_Core')->setEscaper('esc_js', function( \Twig_Environment $env, $string ) {
 			return esc_js( $string );
 		});
 


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
<!-- Description of the problem that this code change is solving -->
Passing the string `'core'` to the `$twig->getExtension` method was deprecated in v1.26 and will be removed in 2.0. The API now requires that the fully qualified class name be used instead.

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Changing the string `'core'` to `'Twig_Extension_Core'`

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->
Shouldn't have any effect, very minor change.

#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->
N/A

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
Deprecation notice is gone and the code works without error, can't get more ideal than that!

#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
There were no tests for this string previously and I didn't add any. Based on the deprecation notice, an app will fail without this change if `2.0 >= $twig_version `. I did not test this.
