### PR TITLE
1387/documentation

### DIFF
--- a/docs/wiki/_cheatsheet.md
+++ b/docs/wiki/_cheatsheet.md
@@ -1,11 +1,11 @@
 # Cheatsheet
 
-Here are some helpful conversions for functions you're probably well familiar with in WordPress and their Timber equivalents. These assume a PHP file with the `Timber::get_context();` function at the top. For example:
+Here are some helpful conversions for functions you’re probably well familiar with in WordPress and their Timber equivalents. These assume a PHP file with the `Timber::get_context();` function at the top. For example:
 
 ```php
 $context = Timber::get_context();
 $context['post'] = new TimberPost();
-Timber::render('single.twig', $context);
+Timber::render( 'single.twig', $context );
 ```
 
 ## Blog Info
@@ -34,8 +34,3 @@ Timber::render('single.twig', $context);
 * `get_stylesheet_directory()` => `{{ theme.path }}`
 
 In WordPress parlance, stylesheet_directory = child theme, template directory = parent theme. Both WP and Timber functions safely return the current theme info if there's no parent/child going on.
-
-
-## wp_functions
-* `wp_footer()` => `{{ wp_footer }}`
-* `wp_head()` => `{{ wp_head }}`

--- a/docs/wiki/_functions.md
+++ b/docs/wiki/_functions.md
@@ -83,3 +83,14 @@ Now you can use it like a "normal" function:
 ### function_wrapper
 
 In Timber versions lower than 1.3, you could use `function_wrapper` to make functions available in Twig. This method is now deprecated. Instead, use one of the methods above.
+
+### Functions that echo output
+
+The concept of Timber (and templating engines like Twig in general) is to prepare all the data before you pass it to a template. Some functions in WordPress echo their output directly. We don’t want this, because the output of this function would be echoed before we call `Timber:render()` and appear before every else on your website. There are two ways to work around this:
+
+- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](http://timber.github.io/timber/#ob_function).
+- If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) you can use `FunctionWrapper`:
+
+```php
+$context['my_custom_function'] = new FunctionWrapper( 'my_custom_function', $array_of_arguments );
+```

--- a/docs/wiki/_functions.md
+++ b/docs/wiki/_functions.md
@@ -1,0 +1,85 @@
+# Functions
+
+My theme/plugin has some functions I need! Do I really have to re-write all of them?
+
+No.
+
+## function()
+
+You can call all PHP functions through `function()` in Twig. For example, if you need to call `wp_head()` and `wp_footer()`, you’d do it like this:
+
+```twig
+{# single.twig #}
+<html>
+	<head>
+	<!-- Add whatever you need in the head, and then...-->
+	{{ function('wp_head') }}
+	</head>
+
+	<!-- etc... -->
+
+	<footer>
+		Copyright &copy; {{ "now"|date('Y') }}
+	</footer>
+	{{ function('wp_footer') }}
+	</body>
+</html>
+```
+
+You can also use `fn('my_function')` as an alias for `function('my_function')`.
+
+### function() with arguments
+
+What if you need to pass arguments to a function? Easy, add them as additional arguments (the first argument will always be the name of the function to call):
+
+```twig
+{# single.twig #}
+<div class="admin-tools">
+	{{ function('edit_post_link', 'Edit', '<span class="edit-link">', '</span>') }}
+</div>
+```
+
+Nice! Any gotchas? Unfortunately yes. While the above example will totally work in a single.twig file it will not in The Loop. Why? Single.twig/single.php retain the context of the current post. A function like `edit_post_link` will try to guess the ID of the post you want to edit from the current post in The Loop. the same function requires some modification in a file like `archive.twig` or `index.twig`. There, you will need to explicitly pass the post ID:
+
+```twig
+{# index.twig #}
+<div class="admin-tools">
+	{{ function('edit_post_link', 'Edit', '<span class="edit-link">', '</span>', post.ID) }}
+</div>
+```
+
+## Make functions available in Twig
+
+If you have functions that you use a lot and want to improve readability of your code, you can make a function available in Twig by using `Twig_SimpleFunction` inside the `timber/twig` hook.
+
+```php
+/**
+ * My custom Twig functionality.
+ *
+ * @param Twig_Environment $twig
+ * @return $twig
+ */
+add_filter( 'timber/twig', function( \Twig_Environment $twig ) {
+	$twig->addFunction( new \Twig_SimpleFunction( 'edit_post_link', 'edit_post_link' ) );
+} );
+```
+
+Now you can use it like a "normal" function:
+
+```twig
+{# single.twig #}
+<div class="admin-tools">
+    {{ edit_post_link }}
+</div>
+{# Calls edit_post_link using default arguments #}
+
+{# single-my-post-type.twig #}
+<div class="admin-tools">
+    {{ edit_post_link(null, '<span class="edit-my-post-type-link">') }}
+</div>
+{# Calls edit_post_link with all defaults, except for second argument #}
+```
+
+### function_wrapper
+
+In Timber versions lower than 1.3, you could use `function_wrapper` to make functions available in Twig. This method is now deprecated. Instead, use one of the methods above.

