### PR TITLE
fix doc block to avoid IDE warnings

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -320,7 +320,7 @@ class Timber {
 	/**
 	 * Render function.
 	 * @api
-	 * @param array   $filenames
+	 * @param array|string   $filenames
 	 * @param array   $data
 	 * @param boolean|integer    $expires
 	 * @param string  $cache_mode


### PR DESCRIPTION
#### Issue
On PHPStorm the `Timber\Timber::render('views/view.twig')` issues a warning `Expected array got string`


#### Solution
Updated doc block to accept string as well
