### PR TITLE
Update documentation for Getting Started guides

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -9,7 +9,8 @@ menu:
 ## Installation
 
 ### Via WordPress.org (easy)
-You can just grab the all-things-included plugin at [WordPress.org](http://wordpress.org/plugins/timber-library/) either through the WP site or your Plugins->Add New in wp-admin. Then skip ahead to [using the starter theme](#use-the-starter-theme).
+
+You can grab the all-things-included plugin at [WordPress.org](http://wordpress.org/plugins/timber-library/) either through the WordPress site or through the Plugins menu in the backend. Then skip ahead to [using the starter theme](#use-the-starter-theme).
 
 ### Via GitHub (for developers)
 
@@ -19,27 +20,31 @@ The GitHub version of Timber requires [Composer](https://getcomposer.org/downloa
 composer require timber/timber
 ```
 
-If your theme is not setup to pull in Composer's autoload file, you will need to:
+If your theme is not setup to pull in Composer’s autoload file, you will need to add the following at the top of your `functions.php` file: 
+
+**functions.php**
 
 ```php
 <?php
-require_once(__DIR__ . '/vendor/autoload.php');
+require_once( __DIR__ . '/vendor/autoload.php' );
 ```
 
-at the top of your `functions.php` file. Initialize Timber with:
+Initialize Timber with:
+
+**functions.php**
 
 ```php
 <?php
-$timber = new \Timber\Timber();
+$timber = new Timber\Timber();
 ```
 
 ## Use the starter theme
 
-The [starter theme](https://github.com/Upstatement/timber-starter-theme) is for starting a project from scratch. You can also use Timber in an existing theme.
+The [starter theme](https://github.com/timber/starter-theme) is for starting a project from scratch. You can also use Timber in an existing theme.
 
 ### Navigate to your WordPress themes directory
 
-Like where twentyeleven and twentytwelve live. The Timber Starter will live at the same level.
+Like where twentyeleven and twentytwelve live. The Timber Starter Theme will live at the same level.
 
 	/wp-content/themes	/twentyeleven
 						/twentytwelve
@@ -53,10 +58,12 @@ You should probably **rename** this to something better.
 
 ### 1. Activate Timber
 
-It will be in wp-admin/plugins.php
+It will be in `wp-admin/plugins.php`.
 
 ### 2. Select your theme in WordPress
 
-Make sure you select the Timber-enabled theme **after** you activate the plugin. The theme will crash unless Timber is activated. Use the **timber-starter-theme** theme from the step above (or whatever you renamed it).
+Make sure you select the Timber-enabled theme **after** you activate the plugin. The theme will crash unless Timber is activated. Use the **timber-starter-theme** theme from the step above (or whatever you renamed it to).
 
-### 3. Let's write our theme!
+### 3. Let’s write our theme!
+
+Continue ahead in [part 2 about Themeing](https://timber.github.io/docs/getting-started/themeing/).

--- a/docs/getting-started/themeing.md
+++ b/docs/getting-started/themeing.md
@@ -7,132 +7,145 @@ menu:
 
 ## Your first Timber project
 
-Let's start with your single post. Find this file:
+Let’s start with your single post. Find this file:
 
-```html
-	wp-content/themes/{timber-starter-theme}/views/single.twig
+```
+wp-content/themes/{timber-starter-theme}/templates/single.twig
 ```
 
 Brilliant! Open it up.
 
 ```twig
 {% extends "base.twig" %}
+
 {% block content %}
-	<div class="content-wrapper">
-		<article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
-			<section class="article-content">
-				<h1 class="article-h1">{{ post.title }}</h1>
-				<h2 class="article-h2">{{ post.subtitle }}</h2>
-				<p class="blog-author"><span>By</span> {{ post.author.name }} <span>&bull;</span> {{ post.post_date|date }}</p>
-				{{ post.content }}
-			</section>
-		</article>
-	</div> <!-- /content-wrapper -->
+    <div class="content-wrapper">
+        <article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+            <section class="article-content">
+                <h1 class="article-h1">{{ post.title }}</h1>
+                <h2 class="article-h2">{{ post.subtitle }}</h2>
+                <p class="blog-author">
+                	<span>By</span> {{ post.author.name }} <span>&bull;</span> {{ post.post_date|date }}
+                </p>
+                {{ post.content }}
+            </section>
+        </article>
+    </div>
 {% endblock %}
 ```
 
 **What did we just do?**
 
-This is the fun part.
+This is the fun part. Instead of calling stuff from the WordPress API like this:
+
+```html
+<h1 class="article-h1"><?php the_title(); ?></h1>
+```
+
+We can do it like this in Twig:
 
 ```twig
 <h1 class="article-h1">{{ post.title }}</h1>
 ```
 
-This is now how we now call stuff from the WordPress API. Instead of this familiar face:
-
-```html
-<h1 class="article-h1"><?php the_title(); ?></h1>
-```
-This is how WordPress wants you to interact with its API. Which sucks. Because soon you get things like:
+WordPress wants you to interact with its API in a certain way, which sucks. Because soon you get things like:
 
 ```html
 <h1 class="article-h1"><a href="<?php get_permalink(); ?>"><?php the_title(); ?></a></h1>
 ```
 
-Okay, not _too_ terrible, but doesn't this (Timber) way look so much nicer:
+Okay, not _too_ terrible, but doesn’t this (Timber) way look so much nicer?
 
 ```twig
 <h1 class="article-h1"><a href="{{ post.link }}">{{ post.title }}</a></h1>
 ```
 
-It gets better. Let's explain some other concepts.
+It get’s better. Let’s explain some other concepts.
 
 ```twig
 {% extends "base.twig" %}
 ```
 
-This means that `single.twig` is using `base.twig` as its parent template. That's why you don't see any `<head>`, `<header>`, or `<footer>` tags, those site-wide (usually) things are all controlled in `base.twig`. You can create any number of base files to extend from (the "base" naming convention is recommended, but not requrired).
+This means that `single.twig` is using `base.twig` as its parent template. That’s why you don't see any `<head>`, `<header>`, or `<footer>` tags, those site-wide (usually) things are all controlled in `base.twig`. You can create any number of base files to extend from (the "base" naming convention is recommended, but not required).
 
 What if you want modify `<head>`, etc? Read on to learn all about blocks.
 
 ## Blocks
 
-Blocks are the single most important and powerful concept in managing your templates. The [official Twig Documentation](http://twig.sensiolabs.org/doc/templates.html#template-inheritance) has more details. Let's cover the basics.
+Blocks are the single most important and powerful concept in managing your templates. The [official Twig Documentation](http://twig.sensiolabs.org/doc/templates.html#template-inheritance) has more details. Let’s cover the basics.
 
 In `single.twig` you see opening and closing block declarations that surround the main page contents.
 
 ```twig
-{% block content %} {# other stuff here ... #} {% endblock %}
+{% block content %}
+    {# other stuff here ... #}
+{% endblock %}
 ```
 
-If you were to peek into **base.twig** you would see a matching set of `{% block content %} / {% endblock %}` tags. **single.twig** is replacing the content of base's `{% block content %}` with its own.
+If you were to peek into **base.twig** you would see a matching set of `{% block content %} / {% endblock %}` tags. **single.twig** is replacing the content of base’s `{% block content %}` with its own.
 
 ### Nesting Blocks, Multiple Inheritance
-This is when things get really cool. Whereas most people use PHP includes in a linear fashion, you can create infinite levels of nested blocks to particularly control your page templates. For example, let's say you occasionally want to replace the title/headline on your `single.twig` template with a custom image or typography.
 
-For this demo let's assume that the name of the page is "All about Jared" (making its slug `all-about-jared`). First, I'm going to surround the part of the template I want to control with block declarations:
+This is when things get really cool. Whereas most people use PHP includes in a linear fashion, you can create infinite levels of nested blocks to particularly control your page templates. For example, let’s say you occasionally want to replace the title/headline on your `single.twig` template with a custom image or typography.
+
+For this demo, let’s assume that the name of the page is "All about Jared" (making its slug `all-about-jared`). First, I'm going to surround the part of the template I want to control with block declarations:
+
+**single.twig**
 
 ```twig
-{# single.twig #}
 {% extends "base.twig" %}
+
 {% block content %}
-	<div class="content-wrapper">
-		<article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
-			<section class="article-content">
-				{% block headline %}
-					<h1 class="article-h1">{{ post.title }}</h1>
-					<h2 class="article-h2">{{ post.subtitle }}</h2>
-				{% endblock %}
-				<p class="blog-author"><span>By</span> {{ post.author.name }} <span>&bull;</span> {{ post.post_date|date }}</p>
-				{{ post.content }}
-			</section>
-		</article>
-	</div> <!-- /content-wrapper -->
+    <div class="content-wrapper">
+        <article class="post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+            <section class="article-content">
+                {% block headline %}
+                    <h1 class="article-h1">{{ post.title }}</h1>
+                    <h2 class="article-h2">{{ post.subtitle }}</h2>
+                {% endblock %}
+
+                <p class="blog-author"><span>By</span> {{ post.author.name }} <span>&bull;</span> {{ post.post_date|date }}</p>
+                {{ post.content }}
+            </section>
+        </article>
+    </div>
 {% endblock %}
 ```
 
 Compared to the earlier example of this page, we now have the `{% block headline %}` bit surrounding the `<h1>` and `<h2>`.
 
-To inject my custom bit of markup, I'm going to create a file called `single-all-about-jared.twig` in the `views` directory. The logic for which template should be selected is controlled in `single.php` but generally follows WordPress conventions on Template Hierarchy. Inside that file, all I need is:
+To inject my custom bit of markup, I’m going to create a file called `single-all-about-jared.twig` in the `views` directory. The logic for which template should be selected is controlled in `single.php` but generally follows WordPress conventions on Template Hierarchy. Inside that file, all I need is:
+
+**single-all-about-jared.twig**
 
 ```twig
-{# single-all-about-jared.twig #}
 {% extends "single.twig" %}
+
 {% block headline %}
-	<h1><img src="/wp-content/uploads/2014/05/jareds-face.jpg" alt="Jared's Mug"/></h1>
+	<h1><img src="/wp-content/uploads/2014/05/jareds-face.jpg" alt="Jared’s Mug"/></h1>
 {% endblock %}
 ```
 
 So two big concepts going on here:
 
-1. **Multiple Inheritance** I'm extending `{% single.twig %}`, which itself extends `{% base.twig %}`. Thus we stay true to DRY and don't have very similar code between my two templates hanging around.
-2. **Nested Blocks** `{% block headline %}` is located inside `{% block content %}`. So while I'm replacing the headline, I get to keep all the other markup and variables found in the parent template.
+1. **Multiple Inheritance:** I’m extending `{% single.twig %}`, which itself extends `{% base.twig %}`. Thus we stay true to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and don’t have very similar code between my two templates hanging around.
+2. **Nested Blocks:** `{% block headline %}` is located inside `{% block content %}`. So while I’m replacing the headline, I get to keep all the other markup and variables found in the parent template.
 
-What if you want to **add** to the block as opposed to replace? No prob, just call `{{ parent() }}` where the parent's content should go.
+What if you want to **add** to the block as opposed to replace? No prob, just call `{{ parent() }}` where the parent’s content should go.
 
 ## The index page
 
-Let's crack open **index.php** and see what's inside:
+Let’s crack open **index.php** and see what’s inside:
 
 ```php
 <?php
 $context = Timber::get_context();
 $context['posts'] = Timber::get_posts();
-Timber::render('index.twig', $context);
+
+Timber::render( 'index.twig', $context );
 ```
 
-This is where we are going to handle the logic that powers our index file. Let's go step-by-step.
+This is where we are going to handle the logic that powers our index file. Let’s go step-by-step.
 
 ### Get the context
 
@@ -141,7 +154,7 @@ This is where we are going to handle the logic that powers our index file. Let's
 $context = Timber::get_context();
 ```
 
-This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you'll want to start with each time (even if you over-write them later). You can do a ```print_r( $context );``` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.
+This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you’ll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.
 
 ### Grab your posts
 
@@ -149,32 +162,34 @@ This is going to return an object with a lot of the common things we need across
 <?php
 $context['posts'] = Timber::get_posts();
 ```
-We're now going to grab the posts that are inside the loop and stick them inside our data object under the **posts** key.
+
+We’re now going to grab the posts that are inside the loop and stick them inside our data object under the **posts** key.
 
 ## How to use Timber::get_posts()
 
 ### Use a WP_Query array
 
 ```php
-	<?php
-	$args = array(
-		'post_type' => 'post',
-		'tax_query' => array(
-			'relation' => 'AND',
-			array(
-				'taxonomy' => 'movie_genre',
-				'field' => 'slug',
-				'terms' => array( 'action', 'comedy' )
-			),
-			array(
-				'taxonomy' => 'actor',
-				'field' => 'id',
-				'terms' => array( 103, 115, 206 ),
-				'operator' => 'NOT IN'
-			)
-		)
-	);
-	$context['posts'] = Timber::get_posts($args);
+<?php
+$args = array(
+    'post_type' => 'post',
+    'tax_query' => array(
+        'relation' => 'AND',
+        array(
+            'taxonomy' => 'movie_genre',
+            'field' => 'slug',
+            'terms' => array( 'action', 'comedy' )
+        ),
+        array(
+            'taxonomy' => 'actor',
+            'field' => 'id',
+            'terms' => array( 103, 115, 206 ),
+            'operator' => 'NOT IN'
+        )
+    )
+);
+
+$context['posts'] = Timber::get_posts( $args );
 ```
 
 You can find all available options in the documentation for [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query).
@@ -182,27 +197,29 @@ You can find all available options in the documentation for [WP_Query](http://co
 ### Use a WP_Query string
 
 ```php
-	<?php
-	$args = 'post_type=movies&numberposts=8&orderby=rand';
-	$context['posts'] = Timber::get_posts($args);
+<?php
+$args = 'post_type=movies&numberposts=8&orderby=rand';
+
+$context['posts'] = Timber::get_posts( $args );
 ```
 
 ### Use Post ID numbers
 
 ```php
-	<?php
-	$ids = array(14, 123, 234, 421, 811, 6);
-	$context['posts'] = Timber::get_posts($ids);
+<?php
+$ids = array( 14, 123, 234, 421, 811, 6 );
+
+$context['posts'] = Timber::get_posts( $ids );
 ```
 
 ## Render
 
 ```php
 <?php
-Timber::render('index.twig', $context);
+Timber::render( 'index.twig', $context );
 ```
 
-We're now telling Twig to find **index.twig** and send it our data object.
+We’re now telling Twig to find **index.twig** and send it our data object.
 
 Timber will look first in the child theme and then falls back to the parent theme (same as WordPress logic). The official load order is:
 
@@ -212,4 +229,4 @@ Timber will look first in the child theme and then falls back to the parent them
 4. Parent theme
 5. Directory of calling PHP script (including the theme)
 
-Item 2 is inserted above others so that if you're using Timber in a plugin it will use the twig files in the plugin's directory.
+Item 2 is inserted above others so that if you’re using Timber in a plugin it will use the twig files in the plugin’s directory.

--- a/docs/getting-started/twig-tools.md
+++ b/docs/getting-started/twig-tools.md
@@ -9,14 +9,17 @@ The purpose of this page is to identify helpful tools for working with Twig.
 
 ## Text editor add-ons
 
-* Text Mate & Sublime text bundle - [Anomareh's PHP-Twig](https://github.com/Anomareh/PHP-Twig.tmbundle)
-* Emacs - [Web Mode](http://web-mode.org/)
-* Geany - add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
-* PHPStorm - Built in coloring and code hinting. The twig extension is recognized and has been for some time. [Twig Details for PHPStorm](http://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/)
+* Text Mate & Sublime text bundle – [Anomareh's PHP-Twig](https://github.com/Anomareh/PHP-Twig.tmbundle)
+* Emacs – [Web Mode](http://web-mode.org/)
+* Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
+* PHPStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PHPStorm](http://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
+* Atom – Syntax highlighting with the [Atom Component](https://atom.io/packages/php-twig).
 
 ## Other
-* [Watson-Ruby](http://goosecode.com/watson/) (inline issue manager - put tags like [todo] in a Twig comment and find it easily later!). Watson supports Twig as of version 1.6.3.
+
+* [Watson-Ruby](http://goosecode.com/watson/) – An inline issue manager. Put tags like `[todo]` in a Twig comment and find it easily later. Watson supports Twig as of version 1.6.3.
 
 ## JavaScript
-* [Twig.js](https://github.com/justjohn/twig.js) use those `.twig` files in the Javascript and AJAX components of your site.
-* [Nunjucks](http://mozilla.github.io/nunjucks/) another JS template language that is also based on [Jinja2](http://jinja.pocoo.org/docs/)
+
+* [Twig.js](https://github.com/justjohn/twig.js) – Use those `.twig` files in the Javascript and AJAX components of your site.
+* [Nunjucks](http://mozilla.github.io/nunjucks/) – Another JS template language that is also based on [Jinja2](http://jinja.pocoo.org/docs/)

--- a/docs/getting-started/video-tutorials.md
+++ b/docs/getting-started/video-tutorials.md
@@ -5,8 +5,6 @@ menu:
     parent: "getting-started"
 ---
 
-I'm in the midst of an install and walk-through on Timber, here are the screencasts thus far:
-
 ## 1. Install Timber
 
 ### Option 1: Via GitHub (for developers)
@@ -17,13 +15,13 @@ I'm in the midst of an install and walk-through on Timber, here are the screenca
 
 #### 2) Use git to grab the repo
 
-	$ git clone git@github.com:jarednova/timber.git
+	$ git clone git@github.com:timber/timber.git
 
 #### 3) Use Composer to download the dependencies (Twig, etc.)
 
 	$ cd timber
 	$ composer install
-	
+
 You can find a guide on [how to get started with Composer](https://getcomposer.org/doc/00-intro.md) in the official documentation.
 
 ### Option 2: Via Composer (for developers)
@@ -34,17 +32,17 @@ You can find a guide on [how to get started with Composer](https://getcomposer.o
 
 #### 2) Use Composer to create project and download the dependencies (Twig, etc.)
 
-	$ composer create-project --no-dev jarednova/timber ./timber
+	$ composer create-project --no-dev timber/timber ./timber
 
 You can find a guide on [how to get started with Composer](https://getcomposer.org/doc/00-intro.md) in the official documentation.
 
 ### Option 3: Via WordPress plugins directory (for non-developers)
 
-If you'd prefer one-click installation, you should use the [WordPress.org](http://wordpress.org/plugins/timber-library/) version.
+If you’d prefer one-click installation, you should use the [WordPress.org](http://wordpress.org/plugins/timber-library/) version.
 
 * * *
 
-Now just activate in your WordPress admin screen. Inside of the timber directory there's a timber-starter-theme. To use this move it into your `themes` directory (probably want to rename it too) and select it.
+Now just activate in your WordPress admin screen. Inside of the timber directory there’s a `timber-starter-theme` directory. To use this, move it into your `themes` directory (probably want to rename it too) and select it.
 
 * * *
 
@@ -54,23 +52,26 @@ Now just activate in your WordPress admin screen. Inside of the timber directory
 
 In which we use an existing WordPress template and implement a very simple Timber usage.
 
-Here's the relevant code:
+Here’s the relevant code:
+
+**index.php**
 
 ```php
 <?php
-/* index.php */
 $context = array();
 $context['headline'] = 'Welcome to my new Timber Blog!';
-Timber::render('welcome.twig', $context);
+
+Timber::render( 'welcome.twig', $context );
 ```
 
+**welcome.twig**
+
 ```twig
-{# welcome.twig #}
 <section class="welcome-block">
-	<div class="inner">
-		<h3>{{headline}}</h3>
-		<p>This will be a superb blog, I will inform you every day</p>
-	</div>
+    <div class="inner">
+        <h3>{{ headline }}</h3>
+        <p>This will be a superb blog, I will inform you every day</p>
+    </div>
 </section>
 ```
 
@@ -83,17 +84,18 @@ Timber::render('welcome.twig', $context);
 ```php
 <?php
 $context = array();
-$context['welcome'] = Timber::get_post(56);
-Timber::render('welcome.twig', $context);
+$context['welcome'] = Timber::get_post( 56 );
+
+Timber::render( 'welcome.twig', $context );
 ```
 
 ```twig
 <section class="welcome-block">
-	<div class="inner">
-		<h3>{{welcome.post_title}}</h3>
-		<p>{{welcome.get_content}}</p>
-		<p>Follow me on <a href="https://twitter.com/{{welcome.twitter_handle}}" target="_blank">Twitter!</a></p>
-	</div>
+    <div class="inner">
+        <h3>{{ welcome.title }}</h3>
+        <p>{{ welcome.content }}</p>
+        <p>Follow me on <a href="https://twitter.com/{{ welcome.twitter_handle }}" target="_blank">Twitter!</a></p>
+    </div>
 </section>
 ```
 
@@ -106,13 +108,15 @@ Timber::render('welcome.twig', $context);
 ```php
 <?php
 $context['posts'] = Timber::get_posts();
-Timber::render('home-main.twig', $context);
+
+Timber::render( 'home-main.twig', $context );
 ```
 
+**home-main.twig**
+
 ```twig
-{# home-main.twig #}
 {% for post in posts %}
-    {% include "tz-post.twig" %}
+    {% include 'teaser-post.twig' %}
 {% endfor %}
 ```
 
@@ -122,65 +126,81 @@ Timber::render('home-main.twig', $context);
 
 [![Using Custom Post Types with Timber](http://img.youtube.com/vi/19T0MStDLSQ/0.jpg)](http://www.youtube.com/watch?v=19T0MStDLSQ)
 
+**home-main.twig**
+
 ```twig
-{# home-main.twig #}
 {% for post in posts %}
-	{# you can send includes an array, in order of precedence #}
-	{% include ["tz-"~post.post_type~".twig", "tz-post.twig"] %}
+    {# You can send an array to "include". Twig will use the first template it finds. #}
+    {% include ['teaser-' ~ post.post_type ~ '.twig', 'teaser-post.twig'] %}
 {% endfor %}
 ```
 
+**teaser-recipe.twig**
+
 ```twig
-{# tz-recipe.twig #}
-<article id="post-{{post.ID}}" class="post-{{post.ID}} {{post.post_type}} type-{{post.post_type}} status-publish hentry">
-	{% if post.get_thumbnail %}
-		<img src="{{post.get_thumbnail.get_src|resize(600, 300)}}" />
-	{% endif %}
-	<h2>{{post.post_title}}</h2>
-	<div class="post-body">
-		{{post.get_content}}
-	</div>
+<article id="post-{{ post.ID }}" class="post-{{ post.ID }} {{ post.post_type }} type-{{ post.post_type }} status-publish hentry">
+    {% if post.thumbnail %}
+        <img src="{{ post.thumbnail.src|resize(600, 300) }}" />
+    {% endif %}
+
+    <h2>{{ post.title }}</h2>
+
+    <div class="post-body">
+        {{ post.content }}
+    </div>
 </article>
 ```
 
 * * *
 
 ## 6. Extending Templates
+
 _Todo: Record Screencast showing this_
 
-This is a **really** important concept for DRY. I'll show how to create a base template that can power your site:
+This is a **really** important concept for DRY. I’ll show how to create a base template that can power your site:
 
 ### Create a `base.twig` file:
 
+**base.twig**
+
 ```twig
-{# base.twig #}
 {% include "html-header.twig" %}
+
 {% block head %}
-	<!-- This is where you'll put template-specific stuff that needs to go in the head tags like custom meta tags, etc. -->
+    <!-- This is where you’ll put template-specific stuff that needs to go in the head tags like custom meta tags, etc. -->
 {% endblock %}
+
 </head>
-<body class="{{body_class}}">
+
+<body class="{{ body_class }}">
+
 {% block content %}
-	<!-- The template's main content will go here. -->
+    <!-- The template’s main content will go here. -->
 {% endblock %}
+
 {% include "footer.twig" %}
-{{wp_footer}}
+
+{{ wp_footer }}
+
 </body>
 </html>
 ```
 
 ### You can use this in a custom `single.twig` file:
 
+**single.twig**
+
 ```twig
-{# single.twig #}
 {% extends "base.twig" %}
+
 {% block head %}
-	<meta property="og:title" value="{{post.title}}" />
+    <meta property="og:title" value="{{ post.title }}" />
 {% endblock %}
+
 {% block content %}
-	<div class="main">
-		<h1>{{post.title}}</h1>
-		<p>{{post.get_content}}</p>
-	</div>
+    <div class="main">
+        <h1>{{ post.title }}</h1>
+        <p>{{ post.content }}</p>
+    </div>
 {% endblock %}
 ```


### PR DESCRIPTION
- Apply coding standards, improve whitespace (indentation, spaces instead of tabs for markdown)
- Reformat Markdown
- Improve wording, fix spelling
- Fix links

This commit also deprecates the wiki pages in the *Getting Started* section.