### PR TITLE
Fixed HTTP error when uploading media files in Windows (#1346)

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -257,8 +257,7 @@ class ImageHelper {
 	protected static function process_delete_generated_files( $filename, $ext, $dir, $search_pattern, $match_pattern = null ) {
 		$searcher = '/'.$filename.$search_pattern;
 		foreach ( glob($dir.$searcher) as $found_file ) {
-			$regexdir = str_replace('/', '\/', $dir);
-			$pattern = '/'.($regexdir).'\/'.$filename.$match_pattern.$ext.'/';
+			$pattern = '/'.preg_quote($dir, '/').'\/'.preg_quote($filename, '/').$match_pattern.preg_quote($ext, '/').'/';
 			$match = preg_match($pattern, $found_file);
 			if ( !$match_pattern || $match ) {
 				unlink($found_file);


### PR DESCRIPTION
**Ticket**: #1346 
**Reviewer**: @jarednova 

#### Issue
Bad response when uploading media files in Windows


#### Solution
Use `preg_quote()` to escape path to the file.


#### Impact
No impact.


#### Usage
No usage changes.


#### Considerations
Make sure that `preg_quote()` is being used elsewhere in the codebase as well.


#### Testing
The code is hard to unit test in different platforms.