### PR TITLE
Update documentation for Text Cookbook

### DIFF
--- a/docs/guides/cookbook-text.md
+++ b/docs/guides/cookbook-text.md
@@ -5,7 +5,7 @@ menu:
     parent: "guides"
 ---
 
-There's tons of stuff you can do with Twig and Timber filters to make complex transformations easy (and fun!)
+There’s tons of stuff you can do with Twig and Timber filters to make complex transformations easy (and fun).
 
 ## Dates
 
@@ -15,8 +15,8 @@ Timber does bylines like a boss:
 
 ```twig
 <p class="byline">
-	<span class="name">By {{ post.author.name }}</span>
-	<span class="date">{{ post.post_date|date('F j, Y') }}</span>
+    <span class="name">By {{ post.author.name }}</span>
+    <span class="date">{{ post.post_date|date('F j, Y') }}</span>
 </p>
 ```
 
@@ -42,17 +42,9 @@ Nothing is worse than an out-of-date copyright year in the footer. Nothing.
 <footer><p class="copyright">&copy; 2015 by The Daily Orange</p></footer>
 ```
 
-* * *
-
 ## Standard transforms
 
-### Automatically link URLs, email addresses, twitter @s and #s
-
-```twig
-<p class="tweet">{{ post.content|twitterify }}</p>
-```
-
-### Run WordPress' auto-paragraph filter
+### Run WordPress’ auto-paragraph filter
 
 ```twig
 <p class="content">{{ post.my_custom_text|wpautop }}</p>
@@ -66,63 +58,24 @@ Nothing is worse than an out-of-date copyright year in the footer. Nothing.
 
 ### Code samples
 
-Code Samples? Lord knows I've got 'em:
+Code Samples? Lord knows I’ve got ’em:
 
 ```twig
 <div class="code-sample">{{ post.code_samples|pretags }}</div>
 ```
 
-### Functions inside of your templates, plugin calls
+### Calling PHP functions inside of your templates
 
-Old template:
+WordPress template:
 
 ```html
 <p class="entry-meta"><?php twentytwelve_entry_meta(); ?></p>
 ```
 
-Timber-fied template:
+Twig template:
 
 ```twig
 <p class="entry-meta">{{ function('twentytwelve_entry_meta') }}</p>
 ```
 
-### Functions "with params" inside of your templates, plugin calls:
-
-Old template:
-
-```html
-<p class="entry-meta"><?php get_the_title( $post->ID ); ?></p>
-```
-
-Timber-fied template:
-
-```twig
-<p class="entry-meta">{{ function('get_the_title', post.ID) }}</p>
-```
-
-* * *
-
-## Debugging
-
-### What properties are inside my object?
-
-```twig
-{{ dump(post) }}
-```
-
-### What properties and methods are inside my object?
-
-Warning: Experimental!
-
-```twig
-{{ post|print_a }}
-```
-This outputs both the database stuff (like `{{ post.post_content }}`) and the contents of methods (like `{{ post.thumbnail }}`)
-
-### What type of object am I working with?
-
-```twig
-{{ post|get_class }}
-```
-
-... will output something like `TimberPost` or your custom wrapper object
+You can read more about using functions in the [Functions](https://timber.github.io/docs/guides/functions/) guide.


### PR DESCRIPTION
- Apply coding standards
- Reformat Markdown
- Improve wording, fix spelling
- Shorten section about functions and link to Functions Guide.
- Remove deprecated sections debugging (now handled in Debugging Guide).

This commit also deprecates the wiki page called «Text Cookbook».

Eventually, the Text Cookbook can be deprecated completely as well, because all content can be handled better by other guides.