### PR TITLE
Improve inline documentation for get_post()

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -8,9 +8,9 @@ use Timber\QueryIterator;
 class PostGetter {
 
 	/**
-	 * @param mixed $query
+	 * @param mixed        $query
 	 * @param string|array $PostClass
-	 * @return array|bool|null
+	 * @return \Timber\Post|bool
 	 */
 	public static function get_post( $query = false, $PostClass = '\Timber\Post' ) {
 		// if a post id is passed, grab the post directly
@@ -26,9 +26,12 @@ class PostGetter {
 		}
 
 		$posts = self::get_posts($query, $PostClass);
+
 		if ( $post = reset($posts) ) {
 			return $post;
 		}
+
+		return false;
 	}
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -120,11 +120,14 @@ class Timber {
 	================================ */
 
 	/**
-	 * Get post.
+	 * Get a post by post ID or query (as a query string or an array of arguments).
+	 *
 	 * @api
-	 * @param mixed   $query
-	 * @param string|array  $PostClass
-	 * @return array|bool|null
+	 * @param mixed        $query     Optional. Post ID or query (as query string or an array of arguments for
+	 *                                WP_Query). If a query is provided, only the first post of the result will be
+	 *                                returned. Default false.
+	 * @param string|array $PostClass Optional. Class to use to wrap the returned post object. Default 'Timber\Post'.
+	 * @return \Timber\Post|bool Timber\Post object if a post was found, false if no post was found.
 	 */
 	public static function get_post( $query = false, $PostClass = 'Timber\Post' ) {
 		return PostGetter::get_post($query, $PostClass);


### PR DESCRIPTION
**Ticket**: #1425 

#### Issue
See ticket

#### Solution

- Fix param and return types
- Add description for function, parameters and return for Timber::get_post()
- Add missing return value to PostGetter::get_post()