### PR TITLE
Documentation: Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   "require-dev": {
     "phpunit/phpunit": "5.7.16",
     "wpackagist-plugin/advanced-custom-fields": "4.*",
-    "wpackagist-plugin/co-authors-plus" : "3.*" 
+    "wpackagist-plugin/co-authors-plus" : "3.*"
   },
   "suggest" : {
     "satooshi/php-coveralls": "1.0.* for code coverage"

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,6 @@
     "wpackagist-plugin/co-authors-plus" : "3.*" 
   },
   "suggest" : {
-    "phpdocumentor/phpdocumentor": "2.* for generating docs",
-    "jarednova/markdowndocs": "dev-master for generating docs",
     "satooshi/php-coveralls": "1.0.* for code coverage"
   },
   "autoload": {
@@ -53,18 +51,6 @@
     {
       "type": "composer",
       "url": "https://wpackagist.org"
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "jarednova/markdowndocs",
-        "version": "dev-master",
-        "source": {
-          "type": "git",
-          "url": "https://github.com/jarednova/PHP-Markdown-Documentation-Generator.git",
-          "reference": "master"
-        }
-      }
     }
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
   ],
   "support": {
     "issues": "https://github.com/timber/timber/issues",
-    "wiki": "https://github.com/timber/timber/wiki",
     "source": "https://github.com/timber/timber"
+    "docs": "https://timber.github.io/docs/",
   },
   "require": {
     "php": ">=5.3.0|7.*",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
   ],
   "support": {
     "issues": "https://github.com/timber/timber/issues",
-    "source": "https://github.com/timber/timber"
-    "docs": "https://timber.github.io/docs/",
+    "source": "https://github.com/timber/timber",
+    "docs": "https://timber.github.io/docs/"
   },
   "require": {
     "php": ">=5.3.0|7.*",


### PR DESCRIPTION
**Reviewer**: @jarednova 

#### Issue

There are still entries related to the old docs in `composer.json`:

- Link to wiki in `support`. The wiki will be deprecated, so this can be removed. Instead, we should use a link to the new docs.
- Package suggestions in `suggest` that are not needed anymore.
- Entry in `repository` that is not needed anymore.