### PR TITLE
Improve documentation for render and compile functions

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -87,8 +87,11 @@ class Loader {
 	}
 
 	/**
-	 * @param array $filenames
-	 * @return bool
+	 * Get first existing template file.
+	 *
+	 * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, the function
+	 *                                 return the first file that exists.
+	 * @return string
 	 */
 	public function choose_template( $filenames ) {
 		if ( is_array($filenames) ) {

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -259,14 +259,30 @@ class Timber {
 	}
 
 	/**
-	 * Compile function.
+	 * Compile a Twig file.
+	 *
+	 * Passes data to a Twig file and returns the output.
+	 *
 	 * @api
-	 * @param array   $filenames
-	 * @param array   $data
-	 * @param boolean|integer    $expires
-	 * @param string  $cache_mode
-	 * @param bool    $via_render
-	 * @return bool|string
+	 * @example
+	 * ```php
+	 * $data = array(
+	 *     'firstname' => 'Jane',
+	 *     'lastname' => 'Doe',
+	 *     'email' => 'jane.doe@example.org',
+	 * );
+	 *
+	 * $team_member = Timber::compile( 'team-member.twig', $data );
+	 * ```
+	 * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, Timber will
+	 *                                 render the first file that exists.
+	 * @param array        $data       Optional. An array of data to use in Twig template.
+	 * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
+	 *                                 array, the first value is used for non-logged in visitors, the second for users.
+	 *                                 Default false.
+	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
+	 * @param bool         $via_render Optional. Whether to apply optional render or compile filters. Default false.
+	 * @return bool|string The returned output.
 	 */
 	public static function compile( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT, $via_render = false ) {
 		if ( !defined('TIMBER_LOADED') ) {
@@ -296,10 +312,19 @@ class Timber {
 	}
 
 	/**
-	 * Compile string.
+	 * Compile a string.
+	 *
 	 * @api
-	 * @param string  $string a string with twig variables.
-	 * @param array   $data   an array with data in it.
+	 * @example
+	 * ```php
+	 * $data = array(
+	 *     'username' => 'Jane Doe',
+	 * );
+	 *
+	 * $welcome = Timber::compile_string( 'Hi {{ username }}, I’m a string with a custom Twig variable', $data );
+	 * ```
+	 * @param string $string A string with Twig variables.
+	 * @param array  $data   Optional. An array of data to use in Twig template.
 	 * @return  bool|string
 	 */
 	public static function compile_string( $string, $data = array() ) {
@@ -311,12 +336,16 @@ class Timber {
 
 	/**
 	 * Fetch function.
+	 *
 	 * @api
-	 * @param array   $filenames
-	 * @param array   $data
-	 * @param bool    $expires
-	 * @param string  $cache_mode
-	 * @return bool|string
+	 * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, Timber will
+	 *                                 render the first file that exists.
+	 * @param array        $data       Optional. An array of data to use in Twig template.
+	 * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
+	 *                                 array, the first value is used for non-logged in visitors, the second for users.
+	 *                                 Default false.
+	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
+	 * @return bool|string The returned output.
 	 */
 	public static function fetch( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {
 		$output = self::compile($filenames, $data, $expires, $cache_mode, true);
@@ -326,12 +355,24 @@ class Timber {
 
 	/**
 	 * Render function.
+	 *
+	 * Passes data to a Twig file and echoes the output.
+	 *
 	 * @api
-	 * @param array|string   $filenames
-	 * @param array   $data
-	 * @param boolean|integer    $expires
-	 * @param string  $cache_mode
-	 * @return boolean|string
+	 * @example
+	 * ```php
+	 * $context = Timber::get_context();
+	 *
+	 * Timber::render( 'index.twig', $context );
+	 * ```
+	 * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, Timber will
+	 *                                 render the first file that exists.
+	 * @param array        $data       Optional. An array of data to use in Twig template.
+	 * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
+	 *                                 array, the first value is used for non-logged in visitors, the second for users.
+	 *                                 Default false.
+	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
+	 * @return bool|string The echoed output.
 	 */
 	public static function render( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {
 		$output = self::fetch($filenames, $data, $expires, $cache_mode);
@@ -340,11 +381,20 @@ class Timber {
 	}
 
 	/**
-	 * Render string.
+	 * Render a string with Twig variables.
+	 *
 	 * @api
-	 * @param string  $string a string with twig variables.
-	 * @param array   $data   an array with data in it.
-	 * @return  bool|string
+	 * @example
+	 * ```php
+	 * $data = array(
+	 *     'username' => 'Jane Doe',
+	 * );
+	 *
+	 * Timber::render_string( 'Hi {{ username }}, I’m a string with a custom Twig variable', $data );
+	 * ```
+	 * @param string $string A string with Twig variables.
+	 * @param array  $data   An array of data to use in Twig template.
+	 * @return bool|string
 	 */
 	public static function render_string( $string, $data = array() ) {
 		$compiled = self::compile_string($string, $data);


### PR DESCRIPTION
- Add descriptions for parameters and return values.
- Apply [WordPress Inline Documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
- Add examples.
- Improve type hinting for IDEs.

#### Considerations

I don’t know what the benefit of the `fetch` function is, if the only difference to the `compile` function is that it applies an additional filter `timber_compile_results`. Is this for backwards compatibility?