### PR TITLE
Return full size of image by default

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -436,7 +436,7 @@ class Image extends Post implements CoreInterface {
 	 * ```
 	 * @return bool|string
 	 */
-	public function src( $size = '' ) {
+	public function src( $size = 'full' ) {
 		if ( isset($this->abs_url) ) {
 			return $this->_maybe_secure_url($this->abs_url);
 		}


### PR DESCRIPTION
#### Issue

With the changes introduced in https://github.com/timber/timber/pull/1320, Timber doesn’t return the full source of an image when the `src` method is called without a parameter. Instead, it returns the default size of `wp_get_attachment_image_src()`, which is `thumbnail`. @davidmaneuver already mentioned this in https://github.com/timber/timber/pull/1320#commitcomment-20979891.

As I understand it, the default size should be `full`, because otherwise filters like the following would resize the thumbnail src instead of the full size.

```twig
<img src="{{ post.thumbnail.src|resize(640) }}" />
```

would result in a src like

```
http://example.org/wp-content/uploads/2016/03/dog-150x150-c-default-640x0-c-default.jpg
```

#### Solution

Change default parameter for `$size` from `''` (empty) to `'full'` in `Image::src()`.

#### Impact

Restores default behaviour?

#### Testing

No (unfortunately, I’m still too inexperienced in testing).