### PR TITLE
1387/Deprecate function_wrapper helper and introduce warning

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -172,13 +172,17 @@ class Helper {
 	}
 
 	/**
-	 * @param mixed $function_name or array( $class( string|object ), $function_name )
-	 * @param array (optional) $defaults
-	 * @param bool (optional) $return_output_buffer Return function output instead of return value (default: false)
-	 * @return Timber\FunctionWrapper|mixed
+	 * @deprecated since 1.3.0
+	 *
+	 * @param mixed $function_name        String or array( $class( string|object ), $function_name ).
+	 * @param array $defaults             Optional.
+	 * @param bool  $return_output_buffer Optional. Return function output instead of return value. Default false.
+	 * @return FunctionWrapper|mixed
 	 */
 	public static function function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false ) {
-		return new FunctionWrapper($function_name, $defaults, $return_output_buffer);
+		Helper::warn( 'function_wrapper is deprecated and will be removed in 1.4. Use {{ function( \'function_to_call\' ) }} instead or use FunctionWrapper directly. For more information refer to http://timber.github.io/timber/#functions' );
+
+		return new FunctionWrapper( $function_name, $defaults, $return_output_buffer );
 	}
 
 	/**
@@ -205,7 +209,7 @@ class Helper {
 	public static function warn( $message ) {
 		return trigger_error($message, E_USER_WARNING);
 	}
-	
+
 	/**
 	 *
 	 *
@@ -338,7 +342,7 @@ class Helper {
 				}
 			}
 			return false;
-		} 
+		}
 		throw new \InvalidArgumentException('$array is not an array, got:');
 		Helper::error_log($array);
 	}

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -244,9 +244,9 @@ class Timber {
 			 * @deprecated as of Timber 1.3.0
 			 * @todo remove in Timber 1.4.*
 			 */
-			self::$context_cache['wp_head'] = Helper::function_wrapper('wp_head');
-			self::$context_cache['wp_footer'] = Helper::function_wrapper('wp_footer');
-			
+			self::$context_cache['wp_head'] = new FunctionWrapper( 'wp_head' );
+			self::$context_cache['wp_footer'] = new FunctionWrapper( 'wp_footer' );
+
 			self::$context_cache = apply_filters('timber_context', self::$context_cache);
 			self::$context_cache = apply_filters('timber/context', self::$context_cache);
 		}
