### PR TITLE
Delegate testing template existence to Twig

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -25,6 +25,8 @@ class Loader {
 
 	protected $cache_mode = self::CACHE_TRANSIENT;
 
+	private $loader;
+
 	protected $locations;
 
 	/**
@@ -32,6 +34,18 @@ class Loader {
 	 */
 	public function __construct( $caller = false ) {
 		$this->locations = LocationManager::get_locations($caller);
+		
+		$open_basedir = ini_get('open_basedir');
+		$paths = array_merge($this->locations, array($open_basedir ? ABSPATH : '/'));
+		$paths = apply_filters('timber/loader/paths', $paths);
+
+		$rootPath = '/';
+		if ( $open_basedir ) {
+			$rootPath = null;
+		}
+		$this->loader = new \Twig_Loader_Filesystem($paths, $rootPath);
+		$this->loader = apply_filters('timber/loader/loader', $this->loader);
+
 		$this->cache_mode = apply_filters('timber_cache_mode', $this->cache_mode);
 		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
 	}
@@ -128,17 +142,7 @@ class Loader {
 	 * @return \Twig_LoaderInterface
 	 */
 	public function get_loader() {
-		$open_basedir = ini_get('open_basedir');
-		$paths = array_merge($this->locations, array($open_basedir ? ABSPATH : '/'));
-		$paths = apply_filters('timber/loader/paths', $paths);
-
-		$rootPath = '/';
-		if ( $open_basedir ) {
-			$rootPath = null;
-		}
-		$fs = new \Twig_Loader_Filesystem($paths, $rootPath);
-		$fs = apply_filters('timber/loader/loader', $fs);
-		return $fs;
+		return $this->loader;
 	}
 
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -87,33 +87,33 @@ class Loader {
 	}
 
 	/**
-	 * Get first existing template file.
+	 * Get first existing template.
 	 *
-	 * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, the function
-	 *                                 return the first file that exists.
+	 * @param array|string $templates  Names of the Twig template to render.
+	 *                                 If this is an array, the first template that exists is returned.
 	 * @return string
 	 */
-	public function choose_template( $filenames ) {
-		if ( is_array($filenames) ) {
+	public function choose_template( $templates ) {
+		if ( is_array($templates) ) {
 			/* its an array so we have to figure out which one the dev wants */
 			$loader = $this->get_loader();
-			foreach ( $filenames as $filename ) {
-				if ( $loader->exists($filename) ) {
-					return $filename;
+			foreach ( $templates as $template ) {
+				if ( $loader->exists($template) ) {
+					return $templates;
 				}
 			}
-			return $filenames[0];
+			return $templates[0];
 		}
-		return $filenames;
+		return $templates;
 	}
 
 	/**
-	 * @param string $file
+	 * @param string $name
 	 * @return bool
 	 * @deprecated 1.3.4 No longer used internally
 	 */
-	protected function template_exists( $file ) {
-		return $this->get_loader()->exists($file);
+	protected function template_exists( $name ) {
+		return $this->get_loader()->exists($name);
 	}
 
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -125,7 +125,7 @@ class Loader {
 
 
 	/**
-	 * @return \Twig_Loader_Filesystem
+	 * @return \Twig_LoaderInterface
 	 */
 	public function get_loader() {
 		$open_basedir = ini_get('open_basedir');

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -27,16 +27,14 @@ class Loader {
 
 	private $loader;
 
-	protected $locations;
-
 	/**
 	 * @param bool|string   $caller the calling directory or false
 	 */
 	public function __construct( $caller = false ) {
-		$this->locations = LocationManager::get_locations($caller);
+		$locations = LocationManager::get_locations($caller);
 		
 		$open_basedir = ini_get('open_basedir');
-		$paths = array_merge($this->locations, array($open_basedir ? ABSPATH : '/'));
+		$paths = array_merge($locations, array($open_basedir ? ABSPATH : '/'));
 		$paths = apply_filters('timber/loader/paths', $paths);
 
 		$rootPath = '/';

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -96,8 +96,9 @@ class Loader {
 	public function choose_template( $filenames ) {
 		if ( is_array($filenames) ) {
 			/* its an array so we have to figure out which one the dev wants */
+			$loader = $this->get_loader();
 			foreach ( $filenames as $filename ) {
-				if ( self::template_exists($filename) ) {
+				if ( $loader->exists($filename) ) {
 					return $filename;
 				}
 			}
@@ -109,15 +110,10 @@ class Loader {
 	/**
 	 * @param string $file
 	 * @return bool
+	 * @deprecated 1.3.4 No longer used internally
 	 */
 	protected function template_exists( $file ) {
-		foreach ( $this->locations as $dir ) {
-			$look_for = $dir.$file;
-			if ( file_exists($look_for) ) {
-				return true;
-			}
-		}
-		return false;
+		return $this->get_loader()->exists($file);
 	}
 
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -89,22 +89,29 @@ class Loader {
 	/**
 	 * Get first existing template.
 	 *
-	 * @param array|string $templates  Names of the Twig template to render.
-	 *                                 If this is an array, the first template that exists is returned.
-	 * @return string
+	 * @param array|string $templates  Name(s) of the Twig template(s) to choose from.
+	 * @return string|bool             Name of chosen template, otherwise false.
 	 */
 	public function choose_template( $templates ) {
-		if ( is_array($templates) ) {
-			/* its an array so we have to figure out which one the dev wants */
-			$loader = $this->get_loader();
-			foreach ( $templates as $template ) {
-				if ( $loader->exists($template) ) {
-					return $templates;
-				}
-			}
-			return $templates[0];
+		// Change $templates into array, if needed 
+		if ( !is_array($templates) ) {
+			$templates = (array) $templates;
 		}
-		return $templates;
+		
+		// Get Twig loader
+		$loader = $this->get_loader();
+		
+		// Run through template array
+		foreach ( $templates as $template ) {
+			// Use the Twig loader to test for existance
+			if ( $loader->exists($template) ) {
+				// Return name of existing template
+				return $template;
+			}
+		}
+
+		// No existing template was found
+		return false;
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -292,22 +292,32 @@ class Timber {
 		$caller = LocationManager::get_calling_script_dir(1);
 		$loader = new Loader($caller);
 		$file = $loader->choose_template($filenames);
+
 		$caller_file = LocationManager::get_calling_script_file(1);
 		apply_filters('timber/calling_php_file', $caller_file);
-		$output = '';
-		if ( is_null($data) ) {
-			$data = array();
+
+		if ( $via_render ) {
+			$file = apply_filters('timber_render_file', $file);
+		} else {
+			$file = apply_filters('timber_compile_file', $file);
 		}
-		if ( strlen($file) ) {
+
+		$output = false;
+
+		if ($file !== false) {
+			if ( is_null($data) ) {
+				$data = array();
+			}
+
 			if ( $via_render ) {
-				$file = apply_filters('timber_render_file', $file);
 				$data = apply_filters('timber_render_data', $data);
 			} else {
-				$file = apply_filters('timber_compile_file', $file);
 				$data = apply_filters('timber_compile_data', $data);
 			}
+
 			$output = $loader->render($file, $data, $expires, $cache_mode);
 		}
+		
 		do_action('timber_compile_done');
 		return $output;
 	}

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -2,9 +2,6 @@
 
 	class TestTimberLoader extends Timber_UnitTestCase {
 
-		/**
-		 * @expectedException Twig_Error_Loader
-		 */
 		function testLoaderChain() {
 			add_filter('timber/loader/custom', function($loaders) {
 				$arr = array(__DIR__.'/custom_loader_dir');
@@ -12,30 +9,26 @@
 				return $loaders;
 			});
 			$str = Timber::compile('test-chain.twig', array('name' => 'Jared'));
-			$this->assertEquals('Hi Jared', $str);
+			$this->assertFalse($str);
 		}
 
 		function testTwigLoaderFilter() {
 		    $php_unit = $this;
 		    add_filter('timber/loader/loader', function ($loader) use ($php_unit) {
-		        $php_unit->assertInstanceOf('Twig_Loader_Filesystem', $loader);
+		        $php_unit->assertInstanceOf('Twig_LoaderInterface', $loader);
 		        return $loader;
 		    });
 		    $str = Timber::compile('assets/single.twig', array());
 		}
 				
-		/**
-     	 * @expectedException Twig_Error_Loader
-     	 */
 		function testBogusTemplate() {
 			$str = Timber::compile('assets/darkhelmet.twig');
+			$this->assertFalse($str);
 		}
 
-		/**
-     	 * @expectedException Twig_Error_Loader
-     	 */
 		function testBogusTemplates() {
 			$str = Timber::compile( array('assets/barf.twig', 'assets/lonestar.twig') );
+			$this->assertFalse($str);
 		}
 
 		function testTwigPathFilter() {

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -2,16 +2,6 @@
 
 	class TestTimberLoader extends Timber_UnitTestCase {
 
-		function testLoaderChain() {
-			add_filter('timber/loader/custom', function($loaders) {
-				$arr = array(__DIR__.'/custom_loader_dir');
-				$loaders[] = new \Twig_Loader_Filesystem($arr);
-				return $loaders;
-			});
-			$str = Timber::compile('test-chain.twig', array('name' => 'Jared'));
-			$this->assertFalse($str);
-		}
-
 		function testTwigLoaderFilter() {
 		    $php_unit = $this;
 		    add_filter('timber/loader/loader', function ($loader) use ($php_unit) {


### PR DESCRIPTION
**Ticket**: #1475

#### Issue
The filter 'timber/loader/loader' allows customization to Timber’s default Twig loader. This way it is possible to make alterations of the template paths or even replace the default loader, but such modifications are ignored by Timber during testing for template existence, since Timber does its own testing.

#### Solution
Testing for template existence should be delegated to Twig via Twig_LoaderInterface::exists().


#### Impact
- Testing template existence is now handled upstream by Twig, and usage of custom loaders is now possible.
- The protected method template_exists() is marked deprecated (from v1.3.4) in the phpdoc, since it it no longer used internally.

#### Usage
- Choose_template() returns false on failure - instead of the first non-existing template.
- Non-existing templates is no longer passed all the way to Twig's render(), which currently generates an exception (in which only the first template name is mentioned, since Twig knows nothing about the possible array of templates).


#### Considerations
- With the current implementation of get_loader() an extra Twig loader object is created. However this is due to the class not implementing the singleton pattern (get_twig() currently also recreates new Twig loaders on each call).