### PR TITLE
ref #1159 -- handles `Term` in Twig to match PHP constructor

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -171,7 +171,7 @@ class Twig {
 		// A user could be sending a TermClass in the first arg, let's test for that ...
 		if ( class_exists($maybe_taxonomy) ) {
 			$tc = new $maybe_taxonomy;
-			if ( is_subclass_of($tc, 'Timber/Term') ) {
+			if ( is_subclass_of($tc, 'Timber\Term') ) {
 				return array('taxonomy' => '', 'TermClass' => $maybe_taxonomy);
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Changes for Theme Developers**
 - Please add any usage changes here so theme developers are informed of changes.
+- You can now interact with Terms in Twig the same as PHP (ex: `{% set term = Term(#1159 (@jarednova)
 - You can now get {{ theme.version }} to get the theme version! #1555 (thanks @herrschuessler)
 
 = 1.5.0 =

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -2,6 +2,17 @@
 
 	class TestTimberTerm extends Timber_UnitTestCase {
 
+		function testConstructor() {
+			register_taxonomy('arts', array('post'));
+
+			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
+			$term = new TimberTerm($term_id, 'arts');
+			$this->assertEquals('Zong', $term->name());
+			$template = '{% set zp_term = TimberTerm("'.$term->ID.'", "arts") %}{{ zp_term.name }}';
+			$string = Timber::compile_string($template);
+			$this->assertEquals('Zong', $string);
+		}
+
 		function testTerm() {
 			$term_id = $this->factory->term->create();
 			$term = new TimberTerm($term_id);

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -2,6 +2,36 @@
 
 	class TestTimberTerm extends Timber_UnitTestCase {
 
+		function testConstructorWithClass() {
+			register_taxonomy('arts', array('post'));
+
+			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'post_tag'));
+			$term = new \Timber\Term($term_id);
+
+			$template = '{% set zp_term = Term("'.$term_id.'", "Arts") %}{{ zp_term.name }} {{ zp_term.taxonomy }}';
+			$string = Timber::compile_string($template);
+			$this->assertEquals('Zong post_tag', $string);
+
+			$template = '{% set zp_term = TimberTerm('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
+			$string = Timber::compile_string($template);
+			$this->assertEquals('Zebra', $string);
+		}
+
+		function testConstructorWithClassAndTaxonomy() {
+			register_taxonomy('arts', array('post'));
+
+			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
+			$term = new \Timber\Term($term_id);
+
+			$template = '{% set zp_term = Term("'.$term_id.'", "arts", "Arts") %}{{ zp_term.name }} {{ zp_term.taxonomy }}';
+			$string = Timber::compile_string($template);
+			$this->assertEquals('Zong arts', $string);
+
+			$template = '{% set zp_term = TimberTerm('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
+			$string = Timber::compile_string($template);
+			$this->assertEquals('Zebra', $string);
+		}
+
 		function testConstructor() {
 			register_taxonomy('arts', array('post'));
 
@@ -213,6 +243,14 @@
 			$links[] = 'http://example.org/wp-admin/edit-tags.php?action=edit&taxonomy=category&tag_ID='.$tid;
 			$links[] = 'http://example.org/wp-admin/term.php?taxonomy=category&term_id='.$tid.'&post_type=post';
 			$this->assertContains($term->edit_link(), $links);
+		}
+
+	}
+
+	class Arts extends Timber\Term {
+
+		function foobar() {
+			return 'Zebra';
 		}
 
 	}


### PR DESCRIPTION
**Ticket**: #1159 

#### Issue
If you create a term in php... 

```php
$term = new \Timber\Term(34, 'arts');
```

the same args will fail in twig
```twig
{% set term = Term(34, 'arts') %}
```

#### Solution
Create a handler in `Timber/Twig` to see if the user is intending to use a taxonomy as opposed to a Term class


#### Impact
No backwards compatibility issues (or, will revise to ensure they're aren't) unless a user used the _same_ name for a Term class AND a taxonomy (including same capitalization)


#### Usage Changes
Added in readme


#### Considerations
Definitely adds some bloat/complexity. 


#### Testing
Written, but will ensure 100% coverage before merging
