### PR TITLE
Prepare Timber\PostCollections to work better with integrations

### DIFF
--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -6,13 +6,33 @@ use Timber\Helper;
 use Timber\Post;
 
 /**
- * PostCollections are internal objects used to hold a collection of posts
+ * Class PostCollection
+ *
+ * PostCollections are internal objects used to hold a collection of posts.
+ *
+ * @package Timber
  */
 class PostCollection extends \ArrayObject {
-
 	public function __construct( $posts = array(), $post_class = '\Timber\Post' ) {
-		$returned_posts = self::init($posts, $post_class);
-		parent::__construct($returned_posts, $flags = 0, 'Timber\PostsIterator');
+		$returned_posts = self::init( $posts, $post_class );
+
+		$posts_iterator = 'Timber\PostsIterator';
+
+		/**
+		 * Filters the PostIterator class to use for a PostCollection.
+		 *
+		 * This filter is useful if you need to set special values or globals on each post. Because many plugins still
+		 * rely on The Loop, a custom PostIterator can make it much easier to integrate third party plugins with Timber.
+		 *
+		 * @since 1.4.x
+		 *
+		 * @param string $posts_iterator The iterator class to use to loop over posts. Default `Timber\PostsIterator`.
+		 * @param array  $returned_posts An array of posts.
+		 * @param string $post_class     The post class to use to extend posts with.
+		 */
+		$posts_iterator = apply_filters( 'timber/class/posts_iterator', $posts_iterator, $returned_posts, $post_class );
+
+		parent::__construct( $returned_posts, 0, $posts_iterator );
 	}
 
 	protected static function init( $posts, $post_class ) {

--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -78,14 +78,7 @@ class PostCollection extends \ArrayObject {
 		return $posts;
 	}
 
-}
 
-class PostsIterator extends \ArrayIterator {
-
-	public function current() {
-		global $post;
-		$post = parent::current();
-		return $post;
 	}
 }
 

--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -97,9 +97,6 @@ class PostCollection extends \ArrayObject {
 
 		return $posts;
 	}
-
-
-	}
 }
 
 class_alias('Timber\PostCollection', 'Timber\PostsCollection');

--- a/lib/PostsIterator.php
+++ b/lib/PostsIterator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Timber;
+
+/**
+ * Class PostsIterator
+ *
+ * @package Timber
+ */
+class PostsIterator extends \ArrayIterator {
+	public function current() {
+		global $post;
+
+		$post = parent::current();
+
+		return $post;
+	}
+}


### PR DESCRIPTION
This pull request prepares `Timber\PostCollection` to be more versatile and possibly make it easier to integrate third party plugins into Timber that still rely heavily on the loop.

## Issue

The `Timber\PostsIterator` class acts as the base for a default WordPress environment, because it sets the `$post` global when looping over an array of posts.

Sometimes other plugins rely on other globals, that are not set when using `Timber\PostsIterator`. WooCommerce for example relies on `$product` global. By making it possible to use a different Iterator class in certain circumstances, it would be easier to integrate third party plugins. Here’s how an Iterator for WooCommerce could look like:

```php
/**
 * Class ProductsIterator
 *
 * @package Timber\Integrations\WooCommerce
 */
class ProductsIterator extends \ArrayIterator {
    /**
     * Set $product global in addition to $post global.
     *
     * For some functionality, WooCommerce works with a global named $product. When looping over multiple product posts,
     * this global is not automatically set. With this custom ArrayIterator, we can prepare the globals that are needed.
     *
     * @see \Timber\PostsIterator::current()
     *
     * @return \Timber\Post
     */
    public function current() {
        global $post, $product;

        $post = parent::current();
        $product = wc_get_product( $post->ID );

        return $post;
    }
}
```

The `current()` method sets the correct values for both `$post` and `$product` globals.

The premise here is that you always need an instance of `Timber\PostsCollection` for this to work. I guess that’s what the `$return_collection` parameter in `Timber::get_posts()` is used for? When set to true, it always returns a collection, and not simply an array of posts.

## Solution

- Move `Timber\PostsIterator` into a separate file to act as a basic example.
- A new filter `timber/class/posts_iterator` that allows it to filter the default class that is used  when looping over a collection of posts.

## Impact

None.

## Usage Changes

No.

## Considerations

The filter is now named `timber/class/posts_iterator`. I don’t know that the current naming convention for filters is, but I guess it’s something like `timber/functionality_or_namespace/value`.

So the reasoning behind this is that all filters that change classes that are used throughout the code could start with `timber/class/` (maybe the `Timber\PostClassMap` filter would have to renamed to `timber/class/post`, but that’s another topic).

### Make it easier to work with `get_post` and `get_posts`

Currently, `Timber::get_posts()` takes three parameters: `$query`, `$PostClass` and `$return_collection`. When working with custom iterators and classes, I don’t always want to set `$PostClass` when I use `$return_collection`. Maybe we could take the approach that WordPress uses for a lot of functionality by using an array with arguments:

```php
// Use default query, but return a collection
$posts = Timber::get_posts( false, array( 'return_collection' => true ) );
```

This example would still use `Timber\Post` as a default for `$PostClass`, but I don’t have to think about setting it.

Or will `get_posts()` be replaced with `PostQuery()` in the future anyway?

## Testing

No, not yet.

## Todo

- [ ] Decide on what naming convention to use for filters used in Timber (@jarednova)?  
- [ ] Write tests.
- [ ] Write documentation.