### PR TITLE
Define coding standards and introduce custom ruleset to apply and check them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,52 @@
 
 Pull requests are highly appreciated. More than fifty people have written parts of Timber (so far). Here are some guidelines to help:
 
-1. **Solve a problem** Features are great, but even better is cleaning-up and fixing issues in the code that you discover.
-2. **Write tests** This helps preserve functionality as the codebase grows and demonstrates how your change affects the code.
-3. **Small > big** Better to have a few small pull requests that address specific parts of the code, than one big pull request that jumps all over.
-4. **Comply with standards** We follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/coding-standards/php/) – which sometimes deviate from [PSR-2](http://www.php-fig.org/psr/psr-2/) and others.
+1. **Solve a problem** – Features are great, but even better is cleaning-up and fixing issues in the code that you discover.
+2. **Write tests** – This helps preserve functionality as the codebase grows and demonstrates how your change affects the code.
+3. **Small > big** – Better to have a few small pull requests that address specific parts of the code, than one big pull request that jumps all over.
+4. **Comply with Coding Standards** – See next section.
+
+## Coding Standards
+
+We try to follow the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/coding-standards/php/) as close as we can, with the following exceptions:
+
+- Class and file names are defined in `StudlyCaps`. We follow the [PSR-0 standard](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names), because we use autoloading via Composer.
+- We use hook names namespaced by `/` instead of underscores (e.g. `timber/context` instead of `timber_context`).
+
+### Inline Documentation
+
+We follow the [WordPress Inline Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/). The [Reference section of the documentation](https://timber.github.io/docs/reference/) is automatically generated from the inline documentation of the Timber code base. That’s why we allow Markdown in the PHPDoc blocks.
+
+### Use PHP_CodeSniffer to detect coding standard violations
+
+To check where the code deviates from the standards, you can use [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer). Timber comes with a `phpcs.xml` in the root folder of the repository, so that the coding standards will automatically be applied for the Timber code base.
+
+- Install PHP_CodeSniffer globally by following this guide: <https://github.com/squizlabs/PHP_CodeSniffer#installation>.
+- Install WPCS by following this guide: <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installation>.
+
+#### Command Line Usage
+
+To run PHP_CodeSniffer with the default settings on all relevant Timber files, use the following command from the root folder of the Timber library: 
+
+```bash
+phpcs
+```
+
+You could check a single file like this:
+
+```bash
+phpcs ./lib/Menu.php
+```
+
+Use `phpcs --help` for a list of available settings.
+
+#### Use it in your IDE
+
+Please refer to <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use> for different ways to use PHP_CodeSniffer directly in your IDE. In some IDEs like PHPStorm, you may have to select the `phpcs.xml` explicitly to apply the proper standards.
+
+#### Whitelisting
+
+If it’s not possible to adapt to certain rules, code could be whitelisted. However, this should be used sparingly.
+
+- <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors>
+- <https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress-Timber">
+    <description>A custom set of rules to check coding standards for Timber.</description>
+
+    <!--
+        Default settings for command line usage
+    -->
+
+    <!-- Exclude folders and files from being checked. -->
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*.twig</exclude-pattern>
+
+    <!-- If no files or directories are specified on the command line, check all relevant files. -->
+    <file>./lib</file>
+
+    <!-- Use colors in output. -->
+    <arg name="colors"/>
+
+    <!-- Show sniff names and progress. -->
+    <arg value="sp"/>
+
+    <!--
+        WordPress-Extra
+        Best practices beyond core WordPress Coding Standards.
+
+        The WordPress-Core standard doesn’t have to be included here,
+        because WordPress-Extra already includes it.
+    -->
+    <rule ref="WordPress-Extra">
+        <!-- Do not check for proper WordPress file names. -->
+        <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+    </rule>
+
+    <!--
+        WordPress-Docs
+        WordPress Coding Standards for Inline Documentation and Comments.
+    -->
+    <rule ref="WordPress-Docs" />
+
+    <!--
+        File Names
+
+        The WordPress Coding Standards state that all class files should start with 'class-'. Timber
+        follows the PSR-0 standard for naming class files, because it uses autoloading via Composer.
+
+        @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#disregard-class-file-name-rules
+    -->
+    <rule ref="WordPress.Files.FileName">
+        <properties>
+            <property name="strict_class_file_names" value="false" />
+        </properties>
+    </rule>
+
+    <!--
+        Hook Names
+
+        While the WordPress Coding Standards state that hook names should be separated by
+        underscores, an optionated approach used by plugins like Advanced Custom Fields is to use
+        '/' to namespace hooks.
+
+        @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-word-delimiters-in-hook-names
+    -->
+    <rule ref="WordPress.NamingConventions.ValidHookName">
+        <properties>
+            <property name="additionalWordDelimiters" value="/"/>
+        </properties>
+    </rule>
+</ruleset>


### PR DESCRIPTION
**Ticket**: #1561

## Issue

Coding Standards need to be documented and there needs to be an easier way to check and fix violations, maybe even automatically. WordPress just recently [applied the WordPress Coding Standards to the whole codebase](https://make.wordpress.org/core/2017/11/30/wordpress-php-now-mostly-conforms-to-wordpress-coding-standards/).

## Solution

Define and document the coding standards and provide a way for developers to check for errors in coding style automatically.

- Introduce a new `phpcs.xml` file, which is a custom ruleset for [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) that inherits from [WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards). The WPCS (WordPress-Coding-Standards) project provides sniff rules for PHP_CodeSniffer to enforce WordPress coding standards in a project.
- Document Coding Standards in `CONTRIBUTING.md`. Define WordPress Coding Standards as the standard for Timber and list the exceptions where the Timber standard deviates from the WordPress Coding Standards. Document how developers can use the custom ruleset to check for coding style errors.

I hope we can all agree that we’d want to use as few exceptions to the WordPress Coding Standards as possible. However, considering how the Timber code base has grown and how it’s used by theme developers, certain exceptions need to be introduced. Currently I found only two exceptions where the Timber Coding Standards would deviate from the WordPress Coding Standards:

- Class and file names are defined in `StudlyCaps`. We follow the [PSR-0 standard](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names), because we use autoloading via Composer.
- We use hook names namespaced by `/` instead of underscores (e.g. `timber/context` instead of `timber_context`).

Probably we’ll have to see how this holds up. This is a first version of the Timber Coding Standards, not a definitive one. But I think it would be best if we can stay as close to the WordPress Coding Standards as possible.

To [automate the process](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically), PHP_CodeSniffer comes with the PHP Code Beautifier and Fixer tool (`phpcbf`) to fix code according to sniff rules. This could maybe help. Still, we need to be extra careful to not introduce errors through this.

Maybe fixing the coding style in the whole code base could be something for Timber version 2.0 as well. 

## Impact

### How big are the changes?

When the coding standards are applied to the code base, mostly it will just be formatting changes.

By inspecting the code with the new sniff rules, I saw that one of the biggest changes introduced would be a naming convention for class name variables. Consider the following line:

https://github.com/timber/timber/blob/4d7609edaf04b9d1fc5d8f2c402cf7c0e5bda7ac/lib/Post.php#L59

PHP_CodeSniffer would mark an error here:

`WordPress.NamingConventions.ValidVariableName.NotSnakeCase: Variable "PostClass" is not in valid snake_case format.`

The variable would need to be changed from `$PostClass` to `$post_class`, which shouldn’t be a problem, because from what I saw, they are only used internally. Deactivating that rule is not really an option, because then other variable names wouldn’t be checked either.

### Whitelisting code

If it’s not possible to adapt to certain rules, certain code could be whitelisted:

- <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors>
- <https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-parts-of-a-file>

I think this should be used sparingly.

### Required inline documentation

A large amount of sniff warnings will be about missing inline documentation. I think this will be a good incentive to improve this. The [Reference](https://timber.github.io/docs/reference/) will benefit from this as well.

### Version history

If applied to the current codebase, the version history will be more difficult to read. However, with Github’s advanced blame feature, it’s easy to go back step by step. WordPress did it [all in one patch](https://make.wordpress.org/core/2017/11/30/wordpress-php-now-mostly-conforms-to-wordpress-coding-standards/), so I guess we could do it in one pull request as well.

## Usage Changes

- None for theme developers.
- Usage instructions for how to use PHP_CodeSniffer to apply standards for pull requests can be found in `CONTRIBUTING.md`.

## Considerations

- WordPress Coding Standards don’t define a maximum length. Should *we* define one?
- Does it need to be [integrated into **Travis**](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#running-your-code-through-wpcs-automatically-using-ci-tools)?
- Does it need to be integrated into **Scrutinizer**? While I don’t know a lot about how Scrutinizer works, it allows you to [run PHP_CodeSniffer](https://scrutinizer-ci.com/docs/tools/php/code-sniffer/).

## Testing

No. Existing tests need to be run after coding styles are applied to the code base.
