### PR TITLE
ref #1518 -- fixing issue with empty and non-values https://stackover…

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -127,7 +127,8 @@ class URLHelper {
 	 * @return bool
 	 */
 	public static function is_local( $url ) {
-		if ( !empty(self::get_host()) && strstr($url, self::get_host()) ) {
+		$host = self::get_host();
+		if ( !empty($host) && strstr($url, $host) ) {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
**Ticket**: #1518 

#### Issue
Hard to explain, but "PHP doesn't have a concept of emptiness" is the best shorthand. Basically, you can't feed anything besides a variable into `empty()` or you risk hell fire:

https://stackoverflow.com/questions/1075534/cant-use-method-return-value-in-write-context

#### Solution
Store the value in a variable!

#### Impact
None

#### Usage Changes
Nope!

#### Testing
Existing tests should pass; current coverage should also be maintained
