### PR TITLE
[Fix] Wrong image path breaking timber resize when using external wp-content-dir (WP_CONTENT_DIR)

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -366,7 +366,12 @@ class ImageHelper {
 				$tmp = str_replace(WP_CONTENT_DIR, '', $tmp);
 			}
 		} else {
-			if ( !$result['absolute'] ) {
+			// if upload dir does not contain site_url, the content-directory seems to be outside of the site_url
+			// therefore using site_url() would lead to a wrong content/ path
+			if (false === strpos($upload_dir['baseurl'], site_url())) {
+				// use HOME_URL and relative image path
+				$tmp = get_home_url().$tmp;
+			} else if ( !$result['absolute'] ) {
 				$tmp = site_url().$tmp;
 			}
 			if ( 0 === strpos($tmp, $upload_dir['baseurl']) ) {


### PR DESCRIPTION
It took me a while to get this one sorted out. This is (probably) happening since the big Timber-Update (from 0.22).

#### Issue
If a wp-setup with an external WP_CONTENT_DIR (ie. site.dev/content instead of site.dev/wp-content) in combination with an external WP_SITEURL (ie. site.dev/wp instead of site.dev/) is used, the analyze_url function creates a faulty path (/site.dev/wp/wp/content/uploads/..) instead of /site.dev/content/uploads..). This breaks the resize function, which therefore will only return the original file src.


#### Solution
In analyze_url we first check, if the site_url is contained in baseurl. If not, the site_url can't be used to build the path and therefore we create the path based on the home_url and the images relative path. 


#### Considerations
Could break the whole image-resize processing if this approach does not fit all cases.


#### Testing
Did test it successfully in the mentioned use case. Needs to be tested on default-directory environments etc. to assure a clean fix.