### PR TITLE
Fix link after site was renamed in #1540

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -66,4 +66,4 @@ Make sure you select the Timber-enabled theme **after** you activate the plugin.
 
 ### 3. Let’s write our theme!
 
-Continue ahead in [part 2 about Themeing](https://timber.github.io/docs/getting-started/themeing/).
+Continue ahead in [part 2 about Theming](https://timber.github.io/docs/getting-started/theming/).


### PR DESCRIPTION
#### Issue

After the Themeing guide was renamed to Theming in #1540, there’s a broken link in the Setup guide.

#### Solution

Fix link.

I already pushed that change to the docs. So there’s nothing more to do.