### PR TITLE
fixes #1625 - WMPL Image resize url issue

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -168,7 +168,7 @@ class URLHelper {
 	 */
 	public static function file_system_to_url( $fs ) {
 		$relative_path = self::get_rel_path($fs);
-		$home = home_url('/'.$relative_path);
+		$home = site_url('/'.$relative_path);
 		$home = apply_filters('timber/URLHelper/file_system_to_url', $home);
 		return $home;
 	}

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -42,15 +42,15 @@
 
         function testFileSystemToURLWithWPML() {
             self::_setLanguage();
-            add_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
+            add_filter('site_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
             $image = TestTimberImage::copyTestImage();
             $url = Timber\URLHelper::file_system_to_url($image);
-            $this->assertEquals('http://enample.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-            remove_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'));
+            $this->assertEquals('http://example2.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+            remove_filter('site_url', array($this, 'addWPMLHomeFilterForRegExTest'));
         }
 
         function addWPMLHomeFilterForRegExTest($url, $path) {
-            return 'http://enample.org/en'.$path;
+            return 'http://example2.org/en'.$path;
         }
 
         function testFileSystemToURL() {


### PR DESCRIPTION
**Ticket**: #1625  

#### Issue
Resized images on WPML-translated pages have urls that contain the language query string which prevents them from displaying and throws an error.

#### Solution
WMPL overwrites `home_url()` therefore using `site_url()` is safer
