### PR TITLE
allow overriding default lifetime of {% cache %}-created transients i…

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -93,14 +93,14 @@ class Loader {
 	 * @return string|bool             Name of chosen template, otherwise false.
 	 */
 	public function choose_template( $templates ) {
-		// Change $templates into array, if needed 
+		// Change $templates into array, if needed
 		if ( !is_array($templates) ) {
 			$templates = (array) $templates;
 		}
-		
+
 		// Get Twig loader
 		$loader = $this->get_loader();
-		
+
 		// Run through template array
 		foreach ( $templates as $template ) {
 			// Use the Twig loader to test for existance
@@ -253,7 +253,8 @@ class Loader {
 
 		$key_generator   = new \Timber\Cache\KeyGenerator();
 		$cache_provider  = new \Timber\Cache\WPObjectCacheAdapter($this);
-		$cache_strategy  = new \Asm89\Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy($cache_provider, $key_generator);
+		$cache_lifetime  = apply_filters('timber/cache/extension/lifetime', 0);
+		$cache_strategy  = new \Asm89\Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy($cache_provider, $key_generator, $cache_lifetime);
 		$cache_extension = new \Asm89\Twig\CacheExtension\Extension($cache_strategy);
 
 		return $cache_extension;


### PR DESCRIPTION
**Ticket**: #1609 

#### Issue
{% cache %}-generated transient items never expire and are auto-loaded by WordPress by default. So both performance and database size are affected.

#### Solution
The small change I made allow theme designers to override the behavior above and make GCS-<hash>-suffixed transient items expirable and not auto-loaded.

#### Impact
If one won't implement add_filter('timber/cache/extension/lifetime', ....); WordPress filter, nothing in default Timber behavior changes, so IMO there is no serious impact to the code base.

#### Usage Changes
Now theme developers can make {% cache %}-generated transient items expirable by implementing `timber/cache/extension/lifetime` filter:
```php
add_filter('timber/cache/extension/lifetime', function() {
        return HOUR_IN_SECONDS * 24;
});
```

#### Considerations
Frankly I don't know if all Timber users use [WP Cron](https://developer.wordpress.org/plugins/cron/scheduling-wp-cron-events/) in order to solve the issue described in #1609 and clear all previously-created and potentially unused transient items. If they don't even know about this problem, we'd consider the possibility to set the default cache strategy lifetime to something other than 0.

#### Testing
Nope. Unfortunately I have a lot of time now. The last time [I contributed to Timber](https://github.com/timber/timber/pull/861) I created tests, but this time I don't think I can do it. However if nobody can help us out with it I will create a unit test.
