### PR TITLE
Update Timber_WP_CLI_Command.php

### DIFF
--- a/lib/Integrations/Timber_WP_CLI_Command.php
+++ b/lib/Integrations/Timber_WP_CLI_Command.php
@@ -19,7 +19,13 @@ class Timber_WP_CLI_Command extends \WP_CLI_Command {
 	 *
 	 */
 	public function clear_cache( $mode = 'all' ) {
-		Command::clear_cache($mode);
+		$mode = $mode ? : 'all';
+		$cleared = Command::clear_cache( $mode );
+		if ( $cleared ) {
+			\WP_CLI::success("Cleared {$mode} cached contents");
+		} else {
+			\WP_CLI::warning("Failed to clear {$mode} cached contents");
+		}
 	}
 
 	/**
@@ -31,12 +37,7 @@ class Timber_WP_CLI_Command extends \WP_CLI_Command {
 	 *
 	 */
 	public function clear_cache_twig() {
-		$clear = Command::clear_cache_twig();
-		if ( $clear ) {
-			WP_CLI::success('Cleared contents of twig cache');
-		} else {
-			WP_CLI::warning('Failed to clear twig cache');
-		}
+		$this->clear_cache( 'twig' );
 	}
 
 	/**
@@ -48,14 +49,6 @@ class Timber_WP_CLI_Command extends \WP_CLI_Command {
 	 *
 	 */
 	public function clear_cache_timber() {
-		$clear = Command::clear_cache_timber();
-		$message = 'Failed to clear timber cache';
-		if ( $clear ) {
-			$message = "Cleared contents of Timber's Cache";
-			WP_CLI::success($message);
-		} else {
-			WP_CLI::warning($message);
-		}
-		return $message;
+		$this->clear_cache( 'timber' );
 	}
 }


### PR DESCRIPTION
This change addresses https://github.com/timber/timber/issues/1429.

**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
https://github.com/timber/timber/issues/1429

#### Solution
Fixed WP_CLI call.
Unified calls and produced result in methods for cache clearing.

#### Impact
The proposed change may impact users/software performing WP_CLI cache clearing commands.
After this update `wp timber cache_clear_twig` and `wp timber cache_clear_timber` should work as expected.
Before this update `wp timber cache_clear` didn't produce any WP_CLI output.
After this update it will report success only when both twig and timber content are cleared, and warning otherwise.

#### Usage
No usage changes required.
