### PR TITLE
Custom WordPress directory image resize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
           env: WP_VERSION=4.6 WP_MULTISITE=0
 
 before_script:
-    ## Runkit
-    - pecl install runkit
-    - if [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then git clone --depth=1 git://github.com/runkit7/runkit7.git runkit; cd runkit; phpize; ./configure; make; make install; cd ../; phpenv config-add tests/travis.php.ini; fi
-    ## Other setup
     - if [ "$TRAVIS_PHP_VERSION" == 5.5 ] || [ "$TRAVIS_PHP_VERSION" == 5.4 ] || [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then autodetect | pecl install imagick; fi
     - if [ "$TRAVIS_PHP_VERSION" == 5.3 ]; then autodetect | pecl install imagick-3.0.1; fi
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -365,13 +365,8 @@ class ImageHelper {
 				$tmp = str_replace(WP_CONTENT_DIR, '', $tmp);
 			}
 		} else {
-			// if upload dir does not contain site_url, the content-directory seems to be outside of the site_url
-			// therefore using site_url() would lead to a wrong content/ path
-			if ( false === strpos($upload_dir['baseurl'], site_url()) ) {
-				// use HOME_URL and relative image path
-				$tmp = get_home_url().$tmp;
-			} else if ( !$result['absolute'] ) {
-				$tmp = site_url().$tmp;
+			if ( !$result['absolute'] ) {
+				$tmp = untrailingslashit(network_home_url()).$tmp;
 			}
 			if ( TextHelper::starts_with($tmp, $upload_dir['baseurl']) ) {
 				$result['base'] = self::BASE_UPLOADS; // upload based
@@ -468,7 +463,7 @@ class ImageHelper {
 			$subdir = URLHelper::url_to_file_system($subdir);
 		}
 		$subdir = self::maybe_realpath($subdir);
-		
+
 		$path = '';
 		if ( self::BASE_UPLOADS == $base ) {
 			//it is in the Uploads directory
@@ -535,7 +530,7 @@ class ImageHelper {
 			$au['subdir'],
 			$au['basename']
 		);
-		
+
 		$new_url = apply_filters('timber/image/new_url', $new_url);
 		$destination_path = apply_filters('timber/image/new_path', $destination_path);
 		// if already exists...

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -41,4 +41,36 @@
 			flush_rewrite_rules( true );
 		}
 
+		function setupCustomWPDirectoryStructure() {
+			add_filter('content_url', [$this, 'setContentUrl']);
+			add_filter('option_upload_path', [$this, 'setUploadPath']);
+			add_filter('option_upload_url_path', [$this, 'setUploadUrlPath']);
+			add_filter('option_siteurl', [$this, 'setSiteUrl']);
+			add_filter('option_home_url', [$this, 'setHomeUrl']);
+		}
+
+		function tearDownCustomWPDirectoryStructure() {
+			remove_filter('content_url', [$this, 'setContentUrl']);
+			remove_filter('option_upload_path', [$this, 'setUploadPath']);
+			remove_filter('option_upload_url_path', [$this, 'setUploadUrlPath']);
+			remove_filter('option_siteurl', [$this, 'setSiteUrl']);
+			remove_filter('option_home_url', [$this, 'setHomeUrl']);
+		}
+
+		function setContentUrl($url) {
+			return 'http://' . $_SERVER['HTTP_HOST'] . '/content';
+		}
+
+		function setUploadPath($dir) {
+			return ABSPATH . 'content/uploads';
+		}
+
+		function setUploadUrlPath($dir) {
+			return 'http://' . $_SERVER['HTTP_HOST'] . '/content/uploads';
+		}
+
+		function setSiteUrl($url) {
+			return 'http://' . $_SERVER['HTTP_HOST'] . '/wp';
+		}
+
 	}

--- a/tests/assets/thumb-test-relative.twig
+++ b/tests/assets/thumb-test-relative.twig
@@ -1,0 +1,1 @@
+<img src="{{post.thumbnail.src|relative|resize(size.width, size.height)}}" />

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -23,19 +23,7 @@
 		}
 
 		function testWeirdImageLocations_PR1343() {
-			$old_WP_CONTENT_URL = WP_CONTENT_URL;
-			$old_WP_CONTENT_DIR = WP_CONTENT_DIR;
-
-			if ( version_compare(phpversion(), '7.0', '>=') ) {
-				$this->markTestSkipped('Updates to constants cant be tested in PHP7');
-				return;
-			}
-
-			runkit_constant_redefine("WP_CONTENT_URL", 'http://' . $_SERVER['HTTP_HOST'] . '/content');
-			runkit_constant_redefine("WP_CONTENT_DIR", $_SERVER['DOCUMENT_ROOT'] . '/content');
-
-			define('WP_SITEURL', 'http://example.org/wp/');
-			define('WP_HOME', 'http://example.org/');
+			$this->setupCustomWPDirectoryStructure();
 
 			$upload_dir = wp_upload_dir();
 			$post_id = $this->factory->post->create();
@@ -55,20 +43,14 @@
 			$data['size'] = array( 'width' => 100, 'height' => 50 );
 			$data['crop'] = 'default';
 			Timber::compile( 'assets/thumb-test.twig', $data );
+
+			$this->tearDownCustomWPDirectoryStructure();
+
 			$exists = file_exists( $filename );
 			$this->assertTrue( $exists );
 			$resized_path = $upload_dir['path'].'/flag-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.png';
 			$exists = file_exists( $resized_path );
 			$this->assertTrue( $exists );
-
-
-			runkit_constant_redefine("WP_CONTENT_URL", $old_WP_CONTENT_URL);
-			runkit_constant_redefine("WP_CONTENT_DIR", $old_WP_CONTENT_DIR);
-
-			runkit_constant_redefine("WP_SITEURL", 'http://example.org/');
-
-
-	
 		}
 
 		function testLetterbox() {

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -22,7 +22,10 @@
 			$this->assertEquals($arch, \Timber\ImageHelper::get_server_location($arch));
 		}
 
-		function testWeirdImageLocations_PR1343() {
+		/**
+     * @dataProvider customDirectoryData
+     */
+		function testCustomWordPressDirectoryStructure($template, $size) {
 			$this->setupCustomWPDirectoryStructure();
 
 			$upload_dir = wp_upload_dir();
@@ -40,9 +43,9 @@
 			add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 			$data = array();
 			$data['post'] = new TimberPost( $post_id );
-			$data['size'] = array( 'width' => 100, 'height' => 50 );
+			$data['size'] = $size;
 			$data['crop'] = 'default';
-			Timber::compile( 'assets/thumb-test.twig', $data );
+			Timber::compile( $template, $data );
 
 			$this->tearDownCustomWPDirectoryStructure();
 
@@ -63,6 +66,18 @@
 			$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 			//whats the bg/color of the image
 			$this->assertTrue( TestTimberImage::checkPixel($location_of_image, 1, 1, "#CCC") );
+		}
+
+		function customDirectoryData() {
+			return [
+				[
+					'assets/thumb-test.twig',
+					['width' => 100, 'height' => 50]
+				], [
+					'assets/thumb-test-relative.twig',
+					['width' => 50, 'height' => 100]
+				]
+			];
 		}
 
 	}

--- a/tests/travis.php.ini
+++ b/tests/travis.php.ini
@@ -1,2 +1,0 @@
-extension=runkit.so
-runkit.internal_override=1


### PR DESCRIPTION
#### Issue

Unfortunately pr #1355 broke the image resizing functionality for us. This is already mentioned by some other people here.
Our setup uses bedrock with its custom wordpress directory structure. WordPress itself is located in a subdirectory `/wp`, the content folder is in `/content`. 
The problem is, that in the previous fix, not only relative, but also absolute urls were prefixed with the `home_url`. This resulted in a url something like `http://example.orghttp://example.org/some-image.ext`.


#### Solution

Revert the previous fix and use `network_home_url` instead of site url. This url needs to be untrailinsgslashed for some reason. Maybe this can help #1056 as well.


#### Considerations
Unfortunately all different scenarios are quite hard to test and would make the test suite even more complex. This solution seems to be working for all the previous test cases and definitely works with bedrock single site install and multi site install with subdirectories. I haven't tested multi site with subdomains yest.

#### Testing
I removed the runkit dependecy that was introduced by #1355. The same behaviour can be achieved by using filters. Then I added another test for relative urls because I believe that caused an issue before.

I tried to make fine grained commits so that the approach is easier comprehensible. First break the test, add a new one and then fix it.

The new test from #1355 could not be run in isolation locally for me. It failed, or rather only succeeded if some other test ran before it. Unfortunately there were some other issue with this interdependency. E.g. files, db entries, etc created in other test. That is why a added a different image size for the relative url test.
