### PR TITLE
fix php notice: "WP_User->id was called with an argument that is depr…

### DIFF
--- a/lib/Integrations/CoAuthorsPlus.php
+++ b/lib/Integrations/CoAuthorsPlus.php
@@ -53,7 +53,7 @@ class CoAuthorsPlus {
 				return null;
 			}
 		} else {
-			return $cauthor->id;
+			return $cauthor->ID;
 		}
 	}
 }


### PR DESCRIPTION
…ecated since version 2.1.0! Use WP_User->ID instead."

**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
The usage of CoAuthorsPlus is generating a php notice.


#### Solution
Change id object property to uppercase.