### PR TITLE
Fix headings

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -8,10 +8,10 @@ menu:
 
 ## Installation
 
-#### Via WordPress.org (easy)
+### Via WordPress.org (easy)
 You can just grab the all-things-included plugin at [WordPress.org](http://wordpress.org/plugins/timber-library/) either through the WP site or your Plugins->Add New in wp-admin. Then skip ahead to [using the starter theme](#use-the-starter-theme).
 
-#### Via GitHub (for developers)
+### Via GitHub (for developers)
 
 The GitHub version of Timber requires [Composer](https://getcomposer.org/download/). If you'd prefer one-click installation, you should use the [WordPress.org](https://wordpress.org/plugins/timber-library/) version.
 
@@ -26,21 +26,19 @@ If your theme is not setup to pull in Composer's autoload file, you will need to
 require_once(__DIR__ . '/vendor/autoload.php');
 ```
 
-at the top of your `functions.php` file.
-
-Initialize Timber with:
+at the top of your `functions.php` file. Initialize Timber with:
 
 ```php
 <?php
 $timber = new \Timber\Timber();
 ```
 
-* * *
+## Use the starter theme
 
-## [Use the starter theme](https://github.com/Upstatement/timber-starter-theme)
-This is for starting a project from scratch. You can also use Timber in an existing theme.
+The [starter theme](https://github.com/Upstatement/timber-starter-theme) is for starting a project from scratch. You can also use Timber in an existing theme.
 
-##### Navigate to your WordPress themes directory
+### Navigate to your WordPress themes directory
+
 Like where twentyeleven and twentytwelve live. The Timber Starter will live at the same level.
 
 	/wp-content/themes	/twentyeleven
@@ -54,9 +52,11 @@ You should now have:
 You should probably **rename** this to something better.
 
 ### 1. Activate Timber
+
 It will be in wp-admin/plugins.php
 
 ### 2. Select your theme in WordPress
+
 Make sure you select the Timber-enabled theme **after** you activate the plugin. The theme will crash unless Timber is activated. Use the **timber-starter-theme** theme from the step above (or whatever you renamed it).
 
 ### 3. Let's write our theme!

--- a/docs/getting-started/themeing.md
+++ b/docs/getting-started/themeing.md
@@ -7,8 +7,7 @@ menu:
 
 ## Your first Timber project
 
-### Let's start with your single post
-Find this file:
+Let's start with your single post. Find this file:
 
 ```html
 	wp-content/themes/{timber-starter-theme}/views/single.twig
@@ -32,7 +31,9 @@ Brilliant! Open it up.
 {% endblock %}
 ```
 
-#### This is the fun part.
+**What did we just do?**
+
+This is the fun part.
 
 ```twig
 <h1 class="article-h1">{{ post.title }}</h1>
@@ -65,7 +66,8 @@ This means that `single.twig` is using `base.twig` as its parent template. That'
 
 What if you want modify `<head>`, etc? Read on to learn all about blocks.
 
-### Blocks
+## Blocks
+
 Blocks are the single most important and powerful concept in managing your templates. The [official Twig Documentation](http://twig.sensiolabs.org/doc/templates.html#template-inheritance) has more details. Let's cover the basics.
 
 In `single.twig` you see opening and closing block declarations that surround the main page contents.
@@ -76,7 +78,7 @@ In `single.twig` you see opening and closing block declarations that surround th
 
 If you were to peek into **base.twig** you would see a matching set of `{% block content %} / {% endblock %}` tags. **single.twig** is replacing the content of base's `{% block content %}` with its own.
 
-##### Nesting Blocks, Multiple Inheritance
+### Nesting Blocks, Multiple Inheritance
 This is when things get really cool. Whereas most people use PHP includes in a linear fashion, you can create infinite levels of nested blocks to particularly control your page templates. For example, let's say you occasionally want to replace the title/headline on your `single.twig` template with a custom image or typography.
 
 For this demo let's assume that the name of the page is "All about Jared" (making its slug `all-about-jared`). First, I'm going to surround the part of the template I want to control with block declarations:
@@ -119,7 +121,7 @@ So two big concepts going on here:
 
 What if you want to **add** to the block as opposed to replace? No prob, just call `{{ parent() }}` where the parent's content should go.
 
-### Loop / Index page
+## The index page
 
 Let's crack open **index.php** and see what's inside:
 
@@ -132,7 +134,7 @@ Timber::render('index.twig', $context);
 
 This is where we are going to handle the logic that powers our index file. Let's go step-by-step.
 
-#### Get the starter
+### Get the context
 
 ```php
 <?php
@@ -141,7 +143,7 @@ $context = Timber::get_context();
 
 This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you'll want to start with each time (even if you over-write them later). You can do a ```print_r( $context );``` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.
 
-#### Grab your posts
+### Grab your posts
 
 ```php
 <?php
@@ -149,9 +151,9 @@ $context['posts'] = Timber::get_posts();
 ```
 We're now going to grab the posts that are inside the loop and stick them inside our data object under the **posts** key.
 
-##### Timber::get_posts() usage
+## How to use Timber::get_posts()
 
-###### Use a [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query) array
+### Use a WP_Query array
 
 ```php
 	<?php
@@ -175,7 +177,9 @@ We're now going to grab the posts that are inside the loop and stick them inside
 	$context['posts'] = Timber::get_posts($args);
 ```
 
-##### Use a [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query) string
+You can find all available options in the documentation for [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query).
+
+### Use a WP_Query string
 
 ```php
 	<?php
@@ -183,7 +187,7 @@ We're now going to grab the posts that are inside the loop and stick them inside
 	$context['posts'] = Timber::get_posts($args);
 ```
 
-##### Use Post ID numbers
+### Use Post ID numbers
 
 ```php
 	<?php
@@ -191,7 +195,7 @@ We're now going to grab the posts that are inside the loop and stick them inside
 	$context['posts'] = Timber::get_posts($ids);
 ```
 
-#### Render
+## Render
 
 ```php
 <?php

--- a/docs/getting-started/video-tutorials.md
+++ b/docs/getting-started/video-tutorials.md
@@ -7,31 +7,40 @@ menu:
 
 I'm in the midst of an install and walk-through on Timber, here are the screencasts thus far:
 
-### 1. Install Timber
+## 1. Install Timber
 
-#### Option 1: Via GitHub (for developers)
+### Option 1: Via GitHub (for developers)
 
-##### 1) Navigate to your WordPress plugins directory
+#### 1) Navigate to your WordPress plugins directory
+
 	$ cd ~/Sites/mywordpress/wp-content/plugins
 
-##### 2) Use git to grab the repo
+#### 2) Use git to grab the repo
+
 	$ git clone git@github.com:jarednova/timber.git
 
-##### 3) Use [Composer](https://getcomposer.org/doc/00-intro.md) to download the dependencies (Twig, etc.)
+#### 3) Use Composer to download the dependencies (Twig, etc.)
+
 	$ cd timber
 	$ composer install
+	
+You can find a guide on [how to get started with Composer](https://getcomposer.org/doc/00-intro.md) in the official documentation.
 
-#### Option 2: Via Composer (for developers)
+### Option 2: Via Composer (for developers)
 
-##### 1) Navigate to your WordPress plugins directory
+#### 1) Navigate to your WordPress plugins directory
+
     $ cd ~/Sites/mywordpress/wp-content/plugins
 
-##### 2) Use [Composer](https://getcomposer.org/doc/00-intro.md) to create project and download the dependencies (Twig, etc.)
-    $ composer create-project --no-dev jarednova/timber ./timber
+#### 2) Use Composer to create project and download the dependencies (Twig, etc.)
 
-#### Option 3: Via WordPress plugins directory (for non-developers)
+	$ composer create-project --no-dev jarednova/timber ./timber
 
-##### If you'd prefer one-click installation, you should use the [WordPress.org](http://wordpress.org/plugins/timber-library/) version.
+You can find a guide on [how to get started with Composer](https://getcomposer.org/doc/00-intro.md) in the official documentation.
+
+### Option 3: Via WordPress plugins directory (for non-developers)
+
+If you'd prefer one-click installation, you should use the [WordPress.org](http://wordpress.org/plugins/timber-library/) version.
 
 * * *
 
@@ -39,7 +48,8 @@ Now just activate in your WordPress admin screen. Inside of the timber directory
 
 * * *
 
-### 2. Including a Twig template and sending data
+## 2. Including a Twig template and sending data
+
 [![Installing Timber](http://img.youtube.com/vi/SlMonnwVi5M/0.jpg)](http://www.youtube.com/watch?v=SlMonnwVi5M)
 
 In which we use an existing WordPress template and implement a very simple Timber usage.
@@ -63,8 +73,11 @@ Timber::render('welcome.twig', $context);
 	</div>
 </section>
 ```
+
 * * *
-### 3. Connecting Twig to your WordPress Admin
+
+## 3. Connecting Twig to your WordPress Admin
+
 [![Connecting Timber](http://img.youtube.com/vi/C7HtYkaG2DQ/0.jpg)](http://www.youtube.com/watch?v=C7HtYkaG2DQ)
 
 ```php
@@ -83,8 +96,11 @@ Timber::render('welcome.twig', $context);
 	</div>
 </section>
 ```
+
 * * *
-### 4. Converting HTML to Twig Templates
+
+## 4. Converting HTML to Twig Templates
+
 [![Connecting HTML Templates](http://img.youtube.com/vi/BxazrNBLK-0/0.jpg)](http://www.youtube.com/watch?v=BxazrNBLK-0)
 
 ```php
@@ -102,7 +118,7 @@ Timber::render('home-main.twig', $context);
 
 * * *
 
-### 5. Using Custom Post Types with Timber + Twig
+## 5. Using Custom Post Types with Timber + Twig
 
 [![Using Custom Post Types with Timber](http://img.youtube.com/vi/19T0MStDLSQ/0.jpg)](http://www.youtube.com/watch?v=19T0MStDLSQ)
 
@@ -126,13 +142,15 @@ Timber::render('home-main.twig', $context);
 	</div>
 </article>
 ```
+
 * * *
-### 6. Extending Templates
+
+## 6. Extending Templates
 _Todo: Record Screencast showing this_
 
 This is a **really** important concept for DRY. I'll show how to create a base template that can power your site:
 
-##### Create a `base.twig` file:
+### Create a `base.twig` file:
 
 ```twig
 {# base.twig #}
@@ -151,7 +169,7 @@ This is a **really** important concept for DRY. I'll show how to create a base t
 </html>
 ```
 
-##### You can use this in a custom `single.twig` file:
+### You can use this in a custom `single.twig` file:
 
 ```twig
 {# single.twig #}

--- a/docs/guides/acf-cookbook.md
+++ b/docs/guides/acf-cookbook.md
@@ -9,7 +9,8 @@ Timber is designed to play nicely with (the amazing) [Advanced Custom Fields](ht
 
 While data saved by ACF is available via `{{post.my_acf_field}}` you will often need to do some additional work to get back the _kind_ of data you want. For example, images are stored as image ID#s which you might want to translate into a specific image object. Read on to learn more about those specific exceptions.
 
-### WYSIWYG field (and other requiring text):
+## WYSIWYG field (and other requiring text)
+
 ```twig
 <h3>{{post.title}}</h3>
 <div class="intro-text">
@@ -19,16 +20,17 @@ While data saved by ACF is available via `{{post.my_acf_field}}` you will often 
 
 This will apply your expected paragraph breaks and other pre-processing to the text.
 
-### Image field type:
+## Image field
+
 You can retrieve an image from a custom field, then use it in a Twig template. The most reliable approach is this: When setting up your custom fields you'll want to save the `image_id` to the field. The image object, url, etc. _will_ work but it's not as fool-proof.
 
-##### The quick way (for most situations)
+### The quick way (for most situations)
 
 ```twig
 <img src="{{TimberImage(post.get_field('hero_image')).src}}" />
 ```
 
-##### The long way (for some special situations)
+### The long way (for some special situations)
 
 This is where we'll start in PHP.
 
@@ -53,16 +55,18 @@ You can now use all the above functions to transform your custom images in the s
 ```
 
 * * *
-### Gallery Field:
+
+## Gallery field
 
 ```twig
 {% for image in post.get_field('gallery') %}
     <img src="{{ TimberImage(image) }}" />
 {% endfor %}
 ```
+
 * * *
 
-### Repeater field
+## Repeater field
 
 You can access repeater fields within twig files:
 
@@ -80,7 +84,7 @@ You can access repeater fields within twig files:
 </div>
 ```
 
-##### Nested?
+### Nested Repeater fields
 
 When you run `get_field` on an outer ACF field, everything inside is ready to be traversed. You can refer to nested fields via item_outer.inner_repeater
 
@@ -95,11 +99,11 @@ When you run `get_field` on an outer ACF field, everything inside is ready to be
 {% endfor %}
 ```
 
-##### Troubleshooting
+### Troubleshooting Repeaters
 
 A common problem in working with repeaters is that you should only call the `get_field` method **once** on an item. In other words if you have a field inside a field (for example, a relationship inside a repeater or a repeater inside a repeater, **do not** call `get_field` on the inner field). More:
 
-###### DON'T DO THIS: (Bad)
+**DON'T DO THIS: (Bad)**
 
 ```twig
 {% for gear in post.get_field('gear_items') %}
@@ -110,7 +114,7 @@ A common problem in working with repeaters is that you should only call the `get
 {% endfor %}
 ```
 
-###### Do THIS: (Good)
+**DO THIS: (Good)**
 
 ```twig
 {% for gear in post.get_field('gear_items') %}
@@ -123,7 +127,7 @@ A common problem in working with repeaters is that you should only call the `get
 
 * * *
 
-### Flexible content field
+## Flexible Content field
 
 Similar to repeaters, get the field by the name of the flexible content field:
 
@@ -142,7 +146,7 @@ Similar to repeaters, get the field by the name of the flexible content field:
 
 * * *
 
-### Options Page
+## Options Page
 
 ```php
 	<?php
@@ -154,7 +158,7 @@ Similar to repeaters, get the field by the name of the flexible content field:
 	<footer>{{site_copyright_info}}</footer>
 ```
 
-###### Get all info from your options page
+### Get all info from your options page
 
 ```php
 	<?php
@@ -168,7 +172,7 @@ ACF Pro has a built in options page, and changes the `get_fields('options')` to 
 	<footer>{{options.copyright_info}}</footer>
 ```
 
-###### Use options info site wide
+### Use options info site wide
 
 To use any options fields site wide, add the `option` context to your functions.php file
 
@@ -192,7 +196,8 @@ Now, you can use any of the option fields across the site instead of per templat
 
 * * *
 
-### Getting ACF info:
+## Getting ACF info
+
 You can grab specific field label data like so:
 
 ```php
@@ -207,11 +212,9 @@ $context["acf"] = get_field_objects($data["post"]->ID);
 
 * * *
 
-### Query by custom field value:
-###### Use a [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query) array
+## Query by custom field value
 
-#### Basic Example
-This example shows the arguments to find all posts where a custom field called ‘color’ has a value of ‘red’.
+This example that uses a [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.
 
 ```php
 <?php

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -5,7 +5,9 @@ menu:
     parent: "guides"
 ---
 
-Timber makes it damn easy to use an image in a tag. Automatically, Timber will interpret images attached to a post's thumbnail field ("Featured Image" in the admin) and treat them as [TimberImages](TimberImage). Then, in your Twig templates, you can access them via `{{post.thumbnail}}`. If you want to see what's inside the TimberImage object you can run a...
+Timber makes it damn easy to use an image in a tag.
+
+Automatically, Timber will interpret images attached to a post's thumbnail field ("Featured Image" in the admin) and treat them as [TimberImages](TimberImage). Then, in your Twig templates, you can access them via `{{post.thumbnail}}`. If you want to see what's inside the TimberImage object you can run a...
 
 ```twig
 {{post.thumbnail|print_r}}
@@ -13,7 +15,7 @@ Timber makes it damn easy to use an image in a tag. Automatically, Timber will i
 
 ...inside one of your Twig templates.
 
-#### Basic Image stuff
+## Basic Image stuff
 
 Again, pretty damn easy:
 
@@ -21,7 +23,7 @@ Again, pretty damn easy:
 <img src="{{post.thumbnail.src}}" class="my-thumb-class" alt="Image for {{post.title}}" />
 ```
 
-#### Use a WP image size
+## Use a WP image size
 
 You can use WP's image sizes (including ones you register with your theme/plugin) by passing the name of the size to `src` like so:
 
@@ -31,7 +33,7 @@ You can use WP's image sizes (including ones you register with your theme/plugin
 
 Note: If the WP size (e.g medium) has not been generated, it will return an empty string.
 
-#### Arbitrary Resizing of Images
+## Arbitrary Resizing of Images
 
 Want to resize an image? Easy! Here we're going to use [Twig Filters](http://twig.sensiolabs.org/doc/filters/index.html).
 
@@ -47,7 +49,8 @@ The first parameter is `width` the second is `height` (but it's optional) so if 
 
 All of these filters are written specifically to interact with WordPress's image API. (So don't worry, no weird TimThumb stuff going on—this is all using WP's internal image sizing stuff).
 
-#### Letterboxing Images
+## Letterboxing Images
+
 Let's say you have an image that you want to contain to a certain size without any cropping. If the proportions don't fit you'll letterbox the extra space. I find this is really useful when getting logos to all appear next to eachother. You can do this with:
 
 ```twig
@@ -55,7 +58,8 @@ Let's say you have an image that you want to contain to a certain size without a
 ```
 Here `width` and `height` are required. The third argument is the background color in hex format (default is #000000).
 
-#### Converting images
+## Converting images
+
 Let's say your client or editor can be a bit lazy (no!), resorting to PNGs where only JPGs are required. I've seen this a lot. People will just upload screenshots that are saved by default as PNGs. No problemo!
 
 ```twig
@@ -70,7 +74,8 @@ You can use this in conjunction with other filters.
 
 Filters are executed from left to right. You'll probably want to convert to JPG before running the resizing, etc.
 
-#### Generating Retina Sizes
+## Generating Retina Sizes
+
 You can use Timber to generate @2x image sizes for retina devices. For example, using `srcset`:
 
 ```twig
@@ -91,18 +96,19 @@ This can be used in conjunction with other filters, so for example:
 
 * * *
 
-#### Using images in custom fields:
+## Using images in custom fields
+
 Let's say you're using a custom field plugin (like the amazing [Advanced Custom Fields](http://www.advancedcustomfields.com/)). You can use the resulting images in your Twig templates very easily.
 
 When setting up your custom fields you'll want to save the `image_id` to the field. The image object, url, etc. _will_ work but it's not as fool-proof.
 
-##### The quick way (for most situations)
+### The quick way (for most situations)
 
 ```twig
 <img src="{{TimberImage(post.hero_image).src}}" />
 ```
 
-##### The long way (for some special situations)
+### The long way (for some special situations)
 
 This is where we'll start in PHP.
 

--- a/docs/guides/cookbook-text.md
+++ b/docs/guides/cookbook-text.md
@@ -7,9 +7,11 @@ menu:
 
 There's tons of stuff you can do with Twig and Timber filters to make complex transformations easy (and fun!)
 
-#### Dates
+## Dates
 
-##### Timber does bylines like a boss:
+### Example 1: Bylines
+
+Timber does bylines like a boss:
 
 ```twig
 <p class="byline">
@@ -18,13 +20,15 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 </p>
 ```
 
-###### Renders:
+**Renders**
 
 ```html
 <p class="byline"><span class="name">By Mr. WordPress</span><span class="date">September 28, 2013</span></p>
 ```
 
-##### Nothing is worse than an out-of-date copyright year in the footer. Nothing.
+### Example 2: Copyright year
+
+Nothing is worse than an out-of-date copyright year in the footer. Nothing.
 
 ```twig
 <footer>
@@ -32,7 +36,7 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 </footer>
 ```
 
-###### Renders:
+**Renders**
 
 ```html
 <footer><p class="copyright">&copy; 2015 by The Daily Orange</p></footer>
@@ -40,33 +44,35 @@ There's tons of stuff you can do with Twig and Timber filters to make complex tr
 
 * * *
 
-#### Standard transforms
+## Standard transforms
 
-##### Automatically link URLs, email addresses, twitter @s and #s
+### Automatically link URLs, email addresses, twitter @s and #s
 
 ```twig
 <p class="tweet">{{ post.content|twitterify }}</p>
 ```
 
-##### Run WordPress' auto-paragraph filter
+### Run WordPress' auto-paragraph filter
 
 ```twig
 <p class="content">{{ post.my_custom_text|wpautop }}</p>
 ```
 
-##### Run WordPress shortcodes over a block of text
+### Run WordPress shortcodes over a block of text
 
 ```twig
 <p class="content">{{ post.my_custom_text|shortcodes }}</p>
 ```
 
-##### Code samples? Lord knows I've got 'em:
+### Code samples
+
+Code Samples? Lord knows I've got 'em:
 
 ```twig
 <div class="code-sample">{{ post.code_samples|pretags }}</div>
 ```
 
-##### Functions inside of your templates, plugin calls:
+### Functions inside of your templates, plugin calls
 
 Old template:
 
@@ -80,7 +86,7 @@ Timber-fied template:
 <p class="entry-meta">{{ function('twentytwelve_entry_meta') }}</p>
 ```
 
-##### Functions "with params" inside of your templates, plugin calls:
+### Functions "with params" inside of your templates, plugin calls:
 
 Old template:
 
@@ -96,15 +102,15 @@ Timber-fied template:
 
 * * *
 
-### Debugging
+## Debugging
 
-##### What properties are inside my object?
+### What properties are inside my object?
 
 ```twig
 {{ dump(post) }}
 ```
 
-##### What properties and _methods_ are inside my object?
+### What properties and methods are inside my object?
 
 Warning: Experimental!
 
@@ -113,7 +119,7 @@ Warning: Experimental!
 ```
 This outputs both the database stuff (like `{{ post.post_content }}`) and the contents of methods (like `{{ post.thumbnail }}`)
 
-##### What type of object am I working with?
+### What type of object am I working with?
 
 ```twig
 {{ post|get_class }}

--- a/docs/guides/cookbook-twig.md
+++ b/docs/guides/cookbook-twig.md
@@ -6,6 +6,7 @@ menu:
 ---
 
 ## Using Twig vars in live type
+
 Imagine this scenario, I let the users set this in the Admin panel:
 
 ```
@@ -20,7 +21,7 @@ Copyright 2013 by Upstatement, LLC. All Rights Reserved
 
 Ready? There are a bunch of ways, but my favorite is:
 
-#### In your PHP file
+**In your PHP file**
 
 ```php
 <?php
@@ -29,31 +30,36 @@ $data['copyright'] = get_option("footer_message"); //"Copyright {{year}} by Upst
 render_twig('footer.twig', $data);
 ```
 
-#### In your HTML file (let's say **footer.twig**)
+**In your HTML file (let's say **footer.twig**)**
 
 ```twig
 {% include template_from_string(copyright) %}
 ```
 
 ## Includes
+
 ### Simple include
 
 ```twig
 {% include "footer.twig" %}
 ```
+
 #### Notes
+
 * Make sure your file actually exists or you're going to have a bad time
 * Timber will look in your ```child-theme/views``` directory first, then ```timber/views``` directory
 * Don't forget the quote marks!
 
 ### Dynamic includes
+
 Use a variable to determine the included file!
 
 ```twig
 {% include ['blocks/block-'~block.slug~'.twig', 'blocks/blog.twig'] ignore missing %}
 ```
 
-#### Huh?
+**Huh?**
+
 * You're telling Twig to include an array of files
 * Same rules as above
 * ~ (tilda) is what twig uses to concatenate a string with your variable

--- a/docs/guides/custom-page-templates.md
+++ b/docs/guides/custom-page-templates.md
@@ -7,10 +7,12 @@ menu:
 
 There are a few ways to manage custom pages in WordPress and Timber, in order from simple-to-complex:
 
-### Custom Twig File
+## Custom Twig File
+
 Say you've created a page called "About Us" and WordPress has given it the slug `about-us`. If you're using the [Timber Starter Theme](https://github.com/Upstatement/timber-starter-theme) you can simply create a file called `page-about-us.twig` inside your `views` and go crazy. I recommend copying-and-pasting the contents of [`page.twig`](https://github.com/Upstatement/timber-starter-theme/blob/master/views/page.twig) into here so you have something to work from.
 
-##### How does this work?
+**How does this work?**
+
 In the `page.php` file you'll see this code...
 
 ```php
@@ -22,12 +24,14 @@ Which is telling PHP to first look for a twig file named `page-{{slug}}.twig` an
 
 * * *
 
-### Custom PHP File
+## Custom PHP File
+
 If you need to do something special for this page in PHP, you can use standard WordPress [template hierarchy](http://codex.wordpress.org/Template_Hierarchy) to gather and manipulate data for this page. In the above example, you would create a file called `/wp-content/themes/my-theme/page-about-us.php` and populate it with the necessary PHP. Again, you can use the contents of the starter theme's [`page.php`](https://github.com/Upstatement/timber-starter-theme/blob/master/page.php) file as a guide.
 
 * * *
 
-### Custom Page Template
+## Custom Page Template
+
 ```php
 <?php
 /*
@@ -43,4 +47,3 @@ In the WordPress admin, this will now display in your page's list of available t
 ![wordpress custom page template chooser](http://codex.wordpress.org/images/thumb/a/a3/page-templates-pulldown-screenshot.png/180px-page-templates-pulldown-screenshot.png)
 
 I recommend naming it something like `/wp-content/themes/my-theme/template-my-custom-page.php`. Do NOT name it something beginning with `page-` or WP will get very confused. Here's [an example of what the PHP in this file](https://github.com/Upstatement/blades/blob/master/template-person.php) looks like.
-

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -5,17 +5,18 @@ menu:
     parent: "guides"
 ---
 
-### Using Twig's native functions
+## Using Twig’s native functions
 Twig includes a `dump` function that can output the properties of an object. To use `WP_DEBUG` must be set to true.
 
-##### wp-config.php
+**wp-config.php**
 
 ```php
 <?php
 define('WP_DEBUG', true);
 ```
 
-##### single.twig
+**single.twig**
+
 ```twig
 {{dump(post)}}
 ```
@@ -38,12 +39,14 @@ This will give you something like:
 
 * * *
 
-### Using Timber Debug Bar plugin
+## Using Timber Debug Bar plugin
+
 There's a [Timber add-on](http://wordpress.org/plugins/debug-bar-timber/) for the [WordPress debug bar](https://wordpress.org/plugins/debug-bar/). Warning: this currently requries PHP 5.4. I'm working on fixing whatever's going on for PHP 5.3
 
-### Using (Legacy) Timber Filters
+## Using (Legacy) Timber Filters
+
 You can also use some quick filters on an object. These are legacy and will be removed in favor of using Twig's built-in functionality. However, these do not require that WP_DEBUG be turned on.
 
 ```twig
-	{{post|print_r}}
+{{post|print_r}}
 ```

--- a/docs/guides/escapers.md
+++ b/docs/guides/escapers.md
@@ -11,7 +11,6 @@ Twig offers a variety of [escapers](http://twig.sensiolabs.org/doc/filters/escap
 
 This all follows the WordPress (and greater development philosophy) to:
 
-
 1. Never trust user input.
 2. Escape as late as possible.
 3. Escape everything from untrusted sources (like databases and users), third-parties (like Twitter), etc.
@@ -22,14 +21,13 @@ This all follows the WordPress (and greater development philosophy) to:
 
 [Relevant Documentation](https://vip.wordpress.com/documentation/vip/best-practices/security/validating-sanitizing-escaping/)
 
-### wp_kses_post
+## wp_kses_post
 
 Background on KSES. KSES is a recursive acronym for `KSES Kills Evil Scripts`. It's goal is to ensure only  "allowed" HTML element names, attribute names and attribute values plus only sane HTML entities in the string. Allowed is based on a configuration.
 
 This uses ths internal WordPress method that sanitize content for allowed HTML tags for post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );` [WordPress Documentation](https://codex.wordpress.org/Function_Reference/wp_kses_post)
 
-
-###### Twig:
+**Twig**
 
 `<p class="intro">{{post.post_content|e('wp_kses_post')}}</p>`
 
@@ -37,51 +35,50 @@ In this example, `post.post_content` is:
 
 `<div foo="bar" src="bum">Foo</div><script>DoEvilThing();</script>`
 
-###### Output:
+**Output**
 
 `<div>Foo</div>DoEvilThing();`
 
 * * *
 
-### esc_url
+## esc_url
 Uses WordPress' internal `esc_url` function on text. This should be used to sanitize URLs. [WordPress Documentation](https://codex.wordpress.org/Function_Reference/esc_url)
 
-###### Twig:
+**Twig**
 
 `<a href="{{ post.get_field('custom_link')|e('esc_url'); }}"></a>`
 
-###### Output
+**Output**
 
 `<a href="http://google.com"></a>`
 
 * * *
 
-### esc_html
+## esc_html
+
 Escaping for HTML blocks. It converts any potentially conflicting HTML entities to their encoded equivalent to prevent them from being rendered as markup by the browser, e.g. converts "<" to "&lt;" and double quotes " to "$quot;"
 
 This is for plain old text. If your content has HTML markup you should not use `esc_html` which will render the HTML as it looks in your code editor -- to preserve the HTML you will want to use `wp_kses_post`
 
-###### Twig:
-
-
+**Twig**
 
 `<div class="equation">{{ post.get_field('equation')|e('esc_html') }}</div>`
 
-###### Output
+**Output**
 
 `<div class="equation">is x &lt; y?</div>`
 
 * * *
 
-### esc_js
+## esc_js
+
 Escapes text strings for echoing in JS. It is intended to be used for inline JS (in a tag attribute, for example onclick=”…”). Note that the strings have to be in single quotes. The filter ‘js_escape’ is also applied.
 
-###### Twig:
-
+**Twig**
 
 `<script>var bar = '{{ post.get_field('name') }}';</script>`
 
-###### Output
+**Output**
 
 `<script>var bar = 'Gabrielle';</script>`
 

--- a/docs/guides/extending-timber.md
+++ b/docs/guides/extending-timber.md
@@ -9,6 +9,8 @@ Myth: Timber is for making simple themes. Fact: It's for making incredibly compl
 
 The beauty of Timber is that the object-oriented nature lets you extend it to match the exact requirements of your theme.
 
+## An example that extends TimberPost
+
 Timber's objects like `TimberPost`, `TimberTerm`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
 
 

--- a/docs/guides/filters.md
+++ b/docs/guides/filters.md
@@ -9,16 +9,17 @@ menu:
 
 Twig offers a variety of [filters](http://twig.sensiolabs.org/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WP theme:
 
-### excerpt
+## excerpt
+
 When you need to trim text to a desired length (in words)
 
-###### Twig:
+**Twig**
 
 ```twig
 <p class="intro">{{post.post_content|excerpt(30)}}...</p>
 ```
 
-###### Output:
+**Output**
 
 ```html
 <p class="intro">Steve-O was born in London, England. His mother, Donna Gay (née Wauthier), was Canadian, and his father, Richard Glover, was American. His paternal grandfather was English and his maternal step-grandfather ...</p>
@@ -26,43 +27,40 @@ When you need to trim text to a desired length (in words)
 
 * * *
 
-### function
+## function
+
 Runs a function where you need. Really valuable for integrating plugins or existing themes
 
-###### Twig:
+**Twig**
 
 ```twig
 <div class="entry-meta">{{function('twenty_ten_entry_meta')}}</div>
 ```
 
-###### Output
+**Output**
 
 ```html
 <div class="entry-meta">Posted on September 6, 2013</div>
 ```
 
-
-### function (deprecated)
+## <del>function (deprecated)<del>
 Runs a function where you need. Really valuable for integrating plugins or existing themes
 
-###### Twig:
+**Twig**
 
 ```twig
 <div class="entry-meta">{{'twenty_ten_entry_meta'|function}}</div>
 ```
 
-###### Output
+**Output**
 
 ```html
 <div class="entry-meta">Posted on September 6, 2013</div>
 ```
 
-
-
-
 * * *
 
-### relative
+## relative
 Converts an absolute URL into a relative one, for example:
 
 ```twig
@@ -75,22 +73,22 @@ My custom link is <a href="/2015/08/my-blog-post">here!</a>
 
 * * *
 
-### pretags
+## pretags
 Converts tags like `<span>` into `&lt;span&gt;`, but only inside of `<pre>` tags. Great for code samples when you need to preserve other formatting in the non-code sample content.
 
 * * *
 
-### sanitize
+## sanitize
 
 Converts Titles like this into `titles-like-this`
 
-###### Twig:
+**Twig**
 
 ```twig
 {{post.title|sanitize}}
 ```
 
-###### Output:
+**Output**
 
 ```html
 my-awesome-post
@@ -98,11 +96,11 @@ my-awesome-post
 
 * * *
 
-### shortcodes
+## shortcodes
 
 Runs text through WordPress's shortcodes filter. In this example imagine that you've added a shortcode to a custom field like `[gallery id="123" size="medium"]`
 
-###### Twig:
+**Twig**
 
 ```twig
 <section class="gallery">
@@ -110,7 +108,7 @@ Runs text through WordPress's shortcodes filter. In this example imagine that yo
 </section>
 ```
 
-###### Output
+**Output**
 
 ```html
 <section class="gallery">
@@ -120,17 +118,17 @@ Here is my gallery <div class="gallery" id="gallery-123"><img src="...." />...</
 
 * * *
 
-### time_ago
+## time_ago
 
 Displays a date in timeago format:
 
-###### Twig:
+**Twig**
 
 ```twig
 <p class="entry-meta">Posted: <time>{{post.post_date_gmt|time_ago}}</time></p>
 ```
 
-###### Output:
+**Output**
 
 ```html
 <p class="entry-meta">Posted: <time>3 days ago</time></p>
@@ -138,15 +136,15 @@ Displays a date in timeago format:
 
 * * *
 
-### truncate
+## truncate
 
-###### Twig:
+**Twig**
 
 ```twig
 <p class="entry-meta">{{ post.character.origin_story | truncate(8) }} ...</p>
 ```
 
-###### Output:
+**Output**
 
 ```html
 <p class="entry-meta">Bruce Wayne's parents were shot outside the opera ...</p>
@@ -154,10 +152,11 @@ Displays a date in timeago format:
 
 * * *
 
-### wpautop
+## wpautop
+
 Adds paragraph breaks to new lines
 
-###### Twig:
+**Twig**
 
 ```twig
 <div class="body">
@@ -165,7 +164,7 @@ Adds paragraph breaks to new lines
 </div>
 ```
 
-###### Output:
+**Output**
 
 ```html
 <div class="body">
@@ -178,23 +177,24 @@ Adds paragraph breaks to new lines
 
 * * *
 
-### list
+## list
+
 Converts an array of strings into a comma-separated list.
 
-###### PHP:
+**PHP**
 
 ```php
 <?php
 $context['contributors'] = array('Blake Allen','Rachel White','Maddy May');
 ```
 
-###### Twig:
+**Twig**
 
 ```twig
 Contributions made by {{contributors|list(',','&')}}
 ```
 
-###### Output:
+**Output**
 
 ```html
 Contributions made by Blake Allen, Rachel White & Maddy May

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -5,9 +5,8 @@ menu:
     parent: "guides"
 ---
 
-My theme/plugin has some functions I need! Do I really have to re-write all of them?
-
-No.
+My theme/plugin has some functions I need! Do I really have to re-write all of them?  
+No, you don’t.
 
 ## function()
 

--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -7,6 +7,8 @@ menu:
 
 Do you like pagination? Stupid question, of course you do. Well, here's how you do it.
 
+## Default pagination
+
 This will only work in a php file with an active query (like `archive.php` or `home.php`):
 
 ```php
@@ -40,8 +42,7 @@ You can then markup the output like so  (of course, the exact markup is up to YO
 </div>
 ```
 
-### What if I'm not using the default query?
-No problem!
+## What if I'm not using the default query?
 
 ```php
 	<?php
@@ -59,7 +60,8 @@ No problem!
 	Timber::render('page-events.twig', $context);
 ```
 
-### The pre_get_posts Way
+## Pagination with pre_get_posts
+
 Custom `query_posts` sometimes shows 404 on example.com/page/2. In that case you can also use `pre_get_posts` in your functions.php file:
 
 ```php

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -7,7 +7,8 @@ menu:
 
 Timber, especially in conjunction with WordPress and Twig, offers a variety of caching strategies to optimize performance. Here's a quick rundown of some of the options, ranked in order of most-broad to most-focused.
 
-### tl;dr
+## tl;dr
+
 In my tests with Debug Bar, Timber has no measurable performance hit. Everything compiles to PHP. @fabpot has an [overview of the performance costs on his blog](http://fabien.potencier.org/article/34/templating-engines-in-php) (scroll down to the table)
 
 You can...
@@ -21,12 +22,12 @@ You can...
 
 * * *
 
-### Cache Everything
+## Cache Everything
 You can still use plugins like [W3 Total Cache](https://wordpress.org/plugins/w3-total-cache/) in conjunction with Timber. In most settings, this will _skip_ the Twig/Timber layer of your files and serve static pages via whatever mechanism the plugin or settings dictate.
 
 * * *
 
-### Cache the Entire Twig File and Data
+## Cache the Entire Twig File and Data
 
 When rendering, use the `$expires` argument in `Timber::render`. For example:
 
@@ -65,7 +66,7 @@ This method is very effective, but crude - the whole template is cached. So if y
 
 * * *
 
-### Cache _Parts_ of the Twig File and Data
+## Cache _Parts_ of the Twig File and Data
 
 This method implements the Twig Cache Extension. It adds the cache tag, for use in templates. Best shown by example:
 
@@ -99,7 +100,7 @@ That is in this scenario:
 'index/content__GCS__' . md5( json_encode( $context['post'] ) )
 ```
 
-###### Extra: TimberKeyGeneratorInterface
+### Extra: TimberKeyGeneratorInterface
 
 Instead of hashing a whole object, you can specify the cache key in the object itself. If the object implements TimberKeyGeneratorInterface, it can pass a unique key through the method get_cache_key. That way a class can for example simply pass last_updated as the unique key.
 If arrays contain the key _cache_key, that one is used as cache key.
@@ -108,7 +109,8 @@ This may save yet another few processor cycles.
 
 * * *
 
-### Cache the Twig File (but not the data)
+## Cache the Twig File (but not the data)
+
 Every time you render a `.twig` file, Twig compiles all the html tags and variables into a big, nasty blob of function calls and echo statements that actually gets run by PHP. In general, this is pretty efficient. However, you can cache the resulting PHP blob by turning on Twig's cache via:
 
 ```php
@@ -118,12 +120,15 @@ if (class_exists('Timber')){
 	Timber::$cache = true;
 }
 ```
+
 You can look in your your `/wp-content/plugins/timber/twig-cache` directory to see what these files look like.
 
 This does not cache the _contents_ of the variables. This is recommended as a last-step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the html for example) will not go live until the cache is flushed.
 
 * * *
-### Cache the PHP data
+
+## Cache the PHP data
+
 Sometimes the most expensive parts of the operations are generating the data needed to populate the twig template. You can of course use WordPress's default [Transient API](http://codex.wordpress.org/Transients_API) to store this data.
 
 You can also use some [syntactic sugar](http://en.wikipedia.org/wiki/Syntactic_sugar) to make the checking/saving/retrieving of transient data a bit easier:
@@ -147,11 +152,13 @@ $context['main_stories'] = TimberHelper::transient('main_stories', function(){
 }, 600);
 Timber::render('home.twig', $context);
 ```
+
 Here `main_stories` is a totally made-up variable. It could be called `foo`, `bar`, `elephant`, etc.
 
 * * *
 
-### Measuring Performance
+## Measuring Performance
+
 Some tools like Debug Bar may not properly measure performance because its data (as in, the actual HTML it's generating to tell you the timing, number of queries, etc.) is swept-up by the page's cache.
 
 Timber provides some quick shortcuts to measure page timing. Here's an example of them in action:
@@ -166,6 +173,3 @@ $context['whatever'] = get_my_foo();
 Timber::render('single.twig', $context, 600);
 echo TimberHelper::stop_timer($start); //this reports the time diff by passing the $start time
 ```
-
-
-

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -7,7 +7,7 @@ menu:
 
 Among its other special powers, Timber includes modern routing in the Express.js/Ruby on Rails mold, making it easy for you to implement custom pagination--and anything else you might imagine in your wildest dreams of URLs and parameters. OMG so easy!
 
-#### Some examples
+## Some examples
 In your functions.php file, this can be called anywhere (don't hook it to init or another action or it might be called too late)
 
 ```php
@@ -24,10 +24,12 @@ Routes::map('blog/:name/page/:pg', function($params){
 });
 ```
 
-#### map
-###### `Routes::map($pattern, $callback)`
+## map
 
-###### Usage:
+`Routes::map($pattern, $callback)`
+
+### Usage
+
 A `functions.php` where I want to display custom paginated content:
 
 ```php
@@ -41,17 +43,19 @@ Routes::map('info/:name/page/:pg', function($params){
 });
 ```
 
-###### Arguments:
+### Arguments
 
 `$pattern` (required)
 Set a pattern for Timber to match on, by default everything is handled as a string. Any segment that begins with a `:` is handled as a variable, for example:
 
 **To paginate:**
+
 ```
 page/:pagenum
 ```
 
 **To edit a user:**
+
 ```
 my-users/:userid/edit
 ```
@@ -67,10 +71,11 @@ So in this example: `'info/:name/page/:pg'`, $params would have data for:
 
 * * *
 
-#### load
-###### `Routes::load($php_file, $args, $query = null, $status_code = 200)`
+## load
 
-###### Arguments:
+`Routes::load($php_file, $args, $query = null, $status_code = 200)`
+
+### Arguments
 
 `$php_file` (required)
 A PHP file to load, in my experience this is usually your archive.php or a generic listing page (but don't worry it can be anything!)
@@ -108,7 +113,3 @@ The query you want to use, it can accept a string or array just like `Timber::ge
 
 `$status_code`
 Send an optional status code. Defaults to 200 for 'Success/OK'
-
-
-
-

--- a/docs/guides/sidebars.md
+++ b/docs/guides/sidebars.md
@@ -5,9 +5,10 @@ menu:
     parent: "guides"
 ---
 
-## So you want a sidebar?
+So you want a sidebar?
 
-### Method 1: PHP file
+## Method 1: PHP file
+
 Let's say every page on the site has the same content going into its sidebar. If so, you would:
 Create a `sidebar.php` file in your theme directory (so `wp-content/themes/mytheme/sidebar.php`)
 
@@ -41,7 +42,8 @@ Timber::render('single.twig', $context);
 
 * * *
 
-### Method 2: Twig file
+## Method 2: Twig file
+
 In this example, you would populate your sidebar from your main PHP file (home.php, single.php, archive.php, etc).
 
 * Make a Twig file for what your sidebar should be:
@@ -78,9 +80,11 @@ Timber::render('single.twig', $context);
 	{{sidebar}}
 </aside>
 ```
+
 * * *
 
-### Method 3: Dynamic
+## Method 3: Dynamic
+
 This is using WordPress's built-in dynamic_sidebar tools (which, confusingly, are referred to as "Widgets" in the interface). Since sidebar is already used; I used widgets in the code to describe these:
 
 ```php
@@ -94,3 +98,4 @@ Timber::render('sidebar.twig', $context);
 <aside class="my-sidebar">
 {{dynamic_sidebar}}
 </aside>
+```

--- a/docs/guides/template-locations.md
+++ b/docs/guides/template-locations.md
@@ -28,11 +28,11 @@ You only need to do this once in your project (like in `functions.php`) then whe
 
 * * *
 
-### Changing the default folder for .twig files
+## Changing the default folder for .twig files
 
 By default, Timber looks in your child and parent theme's `views` directory to pull `.twig` files. If you don't like the default `views` directory (which by default resides in your theme folder) you can change that to. Example: I want to use `/wp-content/themes/my-theme/twigs`:
 
-###### Configure with a string:
+### Configure with a string
 
 ```php
 <?php
@@ -40,7 +40,9 @@ By default, Timber looks in your child and parent theme's `views` directory to p
 Timber::$dirname = 'twigs';
 ```
 
-###### You can also send an array with fallbacks:
+### Send an array with fallbacks
+
+This is an alternativ to configuring `$dirnames` with a string.
 
 ```php
 <?php

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -5,7 +5,7 @@ menu:
     parent: "guides"
 ---
 
-### PHPUnit
+## PHPUnit
 
 To setup tests
 
@@ -16,7 +16,7 @@ To setup tests
 - Install dependencies `composer install`
 - Run PHPUnit! `phpunit`
 
-##### Full code
+**Full code**
 
 ```
 cd ~/Sites
@@ -29,7 +29,7 @@ composer install
 phpunit
 ```
 
-##### Gotchas!
+## Gotchas!
 
 - You may need to setup authorization between VVV and GitHub. Just follow the prompts to create a token if that interrupts the `composer install`
 

--- a/docs/guides/wp-integration.md
+++ b/docs/guides/wp-integration.md
@@ -5,19 +5,10 @@ menu:
     parent: "guides"
 ---
 
-Timber plays nice with your existing WordPress setup. You can still use other plugins, etc. Here's a rundown of the key points:
-
-- [the_content](#the_content)
-- [WordPress Hooks](#hooks)
-- [Functions](#functions)
-- [Actions](#actions)
-- [Filters](#filters)
-- [Widgets](#widgets)
-- [Shortcodes](#shortcodes)
-
-* * *
+Timber plays nice with your existing WordPress setup. You can still use other plugins, etc.
 
 ## the_content
+
 You're probably used to calling `the_content()` in your theme file. This is good. Before outputting, WordPress will run all the filters and actions that your plugins and themes are using. If you want to get this into your new Timber theme (and you probably do). Call it like this:
 
 ```twig
@@ -196,7 +187,7 @@ In `youtube-short.twig` we have the following template:
 
 Now, when the YouTube embed code changes, we only need to edit the `youtube-short.twig` template. No need to search your PHP files for this one particular line.
 
-##### Layouts with Shortcodes
+### Layouts with Shortcodes
 
 Timber and Twig can process your shortcodes by using the `{% filter shortcodes %}` tag. Let's say you're using a `[tab]` shortcode, for example:
 

--- a/docs/upgrade-guides/1.0.md
+++ b/docs/upgrade-guides/1.0.md
@@ -8,21 +8,24 @@ menu:
 A significant part of this 1.0 release is removing lots of deprecated functions and methods that go back to the earliest designs for Timber in early 2013.
 
 ## Should I upgrade?
+
 Maybe. Read on:
 
-#### I have a legacy site
+### I have a legacy site
 If you wrote a theme in 2014, it's running fine and the development of the site has concluded: stop right there! Do not upgrade! While there are some slight performance benefits (and not having the warning light on the plugin dashboard) it's not worth it to you. Close this window and forget you ever heard about Timber 1.0
 
-#### I have a site under continued development
+### I have a site under continued development
+
 Maybe. There are going to be tradeoffs with whatever route you pick. I recommend testing your site thoroughly with a staging or local copy to find all the issues before applying Timber 1.0 to production. However, you're the best judge of how much potential refactoring you're looking at and whether it's worth the benefits.
 
-#### I am starting a new site.
+### I am starting a new site.
+
 Definitely. You'll get the benefits of being on the newest platform. We have some cool stuff ahead that you'll want to include in your development workflow, and of course you'll learn about the newest/best ways to make Timber themes.
 
 ## Routes
 The Routes feature has now been totally deprecated. If you have custom routes you'll need to add the [Upstatement/routes](https://github.com/upstatement/routes) repo to your theme? How to do this?
 
-##### 1. Add to Composer (optional, but recommended)
+### 1. Add to Composer (optional, but recommended)
 Simply add `Upstatement/routes` to your `composer.json` file like so:
 
 ```json
@@ -32,11 +35,12 @@ Simply add `Upstatement/routes` to your `composer.json` file like so:
     "Upstatement/routes": "*"
 },
 ```
+
 Here's a full [Gist](https://gist.github.com/jarednova/dc84cf14735a870dbe3d2763e94095a1) of what this looks like. Run a `composer install` to update your theme's dependencies.
 
 _Note: because we're not monsters, the [Upstatement/routes] repo will continue to be included with Timber for the next several versions_
 
-##### 2. Add to your theme:
+### 2. Add to your theme
 
 If you haven't already, you'll need to load Composer's autoload file into your theme via:
 
@@ -46,11 +50,12 @@ If you haven't already, you'll need to load Composer's autoload file into your t
 require_once('vendor/autoload.php');
 ```
 
-##### 3. Update your Routes:
+### 3. Update your Routes
 
 Now just update the PHP for your old routes to the new ones. It'll be basically the same code, but with cleaner syntax **and a different arguments order for the `::load` method**
 
-###### Before:
+**Before**
+
 ```php
 <?php
 Timber::add_route('myfoo/bar', 'my_callback_function');
@@ -60,7 +65,8 @@ Timber::add_route('my-events/:event', function($params) {
 });
 ```
 
-###### After:
+**After**
+
 ```php
 <?php
 Routes::map('myfoo/bar', 'my_callback_function');
@@ -73,15 +79,14 @@ Routes::map('my-events/:event', function($params) {
 
 ... and that's the hardest part, done!
 
-## Object Properties
+## Post Object Properties
 
-#### Post
 * If you're using `{{ post.permalink }}` or `{{ post.get_permalink }}` you should replace with `{{ post.link }}`
 * If you're using `{{ post.url }}` or `{{ post.get_url }}` you should replace with `{{ post.link }}`
 * If you're using `{{ post.thumbnail.url }}` or `{{ post.get_thumbnail.url }}` you should replace with `{{ post.thumbnail.src }}`
 
-
 ## Static methods
+
 Way back in `0.18`, a new helper library was added for URLs. In my infinite wisdom I called it `TimberURLHelper`. Previously old static methods in `TimberHelper` still worked (like `TimberHelper::get_current_url`) — they don't any longer. The full list of methods you'll need to update is...
 
 * `TimberHelper::get_current_url` --- becomes ---> `Timber\URLHelper::get_current_url()`
@@ -99,4 +104,5 @@ Way back in `0.18`, a new helper library was added for URLs. In my infinite wisd
 * `TimberHelper::get_params` --- becomes ---> `Timber\URLHelper::get_params()`
 
 ## Deprecated
+
 Many of the aliases with `get_*` are now deprecated. For awhile, we've recommended using `post.title` instead of `post.get_title`, `post.thumbnail` instead of `post.get_thumbnail`, etc. In future versions this will be enforced.


### PR DESCRIPTION
#### Issue

With the upcoming new documentation that switches from a onepager to single pages, not all headings are on the same page. This means that headings need to have a different hierarchy.

#### Solution

This pull request optimizes the heading structure:

- Fix hierarchy levels.
- Remove headings where not needed, e.g. to announce language before code examples or where they were used for styling purposes.
- Remove links from headings because they break links in the table of contents. Instead, add the links to the text.
- Remove colons from then end of headings.
- Add some more headings to provide a better structure for the document.
- Add empty lines before and after headings.
- Remove manual table of contents from beginning of documents.
- Remove unnecessary whitespace where spotted.

---

This pull request only looks at the heading structure. There are other smaller fixes to the documentation that will follow in separate pull requests.