--- a/docs/wiki/_getting-started-themeing.md
+++ b/docs/wiki/_getting-started-themeing.md
@@ -123,6 +123,7 @@ $context = Timber::get_context();
 $context['posts'] = Timber::get_posts();
 Timber::render('index.twig', $context);
 ```
+
 This is where we are going to handle the logic that powers our index file. Let's go step-by-step.
 
 #### Get the starter
@@ -132,7 +133,7 @@ This is where we are going to handle the logic that powers our index file. Let's
 $context = Timber::get_context();
 ```
 
-This is going to return an object with a lot of the common things we need across the site. Things like your nav, wp_head and wp_footer you'll want to start with each time (even if you over-write them later). You can do a ```print_r($context);``` to see what's inside or open-up **timber.php** to inspect for yourself
+This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you'll want to start with each time (even if you over-write them later). You can do a ```print_r( $context );``` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.
 
 #### Grab your posts
 

--- a/docs/wiki/_internationalization.md
+++ b/docs/wiki/_internationalization.md
@@ -47,7 +47,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 <p class="entry-meta">{{ __('Posted on %s', 'my-text-domain')|format(posted_on_date) }}</p>
 ```
 
-If you want to use the `sprintf` function in Twig, you have to add it yourself using [`function_wrapper`](http://timber.github.io/timber/#function_wrapper).
+If you want to use the `sprintf` function in Twig, you have to [add it yourself](http://timber.github.io/timber/#make-functions-available-in-twig).
 
 ## Generating localization files
 

--- a/docs/wiki/_wp-integration.md
+++ b/docs/wiki/_wp-integration.md
@@ -4,7 +4,6 @@ Timber plays nice with your existing WordPress setup. You can still use other pl
 
 - [the_content](#the_content)
 - [WordPress Hooks](#hooks)
-- [Scripts + Stylesheets](#scripts--stylesheets)
 - [Functions](#functions)
 - [Actions](#actions)
 - [Filters](#filters)
@@ -13,131 +12,26 @@ Timber plays nice with your existing WordPress setup. You can still use other pl
 
 * * *
 
-### the_content
+## the_content
 You're probably used to calling `the_content()` in your theme file. This is good. Before outputting, WordPress will run all the filters and actions that your plugins and themes are using. If you want to get this into your new Timber theme (and you probably do). Call it like this:
 
 ```twig
 <div class="my-article">
