### PR TITLE
1.4.0 Release Notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,16 +12,15 @@
 <!-- What impact will this have on the current codebase, performance, backwards compatability? -->
 
 
-#### Usage
-<!-- Are there are any usage changes, or are there new usage that we need to know about? If so, add them to the `readme.txt` file so that developers know what usage changes are associated to your PR -->
+#### Usage Changes
+<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
 
-#### Documentation Requirements:
-Check one:
-- [ ] No usage changes. I've updated the `readme.txt` with a quick summary of the change and my GitHub handle
-- [ ] Yes, there's a usage change. I've updated the `readme.txt` with ...
-  - [ ] **Change for Theme Developers:** label
-  - [ ] A quick summary of the change
-  - [ ] New usage instructions
+Alternatively, you’re very welcome to directly edit the readme.txt file with:
+- A quick summary, including your Github handle.
+- A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
+- New usage instructions, possibly with a short code example.
+-->
+
 
 #### Considerations
 <!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
@@ -29,4 +28,3 @@ Check one:
 
 #### Testing
 <!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
-

--- a/bin/timber.php
+++ b/bin/timber.php
@@ -4,7 +4,7 @@ Plugin Name: Timber
 Description: The WordPress Timber Library allows you to write themes using the power of Twig templates.
 Plugin URI: http://timber.upstatement.com
 Author: Jared Novack + Upstatement
-Version: 1.3.4
+Version: 1.4.0
 Author URI: http://upstatement.com/
 */
 // we look for Composer files first in the plugins dir.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: jarednova, connorjburton, lggorman
 Tags: template engine, templates, twig
 Requires at least: 3.7
-Stable tag: 1.3.4
-Tested up to: 4.8
+Stable tag: 1.4.0
+Tested up to: 4.8.1
 PHP version: 5.3.0 or greater
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -41,8 +41,11 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 
 == Changelog ==
 
+= Develop =
+* Please add bullet points here with your PR so theme developers are informed of changes. The heading for this section will get the correct version number once released.
+
 = 1.4.0 =
-* **Change for Theme Developers** Improve loader performance and logic #1489 #1491 (thanks @heino). This introduces potential changes if you were loading templates in a non-standard way and with multiple sources (ex: from a theme and plugin directory)
+* **Change for Theme Developers** Improve loader performance and logic #1476 #1489 #1491 (thanks @heino). This introduces potential changes if you were loading templates in a non-standard way and with multiple sources (ex: from a theme and plugin directory). Non-existing templates are no longer passed all the way to Twig's render(), which currently generates an exception.
 * Improve GIF resize performance #1495 (thanks @ahallais)
 * Fix for get_host which could generate an unncessary warning #1490 (thanks @ahallais)
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,13 +41,26 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 
 == Changelog ==
 
-= Develop =
-* Please add bullet points here with your PR so theme developers are informed of changes. The heading for this section will get the correct version number once released.
+= Develop (next release) =
+
+**Fixes and improvements**
+
+- Please add bullet points here with your PR. The heading for this section will get the correct version number once released.
+
+**Changes for Theme Developers**
+
+- Please add any usage changes here so theme developers are informed of changes.
 
 = 1.4.0 =
-* **Change for Theme Developers** Improve loader performance and logic #1476 #1489 #1491 (thanks @heino). This introduces potential changes if you were loading templates in a non-standard way and with multiple sources (ex: from a theme and plugin directory). Non-existing templates are no longer passed all the way to Twig's render(), which currently generates an exception.
-* Improve GIF resize performance #1495 (thanks @ahallais)
-* Fix for get_host which could generate an unncessary warning #1490 (thanks @ahallais)
+
+**Fixes and Improvements**
+
+- Improve GIF resize performance #1495 (thanks @ahallais)
+- Fix for get_host which could generate an unncessary warning #1490 (thanks @ahallais)
+
+**Changes for Theme Developers**
+
+- Improve loader performance and logic #1476 #1489 #1491 (thanks @heino). This introduces potential changes if you were loading templates in a non-standard way and with multiple sources (ex: from a theme and plugin directory). Non-existing templates are no longer passed all the way to Twig’s `render()`, which currently generates an exception.
 
 = 1.3.4 =
 * Fix for Twig 2.0 compatibility issue #1464 (thanks @luism-s)
@@ -135,7 +148,7 @@ Misc fixes to documentation
 * A new PostQuery object that comes _with_ pagination (thanks @lggorman).
 * You can pass an array of post types to `post.children()` (thanks @njbarrett)
 
-= 1.1.6 = 
+= 1.1.6 =
 * Kill those transients! Timber now wipes expired ones away 9a5851bf36110dcb399e277d51230f1addb0c53c
 * Fixed a warning that was annoying and nobody liked and didn't have any friends c53b4c832cfced01157f8196688468ad3318d3fb
 
@@ -223,7 +236,7 @@ Misc fixes to documentation
 * Updated version numbers and build script (@jarednova) 81a281e
 * Corrected Routes -> /Routes which threw a fatal error (@jarednova) 26b6585
 
-= 0.22.6 = 
+= 0.22.6 =
 * New {{request}} object for post/get variables (thanks @connorjburton) #856
 * New crop positions (thanks @salaros) #861
 * Bug Fixes

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,11 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 
 == Changelog ==
 
+= 1.4.0 =
+* **Change for Theme Developers** Improve loader performance and logic #1489 #1491 (thanks @heino). This introduces potential changes if you were loading templates in a non-standard way and with multiple sources (ex: from a theme and plugin directory)
+* Improve GIF resize performance #1495 (thanks @ahallais)
+* Fix for get_host which could generate an unncessary warning #1490 (thanks @ahallais)
+
 = 1.3.4 =
 * Fix for Twig 2.0 compatibility issue #1464 (thanks @luism-s)
 


### PR DESCRIPTION
#### Issue
With the changes in #1476, #1489, #1491 — I want to ensure theme developers are informed about risks to their setups with the upgrade


#### Solution
The readme includes a new `**Change for Theme Developers**` lead-in for a change that might affect someone's WP setup


#### Impact
Hopefully it makes upgrade processes smoother!


#### Usage
The new PR Template describes what we're looking for with each PR. It now includes a "Documentation Requirements" section so that PR-ers submit with readme.txt changes included


#### Documentation Requirements:
Yes!


#### Considerations
Will the bolding show-up in the WP upgrade modal (in the plugins section)? Not sure...


#### Next steps
@gchtr: if this looks good, please merge and we'll make the official 1.4.0 release!
