### PR TITLE
Deprecate contributing guidelines in wiki, only use CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,12 @@
 
 1. [Star](https://github.com/timber/timber/stargazers) the project!
 2. Answer questions that come through [GitHub issues](https://github.com/timber/timber/issues?state=open)
-3. [Report a bug](https://github.com/timber/timber/issues/new) that you find
-4. Share a [theme](https://github.com/Upstatement/blades) you've built with Timber. This helps transfer knowledge about best practices, etc. _Add it to the [Showcase list](https://github.com/timber/timber/wiki/Showcase)_
-5. Tweet and [blog](http://www.oomphinc.com/blog/2013-10/php-templating-wordpress/#post-content) about the advantages (and criticisms) of the project and Twig
+3. [Report a bug](https://github.com/timber/timber/issues/new) that you find.
+4. Share a theme you’ve built with Timber. This helps transfer knowledge about best practices, etc. _Add it to the [Showcase list](https://github.com/timber/timber/wiki/Showcase)_.
+5. Tweet and [blog](http://www.oomphinc.com/blog/2013-10/php-templating-wordpress/#post-content) about the advantages (and criticisms) of the project and Twig.
 6. Browse [contrib opportunities](https://github.com/timber/timber/issues?labels=contrib-opportunity&page=1&state=open) for areas of WordPress/PHP/code you know well to consider, build or document.
-
+7. Answer questions on [Stack Overflow posted under the «Timber» tag](https://stackoverflow.com/questions/tagged/timber). You can also [subscribe to a tag](https://stackoverflow.blog/2010/12/20/subscribe-to-tags-via-emai/) via email to get notified when someone needs help.
+8. Answer question in the support channel on [Gitter](https://gitter.im/timber/timber).
 
 ### Pull Requests
 
@@ -14,5 +15,5 @@ Pull requests are highly appreciated. More than fifty people have written parts 
 
 1. **Solve a problem** Features are great, but even better is cleaning-up and fixing issues in the code that you discover.
 2. **Write tests** This helps preserve functionality as the codebase grows and demonstrates how your change affects the code.
-3. **Small > big** Better to have a few small PRs that address specific parts of the code, than one big PR that jumps all over.
-4. **Comply with standards** We follow [WordPress coding standards](https://make.wordpress.org/core/handbook/coding-standards/php/) -- which sometimes deviate from [PSR-2](http://www.php-fig.org/psr/psr-2/) and others.
+3. **Small > big** Better to have a few small pull requests that address specific parts of the code, than one big pull request that jumps all over.
+4. **Comply with standards** We follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/coding-standards/php/) – which sometimes deviate from [PSR-2](http://www.php-fig.org/psr/psr-2/) and others.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Please post on [StackOverflow under the "Timber" tag](http://stackoverflow.com/q
 It's MIT-licensed, so please use in personal or commercial work. Just don't re-sell it. Timber is used on [hundreds of sites](http://timber.github.io/timber/#showcase) (and tons more we don't know about)
 
 #### Contributing
-Read the [contributor guidelines](https://github.com/timber/timber/wiki#contributing) in the wiki.
-
+Read the [Contributor Guidelines](https://github.com/timber/timber/blob/master/CONTRIBUTING.md).
 
 ## Documentation
 


### PR DESCRIPTION
This pull request aims to have a single source for contributing guidelines by only using CONTRIBUTING.md and deprecate contributing guidelines in the wiki.

**README.md**

- Update link to CONTRIBUTING.md

**CONTRIBUTING.MD:**

- Small improvements.
- Remove broken link to blades theme.
- Add entries for answering questions on Stack Overflow and on the Gitter channel.

