### PR TITLE
Update documentation for WordPress Integration and WooCommerce guides

### DIFF
--- a/docs/guides/woocommerce.md
+++ b/docs/guides/woocommerce.md
@@ -6,29 +6,27 @@ menu:
 ---
 
 ## Point of entry - main WooCommerce PHP file
-The first step to get your WooCommerce project integrated with Timber is creating a file named `woocommerce.php` in the root of your theme. That will establish the context and data to be passed to your twig files:
+The first step to get your WooCommerce project integrated with Timber is creating a file named `woocommerce.php` in the root of your theme. That will establish the context and data to be passed to your Twig files:
 
 ```php
 <?php
 
-if (!class_exists('Timber')){
+if ( ! class_exists( 'Timber' ) ){
     echo 'Timber not activated. Make sure you activate the plugin in <a href="/wp-admin/plugins.php#timber">/wp-admin/plugins.php</a>';
+
     return;
 }
 
 $context            = Timber::get_context();
-$context['sidebar'] = Timber::get_widgets('shop-sidebar');
+$context['sidebar'] = Timber::get_widgets( 'shop-sidebar' );
 
-if (is_singular('product')) {
-
+if ( is_singular( 'product' ) ) {
     $context['post']    = Timber::get_post();
     $product            = wc_get_product( $context['post']->ID );
     $context['product'] = $product;
 
-    Timber::render('views/woo/single-product.twig', $context);
-
+    Timber::render( 'views/woo/single-product.twig', $context );
 } else {
-
     $posts = Timber::get_posts();
     $context['products'] = $posts;
 
@@ -36,35 +34,33 @@ if (is_singular('product')) {
         $queried_object = get_queried_object();
         $term_id = $queried_object->term_id;
         $context['category'] = get_term( $term_id, 'product_cat' );
-        $context['title'] = single_term_title('', false);
+        $context['title'] = single_term_title( '', false );
     }
 
-    Timber::render('views/woo/archive.twig', $context);
-
+    Timber::render( 'views/woo/archive.twig', $context );
 }
 ```
 
-You will now need the two twig files loaded from `woocommerce.php`:
+You will now need the two Twig files loaded from `woocommerce.php`: `views/woo/single-product.twig` and `views/woo/archive.twig`.
 
 ## Archives
-Create a Twig file accordingly to the location asked by the above file, in this example that would be `views/woo/archive.twig`:
+
+Create a Twig file according to the location asked by the above file, in this example that would be `views/woo/archive.twig`:
 
 ```twig
-{% extends "base.twig" %}
+{% extends 'base.twig' %}
 
 {% block content %}
 
     {% do action('woocommerce_before_main_content') %}
 
     <div class="before-shop-loop">
-        {% do action( 'woocommerce_before_shop_loop') %}
+        {% do action('woocommerce_before_shop_loop') %}
     </div>
 
     <div class="loop">
         {% for post in products %}
-
             {% include ["partials/tease-product.twig"] %}
-
         {% endfor %}
     </div>
 
@@ -74,12 +70,13 @@ Create a Twig file accordingly to the location asked by the above file, in this 
 {% endblock  %}
 ```
 
-You'll notice the inclusion of several woocommerce's default hooks, which you'll need to keep the integration seamless and allow any WooCommerce extension plugin to still work.
+You’ll notice the inclusion of several of WooCommerce’s default hooks, which you’ll need to keep the integration seamless and allow any WooCommerce extension plugin to still work.
 
-Next, we'll take care of the single product view.
+Next, we’ll take care of the single product view.
 
 ## Single Product
-Create a Twig file accordingly to the location asked by the above file, in this example that would be `views/woo/single-product.twig`:
+
+Create a Twig file according to the location asked by the above file, in this example that would be `views/woo/single-product.twig`:
 
 ```twig
 {% extends "base.twig" %}
@@ -88,10 +85,11 @@ Create a Twig file accordingly to the location asked by the above file, in this 
 
     {% do action('woocommerce_before_single_product') %}
 
-    <article itemscope itemtype="http://schema.org/Product" class="single-product-details {{post.class}}">
+    <article itemscope itemtype="http://schema.org/Product" class="single-product-details {{ post.class }}">
 
         <div class="entry-images">
             {% do action('woocommerce_before_single_product_summary') %}
+
             <img src="{{ post.thumbnail.src('shop_single') }}" />
         </div>
 
@@ -110,24 +108,22 @@ Create a Twig file accordingly to the location asked by the above file, in this 
 {% endblock  %}
 ```
 
