### PR TITLE
fix urls of images when using WPML with language in directory setting

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -166,8 +166,13 @@ class URLHelper {
 	 */
 	public static function file_system_to_url( $fs ) {
 		$relative_path = self::get_rel_path($fs);
-		$home = home_url('/'.$relative_path);
-		return $home;
+		$home_url = home_url();
+
+		if (defined('ICL_LANGUAGE_CODE')) {
+			$home_url = preg_replace('/' . ICL_LANGUAGE_CODE . '$/', '', $home_url);
+		}
+
+		return $home_url . $relative_path;
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
When using WPML with a custom wp content directory (bedrock), images URLs are being returned like `https://example.org/us/app/uploads/sites/2/2017/06/599a117bad71440a5b4f98e3807afc70.jpg`

Note the `/us` in the URL. The correct location is not to have the `/us` in the URL, like this:

`https://example.org/app/uploads/sites/2/2017/06/599a117bad71440a5b4f98e3807afc70.jpg`

#### Solution
I attempt to filter our the language code from the URL if it set in the function `file_system_to_url`

#### Impact
Should all tests pass, there should be no impact.


#### Usage
Usage should be transparent and backwards compatible.


#### Considerations


#### Testing
I noticed there is a test already for `testWPMLurlRemote`, and `testWPMLurlLocal` - perhaps these don't work? Or don't work for installs where wordpress is installed differently.
