### PR TITLE
Add public theme version to TimberTheme

### DIFF
--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -33,6 +33,12 @@ class Theme extends Core {
 
 	/**
 	 * @api
+	 * @var string the version of the theme (ex: `1.2.3`)
+	 */
+	public $version;
+
+	/**
+	 * @api
 	 * @var TimberTheme|bool the TimberTheme object for the parent theme (if it exists), false otherwise
 	 */
 	public $parent = false;
@@ -84,6 +90,7 @@ class Theme extends Core {
 	protected function init( $slug = null ) {
 		$this->theme = wp_get_theme($slug);
 		$this->name = $this->theme->get('Name');
+		$this->version = $this->theme->get('Version');
 		$this->slug = $this->theme->get_stylesheet();
 
 		$this->uri = $this->theme->get_template_directory_uri();


### PR DESCRIPTION
**Ticket**: #1503

#### Issue
Theme version is missing as public property in `TimberTheme`.


#### Solution
Add theme version as public property `version` to `TimberTheme`.


#### Impact
None.


#### Usage Changes
Theme version can be accessed in Twig with `{{ theme.version}}`.
