### PR TITLE
Enable Post::convert() to convert also single WP_Posts

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1186,11 +1186,13 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * Finds any WP_Post objects and converts them to Timber\Posts
-	 * @param array $data
+	 * @param array|WP_Post $data
 	 * @param string $class
 	 */
 	public function convert( $data, $class ) {
-		if ( is_array($data) ) {
+		if ( $data instanceof WP_Post ) {
+			$data = new $class($data);
+		} else if ( is_array($data) ) {
 			$func = __FUNCTION__;
 			foreach ( $data as &$ele ) {
 				if ( gettype($ele) === 'array' ) {

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -26,7 +26,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
 		$post = new TimberPost();
-		$timber_post = $post->convert( $wp_post );
+		$timber_post = $post->convert( $wp_post, 'TimberPost' );
 		$this->assertTrue( $timber_post instanceof TimberPost );
 	}
 

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -22,6 +22,25 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$this->assertEquals( 'foobar', $str );
 	}
 
+	function testWPPostConvert() {
+		$pid = $this->factory->post->create();
+		$wp_post = get_post( $pid );
+		$post = new Post();
+		$timber_post = $post->convert( $wp_post );
+		$this->assertTrue( $timber_post instanceof TimberPost );
+	}
+	function testWPPostArrayConvert() {
+		$pid_1 = $this->factory->post->create();
+		$pid_2 = $this->factory->post->create();
+		$wp_post_1 = get_post( $pid_1 );
+		$wp_post_2 = get_post( $pid_2 );
+		$post = new Post();
+		$timber_posts = $post->convert( [ $wp_post_1, $wp_post_2 ] );
+		foreach ( $timber_posts as $timber_post ) {
+			$this->assertTrue( $timber_post instanceof TimberPost );	
+		}
+	}
+
 	function testACFHasFieldPostFalse() {
 		$pid = $this->factory->post->create();
 		$str = '{% if post.has_field("heythisdoesntexist") %}FAILED{% else %}WORKS{% endif %}';

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -25,20 +25,9 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPPostConvert() {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
-		$post = new Post();
+		$post = new TimberPost();
 		$timber_post = $post->convert( $wp_post );
 		$this->assertTrue( $timber_post instanceof TimberPost );
-	}
-	function testWPPostArrayConvert() {
-		$pid_1 = $this->factory->post->create();
-		$pid_2 = $this->factory->post->create();
-		$wp_post_1 = get_post( $pid_1 );
-		$wp_post_2 = get_post( $pid_2 );
-		$post = new Post();
-		$timber_posts = $post->convert( [ $wp_post_1, $wp_post_2 ] );
-		foreach ( $timber_posts as $timber_post ) {
-			$this->assertTrue( $timber_post instanceof TimberPost );	
-		}
 	}
 
 	function testACFHasFieldPostFalse() {


### PR DESCRIPTION
#### Issue
When a developer tries to use get_field on a relationship or repeater field, Timber returns an array with instances of TimberPost. However, that didn't happen for Post Object fields, and a WP_Post was returned instead.


#### Solution
In the convert function used by get_field, a if condition was added to check if the argument given is an instance of WP_Post (and not an array of course), and returns an instance of TimberPost.


#### Impact
None that I'm aware of.


#### Usage
Ability to use get_field() on a Post Object field and get a TimberPost


#### Considerations
None


#### Testing
````
{% set post_obj = post.get_field('single_post') %}
{{ post_obj.thumbnail.src.('medium) }}
````
The last line would fail because `post_obj` wouldn't be a TimberPost, but a WP_Post