-Again we are keep things simple by using WooCommerce's default hooks.
-If you need to override the output of any of those hooks, my advice would be to remove and add the relevant actions using PHP, keeping your upgrade path simple.
+Again we are keeping things simple by using WooCommerce’s default hooks. If you need to override the output of any of those hooks, my advice would be to remove and add the relevant actions using PHP, keeping your upgrade path simple.
 
-Finally, we'll need to create a teaser file for product in the loops. Considering the code above that  would be `views/partials/tease-product.twig`:
+Finally, we’ll need to create a teaser file for products in loops. Considering the code above that would be `views/partials/tease-product.twig`:
 
 ## Tease Product
 
 ```twig
-
 <article {{ fn('post_class', ['$classes', 'entry'] ) }}>
 
-    {{ fn('timber_set_product', post)}}
+    {{ fn('timber_set_product', post) }}
 
-    <div class="Media">
+    <div class="media">
 
         {% if showthumb %}
-            <div class="Media-figure {% if not post.thumbnail %}placeholder{% endif %}">
-                <a href="{{post.link}}">
+            <div class="media-figure {% if not post.thumbnail %}placeholder{% endif %}">
+                <a href="{{ post.link }}">
                     {% if post.thumbnail %}
                         <img src="{{ post.thumbnail.src|resize(post_thumb_size[0], post_thumb_size[1]) }}" />
                     {% else %}
@@ -137,57 +133,62 @@ Finally, we'll need to create a teaser file for product in the loops. Considerin
             </div>
         {% endif %}
 
-        <div class="Media-content">
+        <div class="media-content">
+
             {% do action('woocommerce_before_shop_loop_item_title') %}
+
             {% if post.title %}
-                <h3 class="entry-title"><a href="{{post.link}}">{{ post.title }}</a></h3>
+                <h3 class="entry-title"><a href="{{ post.link }}">{{ post.title }}</a></h3>
             {% else %}
-                <h3 class="entry-title"><a href="{{post.link}}">{{ fn('the_title') }}</a></h3>
+                <h3 class="entry-title"><a href="{{ post.link }}">{{ fn('the_title') }}</a></h3>
             {% endif %}
+
             {% do action( 'woocommerce_after_shop_loop_item_title' ) %}
             {% do action( 'woocommerce_after_shop_loop_item' ) %}
+
         </div>
 
     </div>
 
 </article>
-
 ```
 
 This should all sound familiar by now, except for one line:
 
 ```twig
-{{ fn('timber_set_product', post)}}
+{{ fn('timber_set_product', post) }}
 ```
 
-For some reason products in the loop don't get the right context by default. This line will call the following function that you need to add somewhere in your `functions.php` file:
+For some reason, products in the loop don’t get the right context by default. This line will call the following function that you need to add somewhere in your `functions.php` file:
 
 ```php
 <?php
 function timber_set_product( $post ) {
     global $product;
+    
     if ( is_woocommerce() ) {
-        $product = wc_get_product($post->ID);
+        $product = wc_get_product( $post->ID );
     }
 }
 ```
 
 Without this, some elements of the listed products would show the same information as the first product in the loop.
 
-*Note:* Some users reported issues with the loop context even when using the `timber_set_product` helper function. Turns out the default WooCommerce hooks interfere with the output of the aforementioned function.
+*Note:* Some users reported issues with the loop context even when using the `timber_set_product()` helper function. Turns out the default WooCommerce hooks interfere with the output of the aforementioned function.
 
-One way to get around this is by building your own image calls, that means removing WooCommerce's default hooks and declare on your template the html to show the image:
+One way to get around this is by building your own image calls, that means removing WooCommerce’s default hooks and declare your own template for the HTML to show the image:
 
 ```twig
 {% if post.thumbnail %}
-   <img src="{{ post.thumbnail.src|resize(shop_thumbnail_image_size) }}" />
+    <img src="{{ post.thumbnail.src|resize(shop_thumbnail_image_size) }}" />
 {% endif %}
 ```
+
 To remove the default image, add the following to your `functions.php` file:
 
 ```php
 <?php
-remove_action('woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail');
+remove_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail' );
 ```
 
-This comes with the added benefit that you'll have total control over where your image is created in the markup.
+This comes with the added benefit that you’ll have total control over where your image is created in the markup.

--- a/docs/guides/wp-integration.md
+++ b/docs/guides/wp-integration.md
@@ -5,29 +5,25 @@ menu:
     parent: "guides"
 ---
 
-Timber plays nice with your existing WordPress setup. You can still use other plugins, etc.
+Timber plays nicely with your existing WordPress setup. You can still use other plugins, etc.
 
 ## the_content
 
