### PR TITLE
Use 'pre_get_avatar_data' filter for avatars

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -131,9 +131,8 @@ class Comment extends Core implements CoreInterface {
 
 		$email = $this->avatar_email();
 		
-		$args = array();
-		$args = apply_filters ('pre_get_avatar_data', $args, $email);
-		if( isset($args['url'] ) ) {
+		$args = apply_filters('pre_get_avatar_data', array(), $email);
+		if ( isset($args['url']) ) {
 			return $args['url'];
 		}
 		

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -130,6 +130,13 @@ class Comment extends Core implements CoreInterface {
 		}
 
 		$email = $this->avatar_email();
+		
+		$args = array();
+		$args = apply_filters ('pre_get_avatar_data', $args, $email);
+		if( isset($args['url'] ) ) {
+			return $args['url'];
+		}
+		
 		$email_hash = '';
 		if ( !empty($email) ) {
 			$email_hash = md5(strtolower(trim($email)));


### PR DESCRIPTION
#### Issue
Avatar method in the comment class is ignoring filters set up previously (like 'pre_get_avatar_data).


#### Solution
Add filter to avatar method.


#### Impact
Very low, improving consistency with WordPress core.


#### Usage
Transparent for users.