### PR TITLE
#1597 get_field_object support

### DIFF
--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -7,6 +7,7 @@ class ACF {
 	public function __construct() {
 		add_filter('timber_post_get_meta', array($this, 'post_get_meta'), 10, 2);
 		add_filter('timber_post_get_meta_field', array($this, 'post_get_meta_field'), 10, 3);
+		add_filter('timber_post_get_meta_object_field', array($this, 'post_get_meta_object'), 10, 3);
 		add_filter('timber/term/meta', array($this, 'term_get_meta'), 10, 3);
 		add_filter('timber/term/meta/field', array($this, 'term_get_meta_field'), 10, 4);
 		add_filter('timber_user_get_meta_field_pre', array($this, 'user_get_meta_field'), 10, 3);
@@ -19,6 +20,10 @@ class ACF {
 
 	public function post_get_meta_field( $value, $post_id, $field_name ) {
 		return get_field($field_name, $post_id);
+	}
+
+	public function post_get_meta_object( $value, $post_id, $field_name ) {
+		return get_field_object( $field_name, $post_id );
 	}
 
 	public function term_get_meta_field( $value, $term_id, $field_name, $term ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -702,6 +702,15 @@ class Post extends Core implements CoreInterface {
 		return (!$this->get_field($field_name)) ? false : true;
 	}
 
+	/**
+	 * @param string $field_name
+	 * @return mixed
+	 */
+	public function get_field_object( $field_name ) {
+		$value = apply_filters('timber_post_get_meta_object_field', null, $this->ID, $field_name, $this);
+		$value = $this->convert($value, __CLASS__);
+		return $value;
+	}
 
 	/**
 	 * @param string $field_name


### PR DESCRIPTION
**Ticket**: #1597 

#### Issue
No support for `get_field_object`


#### Solution
It just adds the missing support


#### Impact
It adds two methods. 

In Post object there is a `get_field_object` (with new filter) and in ACF Integration there is 'post_get_meta_object' and a new `add_filter`


#### Usage Changes
You use it just like `get_field`:
```php
post.get_field_object('field_name')
```


#### Considerations
Now it's working only with posts, but if you think it will be useful I can write term and user version too.


#### Testing
I think the tests should be simmilar to `get_field`
