### PR TITLE
Update Internationalization section in docs

### DIFF
--- a/docs/wiki/_cookbook-text.md
+++ b/docs/wiki/_cookbook-text.md
@@ -8,8 +8,8 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 
 ```twig
 <p class="byline">
-	<span class="name">By {{post.author.name}}</span>
-	<span class="date">{{post.post_date|date('F j, Y')}}</span>
+	<span class="name">By {{ post.author.name }}</span>
+	<span class="date">{{ post.post_date|date('F j, Y') }}</span>
 </p>
 ```
 
@@ -23,7 +23,7 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 
 ```twig
 <footer>
-	<p class="copyright">&copy; {{now|date('Y')}} by {{bloginfo('name')}}</p>
+	<p class="copyright">&copy; {{ now|date('Y') }} by {{ bloginfo('name') }}</p>
 </footer>
 ```
 
@@ -33,7 +33,6 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 <footer><p class="copyright">&copy; 2015 by The Daily Orange</p></footer>
 ```
 
-
 * * *
 
 #### Standard transforms
@@ -41,28 +40,29 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 ##### Automatically link URLs, email addresses, twitter @s and #s
 
 ```twig
-<p class="tweet">{{post.content|twitterify}}</p>
+<p class="tweet">{{ post.content|twitterify }}</p>
 ```
 
 ##### Run WordPress' auto-paragraph filter
 
 ```twig
-<p class="content">{{post.my_custom_text|wpautop}}</p>
+<p class="content">{{ post.my_custom_text|wpautop }}</p>
 ```
 
 ##### Run WordPress shortcodes over a block of text
 
 ```twig
-<p class="content">{{post.my_custom_text|shortcodes}}</p>
+<p class="content">{{ post.my_custom_text|shortcodes }}</p>
 ```
 
 ##### Code samples? Lord knows I've got 'em:
 
 ```twig
-<div class="code-sample">{{post.code_samples|pretags}}</div>
+<div class="code-sample">{{ post.code_samples|pretags }}</div>
 ```
 
 ##### Functions inside of your templates, plugin calls:
+
 Old template:
 
 ```html
@@ -72,21 +72,23 @@ Old template:
 Timber-fied template:
 
 ```twig
-<p class="entry-meta">{{function('twentytwelve_entry_meta')}}</p>
+<p class="entry-meta">{{ function('twentytwelve_entry_meta') }}</p>
 ```
 
 ##### Functions "with params" inside of your templates, plugin calls:
+
 Old template:
 
 ```html
-<p class="entry-meta"><?php get_the_title($post->ID); ?></p>
+<p class="entry-meta"><?php get_the_title( $post->ID ); ?></p>
 ```
 
 Timber-fied template:
 
 ```twig
-<p class="entry-meta">{{function('get_the_title', post.ID)}}</p>
+<p class="entry-meta">{{ function('get_the_title', post.ID) }}</p>
 ```
+
 * * *
 
 ### Internationalization
@@ -98,13 +100,13 @@ Timber comes built-in with your ordinary gettext function __() for l10n.
 Old template:
 
 ```html
-<p class="entry-meta"><?php _e('Posted on', 'my-text-domain') ?> [...]</p>
+<p class="entry-meta"><?php _e( 'Posted on', 'my-text-domain' ) ?> [...]</p>
 ```
 
 Timber-fied template:
 
 ```twig
-<p class="entry-meta">{{__('Posted on', 'my-text-domain')}} [...]</p>
+<p class="entry-meta">{{ __('Posted on', 'my-text-domain') }} [...]</p>
 ```
 
 #### sprintf notation
@@ -120,7 +122,7 @@ Old template:
 Timber-fied template:
 
 ```twig
-<p class="entry-meta">{{__('Posted on %s', 'my-text-domain')|format(posted_on_date)}}</p>
+<p class="entry-meta">{{ __('Posted on %s', 'my-text-domain')|format(posted_on_date) }}</p>
 ```
 
 #### Generating .po files using Poedit
@@ -149,7 +151,7 @@ Alternatively, you can use the parser for Python instead. This will throw a warn
 ##### What properties are inside my object?
 
 ```twig
-{{dump(post)}}
+{{ dump(post) }}
 ```
 
 ##### What properties and _methods_ are inside my object?
