### PR TITLE
An easier way (filter) to get a specific item of an array

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -430,8 +430,8 @@ class Helper {
 	 *
 	 * @return mixed
 	 */
-	public static function filter_array( $array, $value, $key = 'slug' ) {
-		$result = wp_list_filter( $array, array( $key => $value ) );
+	public static function filter_array( $array, $value, $key = 'slug', $operator = 'AND' ) {
+		$result = wp_list_filter( $array, array( $key => $value ), $operator );
 		if ( is_array( $result ) ) {
 			$first_element = reset( $result );
 			return $first_element;

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -420,6 +420,24 @@ class Helper {
 		}
 		return $return;
 	}
+	
+	/**
+	 * Filters a list of objects, based on a set of key => value arguments.
+	 * 
+	 * @param        $array
+	 * @param        $value
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public static function filter_array( $array, $value, $key = 'slug' ) {
+		$result = wp_list_filter( $array, array( $key => $value ) );
+		if ( is_array( $result ) ) {
+			$first_element = reset( $result );
+			return $first_element;
+		}
+		return $array;
+	}
 
 	/* Links, Forms, Etc. Utilities
 	======================== */

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -226,6 +226,7 @@ class Twig {
 		$twig->addFilter(new \Twig_SimpleFilter('list', array($this, 'add_list_separators')));
 
 		$twig->addFilter(new \Twig_SimpleFilter('pluck', array('Timber\Helper', 'pluck')));
+		$twig->addFilter(new \Twig_SimpleFilter('filter', array('Timber\Helper', 'filter_array')));
 
 		$twig->addFilter(new \Twig_SimpleFilter('relative', function( $link ) {
 					return URLHelper::get_rel_url($link, true);


### PR DESCRIPTION
#### Issue
What if you want to get an specific item of an array?


#### Solution
**wp_list_filter** is a native WordPress function that filters a list of objects, based on a set of key => value arguments. Perfect for this situation!
In WordPress [documentation](https://codex.wordpress.org/Function_Reference/wp_list_filter) there aren't examples of it in action, but [here](url) there is a good one


#### Impact
```twig
{# Getting two specific posts from a wp-query, post-1 and post-2 #}

Post-1: {{ posts | filter('post-1') }}
<br />
Post-2: {{ posts | filter('post-2') }}
```