### PR TITLE
2.x Make PostQuery available in Twig

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -32,7 +32,11 @@ class Twig {
 	}
 
 	/**
+	 * Add Timber-specific functions to Twig.
 	 *
+	 * @param \Twig_Environment $twig
+	 *
+	 * @return \Twig_Environment
 	 */
 	public function add_timber_functions( $twig ) {
 		/* actions and filters */
@@ -90,6 +94,11 @@ class Twig {
 					}
 					return new $PostClass($pid);
 				} ));
+
+		$twig->addFunction( new Twig_Function( 'PostQuery', function( $args = false, $post_class = '\Timber\Post' ) {
+			return new PostQuery( $args, $post_class );
+		} ) );
+
 		$twig->addFunction(new Twig_Function('Image', function( $pid, $ImageClass = 'Timber\Image' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {

--- a/tests/test-timber-twig-objects.php
+++ b/tests/test-timber-twig-objects.php
@@ -1,5 +1,7 @@
 <?php
 
+use Timber\Timber;
+
 	class TestTimberTwigObjects extends Timber_UnitTestCase {
 
 		function testTimberImageInTwig() {
@@ -65,6 +67,22 @@
 			$pids[] = $this->factory->post->create(array('post_title' => 'Bar'));
 			$str = '{% for post in Post(pids) %}{{post.title}}{% endfor %}';
 			$this->assertEquals('FooBar', Timber::compile_string($str, array('pids' => $pids)));
+		}
+
+		function testPostQueryWithStringInTwig(){
+			$pids[] = $this->factory->post->create( array( 'post_title' => 'Foo' ) );
+			$pids[] = $this->factory->post->create( array( 'post_title' => 'Bar' ) );
+			$str    = "{% for post in PostQuery('post_type=post&posts_per_page=-1&order=ASC') %}{{ post.title }}{% endfor %}";
+
+			$this->assertEquals( 'FooBar', Timber::compile_string( $str, array( 'pids' => $pids ) ) );
+		}
+
+		function testPostQueryWithArgsInTwig(){
+			$pids[] = $this->factory->post->create( array( 'post_title' => 'Foo' ) );
+			$pids[] = $this->factory->post->create( array( 'post_title' => 'Bar' ) );
+			$str    = "{% for post in PostQuery({ post_type: 'post', posts_per_page: -1, order: 'ASC'}) %}{{ post.title }}{% endfor %}";
+
+			$this->assertEquals( 'FooBar', Timber::compile_string( $str, array( 'pids' => $pids ) ) );
 		}
 
 		function testTimberUserInTwig(){


### PR DESCRIPTION
#### Issue

Maybe there are developers out there who’d like to use `PostQuery` directly in Twig?

I thought about this when working on the WooCommerce integration, because there I have only reduced access to PHP templates.

#### Solution

Make `PostQuery` available as a function in Twig.

#### Impact

PHP files could be very lean:

```php
use Timber\Timber;

Timber::render( 'index.twig', Timber::get_context() );
```

But the whole idea probably only works well for simple use cases.

#### Usage Changes

I already added the following to the Upgrade Guide for 2.0.

> You can also use PostQuery in Twig. You can pass in your arguments either as a query string, or define the parameters in an argument hash (in Twig, [key-value arrays are called hashes](https://mijingo.com/blog/key-value-arrays-in-twig), and you use curly braces `{}` instead of brackets `[]` for them).

```twig
{# Query string #}
{% for post in PostQuery({'post_type=post&post_status=publish&posts_per_page=10'}) %}
	<a href="{{ post.link }}">{{ post.title }}</a>
{% endfor %}

{# Hash notation #}
{% for post in PostQuery({
    post_type: 'post',
    post_status: 'publish',
    posts_per_page: 10
}) %}
	<a href="{{ post.link }}">{{ post.title }}</a>
{% endfor %}
```

If this isn’t going to be merged, it can be removed again from the Upgrade Guide.

#### Testing

Yes.