@@ -157,14 +159,14 @@ Alternatively, you can use the parser for Python instead. This will throw a warn
 Warning: Experimental!
 
 ```twig
-{{post|print_a}}
+{{ post|print_a }}
 ```
-This outputs both the database stuff (like {{post.post_content}}) and the contents of methods (like {{post.thumbnail}})
+This outputs both the database stuff (like `{{ post.post_content }}`) and the contents of methods (like `{{ post.thumbnail }}`)
 
 ##### What type of object am I working with?
 
 ```twig
-{{post|get_class}}
+{{ post|get_class }}
 ```
 
 ... will output something like `TimberPost` or your custom wrapper object

--- a/docs/wiki/_cookbook-text.md
+++ b/docs/wiki/_cookbook-text.md
@@ -93,9 +93,20 @@ Timber-fied template:
 
 ### Internationalization
 
-#### __()
+#### Translation functions
 
-Timber comes built-in with your ordinary gettext function __() for l10n.
+Timber supports the gettext i18n functions used in WordPress:
+
+* __()
+* _x()
+* _n()
+* _nx()
+* _n_noop()
+* _nx_noop()
+* translate()
+* translate_nooped_plural()
+
+While `_e()` and `_ex()` are also supported, you probably won’t need them in Twig, because `{{ }}` already echoes the output.
 
 Old template:
 
@@ -111,7 +122,7 @@ Timber-fied template:
 
 #### sprintf notation
 
-You can even use sprintf-type placeholders, using the `format` filter:
+You can use sprintf-type placeholders, using the `format` filter:
 
 Old template:
 
@@ -125,13 +136,17 @@ Timber-fied template:
 <p class="entry-meta">{{ __('Posted on %s', 'my-text-domain')|format(posted_on_date) }}</p>
 ```
 
-#### Generating .po files using Poedit
+#### Generating .po files with Poedit 2
 
-Unfortunately, Twig files with the above functions are not automatically parsed by gettext in Poedit. The quick and dirty workaround is to start each .twig file with `{#<?php#}` (by doing this, gettext will interpret whatever comes next as php, and start looking for `__`).
+[Poedit 2](https://poedit.net/) fully supports parsing of Twig files (Pro version only) with the following functions: __(), _x(), _n(), _nx().
+
+#### Generating .po files with Poedit 1.x
+
+Internationalization functions in Twig files are not automatically parsed by gettext in Poedit 1.x. The quick and dirty workaround is to start each .twig file with `{#<?php#}`. By doing this, gettext will interpret whatever comes next as php, and start looking for `__`.
 
 A nicer solution is to use [Twig-Gettext-Extractor](https://github.com/umpirsky/Twig-Gettext-Extractor), a special Twig parser to Poedit. The linked page contains instructions on how to set it up.
 
-Alternatively, you can use the parser for Python instead. This will throw a warning or two, but your strings are extracted! To add the parser, follow these steps:
+Alternatively, you can use a custom parser for Python instead. This will throw a warning or two, but your strings are extracted! To add the parser, follow these steps:
 
 1. Create a Poedit project for your theme if you haven't already, and make sure to add `__` on the _Sources keywords_ tab.
 2. Go to _Edit_->_Preferences_.
@@ -143,6 +158,19 @@ Alternatively, you can use the parser for Python instead. This will throw a warn
     * An item in input files list: `%f`
     * Source code charset: `--from-code=%c`
 4. Save and Update!
+
+Be aware that with the Python parser, strings inside HTML attributes will not be recognized. This will not work:
+
+```twig
+<nav aria-label="{{ __('Main Menu', 'my-text-domain') }}">
+```
+
+As a workaround, you can assign the translation to a variable, which you can then use in the attribute.
+
+```twig
+{% set nav_aria_label = __('Main Menu', 'my-text-domain') %}
+<nav aria-label="{{ nav_aria_label }}">
+```
 
 * * *
 


### PR DESCRIPTION
With the new version 2 of Poedit, it’s now easier to internationalize a Timber theme. I updated the documentation accordingly:

- Differentiated between using Poedit 1 and Poedit 2
- Added the HTML attribute caveat to Poedit 1 section (http://stackoverflow.com/a/38834931/1059980)
- Listed internationalization functions that are wrapped by default in [Twig.php](https://github.com/timber/timber/blob/master/lib/Twig.php)
- Applied coding standards to code examples