### PR TITLE
Remove dead code from test-timber-loader

### DIFF
--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -122,9 +122,7 @@
 		}
 
 		function _testTwigLoadsFromAbsolutePathOnServerWithSecurityRestriction(){
-			//ini_set('open_basedir', '/srv:/usr:/home/travis/:/tmp:/home:/home/travis/.phpenv/versions/*');
 			$str = Timber::compile('assets/single-foo.twig');
-			//ini_restore('open_basedir');
 		}
 
 		function testTwigLoadsFromAlternateDirName(){


### PR DESCRIPTION
#### Issue

Our hoster notified us about possible security issues with the `open_basedir` override (`Atomicorp.PHP.Bypass.OpenBaseDir`). It's commented out so removing the code doesn't change anything. There's also no reason that the code should be there in the first place.

#### Solution

Removing dead / commented out code.

#### Impact

No notifications of virus scanning softwares about vulnerabilities in the test-timber-loader file.