### PR TITLE
Disable Twig 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=5.3.0|7.*",
-    "twig/twig": "^1.0|2.*",
+    "twig/twig": "^1.0",
     "upstatement/routes": "0.4",
     "composer/installers": "~1.0",
     "asm89/twig-cache-extension": "~1.0"


### PR DESCRIPTION
Based on #1412 and some other anecdotal reports. Twig 2.0 should be downgraded to experimental support — there's just too much going on to verify, even with automated tests.

In this PR I'm removing Twig 2.0 as a dependency; does anyone know if there's a way to indicate "experimental" or "try at your own risk" compatibility?