### PR TITLE
Letterbox transparent background

### DIFF
--- a/lib/Image/Operation/Letterbox.php
+++ b/lib/Image/Operation/Letterbox.php
@@ -57,8 +57,14 @@ class Letterbox extends ImageOperation {
 		$h = $this->h;
 
 		$bg = imagecreatetruecolor($w, $h);
-		$c = self::hexrgb($this->color);
-		$bgColor = imagecolorallocate($bg, $c['red'], $c['green'], $c['blue']);
+		if(!$this->color) {
+			imagesavealpha($bg, true);
+			$bgColor = imagecolorallocatealpha($bg, 0, 0, 0, 127);
+		} else {
+			$c = self::hexrgb($this->color);
+			$bgColor = imagecolorallocate($bg, $c['red'], $c['green'], $c['blue']);
+		}
+
 		imagefill($bg, 0, 0, $bgColor);
 		$image = wp_get_image_editor($load_filename);
 		if ( !is_wp_error($image) ) {

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -152,7 +152,7 @@ class ImageHelper {
 	 * @param bool    $force
 	 * @return string
 	 */
-	public static function letterbox( $src, $w, $h, $color = '#000000', $force = false ) {
+	public static function letterbox( $src, $w, $h, $color = false, $force = false ) {
 		$op = new Letterbox($w, $h, $color);
 		return self::_operate($src, $op, $force);
 	}

--- a/tests/test-timber-image-letterbox.php
+++ b/tests/test-timber-image-letterbox.php
@@ -51,6 +51,20 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 		$this->assertFileExists( $location_of_image );
 	}
 
+	function testLetterboxTransparentBackground() {
+		$base_file = 'eastern-trans.png';
+		$file_loc = TestTimberImage::copyTestImage( $base_file );
+		$upload_dir = wp_upload_dir();
+		$new_file = TimberImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 500, 500 );
+		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$this->addFile( $location_of_image );
+		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
+		//whats the bg/color of the image
+		$is_green = TestTimberImage::checkPixel($location_of_image, 250, 250);
+		$this->assertTrue( $is_green );
+		$this->assertFileExists( $location_of_image );
+	}
+
 	function testLetterboxGif() {
 		$base_file = 'panam.gif';
 		$file_loc = TestTimberImage::copyTestImage( $base_file );

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -89,7 +89,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
  		$resized_one = Timber\ImageHelper::get_server_location($str);
  		sleep(1);
  		$filename = self::copyTestImage('cardinals.jpg', 'arch.jpg');
- 		
+
  		$str = Timber::compile_string($template, array('img' => $attach_id));
  		$resized_tester = Timber\ImageHelper::get_server_location($str);
 
@@ -101,8 +101,6 @@ class TestTimberImage extends TimberImage_UnitTestCase {
  		$this->assertTrue($is_white);
  		$is_also_white = TestTimberImage::checkPixel($resized_one, 5,5, '#FFFFFF');
  		$this->assertTrue($is_also_white);
- 		
-
  	}
 
  	function testResizedReplacedImage() {
@@ -122,7 +120,6 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
  		$pizza_md5 = md5( file_get_contents($resized_pizza) );
  		$this->assertEquals($pizza_md5, $test_md5);
-
  	}
 
  	function testImageLink() {
@@ -457,7 +454,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		return false;
 	}
 
-	public static function checkPixel($file, $x, $y, $color = '#FFFFFF', $upper_color = false) {
+	public static function checkPixel($file, $x, $y, $color = false, $upper_color = false) {
 		if ( self::is_png($file) ) {
 			$image = imagecreatefrompng( $file );
 		} else if ( self::is_gif($file) ) {
@@ -465,12 +462,16 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		} else {
 			$image = imagecreatefromjpeg( $file );
 		}
-		$pixel_rgb = imagecolorat( $image, $x, $y );
-		$colors_of_file = imagecolorsforindex( $image, $pixel_rgb );
+		$pixel_rgba = imagecolorat( $image, $x, $y );
+		$colors_of_file = imagecolorsforindex( $image, $pixel_rgba );
 		if ($upper_color) {
 			$upper_colors = ImageOperation::hexrgb($upper_color);
 		}
 		$test_colors = ImageOperation::hexrgb($color);
+		if( false === $color ) {
+			$alpha = ($pixel_rgba & 0x7F000000) >> 24;
+			return $alpha === 127;
+		}
 		if ( isset($upper_colors) && $upper_colors ) {
 			if (self::checkChannel('red', $test_colors, $colors_of_file, $upper_colors) &&
 				self::checkChannel('green', $test_colors, $colors_of_file, $upper_colors) &&


### PR DESCRIPTION
#### Issue
You can't use letterbox with a transparent background. 

#### Solution
Handle transparent background when using letterbox on a png file. 

#### Impact
None that I am aware of. 

#### Usage Changes
There's now no default color when using letterbox. 

#### Testing
I wrote a test to check if the image has transparency. The test passes. No regressions seen on other transformations.
