### PR TITLE
Add index files for better page title in docs

### DIFF
--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Getting Started"
+---

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Guides"
+---

--- a/docs/upgrade-guides/_index.md
+++ b/docs/upgrade-guides/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Upgrade Guides"
+---


### PR DESCRIPTION
**Ticket**: https://github.com/timber/docs/issues/6

#### Issue

Page titles for index pages couldn’t be set in docs.

#### Solution

This pull request adds `_index.md` files for the different sections (Getting Started, Guides, Upgrade Guides) of the documentation, so that titles used in the `<title>` tags and for the `<h1>` tags can be set individually.

#### Impact

None

#### Usage Changes

None

#### Considerations

The current build of the docs is based on this pull request and includes the new index files. So when this request is merged in, there’s no need to rebuild the docs.

#### Testing

None