-You're probably used to calling `the_content()` in your theme file. This is good. Before outputting, WordPress will run all the filters and actions that your plugins and themes are using. If you want to get this into your new Timber theme (and you probably do). Call it like this:
+You’re probably used to call `the_content()` in your theme file. This is good. Before outputting, WordPress will run all the filters and actions that your plugins and themes are using. If you want to get this into your new Timber theme (and you probably do), call it like this:
 
 ```twig
 <div class="my-article">
-   {{ post.content }}
+    {{ post.content }}
 </div>
 ```
 
-This differs from `{{ post.post_content }}`, which is the raw text stored in your database.
-
-* * *
+This differs from `{{ post.post_content }}`, which will display the raw text stored in the database.
 
 ## Hooks
 
 Timber hooks to interact with WordPress use `this/style/of_hooks` instead of `this_style_of_hooks`. This matches the same methodology as [Advanced Custom Fields](http://www.advancedcustomfields.com/resources/#actions).
 
-Full documentation to come
-
-* * *
+Full documentation to come.
 
 ## Actions
 
@@ -42,11 +38,13 @@ Call them in your Twig template...
 
 ```php
 <?php
-add_action('my_action', 'my_function');
+add_action( 'my_action', 'my_function' );
 
 function my_function( $context ) {
-	// $context stores the template context in case you need to reference it
-	echo $context['post']->post_title; //outputs title of yr post
+    // $context stores the template context in case you need to reference it
+
+    // Outputs title of your post
+    echo $context['post']->post_title;
 }
 ```
 
@@ -55,25 +53,23 @@ function my_function( $context ) {
 add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
 
 function my_function_with_args( $foo, $bar ){
-	echo 'I say ' . $foo . ' and ' . $bar;
+    echo 'I say ' . $foo . ' and ' . $bar;
 }
 ```
 
-You can still get the context object when passing args, it's always the _last_ argument...
+You can still get the context object when passing args, it’s always the _last_ argument...
 
 ```php
 <?php
 add_action( 'my_action_with_args', 'my_function_with_args', 10, 3 );
 
 function my_function_with_args( $foo, $bar, $context ){
-	echo 'I say ' . $foo . ' and ' . $bar;
-	echo 'For the post with title ' . $context['post']->post_title;
+    echo 'I say ' . $foo . ' and ' . $bar;
+    echo 'For the post with title ' . $context['post']->post_title;
 }
 ```
 
 Please note the argument count that WordPress requires for `add_action`.
-
-* * *
 
 ## Filters
 
@@ -84,55 +80,55 @@ Timber already comes with a [set of useful filters](https://timber.github.io/doc
 {{ "my custom string"|apply_filters('my_filter', param1, param2, ...) }}
 ```
 
-* * *
-
 ## Widgets
 
-Everyone loves widgets!
-Of course they do...
+Everyone loves widgets! Of course they do...
 
 ```php
 <?php
-$data['footer_widgets'] = Timber::get_widgets('footer_widgets');
+$data['footer_widgets'] = Timber::get_widgets( 'footer_widgets' );
 ```
 
-...where 'footer_widgets' is the registered name of the widgets you want to get(in twentythirteen these are called `sidebar-1` and `sidebar-2` )
+...where `footer_widgets` is the registered name of the widgets you want to get (in twentythirteen these are called `sidebar-1` and `sidebar-2`).
 
 Then use it in your template:
 
+**base.twig**
+
 ```twig
-{# base.twig #}
 <footer>
-	{{ footer_widgets }}
+    {{ footer_widgets }}
 </footer>
 ```
 
-* * *
-
 ### Using Timber inside your own widgets
 
-You can also use twig templates for your widgets!
-Let's imagine we want a widget that shows a random number each time it is rendered.
+You can also use twig templates for your widgets! Let’s imagine we want a widget that shows a random number each time it is rendered.
 
 Inside the widget class, the widget function is used to show the widget:
 
 ```php
 <?php
-public function widget($args, $instance) {
-	$number = rand();
-	Timber::render('random-widget.twig', array('args' => $args, 'instance' => $instance, 'number' => $number));
+public function widget( $args, $instance ) {
+    $number = rand();
+
+    Timber::render( 'random-widget.twig', array(
+        'args' => $args,
+        'instance' => $instance,
+        'number' => $number
+    ) );
 }
 ```
 
 The corresponding template file `random-widget.twig` looks like this:
 
 ```twig
-{{ args.before_widget | raw }}
-{{ args.before_title | raw }}{{ instance.title | apply_filters('widget_title') }}{{ args.after_title | raw }}
+{{ args.before_widget|raw }}
+{{ args.before_title|raw }}{{ instance.title|apply_filters('widget_title') }}{{ args.after_title|raw }}
 
 <p>Your magic number is: <strong>{{ number }}</strong></p>
 
-{{ args.after_widget | raw }}
+{{ args.after_widget|raw }}
 ```
 The raw filter is needed here to embed the widget properly.
 
@@ -141,39 +137,42 @@ You may also want to check if the Timber plugin was loaded before using it:
 ```php
 <?php
 public function widget( $args, $instance ) {
-	if ( ! class_exists( 'Timber' ) ) {
-		// if you want to show some error message, this is the right place
-		return;
-	}
-	$number = rand();
-	Timber::render( 'random-widget.twig', array( 'args' => $args, 'instance' => $instance, 'number' => $number ) );
+    if ( ! class_exists( 'Timber' ) ) {
+        // if you want to show some error message, this is the right place
+        return;
+    }
+
+    $number = rand();
+
+    Timber::render( 'random-widget.twig', array(
+        'args' => $args,
+        'instance' => $instance,
+        'number' => $number
+    ) );
 }
 ```
 
-* * *
-
 ## Shortcodes
 
-Well, if it works for widgets, why shouldn't it work for shortcodes ?
-Of course it does !
+Well, if it works for widgets, why shouldn't it work for shortcodes? Of course it does!
 
-Let's implement a `[youtube]` shorttag which embeds a youtube video.
-For the desired usage of `[youtube id=xxxx]` we only need a few lines of code:
+Let’s implement a `[youtube]` shortcode which embeds a youtube video.  
+For the desired usage of `[youtube id=xxxx]`, we only need a few lines of code:
 
 ```php
 <?php
 // Should be called from within an init action hook
-add_shortcode( 'youtube', 'youtube_shorttag' );
+add_shortcode( 'youtube', 'youtube_shortcode' );
 
-function youtube_shorttag( $atts ) {
-	if( isset( $atts['id'] ) ) {
-		$id = sanitize_text_field( $atts['id'] );
-	} else {
-		$id = false;
-	}
-	
-	// This time we use Timber::compile since shorttags should return the code
-	return Timber::compile( 'youtube-short.twig', array( 'id' => $id ) );
+function youtube_shortcode( $atts ) {
+    if( isset( $atts['id'] ) ) {
+        $id = sanitize_text_field( $atts['id'] );
+    } else {
+        $id = false;
+    }
+
+    // This time we use Timber::compile since shortcodes should return the code
+    return Timber::compile( 'youtube-short.twig', array( 'id' => $id ) );
 }
 ```
 
@@ -181,7 +180,7 @@ In `youtube-short.twig` we have the following template:
 
 ```twig
 {% if id %}
-<iframe width="560" height="315" src="//www.youtube.com/embed/{{ id }}" frameborder="0" allowfullscreen></iframe>
+	<iframe width="560" height="315" src="//www.youtube.com/embed/{{ id }}" frameborder="0" allowfullscreen></iframe>
 {% endif %}
 ```
 
@@ -189,19 +188,19 @@ Now, when the YouTube embed code changes, we only need to edit the `youtube-shor
 
 ### Layouts with Shortcodes
 
-Timber and Twig can process your shortcodes by using the `{% filter shortcodes %}` tag. Let's say you're using a `[tab]` shortcode, for example:
+Timber and Twig can process your shortcodes by using the `{% filter shortcodes %}` tag. Let’s say you're using a `[tab]` shortcode, for example:
 
 ```twig
 {% filter shortcodes %}
-	[tabs tab1="Tab 1 title" tab2="Tab 2 title" layout="horizontal" backgroundcolor="" inactivecolor=""]
-		[tab id=1]
-			Something something something
-		[/tab]
+    [tabs tab1="Tab 1 title" tab2="Tab 2 title" layout="horizontal" backgroundcolor="" inactivecolor=""]
+        [tab id=1]
+            Something something something
+        [/tab]
 
-		[tab id=2]
-			Tab 2 content here
-		[/tab]
-	[/tabs]
+        [tab id=2]
+            Tab 2 content here
+        [/tab]
+    [/tabs]
 {% endfilter %}
 ```
 


### PR DESCRIPTION
Update documentation for WooCommerce

- Apply coding standards, improve whitespace (spaces instead of tabs for markdown)
- Reformat Markdown
- Improve wording, fix spelling

This commit also deprecates the wiki page about WooCommerce.

---

Update documentation for WordPress Integration

- Apply coding standards, improve whitespace (spaces instead of tabs for markdown)
- Reformat Markdown
- Improve wording, fix spelling

This commit also deprecates the wiki page about WordPress Integration.