### PR TITLE
Update type to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "timber/timber",
-  "type": "library",
+  "type": "wordpress-plugin",
   "description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
   "keywords": [
     "timber",


### PR DESCRIPTION
Changed type to wordpress-plugin according to 
https://getcomposer.org/doc/04-schema.md#type
so when using composer "installer-paths" it will installed in plugins.
https://roots.io/bedrock/docs/composer/

**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
<!-- Description of the problem that this code change is solving -->


#### Solution
<!-- Description of the solution that this code changes are introducing to the application. -->


#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->


#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
