### PR TITLE
1412/fix-get-widgets

### DIFF
--- a/lib/FunctionWrapper.php
+++ b/lib/FunctionWrapper.php
@@ -38,7 +38,7 @@ class FunctionWrapper {
 			if ( (is_string($function[0]) && class_exists($function[0])) || gettype($function[0]) === 'object' ) {
 				$this->_class = $function[0];
 			}
-			
+
 			if ( is_string($function[1]) ) {
 				$this->_function = $function[1];
 			}
@@ -56,20 +56,30 @@ class FunctionWrapper {
 		add_filter('timber/twig', array(&$this, 'add_to_twig'));
 	}
 
-	/**		
-	 *		
+	/**
+	 * Make function available in Twig.
+	 *
+	 * When a function is added more than once, addFunction() will throw a LogicException that states that the function
+	 * is already registered. By catching this exception, we can prevent a fatal error.
+	 * @see Twig_Extension_Staging::addFunction()
+	 *
 	 * @deprecated since 1.3.0
-	 * @todo remove in 1.4.0	
-	 * @param Twig_Environment $twig		
-	 * @return Twig_Environment		
-	 */		
+	 * @todo remove in 1.4.0
+	 * @param \Twig_Environment $twig
+	 * @return \Twig_Environment
+	 */
 	public function add_to_twig( $twig ) {
-		$wrapper = $this;		
-		$twig->addFunction(new \Twig_SimpleFunction($this->_function, function() use ($wrapper) {		
-			return call_user_func_array(array($wrapper, 'call'), func_get_args());		
- 		} ));		
-		
-		return $twig;		
+		$wrapper = $this;
+
+		try {
+			$twig->addFunction( new \Twig_SimpleFunction( $this->_function, function() use ( $wrapper ) {
+				return call_user_func_array( array( $wrapper, 'call' ), func_get_args() );
+			} ) );
+
+		// Use empty 'catch' block and not 'finally', because finally needs PHP 5.5 to work.
+		} catch ( \Exception $e ) {}
+
+		return $twig;
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -402,12 +402,10 @@ class Timber {
 	 *
 	 * @api
 	 * @param int|string $widget_id Optional. Index, name or ID of dynamic sidebar. Default 1.
-	 * @return FunctionWrapper
+	 * @return string
 	 */
 	public static function get_widgets( $widget_id ) {
-		$output = new FunctionWrapper( 'dynamic_sidebar', array( $widget_id ), true );
-
-		return trim( $output );
+		return trim( Helper::ob_function( 'dynamic_sidebar', array( $widget_id ) ) );
 	}
 
 	/*  Pagination


### PR DESCRIPTION
**Ticket**: #1412
**Reviewer**: @jarednova 

#### Issue
When `Timber::get_widgets()` is called more than once, a fatal error occurs:

```
Fatal error: Uncaught LogicException: Function "dynamic_sidebar" is already registered.
```

As @danimbrogno mentioned, if the function is being registered twice in Twig, it causes a `LogicException` to trigger. Because that exception is not catched, a fatal error is thrown.

#### Solution

By wrapping `$twig->addFunction` into a try/catch block, we can ignore this exception. Although there might be multiple registered `FunctionWrapper` instances with the same function name, it doesn’t get added to Twig.

But! We don’t have to use FunctionWrapper for `Timber::get_widgets()`.

I changed `get_widgets()` method to use `Helper::ob_function` instead of `FunctionWrapper`. Because `get_widgets()` is normally called when we build up our context (http://timber.github.io/timber/#widgets), we can use `ob_function`. As I see it, there would be no easy way to call `get_widgets()` from inside a Twig template anyways, so I guess this is a safe way to go?

#### Considerations

I’m still thinking about a use case for `FunctionWrapper`, and I can’t find one yet. Especially if support for using FunctionWrapper to make a function available to Twig will be removed in version 1.4. What will be the difference to just using `Helper::ob_function` then? Maybe I still don’t get the concept behind it.

#### Testing

Manual test with two registered sidebars:

```
$context['sidebar1'] = Timber::get_widgets('sidebar-1');
$context['sidebar2'] = Timber::get_widgets('sidebar-2');
```