@@ -399,12 +399,15 @@ class Timber {
 
 	/**
 	 * Get widgets.
+	 *
 	 * @api
-	 * @param int     $widget_id
-	 * @return TimberFunctionWrapper
+	 * @param int|string $widget_id Optional. Index, name or ID of dynamic sidebar. Default 1.
+	 * @return FunctionWrapper
 	 */
 	public static function get_widgets( $widget_id ) {
-		return trim(Helper::function_wrapper('dynamic_sidebar', array($widget_id), true));
+		$output = new FunctionWrapper( 'dynamic_sidebar', array( $widget_id ), true );
+
+		return trim( $output );
 	}
 
 	/*  Pagination

--- a/tests/test-timber-wp-functions.php
+++ b/tests/test-timber-wp-functions.php
@@ -1,6 +1,9 @@
 <?php
 
-	class TestTimberWPFunctions extends Timber_UnitTestCase {
+use Timber\FunctionWrapper;
+use Timber\Helper;
+
+class TestTimberWPFunctions extends Timber_UnitTestCase {
 
 		function testFunctionFire(){
 			$str = '{{function("my_test_function")}}';
@@ -12,13 +15,13 @@
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'jquery', false, array(), false, true );
-			$fw1 = TimberHelper::function_wrapper('wp_footer', array(), true);
-			$fw2 = TimberHelper::function_wrapper('wp_footer', array(), true);
+			$fw1 = new FunctionWrapper('wp_footer', array(), true);
+			$fw2 = new FunctionWrapper('wp_footer', array(), true);
 			$this->assertGreaterThan(50, strlen($fw1->call()));
 			//this is bunk because footer scripts will only print once
 			$this->assertEquals(0, strlen($fw2->call()));
 			wp_dequeue_script('jquery');
-			$wp_footer_output1 = TimberHelper::function_wrapper('wp_footer', array(), true);
+			$wp_footer_output1 = new FunctionWrapper('wp_footer', array(), true);
 			$this->assertEquals(0, strlen($wp_footer_output1));
 		}
 
@@ -26,7 +29,7 @@
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'jquery', false, array(), false, true );
-			$fw1 = TimberHelper::function_wrapper('wp_footer', array(), true);
+			$fw1 = new FunctionWrapper('wp_footer', array(), true);
 			$this->assertGreaterThan(50, strlen($fw1->call()));
 		}
 
@@ -34,8 +37,8 @@
 			add_action('jared_action', function(){
 				echo 'bar';
 			});
-			$fw1 = TimberHelper::function_wrapper('do_jared_action', array(), true);
-			$fw2 = TimberHelper::function_wrapper('do_jared_action', array(), true);
+			$fw1 = new FunctionWrapper('do_jared_action', array(), true);
+			$fw2 = new FunctionWrapper('do_jared_action', array(), true);
 			$this->assertEquals($fw1->call(), $fw2->call());
 			$this->assertEquals('bar', $fw1->call());
 		}
@@ -44,8 +47,8 @@
 			global $wp_scripts;
 			$wp_scripts = null;
 			add_action('wp_footer', 'echo_junk');
-			$fw1 = TimberHelper::function_wrapper('wp_footer', array(), true);
-			$fw2 = TimberHelper::function_wrapper('wp_footer', array(), true);
+			$fw1 = new FunctionWrapper('wp_footer', array(), true);
+			$fw2 = new FunctionWrapper('wp_footer', array(), true);
 			$this->assertEquals($fw1->call(), $fw2->call());
 			$this->stringContains('foo', $fw2->call());
 			remove_action('wp_footer', 'echo_junk');
@@ -72,7 +75,7 @@
 			$wp_scripts = null;
 			wp_enqueue_script( 'colorpicker', false, array(), false, true);
 			wp_enqueue_script( 'fake-js', 'http://example.org/fake-js.js', array(), false, true );
-			$wp_footer = TimberHelper::ob_function('wp_footer');
+			$wp_footer = Helper::ob_function('wp_footer');
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'colorpicker', false, array(), false, true);


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1387
**Reviewer**: @jarednova 

#### Issue

Developers should get a warning when they still use `Helper::function_wrapper`.

#### Solution

This pull request puts a `Helper::warn` call into the `function_wrapper` method:

> function_wrapper is deprecated and will be removed in 1.4. Use {{ function( \'function_to_call\' ) }} instead or use FunctionWrapper directly. For more information refer to http://timber.github.io/timber/#functions

Many developers still use `function_wrapper` to expose functions to Twig. This solutions is some kind of compromise. It replaces instances in Timber where `Helper::function_wrapper` is still used by using `FunctionWrapper` directly.

The only remaining use case I saw for `Helper::function_wrapper` in Timber is `Timber::get_widgets()` (after `wp_head` and `wp_footer` will be deprecated).

#### Impact

- Developers that use `function_wrapper` to expose functions to Twig will have to refer to the documentation on what to use best, see (#1394). Most use cases will probably be covered by `{{ function() }}`, the use of `Twig_SimpleFunction` or `Helper::ob_function`.
- Developers that use `function_wrapper` like it was intended to be in the beginning will also get the warning. They will also have to use `FunctionWrapper` directly.

@jarednova I don’t know if this a direction you want to take. It’s a proposal that might help.

#### Considerations

The link in the warning would refer to the newly introduced functions guide in #1394.

#### Testing

- Ran phpunit tests for `TestTimberWPFunctions` and `TestTimberWidgets`, all ok.
- I didn’t test manually if widgets still display in the frontend.