### PR TITLE
Update readme.txt and links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div style="text-align:center">
-<a href="https://timber.github.io/docs/"><img src="http://i.imgur.com/PbEwvZ9.png" style="display:block; margin:auto; width:100%; max-width:100%"/></a>
+<a href="https://upstatement.com/timber/"><img src="http://i.imgur.com/PbEwvZ9.png" style="display:block; margin:auto; width:100%; max-width:100%"/></a>
 </div>
 
 By [Jared Novack](https://github.com/jarednova) ([@jarednova](https://twitter.com/jarednova)), [Lukas Gächter](https://github.com/gchtr) ([@lgaechter](https://twitter.com/lgaechter)), [Linda Gorman](https://github.com/lggorman) ([@lggorman](https://twitter.com/lggorman)) and [Upstatement](https://twitter.com/upstatement)
@@ -68,14 +68,14 @@ $timber = new \Timber\Timber();
 ### Mission Statement
 Timber is a tool for developers who want to translate their HTML into high-quality WordPress themes through an intuitive, consistent and fully-accessible interface.
 * **Intuitive**: The API is written to be user-centric around a programmer's expectations.
-* **Consistent**: All WordPress objects can be accessed through polymorphic properties like slug, ID and name.
+* **Consistent**: WordPress objects can be accessed through common polymorphic properties like slug, ID and name.
 * **Accessible**: No black boxes. Every effort is made so the developer has access to 100% of their HTML.
 
 #### What does it look like?
 Nothing. Timber is meant for you to build a theme on. Like the [Starkers](https://github.com/viewportindustries/starkers) or [Boilerplate theme](https://github.com/zencoder/html5-boilerplate-for-wordpress) it comes style-free, because you're the style expert. Instead, Timber handles the logic you need to make a kick-ass looking site.
 
 #### Who is it good for?
-Timber is great for any WordPress developer who cares about writing good, maintainable code. It helps teams of designers and developers working together. At [Upstatement](http://upstatement.com) we made Timber because while our entire team needs to participate in building WordPress sites, not everyone knows the ins-and-outs of the_loop(),  codex and PHP (nor should they). With Timber your best WordPress dev can focus on building the .php files with requests from WordPress and pass the data into .twig files. Once there, designers can easily mark-up data and build out a site's look-and-feel.
+Timber is great for any WordPress developer who cares about writing good, maintainable code. It helps teams of designers and developers working together. At [Upstatement](http://upstatement.com) we made Timber because while our entire team needs to participate in building WordPress sites, not everyone knows the ins-and-outs of the_loop(),  codex and PHP (nor should they). With Timber your best WordPress engineer can focus on building the `.php` files with requests from WordPress and pass the data into `.twig` files. Once there, designers can easily mark-up data and build out a site's look-and-feel.
 
 #### Related Projects
 * [**Timber Starter Theme**](https://github.com/timber/starter-theme) The "_s" of Timber to give you an easy start to the most basic theme you can build upon and customize.
@@ -100,14 +100,14 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 Please post on [StackOverflow under the "Timber" tag](http://stackoverflow.com/questions/tagged/timber). Please use GitHub issues only for specific bugs, feature requests and other types of issues.
 
 #### Should I use it?
-It's MIT-licensed, so please use in personal or commercial work. Just don't re-sell it. Timber is used on [hundreds of sites](https://www.upstatement.com/timber/#showcase) (and tons more we don't know about)
+It's MIT-licensed, so please use in personal or commercial work. Just don't re-sell it. Timber is used on [thousands of sites](https://www.upstatement.com/timber/#showcase) (and tons more we don't know about)
 
 #### Contributing
 Read the [Contributor Guidelines](https://github.com/timber/timber/blob/master/CONTRIBUTING.md).
 
 ## Documentation
 
-The [Documentation for Timber](https://timber.github.io/docs/) is generated from the contents of this repository:
+The Official [Documentation for Timber](https://timber.github.io/docs/) is generated from the contents of this repository:
 
 * Documentation for classes and functions is [auto generated](https://github.com/timber/docs). Any changes to the [Reference section](https://timber.github.io/docs/reference/) of the docs should be made by editing the function’s DocBlock. For inline documentation, we follow the [WordPress PHP Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
 * To make a change to one of the guides, edit the relevant file in the [`docs` directory](https://github.com/timber/timber/tree/master/docs).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By [Jared Novack](https://github.com/jarednova) ([@jarednova](https://twitter.co
 ### Because WordPress is awesome, but the_loop isn't
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](http://twig.sensiolabs.org/) separate from your PHP files.
 
-This cleans-up your theme code so, for example, your php file can focus on being the data/logic, while your twig file can focus 100% on the HTML and display.
+This cleans up your theme code so, for example, your PHP file can focus on being the data/logic, while your Twig file can focus 100% on the HTML and display.
 
 This is what Timber's `.twig` files look like:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div style="text-align:center">
-<a href="http://timber.github.io/timber"><img src="http://i.imgur.com/PbEwvZ9.png" style="display:block; margin:auto; width:100%; max-width:100%"/></a>
+<a href="https://timber.github.io/docs/"><img src="http://i.imgur.com/PbEwvZ9.png" style="display:block; margin:auto; width:100%; max-width:100%"/></a>
 </div>
 
 By [Jared Novack](https://github.com/jarednova) ([@jarednova](https://twitter.com/jarednova)), [Lukas Gächter](https://github.com/gchtr) ([@lgaechter](https://twitter.com/lgaechter)), [Linda Gorman](https://github.com/lggorman) ([@lggorman](https://twitter.com/lggorman)) and [Upstatement](https://twitter.com/upstatement)
@@ -100,7 +100,7 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 Please post on [StackOverflow under the "Timber" tag](http://stackoverflow.com/questions/tagged/timber). Please use GitHub issues only for specific bugs, feature requests and other types of issues.
 
 #### Should I use it?
-It's MIT-licensed, so please use in personal or commercial work. Just don't re-sell it. Timber is used on [hundreds of sites](http://timber.github.io/timber/#showcase) (and tons more we don't know about)
+It's MIT-licensed, so please use in personal or commercial work. Just don't re-sell it. Timber is used on [hundreds of sites](https://www.upstatement.com/timber/#showcase) (and tons more we don't know about)
 
 #### Contributing
 Read the [Contributor Guidelines](https://github.com/timber/timber/blob/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Once Timber is installed and activated in your plugin directory, it gives any Wo
 ### Looking for docs?
 * [Timber Documentation](https://timber.github.io/docs/)
 * [Twig Reference](http://twig.sensiolabs.org/doc/templates.html)
-* [Video Tutorials](https://github.com/timber/timber/wiki/Video-Tutorials)
-* [Overview / Getting Started Guide](https://github.com/timber/timber/wiki/getting-started)
+* [Overview / Getting Started Guide](https://timber.github.io/docs/getting-started/)
+* [Video Tutorials](https://timber.github.io/docs/getting-started/video-tutorials/)
 
 * * *
 

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -92,7 +92,7 @@ In Timber versions lower than 1.3, you could use `function_wrapper` to make func
 
 The concept of Timber (and templating engines like Twig in general) is to prepare all the data before you pass it to a template. Some functions in WordPress echo their output directly. We don’t want this, because the output of this function would be echoed before we call `Timber:render()` and appear before every else on your website. There are two ways to work around this:
 
-- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](http://timber.github.io/timber/#ob_function).
+- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](https://timber.github.io/docs/reference/timber-helper/#ob-function).
 - If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) you can use `FunctionWrapper`:
 
 ```php

--- a/docs/guides/internationalization.md
+++ b/docs/guides/internationalization.md
@@ -52,7 +52,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 <p class="entry-meta">{{ __('Posted on %s', 'my-text-domain')|format(posted_on_date) }}</p>
 ```
 
-If you want to use the `sprintf` function in Twig, you have to [add it yourself](http://timber.github.io/timber/#make-functions-available-in-twig).
+If you want to use the `sprintf` function in Twig, you have to [add it yourself](https://timber.github.io/docs/guides/functions/#make-functions-available-in-twig).
 
 ## Generating localization files
 

--- a/docs/guides/wp-integration.md
+++ b/docs/guides/wp-integration.md
@@ -77,7 +77,7 @@ Please note the argument count that WordPress requires for `add_action`.
 
 ## Filters
 
-Timber already comes with a [set of useful filters](http://timber.github.io/timber/#filters). If you have your own filters that you want to apply, you can use `apply_filters`.
+Timber already comes with a [set of useful filters](https://timber.github.io/docs/guides/filters/). If you have your own filters that you want to apply, you can use `apply_filters`.
 
 ```twig
 {{ post.content|apply_filters('my_filter') }}

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -23,8 +23,8 @@ class Admin {
 			unset($links[2]);
 			$links[] = '<a href="/wp-admin/plugin-install.php?tab=plugin-information&amp;plugin=timber-library&amp;TB_iframe=true&amp;width=600&amp;height=550" class="thickbox" aria-label="More information about Timber" data-title="Timber">View details</a>';
 			$links[] = '<a href="http://upstatement.com/timber" target="_blank">Homepage</a>';
-			$links[] = '<a href="https://github.com/timber/timber/wiki" target="_blank">Documentation</a>';
-			$links[] = '<a href="https://github.com/timber/timber/wiki/getting-started" target="_blank">Starter Guide</a>';
+			$links[] = '<a href="https://timber.github.io/docs/" target="_blank">Documentation</a>';
+			$links[] = '<a href="https://timber.github.io/docs/getting-started/setup/" target="_blank">Starter Guide</a>';
 			return $links;
 		}
 		return $links;
@@ -49,7 +49,7 @@ class Admin {
 
 			<br><strong>Is your theme in active development?</strong> That is, is someone actively in PHP files writing new code? If you answered "no", then <i>do not upgrade</i>. You will not benefit from Timber 1.0<br>';
 
-		$m .= '<br>Read the <strong><a href="https://github.com/timber/timber/wiki/1.0-Upgrade-Guide">Upgrade Guide</a></strong> for more information<br>';
+		$m .= '<br>Read the <strong><a href="https://timber.github.io/docs/upgrade-guides/1.0/">Upgrade Guide</a></strong> for more information<br>';
 
 		$m .= "<br>You can also <b><a href='https://downloads.wordpress.org/plugin/timber-library.0.22.6.zip'>upgrade to version 0.22.6</a></b> if you want to upgrade, but are unsure if you're ready for 1.0<br>";
 		$m .= self::disable_update();

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -180,7 +180,7 @@ class Helper {
 	 * @return FunctionWrapper|mixed
 	 */
 	public static function function_wrapper( $function_name, $defaults = array(), $return_output_buffer = false ) {
-		Helper::warn( 'function_wrapper is deprecated and will be removed in 1.4. Use {{ function( \'function_to_call\' ) }} instead or use FunctionWrapper directly. For more information refer to http://timber.github.io/timber/#functions' );
+		Helper::warn( 'function_wrapper is deprecated and will be removed in 1.4. Use {{ function( \'function_to_call\' ) }} instead or use FunctionWrapper directly. For more information refer to https://timber.github.io/docs/guides/functions/' );
 
 		return new FunctionWrapper( $function_name, $defaults, $return_output_buffer );
 	}

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -219,7 +219,7 @@ class Image extends Post implements CoreInterface {
 	public function init( $iid = false ) {
 		//Make sure we actually have something to work with
 		if ( !$iid ) { Helper::error_log('Initalized TimberImage without providing first parameter.'); return; }
-		
+
 		//If passed TimberImage, grab the ID and continue
 		if ( $iid instanceof self ) {
 			$iid = (int) $iid->ID;
@@ -258,7 +258,7 @@ class Image extends Post implements CoreInterface {
 			/**
 			 * This will catch TimberPost and any post classes that extend TimberPost,
 			 * see http://php.net/manual/en/internals2.opcodes.instanceof.php#109108
-			 * and https://github.com/timber/timber/wiki/Extending-Timber
+			 * and https://timber.github.io/docs/guides/extending-timber/
 			 */
 			$iid = (int) $iid->_thumbnail_id;
 		}

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -12,7 +12,7 @@ use Timber\URLHelper;
 
 /**
  * Implements the Twig image filters:
- * https://github.com/timber/timber/wiki/Image-cookbook#arbitrary-resizing-of-images
+ * https://timber.github.io/docs/guides/cookbook-images/#arbitrary-resizing-of-images
  * - resize
  * - retina
  * - letterbox

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -317,7 +317,7 @@ class Timber {
 
 			$output = $loader->render($file, $data, $expires, $cache_mode);
 		}
-		
+
 		do_action('timber_compile_done');
 		return $output;
 	}
@@ -498,7 +498,7 @@ class Timber {
 	 * @codeCoverageIgnore
 	 */
 	public static function add_route( $route, $callback, $args = array() ) {
-		Helper::warn('Timber::add_route (and accompanying methods for load_view, etc. Have been deprecated and will soon be removed. Please update your theme with Route::map. You can read more in the 1.0 Upgrade Guide: https://github.com/timber/timber/wiki/1.0-Upgrade-Guide');
+		Helper::warn('Timber::add_route (and accompanying methods for load_view, etc. Have been deprecated and will soon be removed. Please update your theme with Route::map. You can read more in the 1.0 Upgrade Guide: https://timber.github.io/docs/upgrade-guides/1.0/');
 		\Routes::map($route, $callback, $args);
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -641,13 +641,13 @@ Please post on [StackOverflow under the "Timber" tag](http://stackoverflow.com/q
 You bet! Watch these **[Video Tutorials](https://timber.github.io/docs/getting-started/video-tutorials/)** to see how.
 
 = Is it used in production? =
-At Upstatement we’ve now used it on more than a dozen client sites. Hundreds of other sites use it too. You can check some of them out in the **[Showcase](http://upstatement.com/timber/#showcase)**.
+Tens of thousands of sites now use Timber. You can check some of them out in the **[Showcase](http://upstatement.com/timber/#showcase)**.
 
 = Doesn't this all make WordPress harder since there’s more to learn? =
-Does jQuery make JavaScript harder? Yes, it’s an extra piece to learn -- but it super-charges your ability to write unencumbered JavaScript (and prevents you from having to learn lots of the messy internals). If your answer is "jQuery sucks and everyone should learn how to write vanilla JavaScript or they’re rotten stupid people," this tool isn’t for you.
+Does jQuery make JavaScript harder? Yes, it’s an extra piece to learn — but it super-charges your ability to write unencumbered JavaScript (and prevents you from having to learn lots of the messy internals). If your answer is "jQuery sucks and everyone should learn how to write vanilla JavaScript or they’re rotten stupid people," this tool isn’t for you.
 
 = Oh, Timber is simple code so it’s for making simple themes =
 Whatever. It simplifies the silly stuff so that you can focus on building more complicated sites and apps. jQuery simplifies Javascript, but you can still use the full range of JavaScript’s abilities.
 
 = Will you support it? =
-As stated above, we’re using it in dozens of sites (and dozens more planned) -- dozens of other developers are using it too. This isn’t going anywhere. Twig is the chosen language for other PHP platforms like Symfony, Drupal 8 and Craft. WordPress will eventually adopt Twig too, I promise you that.
+At [Upstatement](https://upstatement.com) we’re using it in dozens of sites (and many more planned) -- thousands of other developers are using it too. This isn’t going anywhere. Twig is the chosen language for other PHP platforms like Symfony, Drupal 8 and Craft.

--- a/readme.txt
+++ b/readme.txt
@@ -8,36 +8,23 @@ PHP version: 5.3.0 or greater
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Helps you create themes faster with sustainable code. With Timber, you write HTML using Mustache-like Templates http://timber.upstatement.com
+Helps you create themes faster with sustainable code. With Timber, you write HTML using Twig Templates http://www.upstatement.com/timber/
 
 == Description ==
-Timber cleans-up your theme code so, for example, your php file can focus on being the data, while your twig/html file can focus 100% on the HTML and display.
+Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](http://twig.sensiolabs.org/) separate from your PHP files. This cleans up your theme code so, for example, your PHP file can focus on being the data/logic, while your Twig file can focus 100% on the HTML and display.
 
 Once Timber is installed and activated in your plugin directory, it gives any WordPress theme the ability to take advantage of the power of Twig and other Timber features.
 
-### Looking for docs?
+### Want to learn more?
 * **[Project Page](http://upstatement.com/timber)**
+* [Timber on GitHub](http://github.com/timber/timber/)
+
+### Looking for Documentation?
 * [Timber Documentation](https://timber.github.io/docs/)
 * [Twig Reference (from SensioLabs)](http://twig.sensiolabs.org/doc/templates.html)
-
-#### Related Projects
-* [**Timber Debug Bar**](http://wordpress.org/plugins/debug-bar-timber/) Adds a debug bar panel that will show you want template is in-use and the data sent to your twig file.
 _Twig is the template language powering Timber; if you need a little background on what a template language is, [Twig’s homepage has an overview](http://twig.sensiolabs.org/)_
 * **[Video Tutorials](https://timber.github.io/docs/getting-started/video-tutorials/)**
 * [Overview / Getting Started Guide](https://timber.github.io/docs/getting-started/)
-
-#### What does it look like?
-Nothing. Timber is meant for you to build a theme on. Like the [Starkers](https://github.com/viewportindustries/starkers) or [_s theme](https://github.com/Automattic/_s) it comes style-free, because you're the style expert. Instead, Timber handles the logic you need to make a kick-ass looking site.
-
-#### Who is it good for?
-Timber is great for any WordPress developer who cares about writing good, maintainable code. It helps teams of designers and developers working together. At [Upstatement](http://upstatement.com) we made Timber because not everyone knows the ins-and-outs of the_loop(), WordPress codex and PHP (nor should they). With Timber your best WordPress dev can focus on building the .php files with requests from WordPress and pass the data into .twig files. Once there, designers can easily mark-up data and build out a site's look-and-feel.
-
-#### Want to read more?
-* [Timber on GitHub](http://github.com/timber/timber/)
-* [Timber Overview on Tidy Repo](http://tidyrepo.com/timber/)
-* ["Timber and Twig Reignited My Love for WordPress" on CSS-Tricks](https://css-tricks.com/timber-and-twig-reignited-my-love-for-wordpress/)
-
-
 
 == Changelog ==
 
@@ -620,7 +607,7 @@ Misc fixes to documentation
 
 == Screenshots ==
 
-1. This what a normal WordPres PHP file looks like
+1. This what a normal WordPress PHP file looks like
 2. With Timber, you write Twig files that are super-clear and HTML-centric.
 
 == Installation ==
@@ -628,21 +615,21 @@ Misc fixes to documentation
 1. Activate the plugin through the 'Plugins' menu in WordPress
 2. For an example, try modifying your home.php or index.php with something like this:
 
-`
+```
 $context = array();
 $context['message'] = 'Hello Timber!';
-Timber::render('welcome.twig', $context);
-`
+Timber::render( 'welcome.twig', $context );
+```
 
-Then create a subdirectory called `views` in your theme folder. The make this file: `views/welcome.twig`
-`
-{# welcome.twig #}
+Then create a subdirectory called `views` in your theme folder. Then create a file `views/welcome.twig` with these contents:
+
+```
 <div class="welcome">
-	<h3>{{message}}</h3>
+    <h3>{{ message }}</h3>
 </div>
-`
+```
 
-That's Timber!
+That’s Timber!
 
 == Support ==
 
@@ -654,16 +641,13 @@ Please post on [StackOverflow under the "Timber" tag](http://stackoverflow.com/q
 You bet! Watch these **[Video Tutorials](https://timber.github.io/docs/getting-started/video-tutorials/)** to see how.
 
 = Is it used in production? =
-At Upstatement we've now used it on more than a dozen client sites. Hundreds of other sites use it too. You can check some of them out in the **[showcase](http://upstatement.com/timber/#showcase)**.
+At Upstatement we’ve now used it on more than a dozen client sites. Hundreds of other sites use it too. You can check some of them out in the **[Showcase](http://upstatement.com/timber/#showcase)**.
 
-= Doesn't this all make WordPress harder since there's more to learn? =
-Does jQuery make JavaScript harder? Yes, it's an extra piece to learn -- but it super-charges your ability to write unencumbered JavaScript (and prevents you from having to learn lots of the messy internals). If your answer is "jQuery sucks and everyone should learn how to write vanilla JS or they're rotten stupid people," this tool isn't for you.
+= Doesn't this all make WordPress harder since there’s more to learn? =
+Does jQuery make JavaScript harder? Yes, it’s an extra piece to learn -- but it super-charges your ability to write unencumbered JavaScript (and prevents you from having to learn lots of the messy internals). If your answer is "jQuery sucks and everyone should learn how to write vanilla JavaScript or they’re rotten stupid people," this tool isn’t for you.
 
-= Oh, Timber is simple code so it's for making simple themes =
-Whatever. It simplifies the silly stuff so that you can focus on building more complicated sites and apps. jQuery simplifies Javascript, but you can still use the full range of JS's abilities.
+= Oh, Timber is simple code so it’s for making simple themes =
+Whatever. It simplifies the silly stuff so that you can focus on building more complicated sites and apps. jQuery simplifies Javascript, but you can still use the full range of JavaScript’s abilities.
 
 = Will you support it? =
-As stated above, we're using it in dozens of sites (and dozens more planned) -- dozens of other developers are using it too. This isn't going anywhere. Twig is the chosen language for other PHP platforms like Symfony, Drupal 8 and Craft. WordPress will eventually adopt Twig too, I promise you that.
-
-= Support? =
-Leave a [GitHub issue](https://github.com/timber/timber/issues?state=open) and I'll holler back.
+As stated above, we’re using it in dozens of sites (and dozens more planned) -- dozens of other developers are using it too. This isn’t going anywhere. Twig is the chosen language for other PHP platforms like Symfony, Drupal 8 and Craft. WordPress will eventually adopt Twig too, I promise you that.

--- a/readme.txt
+++ b/readme.txt
@@ -17,14 +17,14 @@ Once Timber is installed and activated in your plugin directory, it gives any Wo
 
 ### Looking for docs?
 * **[Project Page](http://upstatement.com/timber)**
-* [Timber Documentation](https://github.com/timber/docs)
+* [Timber Documentation](https://timber.github.io/docs/)
 * [Twig Reference (from SensioLabs)](http://twig.sensiolabs.org/doc/templates.html)
-_Twig is the template language powering Timber; if you need a little background on what a template language is, [Twig's homepage has an overview](http://twig.sensiolabs.org/)_
-* **[Video Tutorials](https://github.com/timber/timber/wiki/Video-Tutorials)**
-* [Overview / Getting Started Guide](https://github.com/timber/timber/wiki/getting-started)
 
 #### Related Projects
 * [**Timber Debug Bar**](http://wordpress.org/plugins/debug-bar-timber/) Adds a debug bar panel that will show you want template is in-use and the data sent to your twig file.
+_Twig is the template language powering Timber; if you need a little background on what a template language is, [Twig’s homepage has an overview](http://twig.sensiolabs.org/)_
+* **[Video Tutorials](https://timber.github.io/docs/getting-started/video-tutorials/)**
+* [Overview / Getting Started Guide](https://timber.github.io/docs/getting-started/)
 
 #### What does it look like?
 Nothing. Timber is meant for you to build a theme on. Like the [Starkers](https://github.com/viewportindustries/starkers) or [_s theme](https://github.com/Automattic/_s) it comes style-free, because you're the style expert. Instead, Timber handles the logic you need to make a kick-ass looking site.
@@ -651,7 +651,7 @@ Please post on [StackOverflow under the "Timber" tag](http://stackoverflow.com/q
 == Frequently Asked Questions ==
 
 = Can it be used in an existing theme? =
-You bet! Watch these **[video tutorials](https://github.com/timber/timber/wiki/Video-Tutorials)** to see how.
+You bet! Watch these **[Video Tutorials](https://timber.github.io/docs/getting-started/video-tutorials/)** to see how.
 
 = Is it used in production? =
 At Upstatement we've now used it on more than a dozen client sites. Hundreds of other sites use it too. You can check some of them out in the **[showcase](http://upstatement.com/timber/#showcase)**.


### PR DESCRIPTION
#### Issue

- A lot of links still point to the wiki pages.
- Some content in readme.txt (for the [Plugin page](https://de.wordpress.org/plugins/timber-library/)) seems to outdated.

#### Solution

- Update links still pointing to the wiki.
- Copy over descriptions from README.md.
- Display links to project page, GitHub repo and documentation more prominently.
- Delete sections that are covered mainly in the README.md of the GitHub repository. This includes the sections "Related Projects", "What does it look like", "Who is it good for?" and "Want to read more?".
- Delete support entry in FAQ in favor of main == Support == section.
- Apply coding standards.

#### Considerations

I deleted a bunch of sections to make the readme.txt for the plugins page lighter. Maybe I’m going too far here, but I thought it might better to reduce the amount of places where there’s information about what Timber is (for better maintainability). And it makes it easier to find the Changelog when writing release notes ;).