### PR TITLE
Add known arguments to avatar filter

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -131,7 +131,8 @@ class Comment extends Core implements CoreInterface {
 
 		$email = $this->avatar_email();
 		
-		$args = apply_filters('pre_get_avatar_data', array(), $email);
+		$args = array('size' => $size, 'default' => $default);
+		$args = apply_filters('pre_get_avatar_data', $args, $email);
 		if ( isset($args['url']) ) {
 			return $args['url'];
 		}


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
Known arguments for avatar (size, default) are not passed to the filter, so they are missed by the functions hooked into the filter (for example, returning an image of the wrong size).

#### Solution
Add known args  to filter method.

#### Impact
Small, and bringing behaviour up to expectation.

