### PR TITLE
1580/custom data

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -240,7 +240,7 @@ class Image extends Post implements CoreInterface {
 				return;
 			}
 
-			$relative = false;
+			$relative  = false;
 			$iid_lower = strtolower($iid);
 			foreach ( $this->file_types as $type ) { if ( strstr($iid_lower, $type) ) { $relative = true; break; } };
 			if ( $relative ) {
@@ -285,13 +285,6 @@ class Image extends Post implements CoreInterface {
 				$this->$key = $value[0];
 			}
 			$this->id = $this->ID;
-		} else {
-			if ( is_array($iid) || is_object($iid) ) {
-				Helper::error_log('Not able to init in TimberImage with iid=');
-				Helper::error_log($iid);
-			} else {
-				Helper::error_log('Not able to init in TimberImage with iid='.$iid);
-			}
 		}
 	}
 
@@ -478,34 +471,4 @@ class Image extends Post implements CoreInterface {
 		return $this->get_dimensions('width');
 	}
 
-	/**
-	 * @deprecated 0.21.9 use TimberImage::src
-	 * @internal
-	 * @param string $size
-	 * @return bool|string
-	 */
-	public function get_src( $size = '' ) {
-		Helper::warn('{{image.get_src}} is deprecated and will be removed in 1.1; use {{image.src}}');
-		return $this->src($size);
-	}
-
-
-	/**
-	 * @deprecated since 0.21.9 use src() instead
-	 * @return string
-	 */
-	public function url( $size = '' ) {
-		Helper::warn('{{image.url}} is deprecated and will be removed in 1.1; use {{image.src}}');
-		return $this->src($size);
-	}
-
-
-	/**
-	 * @deprecated since 0.21.9 use src() instead
-	 * @return string
-	 */
-	public function get_url( $size = '' ) {
-		Helper::warn('{{image.get_url}} is deprecated and will be removed in 1.1; use {{image.src}}');
-		return $this->src($size);
-	}
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -250,7 +250,7 @@ class Image extends Post implements CoreInterface {
 		} else if ( $iid instanceof \WP_Post ) {
 			$ref = new \ReflectionClass($this);
 			$post = $ref->getParentClass()->newInstance($iid->ID);
-			if ( isset($post->_thumbnail_id) && $post->_thumbnail_id ) {
+			if ( $post->_thumbnail_id ) {
 				return $this->init((int) $post->_thumbnail_id);
 			}
 			return $this->init($iid->ID);
@@ -441,7 +441,7 @@ class Image extends Post implements CoreInterface {
 			return $this->_maybe_secure_url($this->abs_url);
 		}
 
-		if (!$this->is_image()) {
+		if ( ! $this->is_image() ) {
 			return wp_get_attachment_url($this->ID);
 		}
 

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -148,6 +148,7 @@ class MenuItem extends Core implements CoreInterface {
 
 	/**
 	 * Allows dev to access the "master object" (ex: post or page) the menu item represents
+	 *
 	 * @api
 	 * @example
 	 * ```twig
@@ -160,38 +161,13 @@ class MenuItem extends Core implements CoreInterface {
 	 * @return mixed Whatever object (Timber\Post, Timber\Term, etc.) the menu item represents.
 	 */
 	public function master_object() {
-		if ( isset($this->_menu_item_object_id) ) {
-			return new $this->PostClass($this->_menu_item_object_id);
+		if ( isset($this->custom['_menu_item_object_id']) &&
+				$this->custom['_menu_item_object_id'] ) {
+			return new $this->PostClass($this->custom['_menu_item_object_id']);
 		}
-		if ( isset($this->menu_object) ) {
+		if ( $this->menu_object ) {
 			return new $this->PostClass($this->menu_object);
 		}
-	}
-
-	/**
-	 * Get link.
-	 *
-	 * @internal
-	 * @see \Timber\MenuItem::link()
-	 * @deprecated since 1.0
-	 * @codeCoverageIgnore
-	 * @return string An absolute URL, e.g. `http://example.org/my-page`.
-	 */
-	public function get_link() {
-		return $this->link();
-	}
-
-	/**
-	 * Get path.
-	 *
-	 * @internal
-	 * @codeCoverageIgnore
-	 * @see        \Timber\MenuItem::path()
-	 * @deprecated since 1.0
-	 * @return string A relative URL, e.g. `/my-page`.
-	 */
-	public function get_path() {
-		return $this->path();
 	}
 
 	/**
@@ -200,18 +176,20 @@ class MenuItem extends Core implements CoreInterface {
 	 * @param \Timber\MenuItem $item The menu item to add.
 	 */
 	public function add_child( $item ) {
-		if ( !$this->has_child_class ) {
+		if ( ! $this->has_child_class ) {
 			$this->add_class('menu-item-has-children');
 			$this->has_child_class = true;
 		}
 		$this->children[] = $item;
-		$item->level = $this->level + 1;
+		$item->level      = $this->level + 1;
 		if ( count($this->children) ) {
 			$this->update_child_levels();
 		}
 	}
 
 	/**
+	 * Update the level data associated with $this.
+	 *
 	 * @internal
 	 * @return bool|null
 	 */
@@ -230,7 +208,7 @@ class MenuItem extends Core implements CoreInterface {
 	 *
 	 * @internal
 	 *
-	 * @param array|object $data
+	 * @param array|object $data to import.
 	 */
 	public function import_classes( $data ) {
 		if ( is_array($data) ) {
@@ -239,7 +217,7 @@ class MenuItem extends Core implements CoreInterface {
 		$this->classes = array_merge($this->classes, $data->classes);
 		$this->classes = array_unique($this->classes);
 		$this->classes = apply_filters('nav_menu_css_class', $this->classes, $this, array(), 0);
-		$this->class = trim(implode(' ', $this->classes));
+		$this->class   = trim(implode(' ', $this->classes));
 	}
 
 	/**
@@ -280,7 +258,7 @@ class MenuItem extends Core implements CoreInterface {
 	 * @return bool Whether the link is external or not.
 	 */
 	public function is_external() {
-		if ( $this->type() != 'custom' ) {
+		if ( $this->type() !== 'custom' ) {
 			return false;
 		}
 		return URLHelper::is_external($this->url);
@@ -370,28 +348,14 @@ class MenuItem extends Core implements CoreInterface {
 	 * @return string A full URL, like `http://mysite.com/thing/`.
 	 */
 	public function link() {
-		if ( !isset($this->url) || !$this->url ) {
-			if ( isset($this->_menu_item_type) && $this->_menu_item_type == 'custom' ) {
+		if ( ! isset($this->url) || !$this->url ) {
+			if ( isset($this->_menu_item_type) && $this->_menu_item_type === 'custom' ) {
 				$this->url = $this->_menu_item_url;
-			} else if ( isset($this->menu_object) && method_exists($this->menu_object, 'get_link') ) {
+			} elseif ( isset($this->menu_object) && method_exists($this->menu_object, 'get_link') ) {
 					$this->url = $this->menu_object->link();
-				}
+			}
 		}
 		return $this->url;
-	}
-
-	/**
-	 * Get the link the menu item points at.
-	 *
-	 * @internal
-	 * @deprecated since 0.21.7 Use link method instead.
-	 * @see \Timber\MenuItem::link()
-	 * @codeCoverageIgnore
-	 * @return string A full URL, like `http://mysite.com/thing/`.
-	 */
-	public function permalink() {
-		Helper::warn('{{ item.permalink }} is deprecated, use {{ item.link }} instead');
-		return $this->link();
 	}
 
 	/**

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -460,7 +460,7 @@ class Post extends Core implements CoreInterface {
 		$post->slug = $post->post_name;
 		$customs = $this->get_post_custom($post->ID);
 		$post->custom = $customs;
-		$post = (object) array_merge((array) $customs, (array) $post);
+		//$post = (object) array_merge((array) $customs, (array) $post);
 		return $post;
 	}
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -170,6 +170,7 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * If you send the constructor nothing it will try to figure out the current post id based on being inside The_Loop
+	 *
 	 * @example
 	 * ```php
 	 * $post = new Timber\Post();
@@ -298,8 +299,8 @@ class Post extends Core implements CoreInterface {
 	 * @internal
 	 * @param integer $pid
 	 */
-	protected function init( $pid = false ) {
-		if ( $pid === false ) {
+	protected function init( $pid = null ) {
+		if ( $pid === null ) {
 			$pid = get_the_ID();
 		}
 		if ( is_numeric($pid) ) {
@@ -446,7 +447,7 @@ class Post extends Core implements CoreInterface {
 	 * @param  int $pid
 	 * @return null|object|WP_Post
 	 */
-	protected function get_info( $pid ) {
+	protected function get_info( $pid = null ) {
 		$post = $this->prepare_post_info($pid);
 		if ( !isset($post->post_status) ) {
 			return null;

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -946,8 +946,10 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
 		$post = get_post($post->ID);
+
 		$str = '{{ TimberImage(post).src }}';
 		$result = Timber::compile_string( $str, array('post' => $post) );
+		
 		$this->assertEquals($image->src(), $result);
 	}
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -386,9 +386,16 @@
 			$this->assertEquals($page2, trim(strip_tags( $post->paged_content() )));
 		}
 
+		/**
+		 * This seems like an incredible edge case test from 1.x
+		 * @ignore
+		 */
+		/*
 		function testMetaCustomArrayFilter(){
-			add_filter('timber_post_get_meta', function($customs){
-				foreach($customs as $key=>$value){
+			add_filter('timber_post_get_meta', function($customs) {
+				error_log('RUN FITER');
+				print_r($customs);
+				foreach( $customs as $key=>$value ){
 					$flat_key = str_replace('-', '_', $key);
 					$flat_key .= '_flat';
 					$customs[$flat_key] = $value;
@@ -401,8 +408,8 @@
 			update_post_meta($post_id, 'with_underscores', 'the_value');
 			$post = new TimberPost($post_id);
 			$this->assertEquals($post->with_underscores_flat, 'the_value');
-			$this->assertEquals($post->the_field_name_flat, 'the-value');
-		}
+			//$this->assertEquals($post->the_field_name_flat, 'the-value');
+		}*/
 
 		function testPostMetaMetaException(){
 			$post_id = $this->factory->post->create();


### PR DESCRIPTION
**Ticket**: #1580 

#### Issue
Timber was grabbing all the custom data in `post_meta` and slapping it to the object. This had both pros and cons...
Pros: 
- Ability to treat custom data on the same level as WP-blessed data (ie `{{ book.title }}` AND `{{ book.isbn }}`
Cons: 
- Ability of custom data to overwrite methods
- Grabs whatever is stored in `wp_postmeta` which isn't necessarily the data the user really wants (for example, a data filtered by ACF or another custom field plugin)

#### Solution
Remove the "auto" importing of data, but still allow the user to get to properties at the top-level by implementing the magic method `__get`

#### Usage Changes
Should be very light, in cases where someone was getting data from the table and filtering it on their own, this could cause issues with their templates. However, in many cases (for example reading a `Timber\Image` into another `Timber\Image`) Timber is resilient enough to recognize the intention and thus some things might be double-filtered which _shouldn't_ matter (other than performance)

#### Considerations
I've disabled the test `TestTimberPost::testMetaCustomArrayFilter`. I'm going to do some more research, but it seemed to be covering an *extreme* edge-case of wanting to filter the names of fields to retrieve. Because field data is now only fetched at run time, this would no longer be possible


#### Testing
Yep!