### PR TITLE
Carbon Fields basic integration

### DIFF
--- a/lib/Integrations.php
+++ b/lib/Integrations.php
@@ -3,33 +3,37 @@
 namespace Timber;
 
 /**
- * This is for integrating external plugins into timber
- * @package  timber
+ * This is for integrating external plugins into Timber
+ * @package Timber
  */
 class Integrations {
 
-	var $acf;
-	var $coauthors_plus;
+  var $acf;
+  var $carbon_fields;
+  var $coauthors_plus;
 
-	public function __construct() {
-		$this->init();
-	}
-    
-	public function init() {
-		add_action('init', array($this, 'maybe_init_integrations'));
+  public function __construct() {
+    $this->init();
+  }
 
-		if ( class_exists('WP_CLI_Command') ) {
-			\WP_CLI::add_command('timber', 'Timber\Integrations\Timber_WP_CLI_Command');
-		}
-	}
+  public function init() {
+    add_action('init', array($this, 'maybe_init_integrations'));
 
-	public function maybe_init_integrations() {
-		if ( class_exists('ACF') ) {
-			$this->acf = new Integrations\ACF();
-		}
-		if ( class_exists('CoAuthors_Plus') ) {
-			$this->coauthors_plus = new Integrations\CoAuthorsPlus();
-		}
-		$this->wpml = new Integrations\WPML();
-	}
+    if ( class_exists('WP_CLI_Command') ) {
+      \WP_CLI::add_command('timber', 'Timber\Integrations\Timber_WP_CLI_Command');
+    }
+  }
+
+  public function maybe_init_integrations() {
+    if ( class_exists('ACF') ) {
+      $this->acf = new Integrations\ACF();
+    }
+    if ( class_exists('Carbon_Fields\Carbon_Fields') ) {
+      $this->carbon_fields = new Integrations\CarbonFields();
+    }
+    if ( class_exists('CoAuthors_Plus') ) {
+      $this->coauthors_plus = new Integrations\CoAuthorsPlus();
+    }
+    $this->wpml = new Integrations\WPML();
+  }
 }

--- a/lib/Integrations/CarbonFields.php
+++ b/lib/Integrations/CarbonFields.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Timber\Integrations;
+
+class CarbonFields {
+
+  public function __construct() {
+    add_filter('timber_post_get_meta_field', array($this, 'post_get_meta_field'), 10, 3);
+    add_filter('timber/term/meta/field', array($this, 'term_get_meta_field'), 10, 3);
+    add_filter('timber_user_get_meta_field', array($this, 'user_get_meta_field'), 10, 3);
+    add_filter('timber_comment_get_meta_field', array($this, 'comment_get_meta_field'), 10, 3);
+  }
+
+  public function post_get_meta_field( $value, $id, $field_name ) {
+    return carbon_get_post_meta($id, $field_name);
+  }
+
+  public function term_get_meta_field( $value, $id, $field_name ) {
+    return carbon_get_term_meta($id, $field_name);
+  }
+
+  public function user_get_meta_field( $value, $id, $field_name ) {
+    return carbon_get_user_meta($id, $field_name);
+  }
+
+  public function comment_get_meta_field( $value, $id, $field_name ) {
+    return carbon_get_comment_meta($id, $field_name);
+  }
+}


### PR DESCRIPTION
**Ticket**: #1474

#### Issue

First steps toward an integration with [Carbon Fields](https://carbonfields.net/). Only supports
post meta, term meta, comment meta, and user meta at present, and no
complex fields.

#### Solution

This copies the existing ACF integration class and links a few Carbon Fields functions to their associated Timber filters.

#### Impact

I'm not entirely certain what impact this might have on custom fields made with ACF or vanilla WP.

#### Usage Changes

Some docs for CF users will be helpful once we figure out what final shape this feature might take.

#### Considerations

Here I will add some notes from scanning both the Timber and CF repos. This is about what's not included:
* Complex fields (similar to ACF repeaters as I understand it); this would require an additional parameter to be passed to the CF functions. Possible solution: have Timber users append `:complex` to a field name *e.g.* `get_field('crb_field_name:complex')` and match the string?
* CF menu item meta (as Timber doesn't seem to support fields for menu items or offer the appropriate filter hook; something that shouldn't be too hard to add if desired).
* CF widgets; something I still haven't properly looked into.
* CF theme options; probably out of scope.
* Updating meta; CF can update/set meta values progrmatically but I'm not entirely sure how this works in Timber or how useful or necessary it would be to integrate this.

#### Testing

No tests yet. Edits/tips/comments welcome. I'm new at this 😁 