### PR TITLE
update regex

### DIFF
--- a/lib/Integrations/WPML.php
+++ b/lib/Integrations/WPML.php
@@ -13,7 +13,7 @@ class WPML {
 
 	public function file_system_to_url($url) {
 		if ( defined('ICL_LANGUAGE_CODE') ) {
-			$url = preg_replace('/\/' . ICL_LANGUAGE_CODE . '/', '', $url);
+			$url = preg_replace('/(?<!:\/)\/' . ICL_LANGUAGE_CODE . '/', '', $url);
 		}
 		return $url;
 	}


### PR DESCRIPTION
**Ticket**: # <!-- Ignore this if not relevant -->

#### Issue
When using WPML and a language code is exists in the domain name, e.g. 
Language code: `en`
Domain: `https://enviroment.com/en`

The language code is being stripped out from the beginning of the domain name where it shouldn't be. So URL begin return is `https:/viroment.com`

#### Solution
Improve the regex that removes the language code from the URL, ensure the match is not proceeded by `:/`.

#### Impact
Should all tests pass, there should be no impact.


#### Usage Changes
Usage should be transparent and backwards compatible.


#### Considerations


#### Testing

