### PR TITLE
fix gethost can be empty and generate a warning

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -127,7 +127,7 @@ class URLHelper {
 	 * @return bool
 	 */
 	public static function is_local( $url ) {
-		if ( strstr($url, self::get_host()) ) {
+		if ( !empty(self::get_host()) && strstr($url, self::get_host()) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->
**Reviewer**: @ <!-- Ignore this if not relevant -->

#### Issue
PHP Warning:  strstr(): Empty needle in /web/app/plugins/timber-library/lib/URLHelper.php on line 130
In wp-cli context  self::get_host() can be empty therefore strstr($url, self::get_host() generate a warning

#### Solution
checking that the needle is not empty


#### Impact
<!-- What impact will this have on the current codebase, performance, backwards compatability? -->


#### Usage
<!-- Are there are any usage changes, or are there new usage that we need to know about? -->


#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