-   {{post.content}}
+   {{ post.content }}
 </div>
 ```
 
-This differs from `{{post.post_content}}` which is the raw text stored in your database
+This differs from `{{ post.post_content }}`, which is the raw text stored in your database.
 
 * * *
 
-### Hooks
+## Hooks
+
 Timber hooks to interact with WordPress use `this/style/of_hooks` instead of `this_style_of_hooks`. This matches the same methodology as [Advanced Custom Fields](http://www.advancedcustomfields.com/resources/#actions).
 
 Full documentation to come
 
 * * *
-
-### Scripts + Stylesheets
-What happened to `wp_head()` and `wp_footer()`? Don't worry, they haven't gone away. In fact, they have a home now in the `Timber::get_context()` object. When you setup your PHP file, you should do something like this:
-
-```php
-<?php
-/* single.php */
-$data = Timber::get_context();
-$data['post'] = new TimberPost();
-Timber::render('single.twig', $data);
-```
-
-Now in the corresponding Twig file:
-
-```twig
-{# single.twig #}
-<html>
-	<head>
-	<!-- Add whatever you need in the head, and then...-->
-	{{wp_head}}
-	</head>
-
-	<!-- etc... -->
-
-	<footer>
-		Copyright &copy; {{"now"|date('Y')}}
-	</footer>
-	{{wp_footer}}
-	</body>
-</html>
-```
-
-WordPress will inject whatever output had been loaded into `wp_head()` and `wp_footer()` through these variables.
-
-* * *
-
-#### Functions
-But my theme/plugin has some functions I need! Do I really have to re-write all of them?
-
-No.
-
-Let's say you modified twentyeleven and need some of the functions back. Here's the quick-and-dirty way:
-
-```twig
-<div class="posted-on">{{function("twentyeleven_posted_on")}}</div>
-```
-
-Oh. That's not so bad. What if there are arguments? Easy:
-
-```twig
-{# single.twig #}
-<div class="admin-tools">
-	{{function('edit_post_link', 'Edit', '<span class="edit-link">', '</span>')}}
-</div>
-```
-
-Nice! Any gotchas? Unfortunately yes. While the above example will totally work in a single.twig file it will not in a loop. Why? Single.twig/single.php retain the context of the current post. Thus for a function like `edit_post_link` (which will try to guess the ID# of the post you want to edit, based on the current post in the loop), the same function requires some modification in a file like `archive.twig` or `index.twig`. There, you will need to explicitly set the post ID:
-
-```twig
-{# index.twig #}
-<div class="admin-tools">
-	{{function('edit_post_link', 'Edit', '<span class="edit-link">', '</span>', post.ID)}}
-</div>
-```
-
-You can also use `fn('my_function')` as an alias.
-
-For a less quick-and-dirty way, you can use the TimberFunctionWrapper. This class sets up your PHP functions as functions you can use in your Twig templates. It will execute them only when you actually call them in your template. You can quickly set up a TimberFunctionWrapper using `TimberHelper`:
-
-```php
-<?php
-/**
- * @param string $function_name
- * @param array (optional) $defaults
- * @param bool (optional) $return_output_buffer Return function output instead of return value (default: false)
- * @return \TimberFunctionWrapper
- */
-TimberHelper::function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false );
-```
-
-So if you want to add `edit_post_link` to your context, you can do something like this:
-
-```php
-<?php
-/* single.php */
-$data = Timber::get_context();
-$data['post'] = new TimberPost();
-$data['edit_post_link'] = TimberHelper::function_wrapper( 'edit_post_link', array( __( 'Edit' ), '<span class="edit-link">', '</span>' ) );
-Timber::render('single.twig', $data);
-```
-
-Now you can use it like a 'normal' function:
-
-```twig
-{# single.twig #}
-<div class="admin-tools">
-    {{edit_post_link}}
-</div>
-{# Calls edit_post_link using default arguments #}
-
-{# single-my-post-type.twig #}
-<div class="admin-tools">
-    {{edit_post_link(null, '<span class="edit-my-post-type-link">')}}
-</div>
-{# Calls edit_post_link with all defaults, except for second argument #}
-```
 
 ## Actions
 
@@ -154,18 +48,18 @@ Call them in your Twig template...
 <?php
 add_action('my_action', 'my_function');
 
-function my_function($context){
-	//$context stores the template context in case you need to reference it
+function my_function( $context ) {
+	// $context stores the template context in case you need to reference it
 	echo $context['post']->post_title; //outputs title of yr post
 }
 ```
 
 ```php
 <?php
-add_action('my_action_with_args', 'my_function_with_args', 10, 2);
+add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
 
-function my_function_with_args($foo, $bar){
-	echo 'I say '.$foo.' and '.$bar;
+function my_function_with_args( $foo, $bar ){
+	echo 'I say ' . $foo . ' and ' . $bar;
 }
 ```
 
@@ -173,28 +67,30 @@ You can still get the context object when passing args, it's always the _last_ a
 
 ```php
 <?php
-add_action('my_action_with_args', 'my_function_with_args', 10, 3);
+add_action( 'my_action_with_args', 'my_function_with_args', 10, 3 );
 
-function my_function_with_args($foo, $bar, $context){
-	echo 'I say '.$foo.' and '.$bar;
-	echo 'For the post with title '.$context['post']->post_title;
+function my_function_with_args( $foo, $bar, $context ){
+	echo 'I say ' . $foo . ' and ' . $bar;
+	echo 'For the post with title ' . $context['post']->post_title;
 }
 ```
 
-Please note the argument count that WordPress requires for `add_action`
+Please note the argument count that WordPress requires for `add_action`.
 
 * * *
 
 ## Filters
 
+Timber already comes with a [set of useful filters](http://timber.github.io/timber/#filters). If you have your own filters that you want to apply, you can use `apply_filters`.
+
 ```twig
 {{ post.content|apply_filters('my_filter') }}
-{{ "my custom string"|apply_filters('my_filter',param1,param2,...) }}
+{{ "my custom string"|apply_filters('my_filter', param1, param2, ...) }}
 ```
 
 * * *
 
-### Widgets
+## Widgets
 
 Everyone loves widgets!
 Of course they do...
@@ -211,12 +107,11 @@ Then use it in your template:
 ```twig
 {# base.twig #}
 <footer>
-	{{footer_widgets}}
+	{{ footer_widgets }}
 </footer>
 ```
 
 * * *
-
 
 ### Using Timber inside your own widgets
 
@@ -233,7 +128,7 @@ public function widget($args, $instance) {
 }
 ```
 
-The corresponding template file ```random-widget.twig``` looks like this:
+The corresponding template file `random-widget.twig` looks like this:
 
 ```twig
 {{ args.before_widget | raw }}
@@ -249,19 +144,19 @@ You may also want to check if the Timber plugin was loaded before using it:
 
 ```php
 <?php
-public function widget($args, $instance) {
-	if (!class_exists('Timber')) {
+public function widget( $args, $instance ) {
+	if ( ! class_exists( 'Timber' ) ) {
 		// if you want to show some error message, this is the right place
 		return;
 	}
 	$number = rand();
-	Timber::render('random-widget.twig', array('args' => $args, 'instance' => $instance, 'number' => $number));
+	Timber::render( 'random-widget.twig', array( 'args' => $args, 'instance' => $instance, 'number' => $number ) );
 }
 ```
 
 * * *
 
-#### Shortcodes
+## Shortcodes
 
 Well, if it works for widgets, why shouldn't it work for shortcodes ?
 Of course it does !
@@ -271,17 +166,18 @@ For the desired usage of `[youtube id=xxxx]` we only need a few lines of code:
 
 ```php
 <?php
-// should be called from within an init action hook
-add_shortcode('youtube', 'youtube_shorttag');
+// Should be called from within an init action hook
+add_shortcode( 'youtube', 'youtube_shorttag' );
 
-function youtube_shorttag($atts) {
-	if(isset($atts['id'])) {
-		$id = sanitize_text_field($atts['id']);
+function youtube_shorttag( $atts ) {
+	if( isset( $atts['id'] ) ) {
+		$id = sanitize_text_field( $atts['id'] );
 	} else {
 		$id = false;
 	}
-	// this time we use Timber::compile since shorttags should return the code
-	return Timber::compile('youtube-short.twig', array('id' => $id));
+	
+	// This time we use Timber::compile since shorttags should return the code
+	return Timber::compile( 'youtube-short.twig', array( 'id' => $id ) );
 }
 ```
 

--- a/lib/FunctionWrapper.php
+++ b/lib/FunctionWrapper.php
@@ -4,6 +4,13 @@ namespace Timber;
 
 use Timber\Helper;
 
+/**
+ * FunctionWrapper Class.
+ *
+ * With Timber, we want to prepare all the data before we echo content through a render function. Some functionality in WordPress directly echoes output instead of returning it. This class makes it easier to store the results of an echoing function by using ob_start() and ob_end_clean() behind the scenes.
+ *
+ * @package Timber
+ */
 class FunctionWrapper {
 
 	private $_class;


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1387
**Reviewer**: @jarednova 

#### Issue

Update documentation to reflect how FunctionWrapper should be used or how to include functions.

#### Solution

- Remove deprecated `wp_head` and `wp_footer` entries in _cheatsheet.md and other references in _getting-started-themeing.md
- Create new guide "Functions" to describe:
    - How functions can be used in Twig, without and with arguments.
    - How functions can be exposed to Twig
    - A small note about the function_wrapper deprecation
    - A section about functions that echo output and how to handle these.
- Remove "Scripts + Styles" section, because `wp_head` and `wp_footer` are handled through `{{ function() }}`. Instead, use `wp_head` and `wp_footer` as the primary example in the Functions guide.
- Harmonize heading levels
- Apply WordPress coding standards to code examples

Please review this carefully, as I may have made some assumptions that might not be exactly correct.

I thought about the use case of `FunctionWrapper` and also saw `Helper::ob_function`, and I asked myself: What’s the difference? Am I right with the following assumptions, that would be inserted into the documentation with this pull request?

- `Helper::ob_function` is used to bypass the output and instead save it as a string for functions that don’t depend on stuff like globals.
- If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) `FunctionWrapper` is a better solution.

If `FunctionWrapper` has it’s own special use case, does it maybe need to be added to https://github.com/timber/timber/blob/master/bin/generate-docs.sh#L27?