### PR TITLE
Fix get_post_preview_id for custom post types that use capability_type

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -264,11 +264,11 @@ class Post extends Core implements CoreInterface {
 
 	protected function get_post_preview_id( $query ) {
 		$can = array(
-			'edit_'.$query->queried_object->post_type.'s',
+			get_post_type_object($query->queried_object->post_type)->cap->edit_post,
 		);
 
 		if ( $query->queried_object->author_id !== get_current_user_id() ) {
-			$can[] = 'edit_others_'.$query->queried_object->post_type.'s';
+			$can[] = get_post_type_object($query->queried_object->post_type)->cap->edit_others_posts;
 		}
 
 		$can_preview = array();

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -274,7 +274,7 @@ class Post extends Core implements CoreInterface {
 		$can_preview = array();
 
 		foreach ( $can as $type ) {
-			if ( current_user_can($type) ) {
+			if ( current_user_can($type, $query->queried_object_id) ) {
 				$can_preview[] = true;
 			}
 		}


### PR DESCRIPTION
**Ticket**: #375 (builds on PR #876)

#### Issue
If a custom post type is registered and sets `capability_type`, the current code does not correctly resolve permissions for the purposes of previewing changes to an already published post.
For example, I have a custom post type of `article`, but with `capability_type`=>`page`:
`'edit_' . $query->queried_object->post_type . 's',` resolves to `edit_articles`, rather than the correct `edit_page`.

#### Solution
Use `get_post_type_object`->`cap` to get the actual name of the capability

#### Impact
This should not break anything for anyone

#### Usage Changes
None

#### Considerations
`get_post_type_object($query->queried_object->post_type)` feels a bit clunky

#### Testing
Needs test?
