### PR TITLE
Process ToJPG only if the filetype is supported

### DIFF
--- a/lib/Image/Operation/ToJpg.php
+++ b/lib/Image/Operation/ToJpg.php
@@ -40,6 +40,20 @@ class ToJpg extends ImageOperation {
 	 * @return bool                  true if everything went fine, false otherwise
 	 */
 	public function run( $load_filename, $save_filename ) {
+		
+		// First, check if the filetype is a valid one. Processing an invalid filetype
+		// results in an exception, which is not really useful.
+		// See issue: "Timber throw exception when trying to convert TIFF to JPEG #1192"
+
+		$ext = wp_check_filetype($load_filename);
+		if ( isset($ext['ext']) ) {
+			$ext = $ext['ext'];
+		}
+		$ext = strtolower($ext);
+		if (!in_array($ext, ['gif', 'png', 'jpg', 'jpeg'])) {
+			return false;
+		}
+		
 		$input = self::image_create($load_filename);
 		list($width, $height) = getimagesize($load_filename);
 		$output = imagecreatetruecolor($width, $height);

--- a/tests/test-timber-image-tojpg.php
+++ b/tests/test-timber-image-tojpg.php
@@ -10,11 +10,14 @@
 		}
 
 		/**
-     	 * @expectedException Twig_Error_Runtime
-     	 */
+		 * This should fail silently as opposed to throwing an exception
+		 * see #1383 and #1192
+		 */
 		function testTIFtoJPG() {
 			$filename = TestTimberImage::copyTestImage( 'white-castle.tif' );
 			$str = Timber::compile_string('{{file|tojpg}}', array('file' => $filename));
+			$this->assertEquals($filename, $str);
+			unlink($filename);
 		}
 
 		function testPNGtoJPG() {


### PR DESCRIPTION
// First, check if the filetype is a valid one. Processing an invalid filetype
// results in an exception, which is not really useful.
// See issue: "Timber throw exception when trying to convert TIFF to JPEG #1192"

**Ticket**: # <!-- Ignore this if not relevant --> #1192 
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
<!-- Description of the problem that this code change is solving -->
Timber throw exception when trying to convert TIFF to JPEG #1192

#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
 First, check if the filetype is a valid one

#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->


#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
