### PR TITLE
Add Timber Debug Extension to documentation and related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 #### Related Projects
 * [**Timber Starter Theme**](https://github.com/timber/starter-theme) The "_s" of Timber to give you an easy start to the most basic theme you can build upon and customize.
 * [**Timber Debug Bar**](https://github.com/timber/debug-bar-timber) Adds a debug bar panel that will show you which template is in-use and the data sent to your twig file.
+* [**Timber Dump Extension**](https://github.com/nlemoine/timber-dump-extension) Debug output with nice formatting.
 * [**TimberPhoton**](https://github.com/slimndap/TimberPhoton) Plug-in to use JetPack's free Photon image manipulation and CDN with Timber.
 * [**Timber CLI**](https://github.com/nclud/wp-timber-cli) A CLI for Timber.
 * [**Timber Sugar**](https://github.com/timber/sugar) A catch-all for goodies to use w Timber.

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -40,6 +40,20 @@ This will give you something like:
 
 ![](http://i.imgur.com/5ZD8VDd.png)
 
+## Formatted output
+
+For a highlighted output like you see it above, you need to have [xDebug](https://xdebug.org/) enabled in your local development environment. With some environments like MAMP, enabling it is as easy as ticking a checkbox and restarting the server. Other times, it might be more complex.
+
+An easier solution is to use the [Timber Dump Extension](https://github.com/nlemoine/timber-dump-extension), which will make use of the Symfony VarDumper component to generate output like this when using `{{ dump() }}` in Twig:
+
+![](https://user-images.githubusercontent.com/2084481/31230351-116569a8-a9e4-11e7-8310-48b7f679892b.png)
+
+It also works in PHP. Instead of using `var_dump` or `print_r`, you will use `dump()` as well:
+
+```php
+dump( $post );
+```
+
 ## Using Timber Debug Bar plugin
 
 There’s a [Timber add-on](http://wordpress.org/plugins/debug-bar-timber/) for the [WordPress debug bar](https://wordpress.org/plugins/debug-bar/).  


### PR DESCRIPTION
**Ticket**: #1443

Here comes a very nice plug-and-play extension from @nlemoine that can add a benefit to a lot of developers 🍻!

- Added a section for the [Debugging Guide](https://timber.github.io/docs/guides/debugging/) about different options for formatted debug output.
- Added link to related projects section in README.