### PR TITLE
1622/iterable error

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -426,16 +426,18 @@ class Helper {
 	 *
 	 * @since 1.5.3
 	 * @ticket #1594
-	 * @param array        $array to filter.
+	 * @param array        $list to filter.
 	 * @param string|array $filter to search for.
 	 * @param string       $operator to use (AND, NOT, OR).
 	 * @return array
 	 */
-	public static function filter_array( $array, $filter, $operator = 'AND' ) {
-		if ( ! is_array($filter) ) {
-			$filter = array( 'slug' => $filter );
+	public static function filter_array( $list, $args, $operator = 'AND' ) {
+		if ( ! is_array($args) ) {
+			$args = array( 'slug' => $args );
 		}
-		return wp_list_filter($array, $filter, $operator);
+
+		$util = new \WP_List_Util( $list );
+		return $util->filter( $args, $operator );
 	}
 
 	/* Links, Forms, Etc. Utilities

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -436,6 +436,10 @@ class Helper {
 			$args = array( 'slug' => $args );
 		}
 
+		if ( ! is_array( $list ) && ! is_a( $list, 'Traversable' ) ) {
+			return array();
+		}
+
 		$util = new \WP_List_Util( $list );
 		return $util->filter( $args, $operator );
 	}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -243,4 +243,11 @@
 			$str = Timber::compile_string($template, array('posts' => $posts));
 			$this->assertEquals('Stringer Bell Snoop', trim($str));
 		}
+
+		function testArrayFilterWithBogusArray() {
+			$template = '{% for post in posts | filter({slug:"snoop", post_content:"Idris Elba"}, "OR")%}{{ post.title }} {% endfor %}';
+			$str = Timber::compile_string($template, array('posts' => 'foobar'));
+			$this->assertEquals('', $str);
+		}
+
 	}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -221,12 +221,12 @@
 			$this->assertEquals('Felicia Pearson', trim($str));
 		}
 
-		function testArrayFilterKeyValue() {
+		function testArrayFilterKeyValueUsingPostQuery() {
 			$posts = [];
 			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
 			$posts[] = $this->factory->post->create(array('post_title' => 'Snoop', 'post_content' => 'Felicia Pearson'));
 			$posts[] = $this->factory->post->create(array('post_title' => 'Cheese', 'post_content' => 'Method Man'));
-			$posts = Timber::get_posts($posts);
+			$posts = new Timber\PostQuery($posts);
 			$template = '{% for post in posts | filter({post_content: "Method Man"
 		})%}{{ post.title }}{% endfor %}';
 			$str = Timber::compile_string($template, array('posts' => $posts));


### PR DESCRIPTION
As described in this WP Core ticket:

https://core.trac.wordpress.org/ticket/43025

The `wp_list_filter` function we use should requires that the list sent to it is an array as opposed to an iterable object (as in, something that isn't an array but can act like one). I ripped the contents of `wp_list_filter` w/o that catch and voila!