### PR TITLE
PostQuery() example call missing Timber namespace

### DIFF
--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -14,7 +14,7 @@ This will only work in a php file with an active query (like `archive.php` or `h
 ```php
 	<?php
 	$context = Timber::get_context();
-	$context['posts'] = new PostQuery();
+	$context['posts'] = new Timber\PostQuery();
 	Timber::render('archive.twig', $context);
 ```
 


### PR DESCRIPTION
**Ticket**: #N/A <!-- Ignore this if not relevant -->

#### Issue
First example calls PostQuery() without Timber namespace, causing an "Uncaught Error: Class 'PostQuery' not found" error.


#### Solution
Include Timber namespace in example PostQuery() call.


#### Impact
No impact to codebase. Improves reliability of documentation.


#### Usage Changes
None.


#### Considerations
None.


#### Testing
None.
