### PR TITLE
Fix polylang performance issue by caching calls to get_home_url()

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -29,8 +29,9 @@ class ImageHelper {
 	const BASE_CONTENT = 2;
 
 	public static function init() {
-		self::add_actions();
-		self::add_filters();
+		add_action('delete_attachment', array(__CLASS__, 'delete_attachment'));
+		add_filter('wp_generate_attachment_metadata', array(__CLASS__, 'generate_attachment_metadata'), 10, 2);
+		add_filter('upload_dir', array(__CLASS__, 'add_relative_upload_dir_key'), 10, 2);
 		return true;
 	}
 
@@ -165,34 +166,41 @@ class ImageHelper {
 		return self::_operate($src, $op, $force);
 	}
 
-	/**
-	 * Deletes all resized versions of an image when the source is deleted
-	 * or its meta data is regenerated
-	 */
-	protected static function add_actions() {
-		add_action('delete_attachment', function( $post_id ) {
-			\Timber\ImageHelper::_delete_generated_if_image($post_id);
-		} );
-		add_filter('wp_generate_attachment_metadata', function( $metadata, $post_id ) {
-			\Timber\ImageHelper::_delete_generated_if_image($post_id);
-			return $metadata;
-		}, 10, 2);
-	}
-
-	/**
-	 * adds a 'relative' key to wp_upload_dir() result.
-	 * It will contain the relative url to upload dir.
-	 * @return void
-	 */
-	static function add_filters() {
-		add_filter('upload_dir', function( $arr ) {
-			$arr['relative'] = str_replace(get_home_url(), '', $arr['baseurl']);
-			return $arr;
-		} );
-	}
-
 	//-- end of public methods --//
 
+	/**
+	 * Deletes all resized versions of an image when the source is deleted.
+	 *
+	 * @param int   $post_id an attachment post id
+	 */
+	public static function delete_attachment( $post_id ) {
+		\Timber\ImageHelper::_delete_generated_if_image($post_id);
+	}
+
+
+	/**
+	 * Delete all resized version of an image when its meta data is regenerated.
+	 *
+	 * @param array $metadata
+	 * @param int   $post_id an attachment post id
+	 * @return array
+	 */
+	public static function generate_attachment_metadata( $metadata, $post_id ) {
+		\Timber\ImageHelper::_delete_generated_if_image($post_id);
+		return $metadata;
+	}
+
+	/**
+	 * Adds a 'relative' key to wp_upload_dir() result.
+	 * It will contain the relative url to upload dir.
+	 *
+	 * @param array $arr
+	 * @return array
+	 */
+	public static function add_relative_upload_dir_key( $arr ) {
+		$arr['relative'] = str_replace(get_home_url(), '', $arr['baseurl']);
+		return $arr;
+	}
 
 	/**
 	 * Checks if attachment is an image before deleting generated files

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -28,7 +28,11 @@ class ImageHelper {
 	const BASE_UPLOADS = 1;
 	const BASE_CONTENT = 2;
 
+	static $home_url;
+
 	public static function init() {
+		self::$home_url = get_home_url();
+
 		add_action('delete_attachment', array(__CLASS__, 'delete_attachment'));
 		add_filter('wp_generate_attachment_metadata', array(__CLASS__, 'generate_attachment_metadata'), 10, 2);
 		add_filter('upload_dir', array(__CLASS__, 'add_relative_upload_dir_key'), 10, 2);
@@ -198,7 +202,7 @@ class ImageHelper {
 	 * @return array
 	 */
 	public static function add_relative_upload_dir_key( $arr ) {
-		$arr['relative'] = str_replace(get_home_url(), '', $arr['baseurl']);
+		$arr['relative'] = str_replace(self::$home_url, '', $arr['baseurl']);
 		return $arr;
 	}
 


### PR DESCRIPTION
**Ticket**: #1461

#### Issue

Repeated calls to `get_home_url()` noticeably slows down performance with the polylang plugin. 

#### Solution

Cache the value of `get_home_url()` and also avoid closures as they are difficult to unhook downstream.

#### Impact

On a site I was building earlier with quite a few images page load went from 4.3s to 2.6s. See #1461 for XHProf comparisons.

#### Usage

No.

#### Documentation Requirements:
Check one:
- [x] No usage changes. I've updated the `readme.txt` with a quick summary of the change and my GitHub handle
- [ ] Yes, there's a usage change. I've updated the `readme.txt` with ...
  - [ ] **Change for Theme Developers:** label
  - [ ] A quick summary of the change
  - [ ] New usage instructions

#### Considerations

None except if the `relative` key is actually needed at all for `wp_upload_dir()` calls.

#### Testing

None added.