### PR TITLE
Rename init() to create_twig_loader(), and move cache filters to controller.

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -51,7 +51,7 @@ class Loader {
 			$rootPath = null;
 		}
 		$loader = new \Twig_Loader_Filesystem($paths, $rootPath);
-		$loader = apply_filters('timber/loader/loader', $this->loader);
+		$loader = apply_filters('timber/loader/loader', $loader);
 		if ( !$loader instanceof \Twig_LoaderInterface ) {
 			throw new \UnexpectedValueException('Loader must implement \Twig_LoaderInterface');
 		}

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -25,17 +25,24 @@ class Loader {
 
 	protected $cache_mode = self::CACHE_TRANSIENT;
 
-	protected $loader;
+	private $loader;
 
 	/**
 	 * @param bool|string   $caller the calling directory or false
 	 */
 	public function __construct( $caller = false ) {
 		$locations = LocationManager::get_locations($caller);
-		$this->init($locations);
+
+		$this->loader = $this->create_twig_loader($locations);
+
+		$this->cache_mode = apply_filters('timber_cache_mode', $this->cache_mode);
+		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
 	}
 
-	protected function init( $locations = array() ) {
+	/**
+	 * @param array   $locations
+	 */
+	protected function create_twig_loader( $locations = array() ) {
 		$open_basedir = ini_get('open_basedir');
 		$paths = array_merge($locations, array($open_basedir ? ABSPATH : '/'));
 		$paths = apply_filters('timber/loader/paths', $paths);
@@ -43,13 +50,12 @@ class Loader {
 		if ( $open_basedir ) {
 			$rootPath = null;
 		}
-		$this->loader = new \Twig_Loader_Filesystem($paths, $rootPath);
-		$this->loader = apply_filters('timber/loader/loader', $this->loader);
+		$loader = new \Twig_Loader_Filesystem($paths, $rootPath);
+		$loader = apply_filters('timber/loader/loader', $this->loader);
 		if ( !$this->loader instanceof \Twig_LoaderInterface ) {
 			throw new \UnexpectedValueException('Loader must implement \Twig_LoaderInterface');
 		}
-		$this->cache_mode = apply_filters('timber_cache_mode', $this->cache_mode);
-		$this->cache_mode = apply_filters('timber/cache/mode', $this->cache_mode);
+		return $loader;
 	}
 
 	/**

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -52,7 +52,7 @@ class Loader {
 		}
 		$loader = new \Twig_Loader_Filesystem($paths, $rootPath);
 		$loader = apply_filters('timber/loader/loader', $this->loader);
-		if ( !$this->loader instanceof \Twig_LoaderInterface ) {
+		if ( !$loader instanceof \Twig_LoaderInterface ) {
 			throw new \UnexpectedValueException('Loader must implement \Twig_LoaderInterface');
 		}
 		return $loader;


### PR DESCRIPTION
The Twig Loader is accessible via get_loader(), and exposing the $loader property makes the class vulnerable to alterations after initialization. Even via get_loader() it is possible to modify the loader, but not replacing the loader object, which could be done via the WordPress hooks already.Renaming the new init() method to create_twig_loader(), and modifying it to return a newly created Twig Loader object, which the controller stores in the private $loader property once and for all, internal integrity is insured and overloading made possible…