### PR TITLE
2.x Use namespaced classes

### DIFF
--- a/docs/guides/acf-cookbook.md
+++ b/docs/guides/acf-cookbook.md
@@ -46,7 +46,7 @@ $data['post'] = $post;
 Timber::render('single.twig', $data);
 ```
 
-`TimberImage` should be initialized using a WordPress image ID#. It can also take URLs and image objects, but that requires extra processing.
+`Timber\Image` should be initialized using a WordPress image ID#. It can also take URLs and image objects, but that requires extra processing.
 
 You can now use all the above functions to transform your custom images in the same way, the format will be:
 

--- a/docs/guides/acf-cookbook.md
+++ b/docs/guides/acf-cookbook.md
@@ -37,9 +37,9 @@ This is where we'll start in PHP.
 ```php
 <?php
 /* single.php */
-$post = new TimberPost();
+$post = new Timber\Post();
 if (isset($post->hero_image) && strlen($post->hero_image)){
-	$post->hero_image = new TimberImage($post->hero_image);
+	$post->hero_image = new Timber\Image($post->hero_image);
 }
 $data = Timber::get_context();
 $data['post'] = $post;

--- a/docs/guides/cheatsheet.md
+++ b/docs/guides/cheatsheet.md
@@ -9,7 +9,7 @@ Here are some helpful conversions for functions you’re probably well familiar 
 
 ```php
 $context = Timber::get_context();
-$context['post'] = new TimberPost();
+$context['post'] = new Timber\Post();
 Timber::render( 'single.twig', $context );
 ```
 

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -120,7 +120,7 @@ $data['post'] = $post;
 Timber::render( 'single.twig', $data );
 ```
 
-`TimberImage` should be initialized using a WordPress image ID. It can also take URLs and image objects, but that requires extra processing.
+`Timber\Image` should be initialized using a WordPress image ID. It can also take URLs and image objects, but that requires extra processing.
 
 You can now use all the above functions to transform your custom images in the same way. The format will be:
 

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -79,4 +79,4 @@ This filter answers the question: What type of object am I working with? It pass
 {{ post|get_class }}
 ```
 
-It will output something like `TimberPost` or your custom wrapper object.
+It will output something like `Timber\Post` or your custom wrapper object.

--- a/docs/guides/extending-timber.md
+++ b/docs/guides/extending-timber.md
@@ -9,9 +9,9 @@ Myth: Timber is for making simple themes. Fact: It's for making incredibly compl
 
 The beauty of Timber is that the object-oriented nature lets you extend it to match the exact requirements of your theme.
 
-## An example that extends TimberPost
+## An example that extends Timber\Post
 
-Timber's objects like `TimberPost`, `TimberTerm`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
+Timber's objects like `Timber\Post`, `Timber\Term`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
 
 
 ```twig
@@ -19,11 +19,11 @@ Timber's objects like `TimberPost`, `TimberTerm`, etc. are a great starting poin
 <h3>From the {{ post.issue.title }} issue</h3>
 ```
 
-Of course, `TimberPost` has no built-in concept of an issue (which I've built as a custom taxonomy called "issues"). So we're going to extend TimberPost to give it one:
+Of course, `Timber\Post` has no built-in concept of an issue (which I've built as a custom taxonomy called "issues"). So we're going to extend `Timber\Post` to give it one:
 
 ```php
 <?php
-class MySitePost extends TimberPost {
+class MySitePost extends Timber\Post {
 
 	var $_issue;
 
@@ -41,7 +41,7 @@ issue data:
 
 ```php
 <?php
-class MySitePost extends TimberPost {
+class MySitePost extends Timber\Post {
 
 	var $_issue;
 
@@ -57,13 +57,13 @@ class MySitePost extends TimberPost {
 }
 ```
 
-Right now I'm in the midst of building a complex site for a hybrid foundation and publication. The posts on the site have some very specific requirements that requires a fair amount of logic. I can take the simple `TimberPost` object and extend it to make it work perfectly for this theme.
+Right now I'm in the midst of building a complex site for a hybrid foundation and publication. The posts on the site have some very specific requirements that requires a fair amount of logic. I can take the simple `Timber\Post` object and extend it to make it work perfectly for this theme.
 
 For example, I have a plugin that let's people insert manually related posts, but if they don't, WordPress will pull some automatically based on how the post is tagged.
 
 ```php
 	<?php
-	class MySitePost extends TimberPost {
+	class MySitePost extends Timber\Post {
 
 		function get_related_auto() {
 			$tags = $this->tags();

--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -40,7 +40,7 @@ $menu = new Timber\Menu( 'primary' );
 Or pass nothing. This is good if you have only one menu. In that case Timber will just grab what you got.
 
 ```php
-$menu = new TimberMenu();
+$menu = new Timber\Menu();
 ```
 
 ## Setting up a menu globally

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -120,7 +120,7 @@ You can also use some [syntactic sugar](http://en.wikipedia.org/wiki/Syntactic_s
 
 $context = Timber::get_context();
 
-$context['main_stories'] = TimberHelper::transient( 'main_stories', function(){
+$context['main_stories'] = Timber\Helper::transient( 'main_stories', function(){
     $posts = Timber::get_posts();
 
     // As an example, do something expensive with these posts
@@ -153,7 +153,7 @@ Timber provides some quick shortcuts to measure page timing. Here’s an example
 ```php
 <?php
 // This generates a starting time
-$start = TimberHelper::start_timer();
+$start = Timber\Helper::start_timer();
 
 $context = Timber::get_context();
 $context['post'] = Timber::get_post();
@@ -162,5 +162,5 @@ $context['whatever'] = get_my_foo();
 Timber::render( 'single.twig', $context, 600 );
 
 // This reports the time diff by passing the $start time
-echo TimberHelper::stop_timer( $start);
+echo Timber\Helper::stop_timer( $start);
 ```

--- a/docs/guides/sidebars.md
+++ b/docs/guides/sidebars.md
@@ -62,7 +62,7 @@ In this example, you would populate your sidebar from your main PHP file (home.p
 <?php
 /* single.php */
 $context = Timber::get_context();
-$post = new TimberPost();
+$post = new Timber\Post();
 $post_cat = $post->get_terms('category');
 $post_cat = $post_cat[0]->ID;
 $context['post'] = $post;

--- a/lib/Archives.php
+++ b/lib/Archives.php
@@ -6,11 +6,11 @@ use Timber\Core;
 use Timber\URLHelper;
 
 /**
- * The TimberArchives class is used to generate a menu based on the date archives of your posts. The [Nieman Foundation News site](http://nieman.harvard.edu/news/) has an example of how the output can be used in a real site ([screenshot](https://cloud.githubusercontent.com/assets/1298086/9610076/3cdca596-50a5-11e5-82fd-acb74c09c482.png)).
+ * The Timber\Archives class is used to generate a menu based on the date archives of your posts. The [Nieman Foundation News site](http://nieman.harvard.edu/news/) has an example of how the output can be used in a real site ([screenshot](https://cloud.githubusercontent.com/assets/1298086/9610076/3cdca596-50a5-11e5-82fd-acb74c09c482.png)).
  *
  * @example
  * ```php
- * $context['archives'] = new TimberArchives( $args );
+ * $context['archives'] = new Timber\Archives( $args );
  * ```
  * ```twig
  * <ul>
@@ -38,7 +38,7 @@ use Timber\URLHelper;
  * ```
  */
 class Archives extends Core {
-	
+
 	public $base = '';
 	/**
 	 * @api

--- a/lib/Cache/WPObjectCacheAdapter.php
+++ b/lib/Cache/WPObjectCacheAdapter.php
@@ -8,7 +8,7 @@ class WPObjectCacheAdapter implements CacheProviderInterface {
 	private $cache_group;
 
 	/**
-	 * @var TimberLoader
+	 * @var Timber\Loader
 	 */
 	private $timberloader;
 

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -7,10 +7,10 @@ use Timber\Core;
 use Timber\CoreInterface;
 
 /**
- * The TimberComment class is used to view the output of comments. 99% of the time this will be in the context of the comments on a post. However you can also fetch a comment directly using its comment ID.
+ * The Timber\Comment class is used to view the output of comments. 99% of the time this will be in the context of the comments on a post. However you can also fetch a comment directly using its comment ID.
  * @example
  * ```php
- * $comment = new TimberComment($comment_id);
+ * $comment = new Timber\Comment($comment_id);
  * $context['comment_of_the_day'] = $comment;
  * Timber::render('index.twig', $context);
  * ```
@@ -130,13 +130,13 @@ class Comment extends Core implements CoreInterface {
 		}
 
 		$email = $this->avatar_email();
-		
+
 		$args = array('size' => $size, 'default' => $default);
 		$args = apply_filters('pre_get_avatar_data', $args, $email);
 		if ( isset($args['url']) ) {
 			return $args['url'];
 		}
-		
+
 		$email_hash = '';
 		if ( !empty($email) ) {
 			$email_hash = md5(strtolower(trim($email)));

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -50,7 +50,7 @@ abstract class Core {
 	 * @example
 	 * ```php
 	 * $data = array('airplane' => '757-200', 'flight' => '5316');
-	 * $post = new TimberPost()
+	 * $post = new Timber\Post();
 	 * $post->import(data);
 	 * echo $post->airplane; //757-200
 	 * ```
@@ -75,7 +75,7 @@ abstract class Core {
 					} else {
 						$this->$key = $value;
 					}
-					
+
 				}
 			}
 		}

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -6,7 +6,7 @@ use Timber\FunctionWrapper;
 use Timber\URLHelper;
 
 /**
- * As the name suggests these are helpers for Timber (and you!) when developing. You can find additional (mainly internally-focused helpers) in TimberURLHelper
+ * As the name suggests these are helpers for Timber (and you!) when developing. You can find additional (mainly internally-focused helpers) in Timber\URLHelper
  */
 class Helper {
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -146,7 +146,7 @@ class Helper {
 	 * }
 	 *
 	 * $context = Timber::get_context();
-	 * $context['post'] = new TimberPost();
+	 * $context['post'] = new Timber\Post();
 	 * $context['my_form'] = TimberHelper::ob_function('the_form');
 	 * Timber::render('single-form.twig', $context);
 	 * ```

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -118,9 +118,9 @@ class Helper {
 	 * For stopping time and getting the data
 	 * @example
 	 * ```php
-	 * $start = TimberHelper::start_timer();
+	 * $start = Timber\Helper::start_timer();
 	 * // do some stuff that takes awhile
-	 * echo TimberHelper::stop_timer( $start );
+	 * echo Timber\Helper::stop_timer( $start );
 	 * ```
 	 * @param int     $start
 	 * @return string
@@ -147,7 +147,7 @@ class Helper {
 	 *
 	 * $context = Timber::get_context();
 	 * $context['post'] = new Timber\Post();
-	 * $context['my_form'] = TimberHelper::ob_function('the_form');
+	 * $context['my_form'] = Timber\Helper::ob_function('the_form');
 	 * Timber::render('single-form.twig', $context);
 	 * ```
 	 * ```twig

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -19,7 +19,7 @@ use Timber\URLHelper;
  *
  * // lets say you have an alternate large 'cover image' for your post stored in a custom field which returns an image ID
  * $cover_image_id = $post->cover_image;
- * $context['cover_image'] = new TimberImage($cover_image_id);
+ * $context['cover_image'] = new Timber\Image($cover_image_id);
  * Timber::render('single.twig', $context);
  * ```
  *
@@ -31,7 +31,7 @@ use Timber\URLHelper;
  *     {{post.content}}
  *   </div>
  *
- *  <img src="{{ Image(post.custom_field_with_image_id).src }}" alt="Another way to initialize images as TimberImages, but within Twig" />
+ *  <img src="{{ Image(post.custom_field_with_image_id).src }}" alt="Another way to initialize images as Timber\Image objects, but within Twig" />
  * </article>
  * ```
  *
@@ -42,7 +42,7 @@ use Timber\URLHelper;
  *   <div class="body">
  *     Whatever whatever
  *   </div>
- *   <img src="http://example.org/wp-content/uploads/2015/06/kurt.jpg" alt="Another way to initialize images as TimberImages, but within Twig" />
+ *   <img src="http://example.org/wp-content/uploads/2015/06/kurt.jpg" alt="Another way to initialize images as Timber\Image objects, but within Twig" />
  * </article>
  * ```
  */
@@ -86,14 +86,14 @@ class Image extends Post implements CoreInterface {
 	protected $_wp_attached_file;
 
 	/**
-	 * Creates a new TimberImage object
+	 * Creates a new Timber\Image object
 	 * @example
 	 * ```php
 	 * // You can pass it an ID number
-	 * $myImage = new TimberImage(552);
+	 * $myImage = new Timber\Image(552);
 	 *
 	 * //Or send it a URL to an image
-	 * $myImage = new TimberImage('http://google.com/logo.jpg');
+	 * $myImage = new Timber\Image('http://google.com/logo.jpg');
 	 * ```
 	 * @param int|string $iid
 	 */
@@ -227,10 +227,10 @@ class Image extends Post implements CoreInterface {
 	public function init( $iid = false ) {
 		// Make sure we actually have something to work with.
 		if ( !$iid ) {
-			Helper::error_log('Initalized TimberImage without providing first parameter.'); return;
+			Helper::error_log('Initalized Timber\Image without providing first parameter.'); return;
 		}
 
-		// If passed TimberImage, grab the ID and continue.
+		// If passed Timber\Image, grab the ID and continue.
 		if ( $iid instanceof self ) {
 			$iid = (int) $iid->ID;
 		}

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -9,12 +9,12 @@ use Timber\URLHelper;
 
 
 /**
- * If TimberPost is the class you're going to spend the most time, TimberImage is the class you're going to have the most fun with.
+ * If Timber\Post is the class you're going to spend the most time, Timber\Image is the class you're going to have the most fun with.
  *
  * @example
  * ```php
  * $context = Timber::get_context();
- * $post = new TimberPost();
+ * $post = new Timber\Post();
  * $context['post'] = $post;
  *
  * // lets say you have an alternate large 'cover image' for your post stored in a custom field which returns an image ID
@@ -266,7 +266,7 @@ class Image extends Post implements CoreInterface {
 			return $this->init($iid->ID);
 		} else if ( $iid instanceof Post ) {
 			/**
-			 * This will catch TimberPost and any post classes that extend TimberPost,
+			 * This will catch Timber\Post and any post classes that extend Timber\Post,
 			 * see http://php.net/manual/en/internals2.opcodes.instanceof.php#109108
 			 * and https://timber.github.io/docs/guides/extending-timber/
 			 */

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -436,7 +436,7 @@ class ImageHelper {
 		if ( !$absolute ) {
 			$url = str_replace(site_url(), '', $url);
 		}
-		// $url = TimberURLHelper::remove_double_slashes( $url);
+		// $url = Timber\URLHelper::remove_double_slashes( $url);
 		return $url;
 	}
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -762,7 +762,7 @@ class Post extends Core implements CoreInterface {
 	 * Get the categoires on a particular post
 	 *
 	 * @api
-	 * @return array of TimberTerms
+	 * @return array of Timber\Term objects
 	 */
 	public function categories() {
 		return $this->terms('category');
@@ -773,7 +773,7 @@ class Post extends Core implements CoreInterface {
 	 *
 	 * @api
 	 * If mulitpuile categories are set, it will return just the first one
-	 * @return TimberTerm|null
+	 * @return \Timber\Term|null
 	 */
 	public function category() {
 		$cats = $this->categories();

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -404,7 +404,7 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * Used internally to fetch the metadata fields (wp_postmeta table)
-	 * and attach them to our TimberPost object
+	 * and attach them to our Timber\Post object
 	 * @internal
 	 * @param int $pid
 	 * @return array
@@ -438,7 +438,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Used internally by init, etc. to build TimberPost object.
+	 * Used internally by init, etc. to build Timber\Post object.
 	 *
 	 * @internal
 	 * @param  int|null $pid The ID to generate info from.

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -823,13 +823,13 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Gets the comments on a Timber\Post and returns them as an array of [TimberComments](#TimberComment) (or whatever comment class you set).
+	 * Gets the comments on a Timber\Post and returns them as an array of `Timber\Comment` objects (or whatever comment class you set).
 	 * @api
 	 * @param int $count Set the number of comments you want to get. `0` is analogous to "all"
 	 * @param string $order use ordering set in WordPress admin, or a different scheme
 	 * @param string $type For when other plugins use the comments table for their own special purposes, might be set to 'liveblog' or other depending on what's stored in yr comments table
 	 * @param string $status Could be 'pending', etc.
-	 * @param string $CommentClass What class to use when returning Comment objects. As you become a Timber pro, you might find yourself extending TimberComment for your site or app (obviously, totally optional)
+	 * @param string $CommentClass What class to use when returning Comment objects. As you become a Timber pro, you might find yourself extending Timber\Comment for your site or app (obviously, totally optional)
 	 * @example
 	 * ```twig
 	 * {# single.twig #}

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -6,15 +6,14 @@ use Timber\Core;
 use Timber\CoreInterface;
 
 /**
- * TimberRequest exposes $_GET and $_POST to the context
+ * Timber\Request exposes $_GET and $_POST to the context
  */
-
 class Request extends Core implements CoreInterface {
 	public $post = array();
 	public $get = array();
-	
+
 	/**
-	 * Constructs a TimberRequest object
+	 * Constructs a Timber\Request object
 	 * @example
 	 */
 	public function __construct() {

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -9,12 +9,12 @@ use Timber\Theme;
 use Timber\Helper;
 
 /**
- * TimberSite gives you access to information you need about your site. In Multisite setups, you can get info on other sites in your network.
+ * Timber\Site gives you access to information you need about your site. In Multisite setups, you can get info on other sites in your network.
  * @example
  * ```php
  * $context = Timber::get_context();
  * $other_site_id = 2;
- * $context['other_site'] = new TimberSite($other_site_id);
+ * $context['other_site'] = new Timber\Site($other_site_id);
  * Timber::render('index.twig', $context);
  * ```
  * ```twig
@@ -95,14 +95,14 @@ class Site extends Core implements CoreInterface {
 	public $atom;
 
 	/**
-	 * Constructs a TimberSite object
+	 * Constructs a Timber\Site object
 	 * @example
 	 * ```php
 	 * //multisite setup
-	 * $site = new TimberSite(1);
-	 * $site_two = new TimberSite("My Cool Site");
+	 * $site = new Timber\Site(1);
+	 * $site_two = new Timber\Site("My Cool Site");
 	 * //non-multisite
-	 * $site = new TimberSite();
+	 * $site = new Timber\Site();
 	 * ```
 	 * @param string|int $site_name_or_id
 	 */
@@ -283,7 +283,7 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 * @deprecated 1.0.4
-	 * @see TimberSite::link
+	 * @see Timber\Site::link
 	 * @return string
 	 */
 	public function url() {

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -72,7 +72,7 @@ class Site extends Core implements CoreInterface {
 	public $siteurl;
 	/**
 	 * @api
-	 * @var [TimberTheme](#TimberTheme)
+	 * @var \Timber\Theme
 	 */
 	public $theme;
 	/**

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -16,13 +16,13 @@ use Timber\URLHelper;
  * @example
  * ```php
  * //Get a term by its ID
- * $context['term'] = new TimberTerm(6);
+ * $context['term'] = new Timber\Term(6);
  * //Get a term when on a term archive page
- * $context['term_page'] = new TimberTerm();
+ * $context['term_page'] = new Timber\Term();
  * //Get a term with a slug
- * $context['team'] = new TimberTerm('patriots');
+ * $context['team'] = new Timber\Term('patriots');
  * //Get a team with a slug from a specific taxonomy
- * $context['st_louis'] = new TimberTerm('cardinals', 'baseball');
+ * $context['st_louis'] = new Timber\Term('cardinals', 'baseball');
  * Timber::render('index.twig', $context);
  * ```
  * ```twig

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -43,10 +43,10 @@ class Theme extends Core {
 	public $version;
 
 	/**
-	 * TimberTheme object for the parent theme (if it exists), false otherwise
+	 * Timber\Theme object for the parent theme (if it exists), false otherwise
 	 *
 	 * @api
-	 * @var TimberTheme|bool the TimberTheme object for the parent theme (if it exists), false otherwise
+	 * @var \Timber\Theme|bool the Timber\Theme object for the parent theme (if it exists), false otherwise
 	 */
 	public $parent = false;
 
@@ -71,12 +71,12 @@ class Theme extends Core {
 	private $theme;
 
 	/**
-	 * Constructs a new TimberTheme object. NOTE the TimberTheme object of the current theme comes in the default `Timber::get_context()` call. You can access this in your twig template via `{{site.theme}}.
+	 * Constructs a new Timber\Theme object. NOTE the Timber\Theme object of the current theme comes in the default `Timber::get_context()` call. You can access this in your twig template via `{{site.theme}}.
 	 * @param string $slug
 	 * @example
 	 * ```php
 	 * <?php
-	 *     $theme = new TimberTheme("my-theme");
+	 *     $theme = new Timber\Theme("my-theme");
 	 *     $context['theme_stuff'] = $theme;
 	 *     Timber::render('single.twig', $context);
 	 * ?>

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -274,7 +274,7 @@ class Timber {
 	 * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
 	 *                                 array, the first value is used for non-logged in visitors, the second for users.
 	 *                                 Default false.
-	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
+	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in Timber\Loader.
 	 * @param bool         $via_render Optional. Whether to apply optional render or compile filters. Default false.
 	 * @return bool|string The returned output.
 	 */
@@ -348,7 +348,7 @@ class Timber {
 	 * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
 	 *                                 array, the first value is used for non-logged in visitors, the second for users.
 	 *                                 Default false.
-	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
+	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in Timber\Loader.
 	 * @return bool|string The returned output.
 	 */
 	public static function fetch( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {
@@ -375,7 +375,7 @@ class Timber {
 	 * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
 	 *                                 array, the first value is used for non-logged in visitors, the second for users.
 	 *                                 Default false.
-	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in TimberLoader.
+	 * @param string       $cache_mode Optional. Any of the cache mode constants defined in Timber\Loader.
 	 * @return bool|string The echoed output.
 	 */
 	public static function render( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -158,7 +158,7 @@ class Twig {
 	}
 
 	/**
-	 * Function for Term or TimberTerm() within Twig
+	 * Function for Term or Timber\Term() within Twig
 	 * @since 1.5.1
 	 * @author @jarednova
 	 * @param integer $tid the term ID to search for
@@ -255,7 +255,7 @@ class Twig {
 					return apply_filters_ref_array($tag, $args);
 				} ));
 
-		
+
 		$twig = apply_filters('timber/twig', $twig);
 		/**
 		 * get_twig is deprecated, use timber/twig

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -404,7 +404,7 @@ class URLHelper {
 	/**
 	 * Returns the url parameters, for example for url http://example.org/blog/post/news/2014/whatever
 	 * this will return array('blog', 'post', 'news', '2014', 'whatever');
-	 * OR if sent an integer like: TimberUrlHelper::get_params(2); this will return 'news';
+	 * OR if sent an integer like: Timber\URLHelper::get_params(2); this will return 'news';
 	 *
 	 * @param int $i the position of the parameter to grab.
 	 * @return array|string

--- a/lib/User.php
+++ b/lib/User.php
@@ -81,7 +81,7 @@ class User extends Core implements CoreInterface {
 	 * This post is by Jared Novack
 	 * ```
 	 *
-	 * @return string a fallback for TimberUser::name()
+	 * @return string a fallback for Timber\User::name()
 	 */
 	public function __toString() {
 		$name = $this->name();

--- a/tests/benchmark/benchmark-timber-loader.php
+++ b/tests/benchmark/benchmark-timber-loader.php
@@ -3,7 +3,7 @@
 	class TimberBenchmark {
 
 		static function testLoader(){
-			$TimberLoader = new TimberLoader();
+			$TimberLoader = new Timber\Loader();
 			for ($i = 0; $i<5000; $i++){
 				$loader = $TimberLoader->get_loader();
 			}

--- a/tests/benchmark/benchmark-timber-loader.php
+++ b/tests/benchmark/benchmark-timber-loader.php
@@ -18,7 +18,7 @@
 			}
 			for ($i = 0; $i<20; $i++){
 				$upload_dir = wp_upload_dir();
-				$img = TimberImageHelper::resize($upload_dir['url'].'/arch.jpg', 500, 200, 'default', true);
+				$img = Timber\ImageHelper::resize($upload_dir['url'].'/arch.jpg', 500, 200, 'default', true);
 			}
 		}
 

--- a/tests/benchmark/benchmark-timber.php
+++ b/tests/benchmark/benchmark-timber.php
@@ -3,7 +3,7 @@
 	class TimberBenchmark {
 
 		static function testLoader(){
-			$TimberLoader = new TimberLoader();
+			$TimberLoader = new Timber\Loader();
 			for ($i = 0; $i<5000; $i++){
 				$loader = $TimberLoader->get_loader();
 			}

--- a/tests/php/timber-post-subclass.php
+++ b/tests/php/timber-post-subclass.php
@@ -1,5 +1,5 @@
 <?php
-	class TimberPostSubclass extends TimberPost {
+	class TimberPostSubclass extends Timber\Post {
 
 		public function foo(){
 			return 'bar';

--- a/tests/php/timber-term-subclass.php
+++ b/tests/php/timber-term-subclass.php
@@ -1,5 +1,5 @@
 <?php
-	class TimberTermSubclass extends TimberTerm {
+	class TimberTermSubclass extends Timber\Term {
 
 		public function foo(){
 			return 'bar';

--- a/tests/test-timber-archives.php
+++ b/tests/test-timber-archives.php
@@ -8,7 +8,7 @@
 				$this->factory->post->create(array('post_date' => $date.' 19:46:41'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'monthly', 'show_year' => false, 'limit' => 3));
+			$archives = new Timber\Archives(array('type' => 'monthly', 'show_year' => false, 'limit' => 3));
 			$this->assertEquals(3, count($archives->items));
 			$this->assertEquals(2, $archives->items[1]['post_count']);
 		}
@@ -20,11 +20,11 @@
 				$this->factory->post->create(array('post_date' => $date.' 19:46:41'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'monthly', 'show_year' => false));
+			$archives = new Timber\Archives(array('type' => 'monthly', 'show_year' => false));
 			$this->assertEquals('December', $archives->items[0]['name']);
 			$this->assertEquals(3, count($archives->items));
 			$this->assertEquals(2, $archives->items[1]['post_count']);
-			$archives = new TimberArchives(array('type' => 'monthly', 'show_year' => true));
+			$archives = new Timber\Archives(array('type' => 'monthly', 'show_year' => true));
 			$this->assertEquals('December 2013', $archives->items[0]['name']);
 		}
 
@@ -34,7 +34,7 @@
 				$this->factory->post->create(array('post_date' => $date.' 19:46:41'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'yearly', 'show_year' => false));
+			$archives = new Timber\Archives(array('type' => 'yearly', 'show_year' => false));
 			$this->assertEquals(3, count($archives->items));
 			$this->assertEquals(2, $archives->items[2]['post_count']);
 		}
@@ -46,7 +46,7 @@
 				$this->factory->post->create(array('post_date' => $date.' 19:46:41'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'daily'));
+			$archives = new Timber\Archives(array('type' => 'daily'));
 			$this->assertEquals(5, count($archives->items));
 			$this->assertEquals(2, $archives->items[2]['post_count']);
 		}
@@ -58,11 +58,11 @@
 				$this->factory->post->create(array('post_date' => $date.' 19:46:41'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'monthly-nested'));
+			$archives = new Timber\Archives(array('type' => 'monthly-nested'));
 			$this->assertEquals(2, count($archives->items));
 			$this->assertEquals(4, $archives->items[1]['post_count']);
 			$this->assertEquals(2, $archives->items[1]['children'][1]['post_count']);
-			$archives = new TimberArchives(array('type' => 'yearlymonthly'));
+			$archives = new Timber\Archives(array('type' => 'yearlymonthly'));
 			$this->assertEquals(2, count($archives->items));
 			$this->assertEquals(4, $archives->items[1]['post_count']);
 			$this->assertEquals(2, $archives->items[1]['children'][1]['post_count']);
@@ -75,7 +75,7 @@
 				$this->factory->post->create(array('post_date' => $date.' 19:46:41'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'weekly'));
+			$archives = new Timber\Archives(array('type' => 'weekly'));
 			$this->assertEquals(3, count($archives->items));
 			$this->assertEquals(3, $archives->items[0]['post_count']);
 		}
@@ -91,7 +91,7 @@
 				$this->factory->post->create(array('post_date' => $post['date'].' 19:46:41', 'post_title' => $post['post_title']));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives(array('type' => 'alpha'));
+			$archives = new Timber\Archives(array('type' => 'alpha'));
 			$this->assertEquals(4, count($archives->items));
 			$this->assertEquals('Quack Quack', $archives->items[3]['name']);
 		}
@@ -109,10 +109,10 @@
 				$this->factory->post->create(array('post_date' => $date. ' 19:46:41', 'post_type' => 'book'));
 			}
 			$this->go_to('/');
-			$archives = new TimberArchives();
+			$archives = new Timber\Archives();
 
 			$this->assertEquals(2, count($archives->items));
-			$archives = new TimberArchives(array('post_type' => 'book', 'type' => 'monthly'));
+			$archives = new Timber\Archives(array('post_type' => 'book', 'type' => 'monthly'));
 			$this->assertEquals(5, count($archives->items));
 		}
 

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -130,7 +130,7 @@
         function testKeyGenerator(){
         	$kg = new Timber\Cache\KeyGenerator();
         	$post_id = $this->factory->post->create(array('post_title' => 'My Test Post'));
-        	$post = new TimberPost($post_id);
+        	$post = new Timber\Post($post_id);
         	$key = $kg->generateKey($post);
         	$this->assertStringStartsWith('Timber\Post|', $key);
         }
@@ -185,7 +185,7 @@
         	$this->assertFileNotExists($cache_dir);
         	Timber::$cache = true;
         	$pid = $this->factory->post->create();
-        	$post = new TimberPost($pid);
+        	$post = new Timber\Post($pid);
         	Timber::compile('assets/single-post.twig', array('post' => $post));
         	sleep(1);
         	$this->assertFileExists($cache_dir);
@@ -197,7 +197,7 @@
 
         function testTimberLoaderCache(){
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post), 600);
             $str_another = Timber::compile('assets/single-parent.twig', array('post' => $post, 'rand' => rand(0, 99)), 500);
             sleep(1);
@@ -218,7 +218,7 @@
             global $wp_object_cache;
             $_wp_using_ext_object_cache = true;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post), 600, \Timber\Loader::CACHE_OBJECT);
             sleep(1);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post), 600, \Timber\Loader::CACHE_OBJECT);
@@ -227,7 +227,7 @@
             $clear = $loader->clear_cache_timber(\Timber\Loader::CACHE_OBJECT);
             $this->assertTrue($clear);
             $works = true;
-            if ( isset($wp_object_cache->cache[\Timber\Loader::CACHEGROUP]) 
+            if ( isset($wp_object_cache->cache[\Timber\Loader::CACHEGROUP])
                 && !empty($wp_object_cache->cache[\Timber\Loader::CACHEGROUP]) ) {
                 $works = false;
             }
@@ -246,7 +246,7 @@
         function testTimberLoaderCacheTransients() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
             sleep($time + 1);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
@@ -261,7 +261,7 @@
             wp_set_current_user(1);
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $r1 = rand(0, 999999);
             $r2 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false));
@@ -270,7 +270,7 @@
             $str_new = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r2), array(600, false));
             $this->assertNotEquals($str_old, $str_new);
             self::_unswapFiles();
-            
+
         }
 
         function _swapFiles() {
@@ -286,7 +286,7 @@
         function testTimberLoaderCacheTransientsAdminLoggedOut() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $r1 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false));
             self::_swapFiles();
@@ -299,7 +299,7 @@
         function testTimberLoaderCacheTransientsAdminLoggedOutWithSiteCache() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $r1 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false), \Timber\Loader::CACHE_SITE_TRANSIENT);
             self::_swapFiles();
@@ -314,7 +314,7 @@
             $_wp_using_ext_object_cache = true;
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $r1 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false), \Timber\Loader::CACHE_OBJECT);
             self::_swapFiles();
@@ -330,7 +330,7 @@
             $_wp_using_ext_object_cache = true;
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             $r1 = rand(0, 999999);
             $r2 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => $r1), $time);
@@ -347,7 +347,7 @@
         function testTimberLoaderCacheTransientsButKeepOtherTransients() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new TimberPost($pid);
+            $post = new Timber\Post($pid);
             set_transient( 'random_600', 'foo', 600 );
             $random_post = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), 600);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
@@ -367,7 +367,7 @@
         public function _get_cache_key() {
             return 'iamakey';
         }
-    } 
+    }
 
 	function my_test_callback(){
 		return "lbj";

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -180,7 +180,7 @@
         function testTwigCache(){
         	$cache_dir = __DIR__.'/../cache/twig';
         	if (is_dir($cache_dir)){
-        		TimberLoader::rrmdir($cache_dir);
+        		Timber\Loader::rrmdir($cache_dir);
         	}
         	$this->assertFileNotExists($cache_dir);
         	Timber::$cache = true;
@@ -190,7 +190,7 @@
         	sleep(1);
         	$this->assertFileExists($cache_dir);
         	Timber::$cache = false;
-        	$loader = new TimberLoader();
+        	$loader = new Timber\Loader();
         	$loader->clear_cache_twig();
         	$this->assertFileNotExists($cache_dir);
         }
@@ -203,7 +203,7 @@
             sleep(1);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post), 600);
             $this->assertEquals($str_old, $str_new);
-            $loader = new TimberLoader();
+            $loader = new Timber\Loader();
             $clear = $loader->clear_cache_timber();
             $this->assertGreaterThan(0, $clear);
             global $wpdb;
@@ -223,7 +223,7 @@
             sleep(1);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post), 600, \Timber\Loader::CACHE_OBJECT);
             $this->assertEquals($str_old, $str_new);
-            $loader = new TimberLoader();
+            $loader = new Timber\Loader();
             $clear = $loader->clear_cache_timber(\Timber\Loader::CACHE_OBJECT);
             $this->assertTrue($clear);
             $works = true;

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -13,30 +13,30 @@
         function testTransientLock() {
 
             $transient = $this->_generate_transient_name();
-            TimberHelper::_lock_transient( $transient, 5 );
-            $this->assertTrue( TimberHelper::_is_transient_locked( $transient ) );
+            Timber\Helper::_lock_transient( $transient, 5 );
+            $this->assertTrue( Timber\Helper::_is_transient_locked( $transient ) );
         }
 
         function testTransientUnlock() {
             $transient = $this->_generate_transient_name();
-            TimberHelper::_lock_transient( $transient, 5 );
-            TimberHelper::_unlock_transient( $transient, 5 );
-            $this->assertFalse( TimberHelper::_is_transient_locked( $transient ) );
+            Timber\Helper::_lock_transient( $transient, 5 );
+            Timber\Helper::_unlock_transient( $transient, 5 );
+            $this->assertFalse( Timber\Helper::_is_transient_locked( $transient ) );
         }
 
         function testTransientExpire() {
             $transient = $this->_generate_transient_name();
 
-            TimberHelper::_lock_transient( $transient, 1 );
+            Timber\Helper::_lock_transient( $transient, 1 );
             sleep(2);
-            $this->assertFalse( TimberHelper::_is_transient_locked( $transient ) );
+            $this->assertFalse( Timber\Helper::_is_transient_locked( $transient ) );
         }
 
         function testTransientLocksInternal() {
             $transient = $this->_generate_transient_name();
 
-            $is_locked = TimberHelper::transient( $transient, function() use ( $transient ) {
-                return TimberHelper::_is_transient_locked( $transient );
+            $is_locked = Timber\Helper::transient( $transient, function() use ( $transient ) {
+                return Timber\Helper::_is_transient_locked( $transient );
             }, 30 );
 
             $this->assertTrue( $is_locked );
@@ -45,8 +45,8 @@
         function testTransientLocksExternal() {
             $transient = $this->_generate_transient_name();
 
-            TimberHelper::_lock_transient($transient, 30);
-            $get_transient = TimberHelper::transient( $transient, '__return_true', 30 );
+            Timber\Helper::_lock_transient($transient, 30);
+            $get_transient = Timber\Helper::transient( $transient, '__return_true', 30 );
 
             $this->assertFalse( $get_transient );
         }
@@ -54,7 +54,7 @@
 		function testTransientAsAnonymousFunction(){
             $transient = $this->_generate_transient_name();
 
-			$result = TimberHelper::transient( $transient, function(){
+			$result = Timber\Helper::transient( $transient, function(){
 				return 'pooptime';
 			}, 200);
 			$this->assertEquals( $result, 'pooptime');
@@ -63,11 +63,11 @@
         function testSetTransient() {
             $transient = $this->_generate_transient_name();
 
-            $first_value = TimberHelper::transient( $transient, function(){
+            $first_value = Timber\Helper::transient( $transient, function(){
                 return 'first_value';
             }, 30 );
 
-            $second_value = TimberHelper::transient( $transient, function(){
+            $second_value = Timber\Helper::transient( $transient, function(){
                 return 'second_value';
             }, 30 );
 
@@ -77,11 +77,11 @@
         function testDisableTransients() {
             $transient = $this->_generate_transient_name();
 
-            $first_value = TimberHelper::transient( $transient, function(){
+            $first_value = Timber\Helper::transient( $transient, function(){
                 return 'first_value';
             }, 30 );
 
-            $second_value = TimberHelper::transient( $transient, function(){
+            $second_value = Timber\Helper::transient( $transient, function(){
                 return 'second_value';
             }, false );
 
@@ -91,17 +91,17 @@
 		function testTransientAsString(){
             $transient = $this->_generate_transient_name();
 
-			$result = TimberHelper::transient( $transient, 'my_test_callback', 200);
+			$result = Timber\Helper::transient( $transient, 'my_test_callback', 200);
 			$this->assertEquals($result, 'lbj');
 		}
 
         function testTransientLocked() {
             $transient = $this->_generate_transient_name();
 
-            TimberHelper::_lock_transient($transient, 30);
+            Timber\Helper::_lock_transient($transient, 30);
 
             // Transient is locked and won't be forced, so it should return false
-            $get_transient = TimberHelper::transient( $transient, '__return_true' );
+            $get_transient = Timber\Helper::transient( $transient, '__return_true' );
 
             $this->assertFalse( $get_transient );
         }
@@ -109,8 +109,8 @@
         function testTransientForce() {
             $transient = $this->_generate_transient_name();
 
-            TimberHelper::_lock_transient($transient, 30);
-            $get_transient = TimberHelper::transient( $transient, '__return_true', 0, 5, true );
+            Timber\Helper::_lock_transient($transient, 30);
+            $get_transient = Timber\Helper::transient( $transient, '__return_true', 0, 5, true );
 
             $this->assertTrue( $get_transient );
         }
@@ -118,10 +118,10 @@
         function testTransientForceAllFilter() {
             $transient = $this->_generate_transient_name();
 
-            TimberHelper::_lock_transient($transient, 30);
+            Timber\Helper::_lock_transient($transient, 30);
 
             add_filter( 'timber_force_transients', '__return_true' );
-            $get_transient = TimberHelper::transient( $transient, '__return_true' );
+            $get_transient = Timber\Helper::transient( $transient, '__return_true' );
             remove_filter( 'timber_force_transients', '__return_true' );
 
             $this->assertTrue( $get_transient );
@@ -152,10 +152,10 @@
         function testTransientForceFilter() {
             $transient = $this->_generate_transient_name();
 
-            TimberHelper::_lock_transient($transient, 30);
+            Timber\Helper::_lock_transient($transient, 30);
 
             add_filter( 'timber_force_transient_' . $transient, '__return_true' );
-            $get_transient = TimberHelper::transient( $transient, '__return_true' );
+            $get_transient = Timber\Helper::transient( $transient, '__return_true' );
             remove_filter( 'timber_force_transient_' . $transient, '__return_true' );
 
             $this->assertTrue( $get_transient );
@@ -164,13 +164,13 @@
         function testExpireTransient() {
             $transient = $this->_generate_transient_name();
 
-            $first_value = TimberHelper::transient( $transient, function(){
+            $first_value = Timber\Helper::transient( $transient, function(){
                 return 'first_value';
             }, 1 );
 
             sleep(2);
 
-            $second_value = TimberHelper::transient( $transient, function(){
+            $second_value = Timber\Helper::transient( $transient, function(){
                 return 'second_value';
             }, 1 );
 

--- a/tests/test-timber-comment-avatar.php
+++ b/tests/test-timber-comment-avatar.php
@@ -8,7 +8,7 @@
 			}
 			$post_id = $this->factory->post->create();
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 
 			# test default gravatr holding image
 			$avatar = $comment->avatar("mystery");
@@ -20,7 +20,7 @@
 			update_option('show_avatars', false);
 			$post_id = $this->factory->post->create();
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 
 			# test default gravatr holding image
 			$avatar = $comment->avatar();
@@ -34,7 +34,7 @@
 			}
 			$post_id = $this->factory->post->create();
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 
 			# test default gravatr holding image
 			$avatar = $comment->avatar(92, "blank");
@@ -48,7 +48,7 @@
 			}
 			$post_id = $this->factory->post->create();
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 
 			# test default gravatr holding image
 			$avatar = $comment->avatar(92, "gravatar_default");
@@ -62,13 +62,13 @@
 			}
 			$post_id = $this->factory->post->create();
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_author' => 'jarednova', 'comment_author_email' => 'jarednova@upstatement.com'));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 			$gravatar = md5(file_get_contents($comment->avatar()));
 			/* this keeps changing b/c of compression tweaks on WP.org, disabling the test */
 			//$this->assertEquals($gravatar, md5(file_get_contents(dirname(__FILE__).'/assets/jarednova.jpeg')));
 
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_author' => 'jarednova', 'comment_author_email' => 'notjared@upstatement.com'));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 			$not_gravatar = md5(file_get_contents($comment->avatar()));
 			$this->assertNotEquals($not_gravatar, md5(file_get_contents(dirname(__FILE__).'/assets/jarednova.jpeg')));
 		}
@@ -80,7 +80,7 @@
 			$theme_url = get_theme_root_uri().'/'.get_stylesheet();
 			$post_id = $this->factory->post->create();
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
-			$comment = new TimberComment($comment_id);
+			$comment = new Timber\Comment($comment_id);
 
 			# test default gravatr holding image
 			$avatar = $comment->avatar(32, "mystery");

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -97,7 +97,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'These pretzels are making me thirsty.', 'user_id' => $kramer, 'comment_date' => '2015-08-21 03:24:07'));
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'Perhaps there’s more to Newman than meets the eye.', 'comment_date' => '2015-08-21 03:25:07'));
 		$child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'No, there’s less.', 'comment_parent' => $comment_id, 'comment_date' => '2015-08-21 03:26:07'));
-		$post = new TimberPost($post_id);
+		$post = new Timber\Post($post_id);
 		$comments = $post->comments();
 		$this->assertEquals(2, count($comments));
 		$this->assertEquals(1, count($comments[1]->children()));
@@ -110,8 +110,8 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$elaine = $this->factory->user->create(array('display_name' => 'Elaine Benes'));
 		$kramer = $this->factory->user->create(array('display_name' => 'Kramer'));
 		$peterman = $this->factory->user->create(array('display_name' => 'J. Peterman'));
-		
-		
+
+
 		$post_id = $this->factory->post->create(array('post_date' => '2016-11-28 02:58:18'));
 		//1st parent @4:58am
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'These pretzels are making me thirsty.', 'user_id' => $kramer, 'comment_date' => '2016-11-28 04:58:18'));

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -5,7 +5,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 	function testComment(){
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertEquals('Timber\Comment', get_class($comment));
 		$this->assertEquals($comment_id, $comment->ID);
 	}
@@ -15,7 +15,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
 		update_comment_meta( $comment_id, 'rebney', 'Winnebago Man');
 		update_comment_meta( $comment_id, 'quote', 'Will you do me a kindness?');
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertEquals('Winnebago Man', $comment->rebney);
 	}
 
@@ -23,7 +23,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$quote = 'Jerry, just remember, it’s not a lie if you believe it.';
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$str = Timber::compile_string('{{comment}}', array('comment' => $comment));
 		$this->assertEquals('<p>'.$quote.'</p>', $str);
 	}
@@ -32,7 +32,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$costanza_quote = "Divorce is always hard. Especially on the kids. ‘Course I am the result of my parents having stayed together so ya never know.";
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $costanza_quote));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertEquals('<p>'.$costanza_quote.'</p>', $comment->content());
 	}
 
@@ -40,11 +40,11 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$kramer_quote = "Oh, you gotta eat before surgery. You need your strength.";
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $kramer_quote));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertTrue($comment->approved());
 
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'You ever dream in 3-D? It’s like the Boogie Man is coming RIGHT AT YOU.', 'comment_approved' => false));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertFalse($comment->approved());
 	}
 
@@ -52,7 +52,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$quote = "So he just shaves his head for no reason? That’s like using a wheelchair for the fun of it!";
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote, 'comment_date' => '2015-08-21 03:24:07'));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertEquals('August 21, 2015', $comment->date());
 	}
 
@@ -60,7 +60,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$quote = "My grandmother used to swear by this, but personally I was always skeptical.";
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote, 'comment_date' => '2015-08-21 03:24:07'));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$this->assertEquals('3:24 am', $comment->time());
 	}
 
@@ -68,7 +68,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$comment_text = "Try the soup";
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $comment_text, 'comment_date' => '2015-08-21 03:24:07'));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$link = $comment->reply_link('Respond');
 		$this->assertEquals('Respond', strip_tags($link));
 	}
@@ -76,7 +76,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 	function testAnonymousComment() {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'Mystery', 'user_id' => 0, 'comment_author' => false));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$twig_string = '{{comment.author.name}}';
 		$result = Timber::compile_string($twig_string, array('comment' => $comment));
 		$this->assertEquals('Anonymous', $result);
@@ -85,7 +85,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 	function testAnonymousCommentWithName() {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'Mystery', 'user_id' => 0, 'comment_author' => 'Milhouse Van Houten'));
-		$comment = new TimberComment($comment_id);
+		$comment = new Timber\Comment($comment_id);
 		$twig_string = '{{comment.author.name}}';
 		$result = Timber::compile_string($twig_string, array('comment' => $comment));
 		$this->assertEquals('Milhouse Van Houten', $result);

--- a/tests/test-timber-core.php
+++ b/tests/test-timber-core.php
@@ -1,6 +1,6 @@
 <?php
 
-class TimberCoreTester extends TimberPost {
+class TimberCoreTester extends Timber\Post {
 
 	public $public = 'public A';
 	protected $protected = 'protected A';

--- a/tests/test-timber-custom-fields.php
+++ b/tests/test-timber-custom-fields.php
@@ -5,21 +5,21 @@ class TestTimberCustomFields extends Timber_UnitTestCase {
 	function testPostCustomField(){
 		$post_id = $this->factory->post->create();
 		update_post_meta($post_id, 'gameshow', 'numberwang');
-		$post = new TimberPost($post_id);
+		$post = new Timber\Post($post_id);
 		$this->assertEquals('numberwang', $post->gameshow);
 	}
 
 	function testPostCustomFieldMethodConflict(){
 		$post_id = $this->factory->post->create(array('post_title' => 'foo'));
 		update_post_meta($post_id, 'title', 'bar');
-		$post = new TimberPost($post_id);
+		$post = new Timber\Post($post_id);
 		$str = '{{post.title}}';
 		$result = Timber::compile_string($str, array('post' => $post));
 		$this->assertEquals('foo', $result);
 		//
 		$str = '{{post.post_title}}';
 		update_post_meta($post_id, 'post_title', 'jiggypoof');
-		$post = new TimberPost($post_id);
+		$post = new Timber\Post($post_id);
 		$result = Timber::compile_string($str, array('post' => $post));
 		$this->assertEquals('foo', $result);
 		$str = '{{post.custom.post_title}}';
@@ -30,7 +30,7 @@ class TestTimberCustomFields extends Timber_UnitTestCase {
 	function testPostCustomFieldPropertyConflict(){
 		$post_id = $this->factory->post->create(array('post_title' => 'foo'));
 		update_post_meta($post_id, 'post_title', 'bar');
-		$post = new TimberPost($post_id);
+		$post = new Timber\Post($post_id);
 		$str = '{{post.title}}';
 		$result = Timber::compile_string($str, array('post' => $post));
 		$this->assertEquals('foo', $result);

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -4,7 +4,7 @@
 
 		function testDate(){
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = 'I am from {{post.date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.date('F j, Y'), $str);
@@ -22,7 +22,7 @@
 
 		function testTime(){
 			$pid = $this->factory->post->create(array('post_date' => '2016-07-07 20:03:00'));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = 'Posted at {{post.time}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('Posted at 8:03 pm', $str);
@@ -30,7 +30,7 @@
 
 		function testPostDisplayDate(){
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = 'I am from {{post.date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.date('F j, Y'), $str);
@@ -38,7 +38,7 @@
 
 		function testPostDate(){
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = 'I am from {{post.post_date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.$post->post_date, $str);
@@ -46,7 +46,7 @@
 
 		function testPostDateWithFilter(){
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = 'I am from {{post.post_date|date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.date('F j, Y'), $str);
@@ -55,7 +55,7 @@
 		function testModifiedDate(){
 			$date = date('F j, Y @ g:i a');
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = "I was modified {{ post.modified_date('F j, Y @ g:i a') }}";
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I was modified '.$date, $str);
@@ -63,7 +63,7 @@
 
 		function testModifiedDateFilter() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			add_filter('get_the_modified_date', function($the_date) {
 				return 'foobar';
 			});
@@ -75,7 +75,7 @@
 		function testModifiedTime(){
 			$date = date('F j, Y @ g:i a');
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$twig = "I was modified {{post.modified_time('F j, Y @ g:i a')}}";
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I was modified '.$date, $str);
@@ -90,7 +90,7 @@
 
 		function testModifiedTimeFilter() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			add_filter('get_the_modified_time', function($the_date) {
 				return 'foobar';
 			});

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -21,7 +21,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 	function testCommentMetaFilter() {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
-		$comment = new TimberComment( $comment_id );
+		$comment = new Timber\Comment( $comment_id );
 		$comment->update( 'ghost', 'busters' );
 		add_filter( 'timber_comment_get_meta_field', array( $this, 'filter_timber_comment_get_meta_field' ), 10, 4 );
 		$this->assertEquals( $comment->meta( 'ghost' ), 'busters' );

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -53,7 +53,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 
 	function testTermMetaFilter() {
 		$tid = $this->factory->term->create();
-		$term = new TimberTerm( $tid );
+		$term = new Timber\Term( $tid );
 		add_filter( 'timber_term_get_meta_field', array( $this, 'filter_timber_term_get_meta_field' ), 10, 4 );
 		$term->meta( 'panic', 'oh yeah' );
 		remove_filter( 'timber_term_get_meta_field', array( $this, 'filter_timber_term_get_meta_field' ) );

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -37,7 +37,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 
 	function testUserMetaFilter() {
 		$uid = $this->factory->user->create();
-		$user = new TimberUser( $uid );
+		$user = new Timber\User( $uid );
 		$user->update( 'jared', 'novack' );
 		add_filter( 'timber_user_get_meta_field', array( $this, 'filter_timber_user_get_meta_field' ), 10, 4 );
 		$this->assertEquals( $user->meta( 'jared' ), 'novack' );

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -5,7 +5,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 	function testPostMetaFieldFilter() {
 		$post_id = $this->factory->post->create();
 		update_post_meta( $post_id, 'Frank', 'Drebin' );
-		$tp = new TimberPost( $post_id );
+		$tp = new Timber\Post( $post_id );
 		add_filter( 'timber_post_get_meta_field', array( $this, 'filter_timber_post_get_meta_field' ), 10, 4 );
 		$this->assertEquals( 'Drebin', $tp->meta( 'Frank' ) );
 		remove_filter( 'timber_post_get_meta_field', array( $this, 'filter_timber_post_get_meta_field' ) );

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -4,7 +4,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 
 	function testToStringWithException() {
 		ob_start();
-		$wrapper = new TimberFunctionWrapper('TestTimberFunctionWrapper::isNum', array('hi'));
+		$wrapper = new Timber\FunctionWrapper('TestTimberFunctionWrapper::isNum', array('hi'));
 		echo $wrapper;
 		$content = trim(ob_get_contents());
 		ob_end_clean();
@@ -13,7 +13,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 
 	function testToStringWithoutException() {
 		ob_start();
-		$wrapper = new TimberFunctionWrapper('TestTimberFunctionWrapper::isNum', array(4));
+		$wrapper = new Timber\FunctionWrapper('TestTimberFunctionWrapper::isNum', array(4));
 		echo $wrapper;
 		$content = trim(ob_get_contents());
 		ob_end_clean();
@@ -22,7 +22,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 
 	function testToStringWithClassObject() {
 		ob_start();
-		$wrapper = new TimberFunctionWrapper(array($this, 'isNum'), array(4));
+		$wrapper = new Timber\FunctionWrapper(array($this, 'isNum'), array(4));
 		echo $wrapper;
 		$content = trim(ob_get_contents());
 		ob_end_clean();
@@ -31,7 +31,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 
 	function testToStringWithClassString() {
 		ob_start();
-		$wrapper = new TimberFunctionWrapper(array(get_class($this), 'isNum'), array(4));
+		$wrapper = new Timber\FunctionWrapper(array(get_class($this), 'isNum'), array(4));
 		echo $wrapper;
 		$content = trim(ob_get_contents());
 		ob_end_clean();

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -57,7 +57,7 @@
 
 		function testCommentForm() {
 			$post_id = $this->factory->post->create();
-			$form = TimberHelper::ob_function( 'comment_form', array( array(), $post_id ) );
+			$form = Timber\Helper::ob_function( 'comment_form', array( array(), $post_id ) );
 			$form = trim($form);
 			$this->assertStringStartsWith('<div id="respond"', $form);
 		}
@@ -66,7 +66,7 @@
         	//since we're testing with twentyfourteen -- need to remove its filters on wp_title
         	remove_all_filters('wp_title');
             remove_theme_support( 'title-tag' );
-        	$this->assertEquals('', TimberHelper::get_wp_title());
+        	$this->assertEquals('', Timber\Helper::get_wp_title());
         }
 
         function testWPTitleSingle(){
@@ -75,7 +75,7 @@
         	$post_id = $this->factory->post->create(array('post_title' => 'My New Post'));
         	$post = get_post($post_id);
             $this->go_to( site_url( '?p='.$post_id ) );
-        	$this->assertEquals('My New Post', TimberHelper::get_wp_title());
+        	$this->assertEquals('My New Post', Timber\Helper::get_wp_title());
         }
 
 		function testCloseTags() {
@@ -86,13 +86,13 @@
 
 		function testArrayToObject(){
 			$arr = array('jared' => 'super cool');
-			$obj = TimberHelper::array_to_object($arr);
+			$obj = Timber\Helper::array_to_object($arr);
 			$this->assertEquals('super cool', $obj->jared);
 		}
 
 		function testArrayArrayToObject() {
 			$arr = array('jared' => 'super cool', 'prefs' => array('food' => 'spicy', 'women' => 'spicier'));
-			$obj = TimberHelper::array_to_object($arr);
+			$obj = Timber\Helper::array_to_object($arr);
 			$this->assertEquals('spicy', $obj->prefs->food);
 		}
 
@@ -104,9 +104,9 @@
 			$obj2->name = 'austin';
 			$obj2->skill = 'cooking';
 			$arr = array($obj1, $obj2);
-			$index = TimberHelper::get_object_index_by_property($arr, 'skill', 'cooking');
+			$index = Timber\Helper::get_object_index_by_property($arr, 'skill', 'cooking');
 			$this->assertEquals(1, $index);
-			$obj = TimberHelper::get_object_by_property($arr, 'skill', 'cooking');
+			$obj = Timber\Helper::get_object_by_property($arr, 'skill', 'cooking');
 			$this->assertEquals('austin', $obj->name);
 		}
 
@@ -115,7 +115,7 @@
 			$obj1->name = 'mark';
 			$obj1->skill = 'acro yoga';
 			$arr = array($obj1);
-			$result = TimberHelper::get_object_by_property($arr, 'skill', 'cooking');
+			$result = Timber\Helper::get_object_by_property($arr, 'skill', 'cooking');
 			$this->assertFalse($result);
 		}
 
@@ -139,13 +139,13 @@
 			$obj1 = new stdClass();
 			$obj1->name = 'mark';
 			$obj1->skill = 'acro yoga';
-			$obj = TimberHelper::get_object_by_property($obj1, 'skill', 'cooking');
+			$obj = Timber\Helper::get_object_by_property($obj1, 'skill', 'cooking');
 		}
 
 		function testTimers() {
-			$start = TimberHelper::start_timer();
+			$start = Timber\Helper::start_timer();
 			sleep(1);
-			$end = TimberHelper::stop_timer($start);
+			$end = Timber\Helper::stop_timer($start);
 			$this->assertContains(' seconds.', $end);
 			$time = str_replace(' seconds.', '', $end);
 			$this->assertGreaterThan(1, $time);
@@ -153,35 +153,35 @@
 
 		function testArrayTruncate() {
 			$arr = array('Buster', 'GOB', 'Michael', 'Lindsay');
-			$arr = TimberHelper::array_truncate($arr, 2);
+			$arr = Timber\Helper::array_truncate($arr, 2);
 			$this->assertContains('Buster', $arr);
 			$this->assertEquals(2, count($arr));
 			$this->assertFalse(in_array('Lindsay', $arr));
 		}
 
 		function testIsTrue() {
-			$true = TimberHelper::is_true('true');
+			$true = Timber\Helper::is_true('true');
 			$this->assertTrue($true);
-			$false = TimberHelper::is_true('false');
+			$false = Timber\Helper::is_true('false');
 			$this->assertFalse($false);
-			$estelleGetty = TimberHelper::is_true('Estelle Getty');
+			$estelleGetty = Timber\Helper::is_true('Estelle Getty');
 			$this->assertTrue($estelleGetty);
 		}
 
 		function testIsEven() {
-			$this->assertTrue(TimberHelper::iseven(2));
-			$this->assertFalse(TimberHelper::iseven(7));
+			$this->assertTrue(Timber\Helper::iseven(2));
+			$this->assertFalse(Timber\Helper::iseven(7));
 		}
 
 		function testIsOdd() {
-			$this->assertFalse(TimberHelper::isodd(2));
-			$this->assertTrue(TimberHelper::isodd(7));
+			$this->assertFalse(Timber\Helper::isodd(2));
+			$this->assertTrue(Timber\Helper::isodd(7));
 		}
 
 		function testErrorLog() {
 			ob_start();
-			$this->assertTrue(TimberHelper::error_log('foo'));
-			$this->assertTrue(TimberHelper::error_log(array('Dark Helmet', 'Barf')));
+			$this->assertTrue(Timber\Helper::error_log('foo'));
+			$this->assertTrue(Timber\Helper::error_log(array('Dark Helmet', 'Barf')));
 			$data = ob_get_flush();
 		}
 
@@ -196,7 +196,7 @@
 			$boo->name = 'Robbie';
 			$boo->year = 1989;
 			$people = array($lauren, $michael, $boo);
-			TimberHelper::osort($people, 'year');
+			Timber\Helper::osort($people, 'year');
 			$this->assertEquals('Michael', $people[0]->name);
 			$this->assertEquals('Lauren', $people[1]->name);
 			$this->assertEquals('Robbie', $people[2]->name);

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -54,7 +54,7 @@
 			$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 			add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 			$data = array();
-			$data['post'] = new TimberPost( $post_id );
+			$data['post'] = new Timber\Post( $post_id );
 			$data['size'] = $size;
 			$data['crop'] = 'default';
 			Timber::compile( $template, $data );

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -16,17 +16,17 @@
 
 		function testIsAnimatedGif() {
 			$image = TestTimberImage::copyTestImage('robocop.gif');
-			$this->assertTrue( TimberImageHelper::is_animated_gif($image) );
+			$this->assertTrue( Timber\ImageHelper::is_animated_gif($image) );
 		}
 
 		function testIsRegularGif() {
 			$image = TestTimberImage::copyTestImage('boyer.gif');
-			$this->assertFalse( TimberImageHelper::is_animated_gif($image) );
+			$this->assertFalse( Timber\ImageHelper::is_animated_gif($image) );
 		}
 
 		function testIsNotGif() {
 			$arch = TestTimberImage::copyTestImage('arch.jpg');
-			$this->assertFalse( TimberImageHelper::is_animated_gif($arch) );
+			$this->assertFalse( Timber\ImageHelper::is_animated_gif($arch) );
 		}
 
 		function testServerLocation() {
@@ -72,8 +72,8 @@
 			$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );
 			$upload_dir = wp_upload_dir();
 			$image = $upload_dir['url'].'/eastern.jpg';
-			$new_file = TimberImageHelper::letterbox( $image, 500, 500, '#CCC', true );
-			$location_of_image = TimberImageHelper::get_server_location( $new_file );
+			$new_file = Timber\ImageHelper::letterbox( $image, 500, 500, '#CCC', true );
+			$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 			$this->addFile( $location_of_image );
 			$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 			//whats the bg/color of the image

--- a/tests/test-timber-image-letterbox.php
+++ b/tests/test-timber-image-letterbox.php
@@ -16,8 +16,8 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 		$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
 		$image = $upload_dir['url'].'/eastern.jpg';
-		$new_file = TimberImageHelper::letterbox( $image, 500, 500, '#CCC', true );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::letterbox( $image, 500, 500, '#CCC', true );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->addFile( $location_of_image );
 		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 		//whats the bg/color of the image
@@ -27,9 +27,9 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 	function testLetterboxColorChange() {
 		$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
-		$new_file_red = TimberImageHelper::letterbox( $upload_dir['url'].'/eastern.jpg', 500, 500, '#FF0000' );
-		$new_file = TimberImageHelper::letterbox( $upload_dir['url'].'/eastern.jpg', 500, 500, '#00FF00' );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file_red = Timber\ImageHelper::letterbox( $upload_dir['url'].'/eastern.jpg', 500, 500, '#FF0000' );
+		$new_file = Timber\ImageHelper::letterbox( $upload_dir['url'].'/eastern.jpg', 500, 500, '#00FF00' );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->addFile( $location_of_image );
 		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 		//whats the bg/color of the image
@@ -44,8 +44,8 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 		$base_file = 'eastern-trans.png';
 		$file_loc = TestTimberImage::copyTestImage( $base_file );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 500, 500, '00FF00', true );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 500, 500, '00FF00', true );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->addFile( $location_of_image );
 		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 		//whats the bg/color of the image
@@ -58,8 +58,8 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 		$base_file = 'eastern-trans.png';
 		$file_loc = TestTimberImage::copyTestImage( $base_file );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 500, 500 );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 500, 500 );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->addFile( $location_of_image );
 		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 		// whats the bg/color of the image?
@@ -72,8 +72,8 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 		$base_file = 'panam.gif';
 		$file_loc = TestTimberImage::copyTestImage( $base_file );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 300, 100, '00FF00', true );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::letterbox( $upload_dir['url'].'/'.$base_file, 300, 100, '00FF00', true );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->addFile( $location_of_image );
 		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 300, 100));
 		//whats the bg/color of the image
@@ -85,8 +85,8 @@ class TestTimberImageLetterbox extends TimberImage_UnitTestCase {
 		$data = array();
 		$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::letterbox( $upload_dir['url'].'/eastern.jpg', 500, 500, '#FFFFFF', true );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::letterbox( $upload_dir['url'].'/eastern.jpg', 500, 500, '#FFFFFF', true );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->addFile( $location_of_image );
 		$this->assertTrue (TestTimberImage::checkSize($location_of_image, 500, 500));
 		//whats the bg/color of the image

--- a/tests/test-timber-image-multisite.php
+++ b/tests/test-timber-image-multisite.php
@@ -17,7 +17,7 @@
 			$blog_id = TestTimberMultisite::createSubDomainSite();
 			$this->assertGreaterThan(1, $blog_id);
 			$pretend_image = 'http://example.org/wp-content/2015/08/fake-pic.jpg';
-			$is_external = TimberURLHelper::is_external_content( $pretend_image );
+			$is_external = Timber\URLHelper::is_external_content( $pretend_image );
 			$this->assertFalse($is_external);
 		}
 
@@ -30,7 +30,7 @@
 			$this->assertGreaterThan(1, $blog_id);
 			$blog_details = get_blog_details($blog_id);
 			$pretend_image = 'http://example.org/wp-content/2015/08/fake-pic.jpg';
-			$is_external = TimberURLHelper::is_external_content( $pretend_image );
+			$is_external = Timber\URLHelper::is_external_content( $pretend_image );
 			$this->assertFalse($is_external);
 		}
 

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -14,7 +14,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 100, 300, 'center');
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_black = TestTimberImage::checkPixel($resized, 10, 20, '#000');
 		$is_white = TestTimberImage::checkPixel($resized, 10, 120, '#FFFFFF');
@@ -30,7 +30,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 100, 200, false);
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_red = TestTimberImage::checkPixel($resized, 20, 20, '#ff0000', '#ff0800');
 		$is_green = TestTimberImage::checkPixel($resized, 0, 100, '#00ff00');
@@ -52,7 +52,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 100, 300, 'right');
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_magenta = TestTimberImage::checkPixel($resized, 50, 50, '#ff00ff');
 		$this->assertTrue( $is_magenta );
@@ -63,7 +63,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'top');
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_magenta = TestTimberImage::checkPixel($resized, 290, 90, '#ff00ff');
 		$this->assertTrue( $is_magenta );
@@ -74,7 +74,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'bottom');
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_teal = TestTimberImage::checkPixel($resized, 290, 90, '#00ffff');
 		$this->assertTrue( $is_teal );
@@ -85,7 +85,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'bottom-center');
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_teal = TestTimberImage::checkPixel($resized, 200, 50, '#00ffff');
 		$this->assertTrue( $is_teal );
@@ -96,7 +96,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'top-center');
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_red = TestTimberImage::checkPixel($resized, 100, 50, '#ff0000', '#ff0800');
 		$this->assertTrue( $is_red );
@@ -107,7 +107,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = Timber\ImageHelper::resize($arch, false, 250);
 
 		$resized = str_replace('http://example.org', '', $resized);
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 
 		$is_sized = TestTimberImage::checkSize($resized, 375, 250);
 		$this->assertTrue( $is_sized );
@@ -128,7 +128,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
 		$this->assertLessThanOrEqual( 1, substr_count($resized, 'example.org') );
 		// make sure the image has been resized
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 		$this->assertTrue( TestTimberImage::checkSize($resized, 50, 50), 'image should be resized' );
 
 	}
@@ -150,7 +150,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
 		$this->assertLessThanOrEqual( 1, substr_count($resized, 'example.org') );
 		// make sure the image has been resized
-		$resized = TimberUrlHelper::url_to_file_system( $resized );
+		$resized = Timber\URLHelper::url_to_file_system( $resized );
 		$this->assertTrue( TestTimberImage::checkSize($resized, 50, 50), 'image should be resized' );
 
 	}

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -11,7 +11,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropCenter() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 100, 300, 'center');
+		$resized = Timber\ImageHelper::resize($cropper, 100, 300, 'center');
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -27,7 +27,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropFalse() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 100, 200, false);
+		$resized = Timber\ImageHelper::resize($cropper, 100, 200, false);
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -49,7 +49,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropRight() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 100, 300, 'right');
+		$resized = Timber\ImageHelper::resize($cropper, 100, 300, 'right');
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -60,7 +60,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropTop() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 300, 100, 'top');
+		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'top');
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -71,7 +71,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropBottom() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 300, 100, 'bottom');
+		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'bottom');
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -82,7 +82,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropBottomCenter() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 300, 100, 'bottom-center');
+		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'bottom-center');
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -93,7 +93,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropTopCenter() {
 		$cropper = TestTimberImage::copyTestImage('cropper.png');
-		$resized = TimberImageHelper::resize($cropper, 300, 100, 'top-center');
+		$resized = Timber\ImageHelper::resize($cropper, 300, 100, 'top-center');
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -104,7 +104,7 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 	function testCropHeight() {
 		$arch = TestTimberImage::copyTestImage('arch.jpg');
-		$resized = TimberImageHelper::resize($arch, false, 250);
+		$resized = Timber\ImageHelper::resize($arch, false, 250);
 
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
@@ -123,14 +123,14 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 
 		$img = 'https://raw.githubusercontent.com/timber/timber/master/tests/assets/arch-2night.jpg';
 		// test with a local and external file
-		$resized = TimberImageHelper::resize($img, 50, 50);
+		$resized = Timber\ImageHelper::resize($img, 50, 50);
 
 		// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
 		$this->assertLessThanOrEqual( 1, substr_count($resized, 'example.org') );
 		// make sure the image has been resized
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
 		$this->assertTrue( TestTimberImage::checkSize($resized, 50, 50), 'image should be resized' );
-		
+
 	}
 
 	function testWPMLurlLocal() {
@@ -144,15 +144,15 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		// test with a local and external file
 		$img = 'arch.jpg';
 		$img = TestTimberImage::copyTestImage($img);
-			
-		$resized = TimberImageHelper::resize($img, 50, 50);
+
+		$resized = Timber\ImageHelper::resize($img, 50, 50);
 
 		// make sure the base url has not been duplicated (https://github.com/timber/timber/issues/405)
 		$this->assertLessThanOrEqual( 1, substr_count($resized, 'example.org') );
 		// make sure the image has been resized
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
 		$this->assertTrue( TestTimberImage::checkSize($resized, 50, 50), 'image should be resized' );
-		
+
 	}
 
 }

--- a/tests/test-timber-image-retina.php
+++ b/tests/test-timber-image-retina.php
@@ -4,14 +4,14 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 
 	function testImageRetina() {
 		$file = TestTimberImage::copyTestImage();
-		$ret = TimberImageHelper::retina_resize($file, 2);
+		$ret = Timber\ImageHelper::retina_resize($file, 2);
 		$image = new Timber\Image( $ret );
 		$this->assertEquals( 3000, $image->width() );
 	}
 
 	function testImageBiggerRetina() {
 		$file = TestTimberImage::copyTestImage();
-		$ret = TimberImageHelper::retina_resize($file, 3);
+		$ret = Timber\ImageHelper::retina_resize($file, 3);
 		$image = new Timber\Image( $ret );
 		$this->assertEquals( 4500, $image->width() );
 	}

--- a/tests/test-timber-image-retina.php
+++ b/tests/test-timber-image-retina.php
@@ -5,14 +5,14 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 	function testImageRetina() {
 		$file = TestTimberImage::copyTestImage();
 		$ret = TimberImageHelper::retina_resize($file, 2);
-		$image = new TimberImage( $ret );
+		$image = new Timber\Image( $ret );
 		$this->assertEquals( 3000, $image->width() );
 	}
 
 	function testImageBiggerRetina() {
 		$file = TestTimberImage::copyTestImage();
 		$ret = TimberImageHelper::retina_resize($file, 3);
-		$image = new TimberImage( $ret );
+		$image = new Timber\Image( $ret );
 		$this->assertEquals( 4500, $image->width() );
 	}
 
@@ -34,7 +34,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$str = '{{post.thumbnail.src|retina}}';
 		$compiled = Timber::compile_string($str, $data);
 		$this->assertContains('@2x', $compiled);
-		$img = new TimberImage($compiled);
+		$img = new Timber\Image($compiled);
 		$this->assertEquals(500, $img->width());
 	}
 
@@ -56,7 +56,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$str = '{{post.thumbnail.src|retina(1.5)}}';
 		$compiled = Timber::compile_string($str, $data);
 		$this->assertContains('@1.5x', $compiled);
-		$img = new TimberImage($compiled);
+		$img = new Timber\Image($compiled);
 		$this->assertEquals(375, $img->width());
 	}
 
@@ -76,7 +76,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$data['post'] = new Timber\Post( $post_id );
 		$str = '{{post.thumbnail.src|resize(100, 50)|retina(3)}}';
 		$compiled = Timber::compile_string($str, $data);
-		$img = new TimberImage($compiled);
+		$img = new Timber\Image($compiled);
 		$this->assertContains('@3x', $compiled);
 		$this->assertEquals(300, $img->width());
 	}

--- a/tests/test-timber-image-retina.php
+++ b/tests/test-timber-image-retina.php
@@ -29,7 +29,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$post = new TimberPost( $post_id );
+		$post = new Timber\Post( $post_id );
 		$data['post'] = $post;
 		$str = '{{post.thumbnail.src|retina}}';
 		$compiled = Timber::compile_string($str, $data);
@@ -51,7 +51,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$post = new TimberPost( $post_id );
+		$post = new Timber\Post( $post_id );
 		$data['post'] = $post;
 		$str = '{{post.thumbnail.src|retina(1.5)}}';
 		$compiled = Timber::compile_string($str, $data);
@@ -73,7 +73,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$data['post'] = new TimberPost( $post_id );
+		$data['post'] = new Timber\Post( $post_id );
 		$str = '{{post.thumbnail.src|resize(100, 50)|retina(3)}}';
 		$compiled = Timber::compile_string($str, $data);
 		$img = new TimberImage($compiled);

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -178,8 +178,8 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data = array();
 		$file_loc = self::copyTestImage( 'stl.jpg' );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::resize( $upload_dir['url'].'/stl.jpg', 500, 200, 'default', true );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::resize( $upload_dir['url'].'/stl.jpg', 500, 200, 'default', true );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$size = getimagesize( $location_of_image );
 		$this->assertEquals( 500, $size[0] );
 	}
@@ -188,8 +188,8 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data = array();
 		$file_loc = self::copyTestImage( 'stl.jpg' );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::resize( $upload_dir['url'].'/stl.jpg', 500, 300, 'default', true );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::resize( $upload_dir['url'].'/stl.jpg', 500, 300, 'default', true );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$size = getimagesize( $location_of_image );
 		$this->assertEquals( 500, $size[0] );
 		$this->assertEquals( 300, $size[1] );
@@ -234,11 +234,11 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	function testIsNotAGif() {
 		$image = self::copyTestImage('arch.jpg');
-		$this->assertFalse( TimberImageHelper::is_animated_gif($image) );
+		$this->assertFalse( Timber\ImageHelper::is_animated_gif($image) );
 	}
 
 	function testIsNotAGifFile() {
-		$this->assertFalse( TimberImageHelper::is_animated_gif('notreal.gif') );
+		$this->assertFalse( Timber\ImageHelper::is_animated_gif('notreal.gif') );
 	}
 
 	function testAnimatedGifResize() {
@@ -255,7 +255,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$resized_path = $upload_dir['path'].'/robocop-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.gif';
 		$this->addFile( $resized_path );
 		$this->assertFileExists( $resized_path );
-		$this->assertTrue(TimberImageHelper::is_animated_gif($resized_path));
+		$this->assertTrue(Timber\ImageHelper::is_animated_gif($resized_path));
 	}
 
 	function testImageArray() {
@@ -387,7 +387,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$file = 'eastern.jpg';
 		$file_loc = self::copyTestImage( $file );
 		$upload_dir = wp_upload_dir();
-		$filename = TimberImageHelper::get_resize_file_url( self::getTestImageURL($file, true), 300, 500, 'default' );
+		$filename = Timber\ImageHelper::get_resize_file_url( self::getTestImageURL($file, true), 300, 500, 'default' );
 		$expected = $upload_dir['relative'].$upload_dir['subdir'].'/eastern-300x500-c-default.jpg';
 		$this->assertEquals( $expected, $filename );
 	}
@@ -396,7 +396,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$file_loc = self::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
 		$url_src = $upload_dir['url'].'/eastern.jpg';
-		$filename = TimberImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
+		$filename = Timber\ImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
 		$this->assertEquals( $upload_dir['url'].'/eastern-300x500-c-default.jpg', $filename );
 	}
 
@@ -405,7 +405,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$file_loc = self::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
 		$url_src = $upload_dir['url'].'/eastern.jpg';
-		$filename = TimberImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
+		$filename = Timber\ImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
 		$this->assertEquals( $upload_dir['url'].'/eastern-300x500-c-default.jpg', $filename );
 		remove_filter( 'home_url', array($this, 'add_lang_to_home'), 1 );
 	}
@@ -414,7 +414,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$file_loc = self::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
 		$url_src = $upload_dir['url'].'/eastern.jpg';
-		$filename = TimberImageHelper::get_letterbox_file_url( $url_src, 300, 500, '#FFFFFF' );
+		$filename = Timber\ImageHelper::get_letterbox_file_url( $url_src, 300, 500, '#FFFFFF' );
 		$this->assertEquals( $upload_dir['url'].'/eastern-lbox-300x500-FFFFFF.jpg', $filename );
 	}
 
@@ -510,8 +510,8 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		}
 		$file_loc = self::copyTestImage( 'eastern-trans.png' );
 		$upload_dir = wp_upload_dir();
-		$new_file = TimberImageHelper::img_to_jpg( $upload_dir['url'].'/eastern-trans.png', '#FFFF00' );
-		$location_of_image = TimberImageHelper::get_server_location( $new_file );
+		$new_file = Timber\ImageHelper::img_to_jpg( $upload_dir['url'].'/eastern-trans.png', '#FFFF00' );
+		$location_of_image = Timber\ImageHelper::get_server_location( $new_file );
 		$this->assertFileExists( $location_of_image );
 		$image = imagecreatefromjpeg( $location_of_image );
 		$pixel_rgb = imagecolorat( $image, 1, 1 );
@@ -528,19 +528,19 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$file = self::copyTestImage( 'arch-2night.jpg' );
 		$data['test_image'] = $upload_dir['url'].'/arch-2night.jpg';
 		$data['crop'] = 'default';
-		$arch_2night = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$arch_2night = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		Timber::compile( 'assets/image-test.twig', $data );
 
 		$file = self::copyTestImage( 'arch.jpg' );
 		$data['test_image'] = $upload_dir['url'].'/arch.jpg';
 		$data['size'] = array( 'width' => 520, 'height' => 250 );
 		$data['crop'] = 'left';
-		$arch_regular = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$arch_regular = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		Timber::compile( 'assets/image-test.twig', $data );
 		$this->assertFileExists( $arch_regular );
 		$this->assertFileExists( $arch_2night );
 		//Delte the regular arch image
-		TimberImageHelper::delete_generated_files( $file );
+		Timber\ImageHelper::delete_generated_files( $file );
 		//The child of the regular arch image should be like
 		//poof-be-gone
 		$this->assertFileNotExists( $arch_regular );
@@ -557,16 +557,16 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data['test_image'] = $upload_dir['url'].'/city-museum.jpg';
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_500_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_500_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		$data['size'] = array( 'width' => 520, 'height' => 250 );
 		$data['crop'] = 'left';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_520_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_520_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		//make sure it generated the sizes we're expecting
 		$this->assertFileExists( $resized_500_file );
 		$this->assertFileExists( $resized_520_file );
 		//Now delete the "parent" image
-		TimberImageHelper::delete_generated_files( $file );
+		Timber\ImageHelper::delete_generated_files( $file );
 		//Have the children been deleted as well?
 		$this->assertFileNotExists( $resized_520_file );
 		$this->assertFileNotExists( $resized_500_file );
@@ -589,16 +589,16 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data['test_image'] = $upload_dir['url'].'/flag.png';
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_500_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_500_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		$data['size'] = array( 'width' => 520, 'height' => 250 );
 		$data['crop'] = 'left';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_520_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_520_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		//make sure it generated the sizes we're expecting
 		$this->assertFileExists( $resized_500_file );
 		$this->assertFileExists( $resized_520_file );
 		//Now delete the "parent" image
-		TimberImageHelper::delete_generated_files( $data['test_image'] );
+		Timber\ImageHelper::delete_generated_files( $data['test_image'] );
 		//Have the children been deleted as well?
 		$this->assertFileNotExists( $resized_520_file );
 		$this->assertFileNotExists( $resized_500_file );
@@ -621,11 +621,11 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data['test_image'] = $upload_dir['url'].'/flag.png';
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_500_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_500_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		$data['size'] = array( 'width' => 520, 'height' => 250 );
 		$data['crop'] = 'left';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_520_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_520_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		//make sure it generated the sizes we're expecting
 		$this->assertFileExists( $resized_500_file );
 		$this->assertFileExists( $resized_520_file );
@@ -653,17 +653,17 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data['test_image'] = $upload_dir['url'].'/flag.png';
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_500_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_500_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		$data['size'] = array( 'width' => 520, 'height' => 250 );
 		$data['crop'] = 'left';
 		Timber::compile( 'assets/image-test.twig', $data );
-		$resized_520_file = TimberImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
+		$resized_520_file = Timber\ImageHelper::get_resize_file_path( $data['test_image'], $data['size']['width'], $data['size']['height'], $data['crop'] );
 		//make sure it generated the sizes we're expecting
 		$this->assertFileExists( $resized_500_file );
 		$this->assertFileExists( $resized_520_file );
 		//Now delete the "parent" image
 		$post = new Timber\Image( $attach_id );
-		TimberImageHelper::delete_generated_files( $post->file_loc );
+		Timber\ImageHelper::delete_generated_files( $post->file_loc );
 		//Have the children been deleted as well?
 		$this->assertFileNotExists( $resized_520_file );
 		$this->assertFileNotExists( $resized_500_file );
@@ -677,11 +677,11 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$file = self::copyTestImage( 'city-museum.jpg' );
 		$upload_dir = wp_upload_dir();
 		$data['test_image'] = $upload_dir['url'].'/city-museum.jpg';
-		$new_file = TimberImageHelper::letterbox( $data['test_image'], 500, 500, '#00FF00' );
-		$letterboxed_file = TimberImageHelper::get_letterbox_file_path( $data['test_image'], 500, 500, '#00FF00' );
+		$new_file = Timber\ImageHelper::letterbox( $data['test_image'], 500, 500, '#00FF00' );
+		$letterboxed_file = Timber\ImageHelper::get_letterbox_file_path( $data['test_image'], 500, 500, '#00FF00' );
 		$this->assertFileExists( $letterboxed_file );
 		//Now delete the "parent" image
-		TimberImageHelper::delete_generated_files( $file );
+		Timber\ImageHelper::delete_generated_files( $file );
 		//Have the children been deleted as well?
 		$this->assertFileNotExists( $letterboxed_file );
 	}
@@ -751,7 +751,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		copy($source, $dest);
 		$image = $theme_url.'/cardinals.jpg';
 		$image = str_replace( 'http://example.org', '', $image );
-		$letterboxed = TimberImageHelper::letterbox( $image, 600, 300, '#FF0000' );
+		$letterboxed = Timber\ImageHelper::letterbox( $image, 600, 300, '#FF0000' );
 		$this->assertFileExists( realpath(get_template_directory().'/cardinals-lbox-600x300-FF0000.jpg') );
 		unlink( realpath(get_template_directory().'/cardinals-lbox-600x300-FF0000.jpg') );
 	}
@@ -905,7 +905,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	}
 
 	function testImageHelperInit() {
-		$helper = TimberImageHelper::init();
+		$helper = Timber\ImageHelper::init();
 		$this->assertTrue($helper);
 	}
 
@@ -1024,7 +1024,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
 
-		$resized_520_file = TimberImageHelper::resize($image->src, 520, 500);
+		$resized_520_file = Timber\ImageHelper::resize($image->src, 520, 500);
 
 		remove_filter('upload_dir', array($this, '_filter_upload'));
 

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -68,7 +68,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$pid = $this->factory->post->create();
 		$iid = self::get_image_attachment( $pid );
 		add_post_meta( $pid, '_thumbnail_id', $iid, true );
-		$post = new TimberPost($pid);
+		$post = new Timber\Post($pid);
 		return $post;
 	}
 
@@ -352,7 +352,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$data['post'] = new TimberPost( $post_id );
+		$data['post'] = new Timber\Post( $post_id );
 		$data['size'] = array( 'width' => 100, 'height' => 50 );
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/thumb-test.twig', $data );
@@ -379,7 +379,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		add_post_meta( $attach_id, '_wp_attachment_image_alt', $thumb_alt, true );
 		$data = array();
-		$data['post'] = new TimberPost( $post_id );
+		$data['post'] = new Timber\Post( $post_id );
 		$this->assertEquals( $data['post']->thumbnail()->alt(), $thumb_alt );
 	}
 
@@ -762,7 +762,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$photo = TimberURLHelper::get_rel_path($photo);
 		update_post_meta($pid, 'custom_photo', '/'.$photo);
 		$str = '{{TimberImage(post.custom_photo).width}}';
-		$post = new TimberPost($pid);
+		$post = new Timber\Post($pid);
 		$rendered = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals( 1500, $rendered );
 	}
@@ -825,7 +825,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$attach_id = wp_insert_attachment($attachment, $filename, $post_id);
 		add_post_meta($post_id, '_thumbnail_id', $attach_id, true);
 		$data = array();
-		$data['post'] = new TimberPost($post_id);
+		$data['post'] = new Timber\Post($post_id);
 		$data['size'] = 'timber-testPostThumbnailsNamed';
 		Timber::compile('assets/image-thumb-named.twig', $data);
 		$resized_path = $upload_dir['path'].'/flag-'.$width.'x'.$height.'-c-default.png';
@@ -847,7 +847,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$attach_id = wp_insert_attachment($attachment, $filename, $post_id);
 		add_post_meta($post_id, '_thumbnail_id', $attach_id, true);
 		$data = array();
-		$data['post'] = new TimberPost($post_id);
+		$data['post'] = new Timber\Post($post_id);
 		$data['size'] = 'medium';
 		$result = Timber::compile('assets/image-thumb-named.twig', $data);
 		$filename = 'flag-300x300-c-default.png';
@@ -949,7 +949,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 		$str = '{{ TimberImage(post).src }}';
 		$result = Timber::compile_string( $str, array('post' => $post) );
-		
+
 		$this->assertEquals($image->src(), $result);
 	}
 
@@ -1001,7 +1001,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	function testNoThumbnail() {
 		$pid = $this->factory->post->create();
-		$post = new TimberPost($pid);
+		$post = new Timber\Post($pid);
 		$str = Timber::compile_string('Image?{{post.thumbnail.src}}', array('post' => $post));
 		$this->assertEquals('Image?', $str);
 	}

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -330,7 +330,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	function testInitFromURL() {
 		$destination_path = self::copyTestImage();
-		$destination_path = TimberURLHelper::get_rel_path( $destination_path );
+		$destination_path = Timber\URLHelper::get_rel_path( $destination_path );
 		$destination_url = 'http://'.$_SERVER['HTTP_HOST'].$destination_path;
 		$image = new Timber\Image( $destination_url );
 		$this->assertEquals( $destination_url, $image->src() );
@@ -759,7 +759,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testImageWidthWithFilter() {
 		$pid = $this->factory->post->create();
 		$photo = $this->copyTestImage();
-		$photo = TimberURLHelper::get_rel_path($photo);
+		$photo = Timber\URLHelper::get_rel_path($photo);
 		update_post_meta($pid, 'custom_photo', '/'.$photo);
 		$str = '{{TimberImage(post.custom_photo).width}}';
 		$post = new Timber\Post($pid);
@@ -919,7 +919,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$result = Timber::compile_string($str);
 		$resized_url = str_replace('loading.gif', 'loading-200x0-c-default.gif', $gif_url);
 		$resized_path = str_replace('http://example.org', ABSPATH, $resized_url);
-		$resized_path = TimberURLHelper::remove_double_slashes($resized_path);
+		$resized_path = Timber\URLHelper::remove_double_slashes($resized_path);
 		$this->assertFileExists($resized_path);
 	}
 

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -74,7 +74,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	public static function get_timber_image_object($file = 'cropper.png') {
 		$iid = self::get_image_attachment(0, $file);
-		return new TimberImage($iid);
+		return new Timber\Image($iid);
 	}
 
 /* ----------------
@@ -125,7 +125,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
  	function testImageLink() {
  		self::setPermalinkStructure();
  		$attach = self::get_image_attachment();
- 		$image = new TimberImage($attach);
+ 		$image = new Timber\Image($attach);
  		$links = array();
  		$links[] = 'http://example.org/'.$image->post_name.'/';
  		$links[] = 'http://example.org/?attachment_id='.$image->ID;
@@ -302,13 +302,13 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testInitFromRelativePath() {
 		$filename = self::copyTestImage( 'arch.jpg' );
 		$path = str_replace(ABSPATH, '/', $filename);
-		$image = new TimberImage( $path );
+		$image = new Timber\Image( $path );
 		$this->assertEquals( 1500, $image->width() );
 	}
 
 	function testImagePath() {
 		$filename = self::copyTestImage( 'arch.jpg' );
-		$image = new TimberImage( $filename );
+		$image = new Timber\Image( $filename );
 		$this->assertStringStartsWith('/wp-content', $image->path());
 		$this->assertStringEndsWith('.jpg', $image->path());
 	}
@@ -318,13 +318,13 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$filename = self::copyTestImage( 'arch.jpg' );
 		$attachment = array( 'post_title' => 'The Arch', 'post_content' => '' );
 		$iid = wp_insert_attachment( $attachment, $filename, $pid );
-		$image = new TimberImage( $iid );
+		$image = new Timber\Image( $iid );
 		$this->assertEquals( 1500, $image->width() );
 	}
 
 	function testInitFromFilePath() {
 		$image_file = self::copyTestImage();
-		$image = new TimberImage( $image_file );
+		$image = new Timber\Image( $image_file );
 		$this->assertEquals( 1500, $image->width() );
 	}
 
@@ -332,7 +332,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$destination_path = self::copyTestImage();
 		$destination_path = TimberURLHelper::get_rel_path( $destination_path );
 		$destination_url = 'http://'.$_SERVER['HTTP_HOST'].$destination_path;
-		$image = new TimberImage( $destination_url );
+		$image = new Timber\Image( $destination_url );
 		$this->assertEquals( $destination_url, $image->src() );
 		$this->assertEquals( $destination_url, (string)$image );
 	}
@@ -662,7 +662,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertFileExists( $resized_500_file );
 		$this->assertFileExists( $resized_520_file );
 		//Now delete the "parent" image
-		$post = new TimberImage( $attach_id );
+		$post = new Timber\Image( $attach_id );
 		TimberImageHelper::delete_generated_files( $post->file_loc );
 		//Have the children been deleted as well?
 		$this->assertFileNotExists( $resized_520_file );
@@ -867,7 +867,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		if (!is_int($file_id)) {
 			error_log(print_r($file_id, true));
 		}
-		$image = new TimberImage($file_id);
+		$image = new Timber\Image($file_id);
 		$str = '<img src="{{image.src(\'medium\')}}" />';
 		$result = Timber::compile_string($str, array('image' => $image));
 		$upload_dir = wp_upload_dir();
@@ -885,7 +885,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		if (!is_int($file_id)) {
 			error_log(print_r($file_id, true));
 		}
-		$image = new TimberImage($file_id);
+		$image = new Timber\Image($file_id);
 		$str = '<img src="{{image.src(\'medium\')}}" />';
 		$result = Timber::compile_string($str, array('image' => $image));
 		$upload_dir = wp_upload_dir();
@@ -925,7 +925,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	function testImageNoParent() {
 		$filename = self::copyTestImage( 'arch.jpg' );
-		$image = new TimberImage( $filename );
+		$image = new Timber\Image( $filename );
 		$this->assertFalse($image->parent());
 	}
 
@@ -937,7 +937,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	function testPathInfo() {
 		$filename = self::copyTestImage( 'arch.jpg' );
-		$image = new TimberImage( $filename );
+		$image = new Timber\Image( $filename );
 		$path_parts = $image->get_pathinfo();
 		$this->assertEquals('jpg', $path_parts['extension']);
 	}
@@ -956,8 +956,8 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testTimberImageFromTimberImage() {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
-		$post = new TimberImage($image);
 		$str = '{{ TimberImage(post).src }}';
+		$post = new Timber\Image($image);
 		$result = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals($image->src(), $result);
 	}
@@ -965,8 +965,8 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testTimberImageFromTimberImageID() {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
-		$post = new TimberImage($image->ID);
 		$str = '{{ TimberImage(post).src }}';
+		$post = new Timber\Image($image->ID);
 		$result = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals($image->src(), $result);
 	}
@@ -982,7 +982,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	function testTimberImageFromAttachment() {
 		$iid = self::get_image_attachment();
-		$image = new TimberImage($iid);
+		$image = new Timber\Image($iid);
 		$post = get_post($iid);
 		$str = '{{ TimberImage(post).src }}';
 		$result = Timber::compile_string( $str, array('post' => $post) );
@@ -993,8 +993,8 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testTimberImageFromDocument() {
 		$pid = $this->factory->post->create();
 		$iid = self::get_image_attachment($pid, 'dummy-pdf.pdf');
-		$attachment = new TimberImage($iid);
 		$str = '{{ TimberImage(post).src }}';
+		$attachment = new Timber\Image($iid);
 		$result = Timber::compile_string( $str, array('post' => $iid) );
 		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/dummy-pdf.pdf', $result);
 	}

--- a/tests/test-timber-integrations-coauthors.php
+++ b/tests/test-timber-integrations-coauthors.php
@@ -59,7 +59,7 @@
 			$uids[] = $this->factory->user->create(array('display_name' => 'Mike Swartz', 'user_login' => 'm_swartz'));
 			$uids[] = $this->factory->user->create(array('display_name' => 'JP Boneyard', 'user_login' => 'jpb'));
 			$pid = $this->factory->post->create(array('post_author' => $uids[0]));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$cap = new CoAuthors_Plus();
 			$added = $cap->add_coauthors($pid, array('mbottitta', 'm_swartz', 'jpb'));
 			$this->assertTrue($added);
@@ -77,7 +77,7 @@
 		function testAuthors() {
 			$uid = $this->factory->user->create(array('display_name' => 'Jen Weinman', 'user_login' => 'aquajenus'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$template_string = '{% for author in post.authors %}{{author.name}}{% endfor %}';
 			$str = Timber::compile_string($template_string, array('post' => $post));
 			$this->assertEquals('Jen Weinman', $str);
@@ -85,7 +85,7 @@
 
 		function testGuestAuthor(){
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			$user_login = 'bmotia';
 			$display_name = 'Motia';
@@ -105,7 +105,7 @@
 		function testGuestAuthorWithRegularAuthor(){
 			$uid = $this->factory->user->create(array('display_name' => 'Alexander Hamilton', 'user_login' => 'ahamilton'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			$user_login = 'bmotia';
 			$display_name = 'Motia';
@@ -129,7 +129,7 @@
 			global $coauthors_plus;
 
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			$user_login = 'truelogin';
 			$display_name = 'True Name';
@@ -162,7 +162,7 @@
 
 		function testGuestAuthorAvatar(){
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$user_login = 'withfeaturedimage';
 			$display_name = 'Have Featured';
 			$email = 'admin@admin.com';

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -97,7 +97,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPCLIClearCacheTwig(){
 		$cache_dir = __DIR__.'/../cache/twig';
     	if (is_dir($cache_dir)){
-    		TimberLoader::rrmdir($cache_dir);
+    		Timber\Loader::rrmdir($cache_dir);
     	}
     	$this->assertFileNotExists($cache_dir);
     	Timber::$cache = true;
@@ -114,7 +114,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPCLIClearCacheAll(){
 		$cache_dir = __DIR__.'/../cache/twig';
     	if (is_dir($cache_dir)){
-    		TimberLoader::rrmdir($cache_dir);
+    		Timber\Loader::rrmdir($cache_dir);
     	}
     	$this->assertFileNotExists($cache_dir);
     	Timber::$cache = true;
@@ -132,7 +132,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPCLIClearCacheAllArray(){
 		$cache_dir = __DIR__.'/../cache/twig';
     	if (is_dir($cache_dir)){
-    		TimberLoader::rrmdir($cache_dir);
+    		Timber\Loader::rrmdir($cache_dir);
     	}
     	$this->assertFileNotExists($cache_dir);
     	Timber::$cache = true;

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -17,7 +17,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$pid = $this->factory->post->create();
 		update_field( 'subhead', 'foobar', $pid );
 		$str = '{{post.get_field("subhead")}}';
-		$post = new TimberPost( $pid );
+		$post = new Timber\Post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals( 'foobar', $str );
 	}
@@ -25,15 +25,15 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPPostConvert() {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
-		$post = new TimberPost();
-		$timber_post = $post->convert( $wp_post, 'TimberPost' );
-		$this->assertTrue( $timber_post instanceof TimberPost );
+		$post = new Timber\Post();
+		$timber_post = $post->convert( $wp_post, 'Timber\Post' );
+		$this->assertTrue( $timber_post instanceof Timber\Post );
 	}
 
 	function testACFHasFieldPostFalse() {
 		$pid = $this->factory->post->create();
 		$str = '{% if post.has_field("heythisdoesntexist") %}FAILED{% else %}WORKS{% endif %}';
-		$post = new TimberPost( $pid );
+		$post = new Timber\Post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals('WORKS', $str);
 	}
@@ -42,7 +42,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$pid = $this->factory->post->create();
 		update_post_meta($pid, 'best_radiohead_album', 'in_rainbows');
 		$str = '{% if post.has_field("best_radiohead_album") %}In Rainbows{% else %}OK Computer{% endif %}';
-		$post = new TimberPost( $pid );
+		$post = new Timber\Post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals('In Rainbows', $str);
 	}
@@ -71,13 +71,13 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}
 
-	
+
 	function testACFFieldObject() {
-		$fp_id = $this->factory->post->create(array('post_content' => 'a:10:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:2:"50";s:5:"class";s:8:"thingerz";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";}', 'post_title' => 'Thinger', 'post_name' => 'field_5a43eae2cde80'));	
+		$fp_id = $this->factory->post->create(array('post_content' => 'a:10:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:2:"50";s:5:"class";s:8:"thingerz";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";}', 'post_title' => 'Thinger', 'post_name' => 'field_5a43eae2cde80'));
 		$pid      = $this->factory->post->create();
 		update_field( 'thinger', 'foo', $pid );
 		update_field( '_thinger', 'field_5a43eae2cde80', $pid );
-		$post     = new TimberPost($pid);
+		$post     = new Timber\Post($pid);
 		$template = '{{ post.meta("thinger") }} / {{ post.field_object("thinger").key }}';
 		$str      = Timber::compile_string($template, array( 'post' => $post ));
 		$this->assertEquals('foo / field_thinger', $str);
@@ -102,7 +102,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
     	$this->assertFileNotExists($cache_dir);
     	Timber::$cache = true;
     	$pid = $this->factory->post->create();
-    	$post = new TimberPost($pid);
+    	$post = new Timber\Post($pid);
     	Timber::compile('assets/single-post.twig', array('post' => $post));
     	sleep(1);
     	$this->assertFileExists($cache_dir);
@@ -119,7 +119,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
     	$this->assertFileNotExists($cache_dir);
     	Timber::$cache = true;
     	$pid = $this->factory->post->create();
-    	$post = new TimberPost($pid);
+    	$post = new Timber\Post($pid);
     	Timber::compile('assets/single-post.twig', array('post' => $post));
     	sleep(1);
     	$this->assertFileExists($cache_dir);
@@ -137,7 +137,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
     	$this->assertFileNotExists($cache_dir);
     	Timber::$cache = true;
     	$pid = $this->factory->post->create();
-    	$post = new TimberPost($pid);
+    	$post = new Timber\Post($pid);
     	Timber::compile('assets/single-post.twig', array('post' => $post));
     	sleep(1);
     	$this->assertFileExists($cache_dir);

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -49,7 +49,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 
 	function testACFGetFieldTermCategory() {
 		update_field( 'color', 'blue', 'category_1' );
-		$cat = new TimberTerm( 1 );
+		$cat = new Timber\Term( 1 );
 		$this->assertEquals( 'blue', $cat->color );
 		$str = '{{term.color}}';
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $cat ) ) );
@@ -58,7 +58,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testACFCustomFieldTermTag() {
 		$tid = $this->factory->term->create();
 		update_field( 'color', 'green', 'post_tag_'.$tid );
-		$term = new TimberTerm( $tid );
+		$term = new Timber\Term( $tid );
 		$str = '{{term.color}}';
 		$this->assertEquals( 'green', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}
@@ -66,7 +66,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testACFGetFieldTermTag() {
 		$tid = $this->factory->term->create();
 		update_field( 'color', 'blue', 'post_tag_'.$tid );
-		$term = new TimberTerm( $tid );
+		$term = new Timber\Term( $tid );
 		$str = '{{term.get_field("color")}}';
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}

--- a/tests/test-timber-iterator.php
+++ b/tests/test-timber-iterator.php
@@ -4,7 +4,7 @@ class TestTimberIterator extends Timber_UnitTestCase {
 
     function testQueryPosts(){
         $this->factory->post->create();
-        $posts = TimberPostGetter::query_posts('post_type=post');
+        $posts = Timber\PostGetter::query_posts('post_type=post');
         $this->assertInstanceOf( 'TimberQueryIterator', $posts );
     }
 
@@ -15,7 +15,7 @@ class TestTimberIterator extends Timber_UnitTestCase {
             ) );
         }
         $results = Timber::compile('assets/iterator-test.twig', array(
-            'posts' => TimberPostGetter::query_posts( 'post_type=post' )
+            'posts' => Timber\PostGetter::query_posts( 'post_type=post' )
         ) );
 
         $results = trim( $results );
@@ -26,10 +26,10 @@ class TestTimberIterator extends Timber_UnitTestCase {
 
     function testTwigLoopVar() {
 	    $posts = $this->factory->post->create_many( 3 );
-	    $posts = TimberPostGetter::query_posts($posts);
+	    $posts = Timber\PostGetter::query_posts($posts);
 
 	    $compiled = Timber::compile('assets/iterator-loop-test.twig', array(
-		    'posts' => TimberPostGetter::query_posts( 'post_type=post' )
+		    'posts' => Timber\PostGetter::query_posts( 'post_type=post' )
 	    ) );
 
 	    $loop = array_map('json_decode', explode("\n", trim($compiled)));
@@ -55,7 +55,7 @@ class TestTimberIterator extends Timber_UnitTestCase {
 
     function testPostCount() {
     	$posts = $this->factory->post->create_many( 8 );
-        $posts = TimberPostGetter::query_posts('post_type=post');
+        $posts = Timber\PostGetter::query_posts('post_type=post');
         $this->assertEquals( 8, $posts->post_count() );
         $this->assertEquals( 8, count($posts) );
     }

--- a/tests/test-timber-iterator.php
+++ b/tests/test-timber-iterator.php
@@ -5,7 +5,7 @@ class TestTimberIterator extends Timber_UnitTestCase {
     function testQueryPosts(){
         $this->factory->post->create();
         $posts = Timber\PostGetter::query_posts('post_type=post');
-        $this->assertInstanceOf( 'TimberQueryIterator', $posts );
+        $this->assertInstanceOf( 'Timber\QueryIterator', $posts );
     }
 
     function testTheLoop(){

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -17,7 +17,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals( '/home/', $item->path() );
 	}
 
-	
+
 	function testTrailingSlashesOrNot() {
 		self::setPermalinkStructure();
 		$items = array();
@@ -49,7 +49,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		add_post_meta( $pid, '_thumbnail_id', $iid, true );
 
 		// Lets confirm this post has a thumbnail on it!
-		$post = new TimberPost($pid);
+		$post = new Timber\Post($pid);
 		$this->assertEquals('http://example.org/wp-content/uploads/' . date( 'Y/m' ) . '/arch.jpg', $post->thumbnail());
 
 		$nav_menu = new Timber\Menu( $menu_term['term_id'] );
@@ -307,7 +307,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $child_menu_item, '_menu_item_object_id', $child_id );
 		update_post_meta( $child_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $child_menu_item, '_menu_item_url', '' );
-		$post = new TimberPost( $child_menu_item );
+		$post = new Timber\Post( $child_menu_item );
 		$menu_items[] = $child_menu_item;
 
 		/* make a grandchild page */
@@ -328,7 +328,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
 		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
-		$post = new TimberPost( $grandchild_menu_item );
+		$post = new Timber\Post( $grandchild_menu_item );
 		$menu_items[] = $grandchild_menu_item;
 
 		/* make another grandchild page */
@@ -349,7 +349,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
 		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
-		$post = new TimberPost( $grandchild_menu_item );
+		$post = new Timber\Post( $grandchild_menu_item );
 		$menu_items[] = $grandchild_menu_item;
 
 		$root_url_link_id = wp_insert_post(

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -5,7 +5,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	function testBlankMenu() {
 		self::setPermalinkStructure();
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
@@ -25,7 +25,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$items[] = (object) array('type' => 'link', 'link' => '/foo');
 		$items[] = (object) array('type' => 'link', 'link' => '/bar/');
 		$mid = $this->buildMenu('Blanky', $items);
-		$menu = new TimberMenu($mid);
+		$menu = new Timber\Menu($mid);
 		$items = $menu->get_items();
 		$this->assertEquals('/', $items[0]->path());
 		$this->assertEquals('/foo', $items[1]->path());
@@ -70,7 +70,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$iid = TestTimberImage::get_image_attachment($pid);
 		add_post_meta( $pid, '_thumbnail_id', $iid, true );
 		$post = new \Timber\Post($pid);
-		$page_menu = new TimberMenu();
+		$page_menu = new Timber\Menu();
 		$str = '{% for item in menu.items %}{{item.thumbnail.src}}{% endfor %}';
 		$result = Timber::compile_string($str, array('menu' => $page_menu));
 		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $result);
@@ -80,12 +80,12 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	function testPagesMenu() {
 		$pg_1 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Foo Page', 'menu_order' => 10 ) );
 		$pg_2 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Bar Page', 'menu_order' => 1 ) );
-		$page_menu = new TimberMenu();
+		$page_menu = new Timber\Menu();
 		$this->assertEquals( 2, count( $page_menu->items ) );
 		$this->assertEquals( 'Bar Page', $page_menu->items[0]->title() );
 		self::_createTestMenu();
 		//make sure other menus are still more powerful
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 	}
 
@@ -94,12 +94,12 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	function testPagesMenuWithFalse() {
 		$pg_1 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Foo Page', 'menu_order' => 10 ) );
 		$pg_2 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Bar Page', 'menu_order' => 1 ) );
-		$page_menu = new TimberMenu();
+		$page_menu = new Timber\Menu();
 		$this->assertEquals( 2, count( $page_menu->items ) );
 		$this->assertEquals( 'Bar Page', $page_menu->items[0]->title() );
 		self::_createTestMenu();
 		//make sure other menus are still more powerful
-		$menu = new TimberMenu(false);
+		$menu = new Timber\Menu(false);
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 	}
 
@@ -109,7 +109,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	function testMissingMenu() {
 		$pg_1 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Foo Page', 'menu_order' => 10 ) );
 		$pg_2 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => 'Bar Page', 'menu_order' => 1 ) );
-		$missing_menu = new TimberMenu( 14 );
+		$missing_menu = new Timber\Menu( 14 );
 		$this->assertTrue( empty( $missing_menu->items ) );
 	}
 
@@ -118,7 +118,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$context = Timber::get_context();
 		self::_createTestMenu();
 		$this->go_to( home_url( '/child-page' ) );
-		$context['menu'] = new TimberMenu();
+		$context['menu'] = new Timber\Menu();
 		$str = Timber::compile( 'assets/child-menu.twig', $context );
 		$str = preg_replace( '/\s+/', '', $str );
 		$str = preg_replace( '/\s+/', '', $str );
@@ -130,7 +130,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		self::_createTestMenu();
 		$this->go_to( home_url( '/home' ) );
 		$context = Timber::get_context();
-		$context['menu'] = new TimberMenu();
+		$context['menu'] = new Timber\Menu();
 		$str = Timber::compile( 'assets/menu-classes.twig', $context );
 		$str = trim( $str );
 		$this->assertContains( 'current_page_item', $str );
@@ -142,7 +142,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	function testMenuItemLink() {
 		self::setPermalinkStructure();
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
@@ -155,7 +155,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 	function testMenuMeta() {
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$items = $menu->get_items();
 		$item = $items[0];
 		$this->assertEquals( 'funke', $item->tobias );
@@ -164,7 +164,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 	function testMenuItemWithHash() {
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$items = $menu->get_items();
 		$item = $items[3];
 		$this->assertEquals( '#people', $item->link() );
@@ -175,7 +175,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 	function testMenuHome() {
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$items = $menu->get_items();
 		$item = $items[2];
 		$this->assertEquals( '/', $item->link() );
@@ -238,7 +238,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	function testWPMLMenu() {
 		self::setPermalinkStructure();
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$nav_menu = wp_nav_menu( array( 'echo' => false ) );
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
@@ -479,13 +479,13 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 		$wpdb->query( $query );
 		$this->go_to( home_url( '/gallery' ) );
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$this->assertContains( 'current-page-item', $menu->items[0]->classes );
 	}
 
 	function testMenuLevels() {
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$parent = $menu->items[0];
 		$this->assertEquals(0, $parent->level);
 		$child = $parent->children[0];
@@ -500,7 +500,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 	function testMenuLevelsChildren() {
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$parent = $menu->items[0];
 		$this->assertEquals(0, $parent->level);
 		$children = $parent->children();
@@ -510,14 +510,14 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 	function testMenuItemMeta() {
 		$menu_info = $this->_createSimpleMenu();
-		$menu = new TimberMenu($menu_info['term_id']);
+		$menu = new Timber\Menu($menu_info['term_id']);
 		$item = $menu->items[0];
 		$this->assertEquals('molasses', $item->meta('flood'));
 	}
 
 	function testMenuName() {
 		self::_createTestMenu();
-		$menu = new TimberMenu();
+		$menu = new Timber\Menu();
 		$str = Timber::compile_string('{{menu.items[0].title}}', array('menu' => $menu));
 		$this->assertEquals('Home', $str);
 		$str = Timber::compile_string('{{menu.items[0]}}', array('menu' => $menu));
@@ -546,7 +546,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 				'bonus' => 'The Bonus'
 		    )
 		);
-		$menu = new TimberMenu('extra-menu');
+		$menu = new Timber\Menu('extra-menu');
 		$this->assertEquals('Ziggy', $menu->name);
 	}
 
@@ -558,7 +558,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 		$this->buildMenu('Fancy Suit', $items);
 
-		$menu = new TimberMenu('Fancy Suit');
+		$menu = new Timber\Menu('Fancy Suit');
 		$this->assertEquals( 3, count($menu->get_items()) );
 	}
 
@@ -570,7 +570,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 		$this->buildMenu('Jolly Jeepers', $items);
 
-		$menu = new TimberMenu('jolly-jeepers');
+		$menu = new Timber\Menu('jolly-jeepers');
 		$this->assertEquals( 3, count($menu->get_items()) );
 	}
 

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -536,7 +536,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$built_menu_id = $built_menu['term_id'];
 
 		$this->buildMenu('Zappy', $items);
-		$theme = new TimberTheme();
+		$theme = new Timber\Theme();
 		$data = array('nav_menu_locations' => array('header-menu' => 0, 'extra-menu' => $built_menu_id, 'bonus' => 0));
 		update_option('theme_mods_'.$theme->slug, $data);
 		register_nav_menus(

--- a/tests/test-timber-pages.php
+++ b/tests/test-timber-pages.php
@@ -9,7 +9,7 @@ class TestTimberPages extends Timber_UnitTestCase {
 		$this->go_to($cat->path());
 		$term = new TimberTerm();
 		$this->assertEquals($category_id, $term->ID);
-		$post = new TimberPost();
+		$post = new Timber\Post();
 		$this->assertEquals(0, $post->ID);
 	}
 

--- a/tests/test-timber-pages.php
+++ b/tests/test-timber-pages.php
@@ -5,9 +5,9 @@ class TestTimberPages extends Timber_UnitTestCase {
 	function testTimberPostOnCategoryPage() {
 		$post_id = $this->factory->post->create();
 		$category_id = $this->factory->term->create(array('taxonomy' => 'category', 'name' => 'News'));
-		$cat = new TimberTerm($category_id);
+		$cat = new Timber\Term($category_id);
 		$this->go_to($cat->path());
-		$term = new TimberTerm();
+		$term = new Timber\Term();
 		$this->assertEquals($category_id, $term->ID);
 		$post = new Timber\Post();
 		$this->assertEquals(0, $post->ID);

--- a/tests/test-timber-parent-child.php
+++ b/tests/test-timber-parent-child.php
@@ -11,7 +11,7 @@
 			$dest_dir = WP_CONTENT_DIR.'/themes/twentyfifteen';
 			copy(__DIR__.'/assets/single-course.twig', $dest_dir.'/views/single-course.twig');
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile(array('single-course.twig', 'single.twig'), array( 'post' => $post ));
 			$this->assertEquals('I am single course', $str);
 		}

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -5,7 +5,7 @@
 		function testComments() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
 			$comment_id_array = $this->factory->comment->create_many( 5, array('comment_post_ID' => $post_id) );
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals( 5, count($post->comments()) );
 			$this->assertEquals( 5, $post->comment_count() );
 		}
@@ -13,7 +13,7 @@
 		function testCommentCount() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
 			$comment_id_array = $this->factory->comment->create_many( 5, array('comment_post_ID' => $post_id) );
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals( 2, count($post->comments(2)) );
 			$this->assertEquals( 5, count($post->comments()) );
 		}
@@ -31,7 +31,7 @@
 			wp_set_current_user( $uid );
 			$quote = "You know, I always wanted to pretend I was an architect";
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote, 'user_id' => $uid, 'comment_approved' => 0));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals(1, count($post->comments()));
 			wp_set_current_user( 0 );
 		}
@@ -40,7 +40,7 @@
 			require_once(__DIR__.'/php/timber-custom-comment.php');
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
 			$comment_id_array = $this->factory->comment->create_many( 5, array('comment_post_ID' => $post_id) );
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$comments = $post->comments(null, 'wp', 'comment', 'approve', 'CustomComment');
 			$this->assertEquals('CustomComment', get_class($comments[0]));
 		}
@@ -54,7 +54,7 @@
 			$commenter = wp_get_current_commenter();
 			$quote = "And in that moment, I was a marine biologist";
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote,'comment_approved' => 0, 'comment_author_email' => 'jarednova@upstatement.com'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals(1, count($post->comments()));
 		}
 
@@ -65,7 +65,7 @@
 			$child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $comment_id));
 			$grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $child_id));
 			$grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $child_id));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$comments = $post->comments();
 			$this->assertEquals(1, count($comments));
 			$children = $comments[0]->children();
@@ -81,7 +81,7 @@
 			$parent_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_date' => '2016-11-28 14:00:00', 'comment_content' => 'i am the Parent'));
 			$child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $parent_id, 'comment_date' => '2016-11-28 15:00:00', 'comment_content' => 'I am the child'));
 			$grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $child_id, 'comment_date' => '2016-11-28 16:00:00', 'comment_content' => 'I am the GRANDchild'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$comments = $post->comments();
 			$children = $comments[1]->children();
 			$this->assertEquals($parent_id, $children[0]->comment_parent);
@@ -96,7 +96,7 @@
 			$comment2_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'second!', 'comment_date' => '2016-11-28 13:58:18'));
 			$comment2_child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $comment2_id, 'comment_content' => 'response', 'comment_date' => '2016-11-28 14:58:18'));
 			$comment2_grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $comment2_child_id, 'comment_content' => 'Respond2Respond', 'comment_date' => '2016-11-28 15:58:18'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$str = Timber::compile('assets/comments-thread.twig', array('post' => $post));
 		}
 

--- a/tests/test-timber-post-convert.php
+++ b/tests/test-timber-post-convert.php
@@ -4,7 +4,7 @@
 
 		function testConvertWP_Post() {
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post_id = $this->factory->post->create(array('post_title' => 'Maybe Child Post'));
 			$posts = get_posts(array('post__in' => array($post_id)));
 			$converted = $post->convert($posts[0]);
@@ -14,7 +14,7 @@
 
 		function testConvertSingleItemArray() {
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post_id = $this->factory->post->create(array('post_title' => 'Maybe Child Post'));
 			$posts = get_posts(array('post__in' => array($post_id)));
 			$converted = $post->convert($posts);
@@ -26,7 +26,7 @@
 			$post_ids = $this->factory->post->create_many(8, array('post_title' => 'Sample Post '.rand(1, 999)));
 
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$posts = get_posts(array('post__in' => $post_ids, 'orderby' => 'post__in'));
 			$converted = $post->convert($posts);
 			$this->assertEquals($post_ids[2], $converted[2]->id);
@@ -37,7 +37,7 @@
 			$post_ids = $this->factory->post->create_many(8, array('post_title' => 'Sample Post '.rand(1, 999)));
 
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$posts = get_posts(array('post__in' => $post_ids, 'orderby' => 'post__in'));
 			$arr = array($post, $posts);
 

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -50,7 +50,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$cats = $this->factory->post->create_many(3, array('post_category' => array($cat)) );
 		$cat_post = $this->factory->post->create(array('post_category' => array($cat)) );
 
-		$cat_post = new TimberPost($cat_post);
+		$cat_post = new Timber\Post($cat_post);
 		$this->assertEquals('News', $cat_post->category()->name());
 
 		$posts = Timber::get_posts(array('cat' => $cat));
@@ -82,7 +82,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$cats = $this->factory->post->create_many(3, array('post_category' => array($cat)) );
 		$cat_post = $this->factory->post->create(array('post_category' => array($cat)) );
 
-		$cat_post = new TimberPost($cat_post);
+		$cat_post = new Timber\Post($cat_post);
 		$this->assertEquals('News', $cat_post->category()->name());
 
 		$posts = Timber::get_posts(array('category' => $cat));
@@ -177,7 +177,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$data['post'] = new TimberPost( $post_id );
+		$data['post'] = new Timber\Post( $post_id );
 		$data['size'] = array( 'width' => 100, 'height' => 50 );
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/thumb-test.twig', $data );
@@ -303,7 +303,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 	function testCustomPostTypeAndClassOnSinglePage() {
 		register_post_type('job');
 		$post_id = $this->factory->post->create( array( 'post_type' => 'job' ) );
-		$post = new TimberPost($post_id);
+		$post = new Timber\Post($post_id);
 		$this->go_to('?p='.$post->ID);
 		$jobs = $this->factory->post->create_many( 10, array('post_type' => 'job'));
 		$jobPosts = Timber::get_posts(array('post_type' => 'job'));

--- a/tests/test-timber-post-password.php
+++ b/tests/test-timber-post-password.php
@@ -5,7 +5,7 @@
 		function testPasswordedContentDefault(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post->post_content = $quote;
 			$post->post_password = 'burrito';
 			wp_update_post($post);
@@ -19,7 +19,7 @@
 			});
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post->post_content = $quote;
 			$post->post_password = 'burrito';
 			wp_update_post($post);
@@ -36,7 +36,7 @@
 			}, 10, 2);
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create(array('post_title' => 'Secrets!'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post->post_content = $quote;
 			$post->post_password = 'burrito';
 			wp_update_post($post);

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -7,10 +7,10 @@
 		function testPreviewWithStyleTags() {
 			global $wpdb;
 			$style = '<style>body { background-color: red; }</style><b>Yo.</b> ';
-			$id = $wpdb->insert( 
-				$wpdb->posts, 
-				array( 
-					'post_author' => '1', 
+			$id = $wpdb->insert(
+				$wpdb->posts,
+				array(
+					'post_author' => '1',
 					'post_content' => $style.$this->gettysburg,
 					'post_title' => 'Thing',
 					'post_date' => '2017-03-01 00:21:40',
@@ -18,7 +18,7 @@
 				)
 			);
 			$post_id = $wpdb->insert_id;
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{ post.preview.length(9).read_more(false).strip(true) }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Yo. Four score and seven years ago our fathers&hellip;', $str);
@@ -26,7 +26,7 @@
 
 		function testPreviewTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{post.preview.length(3).read_more(false).strip(false)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertNotContains('</p>', $str);
@@ -35,7 +35,7 @@
 		function testPostPreviewObjectWithCharAndWordLengthWordsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(2).chars(20) }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -43,7 +43,7 @@
 		function testPostPreviewObjectWithCharAndWordLengthCharsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(20).chars(20) }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score and seven&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -51,7 +51,7 @@
 		function testPostPreviewObjectWithCharLength() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.chars(20) }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score and seven&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -59,7 +59,7 @@
 		function testPostPreviewObjectWithLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(4) }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Lauren is a duck&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -67,7 +67,7 @@
 		function testPostPreviewObjectWithForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.force.length(3) }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -75,7 +75,7 @@
 		function testPostPreviewObject() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -83,7 +83,7 @@
 		function testPostPreviewObjectStrip() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview.strip(false) }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -91,7 +91,7 @@
 		function testPostPreviewObjectWithReadMore() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.read_more("Keep Reading") }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
@@ -99,27 +99,27 @@
 		function testPostPreviewObjectWithEverything() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.length(6).force.end("-->").read_more("Keep Reading") }}';
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable--> <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
 
 		function testPreviewWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 
 			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
 		function testPreviewWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
 		}
 
 		function testPreviewWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$template = '{{post.preview.length(3).force}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $str);
@@ -127,7 +127,7 @@
 
 		function testPreviewWithStripAndClosingPTag() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$template = '{{post.preview.strip(false)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('<p>Lauren is a duck, but a great duck let me tell you why <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a></p>', $str);
@@ -135,7 +135,7 @@
 
 		function testPreviewWithStripAndClosingPTagForced() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$template = '{{post.preview.strip(false).force(4)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('<p>Lauren is a duck, but a great duck let me tell you why&hellip;  <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a></p>', $str);
@@ -143,7 +143,7 @@
 
 		function testEmptyPreview() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '', 'post_content' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$template = '{{ post.preview }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('', $str);

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -4,7 +4,7 @@
 
 		function testDoubleEllipsis(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post->post_excerpt = 'this is super dooper trooper long words';
 			$prev = $post->get_preview(3, true);
 			$this->assertEquals(1, substr_count($prev, '&hellip;'));
@@ -15,14 +15,14 @@
 				return $class . ' and-foo';
 			});
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$text = $post->get_preview(10);
 			$this->assertContains('and-foo', (string) $text);
 		}
 
 		function testPreviewTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$text = $post->get_preview(20, false, '', false);
 			$this->assertNotContains('</p>', (string) $text);
 		}
@@ -33,7 +33,7 @@
 			$wp_rewrite->permalink_structure = $struc;
 			update_option('permalink_structure', $struc);
 			$post_id = $this->factory->post->create(array('post_content' => 'this is super dooper trooper long words'));
-			$post               = new TimberPost($post_id);
+			$post               = new Timber\Post($post_id);
 
 			// no excerpt
 			$post->post_excerpt = '';
@@ -63,7 +63,7 @@
 				return 'mythangy';
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [mythang]', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
 		}
 
@@ -72,31 +72,31 @@
 				return 'Quack!';
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [duck] <!--more--> joojoo', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
 		}
 
 		function testPreviewWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true));
 		}
 
 		function testPreviewWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
 		}
 
 		function testPreviewWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->get_preview());
 		}
 
 		function testPreviewWithCustomEnd() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck', 'post_excerpt' => '') );
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$this->assertEquals('Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true, 'Read More', true, ' ???'));
 		}
 
@@ -107,7 +107,7 @@
 			$pid = $this->factory->post->create(array(
 				'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
 			));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$post->post_excerpt = '';
 			$preview = $post->get_preview(6, true, 'Read More', '<span>');
 			$this->assertEquals('<span>Even in the world of</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $preview);

--- a/tests/test-timber-post-terms.php
+++ b/tests/test-timber-post-terms.php
@@ -4,7 +4,7 @@
 
 		function testPostTerms() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			// create a new tag and associate it with the post
 			$dummy_tag = wp_insert_term('whatever', 'post_tag');
@@ -13,7 +13,7 @@
 			$terms = $post->terms('post_tag', 'MyTimberTerm');
 			$this->assertEquals( 'MyTimberTerm', get_class($terms[0]) );
 
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$terms = $post->terms('post_tag', true, 'MyTimberTerm');
 			$this->assertEquals( 'MyTimberTerm', get_class($terms[0]) );
 
@@ -22,7 +22,7 @@
 		function testTermExceptions() {
 			self::enable_error_log(false);
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$terms = $post->terms('foobar');
 			$this->assertEquals(array(), $terms);
 			self::enable_error_log(true);
@@ -37,7 +37,7 @@
 			$dummy_cat = wp_insert_term('thingy', 'category');
 			wp_set_object_terms($pid, $dummy_cat['term_id'], 'category', true);
 
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$terms = $post->terms('all', false);
 			$this->assertEquals($terms['post_tag'][0]->name, 'whatever');
 

--- a/tests/test-timber-post-terms.php
+++ b/tests/test-timber-post-terms.php
@@ -45,6 +45,6 @@
 
 	}
 
-	class MyTimberTerm extends TimberTerm {
+	class MyTimberTerm extends Timber\Term {
 
 	}

--- a/tests/test-timber-post-title.php
+++ b/tests/test-timber-post-title.php
@@ -4,7 +4,7 @@
 
 		function testAmpersandInTitle() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Jared & Lauren'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals(get_the_title($post_id), $post->title());
 			$this->assertEquals(get_the_title($post_id), $post->post_title);
 		}

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -9,13 +9,13 @@
 
 		function testPostTypeProperty(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals('post', $post->post_type);
 		}
 
 		function testPostTypeMethodInTwig() {
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{post.post_type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('post', $str);
@@ -23,7 +23,7 @@
 
 		function testTypeMethodInTwig() {
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{post.type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('post', $str);
@@ -31,7 +31,7 @@
 
 		function testTypeMethodInTwigLabels() {
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{post.type.labels.name}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Posts', $str);
@@ -40,7 +40,7 @@
 		function testLegacyTypeCustomField() {
 			$post_id = $this->factory->post->create();
 			update_post_meta($post_id, 'type', 'numberwang');
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{post.type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('numberwang', $str);
@@ -49,7 +49,7 @@
 		function testUnderscoreTypeCustomField() {
 			$post_id = $this->factory->post->create();
 			update_post_meta($post_id, '_type', 'numberwang');
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$template = '{{post._type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('numberwang', $str);

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -817,7 +817,7 @@
 			$pid = $this->factory->post->create(array('post_content' => $quote));
 			$post = new Timber\Post($pid);
 			$expected = array(
-				'<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>',
+				'<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
 			);
 
 			$this->assertEquals($expected, $post->video());

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -4,24 +4,24 @@
 
 		function testPostObject(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals('Timber\Post', get_class($post));
 			$this->assertEquals($post_id, $post->ID);
 		}
 
 		function testPostPasswordReqd(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertFalse($post->password_required());
 
 			$post_id = $this->factory->post->create(array('post_password' => 'jiggypoof'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertTrue($post->password_required());
 		}
 
 		function testNameMethod() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Battlestar Galactica'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals('Battlestar Galactica', $post->name());
 		}
 
@@ -31,7 +31,7 @@
 			$attachment = array( 'post_title' => 'The Arch', 'post_content' => '' );
 			$iid = wp_insert_attachment( $attachment, $filename, $post_id );
 			update_post_meta($post_id, 'landmark', $iid);
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$image = $post->get_field('landmark');
 			$image = new Timber\Image($image);
 			$this->assertEquals('The Arch', $image->title());
@@ -39,7 +39,7 @@
 
 		function testPostString() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$str = Timber::compile_string('<h1>{{post}}</h1>', array('post' => $post));
 			$this->assertEquals('<h1>Gobbles</h1>', $str);
 		}
@@ -59,7 +59,7 @@
 		function testPostOnSingle(){
 			$post_id = $this->factory->post->create();
 			$this->go_to(home_url('/?p='.$post_id));
-			$post = new TimberPost();
+			$post = new Timber\Post();
 			$this->assertEquals($post_id, $post->ID);
 		}
 
@@ -86,19 +86,19 @@
 		// 	$this->go_to(home_url('/?p='.$post_id));
 		// 	$_post = $post;
 		// 	$post = false;
-		// 	$my_post = new TimberPost();
+		// 	$my_post = new Timber\Post();
 		// 	$this->assertEquals($post_id, $my_post->ID);
 		// }
 
 		function testNonexistentProperty(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost( $post_id );
+			$post = new Timber\Post( $post_id );
 			$this->assertFalse( $post->zebra );
 		}
 
 		function testNonexistentMethod(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost( $post_id );
+			$post = new Timber\Post( $post_id );
 			$template = '{{post.donkey}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('', $str);
@@ -111,8 +111,8 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$firstPost = new TimberPost($posts[0]);
-			$nextPost = new TimberPost($posts[1]);
+			$firstPost = new Timber\Post($posts[0]);
+			$nextPost = new Timber\Post($posts[1]);
 			$this->assertEquals($firstPost->next()->ID, $nextPost->ID);
 		}
 
@@ -124,8 +124,8 @@
 			}
 			wp_set_object_terms($posts[0], 'TestMe', 'category', false);
 			wp_set_object_terms($posts[2], 'TestMe', 'category', false);
-			$firstPost = new TimberPost($posts[0]);
-			$nextPost = new TimberPost($posts[2]);
+			$firstPost = new Timber\Post($posts[0]);
+			$nextPost = new Timber\Post($posts[2]);
 			$this->assertEquals($firstPost->next('category')->ID, $nextPost->ID);
 		}
 
@@ -143,8 +143,8 @@
 				wp_set_object_terms($posts[0], 'Cheese', 'pizza', false);
 				wp_set_object_terms($posts[2], 'Cheese', 'pizza', false);
 				wp_set_object_terms($posts[3], 'Mushroom', 'pizza', false);
-				$firstPost = new TimberPost($posts[0]);
-				$nextPost = new TimberPost($posts[2]);
+				$firstPost = new Timber\Post($posts[0]);
+				$nextPost = new Timber\Post($posts[2]);
 				$this->assertEquals($firstPost->next('pizza')->ID, $nextPost->ID);
 			}
 		}
@@ -155,8 +155,8 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$lastPost = new TimberPost($posts[1]);
-			$prevPost = new TimberPost($posts[0]);
+			$lastPost = new Timber\Post($posts[1]);
+			$prevPost = new Timber\Post($posts[0]);
 			$this->assertEquals($lastPost->prev()->ID, $prevPost->ID);
 		}
 
@@ -174,7 +174,7 @@
 				$cat = wp_insert_term('Cheese', 'pizza');
 				self::set_object_terms($posts[0], $cat, 'pizza', false);
 				self::set_object_terms($posts[2], $cat, 'pizza', false);
-				$lastPost = new TimberPost($posts[2]);
+				$lastPost = new Timber\Post($posts[2]);
 				// echo "\n".'$lastPost'."\n";
 				// print_r($lastPost);
 				// echo "\n".'$lastPost->prev(pizza)'."\n";
@@ -194,8 +194,8 @@
 			$cat = wp_insert_term('TestMe', 'category');
 			self::set_object_terms($posts[0], $cat, 'category', false);
 			self::set_object_terms($posts[2], $cat, 'category', false);
-			$lastPost = new TimberPost($posts[2]);
-			$prevPost = new TimberPost($posts[0]);
+			$lastPost = new Timber\Post($posts[2]);
+			$prevPost = new Timber\Post($posts[0]);
 			$this->assertEquals($lastPost->prev('category')->ID, $prevPost->ID);
 		}
 
@@ -205,9 +205,9 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$firstPost = new TimberPost($posts[0]);
-			$nextPost = new TimberPost($posts[1]);
-			$nextPostAfter = new TimberPost($posts[2]);
+			$firstPost = new Timber\Post($posts[0]);
+			$nextPost = new Timber\Post($posts[1]);
+			$nextPostAfter = new Timber\Post($posts[2]);
 			wp_update_post( array('ID' =>$nextPost->ID, 'post_status' => 'draft') );
 			$this->assertEquals($nextPostAfter->ID, $firstPost->next()->ID);
 		}
@@ -218,8 +218,8 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$firstPost = new TimberPost($posts[0]);
-			$nextPost = new TimberPost($posts[1]);
+			$firstPost = new Timber\Post($posts[0]);
+			$nextPost = new Timber\Post($posts[1]);
 			$nextPost->post_status = 'draft';
 			wp_update_post($nextPost);
 			$nextPostTest = $firstPost->next();
@@ -228,7 +228,7 @@
 		function testPostInitObject(){
 			$post_id = $this->factory->post->create();
 			$post = get_post($post_id);
-			$post = new TimberPost($post);
+			$post = new Timber\Post($post);
 			$this->assertEquals($post->ID, $post_id);
 		}
 
@@ -237,24 +237,24 @@
 		 */
 		function testPostByName(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
-			$post2 = new TimberPost($post->post_name);
+			$post = new Timber\Post($post_id);
+			$post2 = new Timber\Post($post->post_name);
 			$this->assertEquals($post2->id, $post_id);
 		}
 
 		function testUpdate(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$rand = rand_str();
 			$post->update('test_meta', $rand);
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals($rand, $post->test_meta);
 		}
 
 		function testCanEdit(){
 			wp_set_current_user(1);
 			$post_id = $this->factory->post->create(array('post_author' => 1));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertTrue($post->can_edit());
 			wp_set_current_user(0);
 		}
@@ -264,7 +264,7 @@
 		function testTitle(){
 			$title = 'Fifteen Million Merits';
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post->post_title = $title;
 			wp_update_post($post);
 			$this->assertEquals($title, trim(strip_tags($post->title())));
@@ -297,7 +297,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			$post = new TimberPost();
+			$post = new Timber\Post();
 			$this->assertEquals( $quote . 'Yes', $post->post_content );
 		}
 
@@ -335,14 +335,14 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			$post = new TimberPost();
+			$post = new Timber\Post();
 			$this->assertEquals('I am the one', $post->post_content);
 		}
 
 		function testContent(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$post->post_content = $quote;
 			wp_update_post($post);
 			$this->assertEquals($quote, trim(strip_tags($post->content())));
@@ -354,7 +354,7 @@
             $quote .= $page2 = "And do not let your tongue get ahead of your mind.";
 
             $post_id = $this->factory->post->create();
-            $post = new TimberPost($post_id);
+            $post = new Timber\Post($post_id);
             $post->post_content = $quote;
             wp_update_post($post);
 
@@ -406,18 +406,18 @@
 			$post_id = $this->factory->post->create();
 			update_post_meta($post_id, 'the-field-name', 'the-value');
 			update_post_meta($post_id, 'with_underscores', 'the_value');
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals($post->with_underscores_flat, 'the_value');
 			//$this->assertEquals($post->the_field_name_flat, 'the-value');
 		}*/
 
 		function testPostMetaMetaException(){
 			$post_id = $this->factory->post->create();
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$string = Timber::compile_string('My {{post.meta}}', array('post' => $post));
 			$this->assertEquals('My', trim($string));
 			update_post_meta($post_id, 'meta', 'steak');
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$string = Timber::compile_string('My {{post.custom.meta}}', array('post' => $post));
 			//sorry you can't over-write methods now
 			$this->assertEquals('My steak', trim($string));
@@ -426,20 +426,20 @@
 		function testPostParent(){
 			$parent_id = $this->factory->post->create();
 			$child_id = $this->factory->post->create(array('post_parent' => $parent_id));
-			$child_post = new TimberPost($child_id);
+			$child_post = new Timber\Post($child_id);
 			$this->assertEquals($parent_id, $child_post->parent()->ID);
 		}
 
 		function testPostSlug(){
 			$pid = $this->factory->post->create(array('post_name' => 'the-adventures-of-tom-sawyer'));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('the-adventures-of-tom-sawyer', $post->slug);
 		}
 
 		function testPostAuthor(){
 			$author_id = $this->factory->user->create(array('display_name' => 'Jared Novack', 'user_login' => 'jared-novack'));
 			$pid = $this->factory->post->create(array('post_author' => $author_id));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('jared-novack', $post->author()->slug());
 			$this->assertEquals('Jared Novack', $post->author()->name());
 			$template = 'By {{post.author}}';
@@ -453,7 +453,7 @@
 		function testPostAuthorInTwig(){
 			$author_id = $this->factory->user->create(array('display_name' => 'Jon Stewart', 'user_login' => 'jon-stewart'));
 			$pid = $this->factory->post->create(array('post_author' => $author_id));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('jon-stewart', $post->author()->slug());
 			$this->assertEquals('Jon Stewart', $post->author()->name());
 			$template = 'By {{post.author}}';
@@ -468,7 +468,7 @@
 			$author_id = $this->factory->user->create(array('display_name' => 'Woodward', 'user_login' => 'bob-woodward'));
 			$mod_author_id = $this->factory->user->create(array('display_name' => 'Bernstein', 'user_login' => 'carl-bernstein'));
 			$pid = $this->factory->post->create(array('post_author' => $author_id));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('bob-woodward', $post->author()->slug());
 			$this->assertEquals('bob-woodward', $post->modified_author()->slug());
 			$this->assertEquals('Woodward', $post->author()->name());
@@ -500,7 +500,7 @@
 			add_theme_support( 'post-formats', array( 'aside', 'gallery' ) );
 			$pid = $this->factory->post->create();
 			set_post_format($pid, 'aside');
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('aside', $post->format());
 		}
 
@@ -508,7 +508,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string("{{ post.class }}", array('post' => $post));
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $str);
 		}
@@ -517,7 +517,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->post_class());
 		}
 
@@ -525,7 +525,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->css_class());
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized additional-css-class', $post->css_class('additional-css-class'));
 		}
@@ -534,7 +534,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->class());
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized additional-css-class', $post->class('additional-css-class'));
 		}
@@ -543,14 +543,14 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->class);
 		}
 
 		function testPostChildren(){
 			$parent_id = $this->factory->post->create();
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id));
-			$parent = new TimberPost($parent_id);
+			$parent = new Timber\Post($parent_id);
 			$this->assertEquals(8, count($parent->children()));
 		}
 
@@ -559,7 +559,7 @@
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id));
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id,
 			                                                       'post_status' => 'inherit'));
-			$parent = new TimberPost($parent_id);
+			$parent = new Timber\Post($parent_id);
 			$this->assertEquals(8, count($parent->children()));
 		}
 
@@ -567,7 +567,7 @@
 			$parent_id = $this->factory->post->create(array('post_type' => 'foo'));
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id));
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id, 'post_type' => 'foo'));
-			$parent = new TimberPost($parent_id);
+			$parent = new Timber\Post($parent_id);
 			$this->assertEquals(4, count($parent->children('parent')));
 		}
 
@@ -575,21 +575,21 @@
 			$parent_id = $this->factory->post->create(array('post_type' => 'foo'));
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id, 'post_type' => 'bar'));
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id, 'post_type' => 'foo'));
-			$parent = new TimberPost($parent_id);
+			$parent = new Timber\Post($parent_id);
 			$this->assertEquals(12, count($parent->children(array('foo', 'bar'))));
 		}
 
 		function testPostNoConstructorArgument(){
 			$pid = $this->factory->post->create();
 			$this->go_to('?p='.$pid);
-			$post = new TimberPost();
+			$post = new Timber\Post();
 			$this->assertEquals($pid, $post->ID);
 		}
 
 		function testPostPathUglyPermalinks(){
 			update_option('permalink_structure', '');
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('http://example.org/?p='.$pid, $post->link());
 			$this->assertEquals('/?p='.$pid, $post->path());
 		}
@@ -598,7 +598,7 @@
 			$struc = '/blog/%year%/%monthnum%/%postname%/';
 			update_option('permalink_structure', $struc);
 			$pid = $this->factory->post->create(array('post_date' => '2014-05-28'));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertStringStartsWith('http://example.org/blog/2014/05/post-title', $post->link());
 			$this->assertStringStartsWith('/blog/2014/05/post-title', $post->path());
 		}
@@ -607,7 +607,7 @@
 			$cat = wp_insert_term('News', 'category');
 			$pid = $this->factory->post->create();
 			self::set_object_terms($pid, $cat, 'category');
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals('News', $post->category()->name);
 		}
 
@@ -615,7 +615,7 @@
 			$pid = $this->factory->post->create();
 			$cat = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $cat, 'category');
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$category_names = array('News', 'Sports', 'Obits');
 
 			// Uncategorized is applied by default
@@ -631,7 +631,7 @@
 
 		function testPostTags() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$tag_names = array('News', 'Sports', 'Obits');
 
 			foreach ( $tag_names as $tag_name ) {
@@ -644,7 +644,7 @@
 
 		function testPostTerms() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category');
 
@@ -716,7 +716,7 @@
 
 			// create new post
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			// create a new tag, associate with post
 			$dummy_tag = wp_insert_term('whatever', 'post_tag');
@@ -734,21 +734,21 @@
 		function testPostContentLength() {
 			$crawl = "The evil leaders of Planet Spaceball having foolishly spuandered their precious atmosphere, have devised a secret plan to take every breath of air away from their peace-loving neighbor, Planet Druidia. Today is Princess Vespa's wedding day. Unbeknownest to the princess, but knowest to us, danger lurks in the stars above...";
 			$pid = $this->factory->post->create(array('post_content' => $crawl));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$content = trim(strip_tags($post->content(0, 6)));
 			$this->assertEquals("The evil leaders of Planet Spaceball&hellip;", $content);
 		}
 
 		function testPostTypeObject() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$pto = $post->type();
 			$this->assertEquals('Posts', $pto->label);
 		}
 
 		function testPage() {
 			$pid = $this->factory->post->create(array('post_type' => 'page', 'post_title' => 'My Page'));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$this->assertEquals($pid, $post->ID);
 			$this->assertEquals('My Page', $post->title());
 		}
@@ -762,7 +762,7 @@
 
 		function testPostWithoutGallery() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			$this->assertEquals(null, $post->gallery());
 		}
@@ -776,7 +776,7 @@
 
 		function testPostWithoutAudio() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			$this->assertEquals(array(), $post->audio());
 		}
@@ -787,7 +787,7 @@
 			$quote .= "No, try not. Do or do not. There is no try.";
 
 			$pid = $this->factory->post->create(array('post_content' => $quote));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$expected = array(
 				'<audio class="wp-audio-shortcode" id="audio-1-1" preload="none" style="width: 100%;" controls="controls"><source type="audio/mpeg" src="http://www.noiseaddicts.com/samples_1w72b820/280.mp3?_=1" /><a href="http://www.noiseaddicts.com/samples_1w72b820/280.mp3">http://www.noiseaddicts.com/samples_1w72b820/280.mp3</a></audio>',
 			);
@@ -804,7 +804,7 @@
 
 		function testPostWithoutVideo() {
 			$pid = $this->factory->post->create();
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 
 			$this->assertEquals(array(), $post->video());
 		}
@@ -815,7 +815,7 @@
 			$quote .= "No, try not. Do or do not. There is no try.";
 
 			$pid = $this->factory->post->create(array('post_content' => $quote));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$expected = array(
 				'<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>',
 			);
@@ -842,7 +842,7 @@
 
 			$uid = $this->factory->user->create(array('display_name' => 'Franklin Delano Roosevelt', 'user_login' => 'fdr'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$edit_url = $post->edit_link();
 			$this->assertEquals('', $edit_url);
 			$user = wp_set_current_user($uid);

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -654,7 +654,7 @@
 
 			// test expected tags
 			$timber_tags = $post->terms('post_tag');
-			$dummy_timber_tag = new TimberTerm($dummy_tag['term_id'], 'post_tag');
+			$dummy_timber_tag = new Timber\Term($dummy_tag['term_id'], 'post_tag');
 			$this->assertEquals('whatever', $timber_tags[0]->slug);
 			$this->assertEquals($dummy_timber_tag, $timber_tags[0]);
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -50,7 +50,7 @@
 			$attachment = array( 'post_title' => 'The Arch', 'post_content' => '' );
 			$iid = wp_insert_attachment( $attachment, $filename, $pid );
 			update_post_meta( $iid, 'architect', 'Eero Saarinen' );
-			$image = new TimberImage( $iid );
+			$image = new Timber\Image( $iid );
 			$parent = $image->parent();
 			$this->assertEquals($pid, $parent->ID);
 			$this->assertFalse($parent->parent());

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -8,7 +8,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 		$term_id = wp_insert_term( 'baseball', 'post_tag' );
 		$term_id = $term_id['term_id'];
-		$post = new TimberPost( $post_id );
+		$post = new Timber\Post( $post_id );
 		$user = new TimberUser( $user_id );
 		$term = new TimberTerm( $term_id );
 		$comment = new TimberComment( $comment_id );
@@ -29,7 +29,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 		$term_id = wp_insert_term( 'baseball', 'post_tag' );
 		$term_id = $term_id['term_id'];
-		$post = new TimberPost( $post_id );
+		$post = new Timber\Post( $post_id );
 		$user = new TimberUser( $user_id );
 		$term = new TimberTerm( $term_id );
 		$comment = new TimberComment( $comment_id );

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -11,7 +11,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$post = new Timber\Post( $post_id );
 		$user = new TimberUser( $user_id );
 		$term = new TimberTerm( $term_id );
-		$comment = new TimberComment( $comment_id );
+		$comment = new Timber\Comment( $comment_id );
 		$this->assertEquals( $post_id, $post->ID );
 		$this->assertEquals( $post_id, $post->id );
 		$this->assertEquals( $user_id, $user->ID );
@@ -32,7 +32,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$post = new Timber\Post( $post_id );
 		$user = new TimberUser( $user_id );
 		$term = new TimberTerm( $term_id );
-		$comment = new TimberComment( $comment_id );
+		$comment = new Timber\Comment( $comment_id );
 		$site = new TimberSite();
 		return array( 'post' => $post, 'user' => $user, 'term' => $term, 'comment' => $comment, 'site' => $site );
 	}

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -9,7 +9,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$term_id = wp_insert_term( 'baseball', 'post_tag' );
 		$term_id = $term_id['term_id'];
 		$post = new Timber\Post( $post_id );
-		$user = new TimberUser( $user_id );
+		$user = new Timber\User( $user_id );
 		$term = new Timber\Term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
 		$this->assertEquals( $post_id, $post->ID );
@@ -30,7 +30,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$term_id = wp_insert_term( 'baseball', 'post_tag' );
 		$term_id = $term_id['term_id'];
 		$post = new Timber\Post( $post_id );
-		$user = new TimberUser( $user_id );
+		$user = new Timber\User( $user_id );
 		$term = new Timber\Term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
 		$site = new Timber\Site();

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -10,7 +10,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$term_id = $term_id['term_id'];
 		$post = new Timber\Post( $post_id );
 		$user = new TimberUser( $user_id );
-		$term = new TimberTerm( $term_id );
+		$term = new Timber\Term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
 		$this->assertEquals( $post_id, $post->ID );
 		$this->assertEquals( $post_id, $post->id );
@@ -31,7 +31,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$term_id = $term_id['term_id'];
 		$post = new Timber\Post( $post_id );
 		$user = new TimberUser( $user_id );
-		$term = new TimberTerm( $term_id );
+		$term = new Timber\Term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
 		$site = new Timber\Site();
 		return array( 'post' => $post, 'user' => $user, 'term' => $term, 'comment' => $comment, 'site' => $site );

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -33,7 +33,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$user = new TimberUser( $user_id );
 		$term = new TimberTerm( $term_id );
 		$comment = new Timber\Comment( $comment_id );
-		$site = new TimberSite();
+		$site = new Timber\Site();
 		return array( 'post' => $post, 'user' => $user, 'term' => $term, 'comment' => $comment, 'site' => $site );
 	}
 

--- a/tests/test-timber-sidebar.php
+++ b/tests/test-timber-sidebar.php
@@ -6,7 +6,7 @@
 			$context = Timber::get_context();
 			$sidebar_post = $this->factory->post->create(array('post_title' => 'Sidebar post content'));
 			$sidebar_context = array();
-			$sidebar_context['post'] = new TimberPost($sidebar_post);
+			$sidebar_context['post'] = new Timber\Post($sidebar_post);
 			$context['sidebar'] = Timber::get_sidebar('assets/sidebar.twig', $sidebar_context);
 			$result = Timber::compile('assets/main-w-sidebar.twig', $context);
 			$this->assertEquals('I am the main stuff <h4>Sidebar post content</h4>', trim($result));

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -4,7 +4,7 @@ class TestTimberSite extends Timber_UnitTestCase {
 
 	function testStandardThemeLocation() {
 		switch_theme( 'twentyfifteen' );
-		$site = new TimberSite();
+		$site = new Timber\Site();
 		$content_subdir = Timber\URLHelper::get_content_subdir();
 		$this->assertEquals( $content_subdir.'/themes/twentyfifteen', $site->theme->path );
 	}
@@ -14,7 +14,7 @@ class TestTimberSite extends Timber_UnitTestCase {
 		$content_subdir = Timber\URLHelper::get_content_subdir();
 		$this->assertFileExists( WP_CONTENT_DIR.'/themes/fake-child-theme/style.css' );
 		switch_theme( 'fake-child-theme' );
-		$site = new TimberSite();
+		$site = new Timber\Site();
 		$this->assertEquals( $content_subdir.'/themes/fake-child-theme', $site->theme->path );
 		$this->assertEquals( $content_subdir.'/themes/twentyfifteen', $site->theme->parent->path );
 	}
@@ -45,7 +45,7 @@ class TestTimberSite extends Timber_UnitTestCase {
 	function testSiteIcon() {
 		$icon_id = TestTimberImage::get_image_attachment(0, 'cardinals.jpg');
 		update_option('site_icon', $icon_id);
-		$site = new TimberSite();
+		$site = new Timber\Site();
 		$icon = $site->icon();
 		$this->assertEquals('Timber\Image', get_class($icon));
 		$this->assertContains('cardinals.jpg', $icon->src());
@@ -53,12 +53,12 @@ class TestTimberSite extends Timber_UnitTestCase {
 
 	function testSiteGet() {
 		update_option( 'foo', 'bar' );
-		$site = new TimberSite();
+		$site = new Timber\Site();
 		$this->assertEquals( 'bar', $site->foo );
 	}
 
 	function testSiteMeta() {
-		$ts = new TimberSite();
+		$ts = new Timber\Site();
 		update_option('foo', 'magoo');
 		$this->assertEquals('magoo', $ts->meta('foo'));
 	}

--- a/tests/test-timber-static.php
+++ b/tests/test-timber-static.php
@@ -13,7 +13,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$page_id = $this->factory->post->create(array('post_type' => 'page'));
 		update_option('page_for_posts', $page_id);
 		$this->go_to(home_url('/?page_id='.$page_id));
-		$page = new TimberPost();
+		$page = new Timber\Post();
 		$this->assertEquals($page_id, $page->ID);
 	}
 
@@ -21,7 +21,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$pids = $this->factory->post->create_many(6);
 		$page_id = $this->factory->post->create(array('post_title' => 'Foobar', 'post_name' => 'foobar', 'post_type' => 'page'));
 		$this->go_to(home_url('/?page_id='.$page_id));
-		$page = new TimberPost();
+		$page = new Timber\Post();
 		$this->assertEquals($page_id, $page->ID);
 	}
 
@@ -32,7 +32,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$this->go_to(home_url('/'));
 		global $wp_query;
 		$wp_query->queried_object_id = $page_id;
-		$page = new TimberPost();
+		$page = new Timber\Post();
 		$this->assertEquals($page_id, $page->ID);
 	}
 
@@ -42,7 +42,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			update_option('show_on_front', 'page');
 			update_option('page_on_front', $page_id);
 			$this->go_to(home_url('/'));
-			$post = new TimberPost();
+			$post = new Timber\Post();
 			$this->assertEquals($page_id, $post->ID);
 		}
 
@@ -61,9 +61,9 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			update_option('page_for_posts', $page_id);
 			$post_id = $this->factory->post->create(array('post_title' => 'My Real post', 'post_type' => 'post'));
 			$this->go_to(home_url('/?p='.$page_id));
-			$post = new TimberPost($post_id);
+			$post = new Timber\Post($post_id);
 			$this->assertEquals($post_id, $post->ID);
-			$page = new TimberPost();
+			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
 
@@ -73,7 +73,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$this->go_to(home_url('/?p='.$page_id));
 			$posts = Timber::get_posts();
 			$this->assertEquals(0, count($posts));
-			$page = new TimberPost();
+			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
 
@@ -81,7 +81,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$page_id = $this->factory->post->create(array('post_title' => 'Mister Slave', 'post_type' => 'page'));
 			$children = $this->factory->post->create_many(10, array('post_title' => 'Timmy'));
 			$this->go_to(home_url('/?p='.$page_id));
-			$page = new TimberPost();
+			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 			$posts = Timber::get_posts();
 			$this->assertEquals(0, count($posts));

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -36,7 +36,7 @@
 			register_taxonomy('arts', array('post'));
 
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
-			$term = new TimberTerm($term_id, 'arts');
+			$term = new Timber\Term($term_id, 'arts');
 			$this->assertEquals('Zong', $term->name());
 			$template = '{% set zp_term = TimberTerm("'.$term->ID.'", "arts") %}{{ zp_term.name }}';
 			$string = Timber::compile_string($template);
@@ -45,7 +45,7 @@
 
 		function testTerm() {
 			$term_id = $this->factory->term->create();
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$this->assertEquals('Timber\Term', get_class($term));
 		}
 
@@ -53,20 +53,20 @@
 			$term_id = $this->factory->term->create(array('name' => 'Famous Commissioners'));
 			$term_data = get_term($term_id, 'post_tag');
 			$this->assertTrue( in_array( get_class($term_data), array('WP_Term', 'stdClass') ) );
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$this->assertEquals('Famous Commissioners', $term->name());
 			$this->assertEquals('Timber\Term', get_class($term));
 		}
 
 		function testTermConstructWithSlug() {
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots'));
-			$term = new TimberTerm('new-england-patriots');
+			$term = new Timber\Term('new-england-patriots');
 			$this->assertEquals($term->ID, $term_id);
 		}
 
 		function testTermToString() {
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots'));
-			$term = new TimberTerm('new-england-patriots');
+			$term = new Timber\Term('new-england-patriots');
 			$str = Timber::compile_string('{{term}}', array('term' => $term));
 			$this->assertEquals('New England Patriots', $str);
 		}
@@ -74,32 +74,32 @@
 		function testTermDescription() {
 			$desc = 'An honest football team';
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots', 'description' => $desc));
-			$term = new TimberTerm($term_id, 'post_tag');
+			$term = new Timber\Term($term_id, 'post_tag');
 			$this->assertEquals($desc, $term->description());
 		}
 
 		function testTermConstructWithName() {
 			$term_id = $this->factory->term->create(array('name' => 'St. Louis Cardinals'));
-			$term = new TimberTerm('St. Louis Cardinals');
+			$term = new Timber\Term('St. Louis Cardinals');
 			$this->assertNull($term->ID);
 		}
 
 		function testTermInitObject() {
 			$term_id = $this->factory->term->create();
 			$term = get_term($term_id, 'post_tag');
-			$term = new TimberTerm($term);
+			$term = new Timber\Term($term);
 			$this->assertEquals($term->ID, $term_id);
 		}
 
 		function testTermLink() {
 			$term_id = $this->factory->term->create();
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$this->assertContains('http://', $term->link());
 		}
 
 		function testTermPath() {
 			$term_id = $this->factory->term->create();
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$this->assertFalse(strstr($term->path(), 'http://'));
 		}
 
@@ -108,7 +108,7 @@
 			$term_id = $this->factory->term->create(array('name' => 'Zong'));
 			$posts = $this->factory->post->create_many(3, array('post_type' => 'post', 'tags_input' => 'zong') );
 			$posts = $this->factory->post->create_many(5, array('post_type' => 'portfolio', 'tags_input' => 'zong') );
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$posts_gotten = $term->posts('posts_per_page=4');
 			$this->assertEquals(4, count($posts_gotten));
 
@@ -122,7 +122,7 @@
 
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
 			$posts = $this->factory->post->create_many(5, array('post_type' => 'portfolio' ));
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			foreach($posts as $post_id) {
 				wp_set_object_terms($post_id, $term_id, 'arts', true);
 			}
@@ -142,7 +142,7 @@
 			foreach($posts as $post_id){
 				wp_set_object_terms($post_id, $term_id, 'post_tag', true);
 			}
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$gotten_posts = $term->get_posts();
 			$this->assertEquals(count($posts), count($gotten_posts));
 		}
@@ -157,7 +157,7 @@
 				set_post_type($post_id, 'page');
 				wp_set_object_terms($post_id, $term_id, 'post_tag', true);
 			}
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$gotten_posts = $term->posts(count($posts), 'page');
 			$this->assertEquals(count($posts), count($gotten_posts));
 			$gotten_posts = $term->posts(count($posts), 'any');
@@ -177,7 +177,7 @@
 				set_post_type($post_id, 'page');
 				wp_set_object_terms($post_id, $term_id, 'post_tag', true);
 			}
-			$term = new TimberTerm($term_id);
+			$term = new Timber\Term($term_id);
 			$gotten_posts = $term->get_posts('post_type=page');
 			$this->assertEquals(count($posts), count($gotten_posts));
 			$gotten_posts = $term->get_posts('post_type=page', 'TimberPostSubclass');
@@ -193,7 +193,7 @@
 			$local = $this->factory->term->create(array('name' => 'Local', 'parent' => $parent_id, 'taxonomy' => 'category'));
 			$int = $this->factory->term->create(array('name' => 'International', 'parent' => $parent_id, 'taxonomy' => 'category'));
 
-			$term = new TimberTerm($parent_id);
+			$term = new Timber\Term($parent_id);
 			$children = $term->children();
 			$this->assertEquals(2, count($children));
 			$this->assertEquals('Local', $children[0]->name);
@@ -205,7 +205,7 @@
 		function testTermWithNativeMeta() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
 			add_term_meta($tid, 'foo', 'bar');
-			$term = new TimberTerm($tid);
+			$term = new Timber\Term($tid);
 			$template = '{{term.foo}}';
 			$compiled = Timber::compile_string($template, array('term' => $term));
 			$this->assertEquals('bar', $compiled);
@@ -217,7 +217,7 @@
 		function testTermWithNativeMetaFalse() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
 			add_term_meta($tid, 'foo', false);
-			$term = new TimberTerm($tid);
+			$term = new Timber\Term($tid);
 			$this->assertEquals('', $term->meta('foo'));
 		}
 
@@ -226,14 +226,14 @@
 		 */
 		function testTermWithNativeMetaNotExisting() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
-			$term = new TimberTerm($tid);
+			$term = new Timber\Term($tid);
 			$this->assertFalse($term->meta('foo'));
 		}
 
 		function testTermEditLink() {
 			wp_set_current_user(1);
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
-			$term = new TimberTerm($tid);
+			$term = new Timber\Term($tid);
 			$links = array();
 
 			$links[] = 'http://example.org/wp-admin/term.php?taxonomy=category&tag_ID='.$tid.'&post_type=post';

--- a/tests/test-timber-theme.php
+++ b/tests/test-timber-theme.php
@@ -6,14 +6,14 @@
 
 		function testThemeVersion() {
 			switch_theme('twentysixteen');
-			$theme = new TimberTheme();
+			$theme = new Timber\Theme();
 			$this->assertGreaterThan(1.2, $theme->version);
 			switch_theme('default');
 		}
-		
+
 		function testThemeMods(){
 			set_theme_mod('foo', 'bar');
-			$theme = new TimberTheme();
+			$theme = new Timber\Theme();
 			$mods = $theme->theme_mods();
 			$this->assertEquals('bar', $mods['foo']);
 			$bar = $theme->theme_mod('foo');
@@ -66,7 +66,7 @@
 		function tearDown() {
 			global $wp_theme_directories;
 
-			$wp_theme_directories = $this->backup_wp_theme_directories;	
+			$wp_theme_directories = $this->backup_wp_theme_directories;
 
 			wp_clean_themes_cache();
 			unset( $GLOBALS['wp_themes'] );

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -23,7 +23,7 @@
 
 		function _setupTranslationFiles() {
 			$lang_dir = get_stylesheet_directory().'/languages';
-			
+
 			if ( !file_exists($lang_dir.'/en_US.po') ) {
 				$this->installTranlsationFiles($lang_dir);
 			}
@@ -125,7 +125,7 @@
 				$php_unit->assertContains('my_action_context', $action_context_tally);
 			});
 			$post_id = $this->factory->post->create(array('post_title' => "Jaredz Post", 'post_content' => 'stuff to say'));
-			$context['post'] = new TimberPost($post_id);
+			$context['post'] = new Timber\Post($post_id);
 			$str = Timber::compile('assets/test-action-context.twig', $context);
 			$this->assertEquals('Here: stuff to say', trim($str));
 		}
@@ -136,7 +136,7 @@
 			add_filter('protected_title_format', function($title){
 				return 'Protected: '.$title;
 			});
-			$context['post'] = new TimberPost($post_id);
+			$context['post'] = new Timber\Post($post_id);
 			if (post_password_required($post_id)){
 				$this->assertTrue(true);
 				$str = Timber::compile('assets/test-wp-filters.twig', $context);
@@ -167,7 +167,7 @@
 
 		function testFilterFunction() {
 			$pid = $this->factory->post->create(array('post_title' => 'Foo'));
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$str = 'I am a {{post | get_class }}';
 			$this->assertEquals('I am a Timber\Post', Timber::compile_string($str, array('post' => $post)));
 		}
@@ -246,7 +246,7 @@
      	*/
 		function testSetObject() {
 			$pid = $this->factory->post->create(array('post_title' => 'Spaceballs'));
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$result = Timber::compile('assets/set-object.twig', array('post' => $post));
 			$this->assertEquals('Spaceballs: may the schwartz be with you', trim($result));
 		}

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -89,7 +89,7 @@
 
         function testURLToFileSystem() {
             $url = 'http://example.org/wp-content/uploads/2012/06/mypic.jpg';
-            $file = TimberURLHelper::url_to_file_system($url);
+            $file = Timber\URLHelper::url_to_file_system($url);
             $this->assertStringStartsWith(ABSPATH, $file);
             $this->assertStringEndsWith('/2012/06/mypic.jpg', $file);
             $this->assertNotContains($file, 'http://example.org');
@@ -188,11 +188,11 @@
         function testPathBase() {
             $struc = '/%year%/%monthnum%/%postname%/';
             $this->setPermalinkStructure( $struc );
-        	$this->assertEquals('/', TimberURLHelper::get_path_base());
+        	$this->assertEquals('/', Timber\URLHelper::get_path_base());
         }
 
         function testIsLocal() {
-        	$this->assertFalse(TimberURLHelper::is_local('http://wordpress.org'));
+        	$this->assertFalse(Timber\URLHelper::is_local('http://wordpress.org'));
         }
 
         function testCurrentURLWithServerPort(){
@@ -202,7 +202,7 @@
                 $_SERVER['SERVER_NAME'] = 'example.org';
             }
             $this->go_to('/');
-            $url = TimberURLHelper::get_current_url();
+            $url = Timber\URLHelper::get_current_url();
             $this->assertEquals('http://example.org:3000/', $url);
             $_SERVER['SERVER_PORT'] = $old_port;
         }
@@ -215,7 +215,7 @@
                 $_SERVER['SERVER_NAME'] = 'example.org';
             }
             $this->go_to('/');
-            $url = TimberURLHelper::get_current_url();
+            $url = Timber\URLHelper::get_current_url();
             $this->assertEquals('http://example.org/', $url);
         }
 
@@ -228,37 +228,37 @@
             }
             $_SERVER['HTTPS'] = 'on';
             $this->go_to('/');
-            $url = TimberURLHelper::get_current_url();
+            $url = Timber\URLHelper::get_current_url();
             $this->assertEquals('https://example.org/', $url);
         }
 
         function testUrlSchemeIsSecure() {
             $_SERVER['HTTPS'] = 'on';
-            $scheme = TimberURLHelper::get_scheme();
+            $scheme = Timber\URLHelper::get_scheme();
             $this->assertEquals('https', $scheme);
         }
 
         function testUrlSchemeIsNotSecure() {
             $_SERVER['HTTPS'] = 'off';
-            $scheme = TimberURLHelper::get_scheme();
+            $scheme = Timber\URLHelper::get_scheme();
             $this->assertEquals('http', $scheme);
         }
 
         function testIsURL(){
             $url = 'http://example.org';
             $not_url = '/blog/2014/05/whatever';
-            $this->assertTrue(TimberURLHelper::is_url($url));
-            $this->assertFalse(TimberURLHelper::is_url($not_url));
-      		$this->assertFalse(TimberURLHelper::is_url(8000));
+            $this->assertTrue(Timber\URLHelper::is_url($url));
+            $this->assertFalse(Timber\URLHelper::is_url($not_url));
+      		$this->assertFalse(Timber\URLHelper::is_url(8000));
         }
 
         function testIsExternal(){
             $local = 'http://example.org';
             $subdomain = 'http://cdn.example.org';
             $external = 'http://upstatement.com';
-            $this->assertFalse(TimberURLHelper::is_external($local));
-            $this->assertFalse(TimberURLHelper::is_external($subdomain));
-            $this->assertTrue(TimberURLHelper::is_external($external));
+            $this->assertFalse(Timber\URLHelper::is_external($local));
+            $this->assertFalse(Timber\URLHelper::is_external($subdomain));
+            $this->assertTrue(Timber\URLHelper::is_external($external));
         }
 
 		function testIsExternalContent() {
@@ -267,10 +267,10 @@
 			$internal_in_uploads = 'http://example.org/uploads/uploads/my-image.png';
 			$external = 'http://upstatement.com/my-image.png';
 
-			$this->assertFalse( TimberURLHelper::is_external_content( $internal ) );
-			$this->assertTrue( TimberURLHelper::is_external_content( $internal_in_uploads ) );
-			$this->assertTrue( TimberURLHelper::is_external_content( $internal_in_abspath ) );
-			$this->assertTrue( TimberURLHelper::is_external_content( $external ) );
+			$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
+			$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
+			$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
+			$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
 		}
 
 		function testIsExternalContentMovingFolders() {
@@ -284,10 +284,10 @@
 
 			$this->mockUploadDir = true;
 
-			$this->assertFalse( TimberURLHelper::is_external_content( $internal ) );
-			$this->assertFalse( TimberURLHelper::is_external_content( $internal_in_uploads ) );
-			$this->assertFalse( TimberURLHelper::is_external_content( $internal_in_abspath ) );
-			$this->assertTrue( TimberURLHelper::is_external_content( $external ) );
+			$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
+			$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
+			$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
+			$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
 
 			$this->mockUploadDir = false;
 		}
@@ -316,32 +316,32 @@
             $subdomain = 'http://cdn.example.org/directory';
             $external = 'http://upstatement.com';
             $rel_url = '/directory/';
-            $this->assertEquals('/directory', TimberURLHelper::get_rel_url($local));
-            $this->assertEquals($subdomain, TimberURLHelper::get_rel_url($subdomain));
-            $this->assertEquals($external, TimberURLHelper::get_rel_url($external));
-            $this->assertEquals($rel_url, TimberURLHelper::get_rel_url($rel_url));
+            $this->assertEquals('/directory', Timber\URLHelper::get_rel_url($local));
+            $this->assertEquals($subdomain, Timber\URLHelper::get_rel_url($subdomain));
+            $this->assertEquals($external, Timber\URLHelper::get_rel_url($external));
+            $this->assertEquals($rel_url, Timber\URLHelper::get_rel_url($rel_url));
         }
 
         function testRemoveTrailingSlash(){
             $url_with_trailing_slash = 'http://example.org/directory/';
             $root_url = "/";
-            $this->assertEquals('http://example.org/directory', TimberURLHelper::remove_trailing_slash($url_with_trailing_slash));
-            $this->assertEquals('/', TimberURLHelper::remove_trailing_slash($root_url));
+            $this->assertEquals('http://example.org/directory', Timber\URLHelper::remove_trailing_slash($url_with_trailing_slash));
+            $this->assertEquals('/', Timber\URLHelper::remove_trailing_slash($root_url));
         }
 
         function testGetParams(){
             $_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
-            $params = TimberURLHelper::get_params();
+            $params = Timber\URLHelper::get_params();
             $this->assertEquals(7, count($params));
-            $whatever = TimberURLHelper::get_params(-1);
-            $blog = TimberURLHelper::get_params(2);
+            $whatever = Timber\URLHelper::get_params(-1);
+            $blog = Timber\URLHelper::get_params(2);
             $this->assertEquals('whatever', $whatever);
             $this->assertEquals('blog', $blog);
         }
 
         function testGetParamsNadda(){
             $_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
-            $params = TimberURLHelper::get_params(93);
+            $params = Timber\URLHelper::get_params(93);
             $this->assertNull($params);
         }
 

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -22,7 +22,7 @@
 			$user = new TimberUser($uid);
 			$this->assertEquals('Sixteenth President', $user->description);
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new TimberPost($pid);
+			$post = new Timber\Post($pid);
 			$str = Timber::compile_string('{{post.author.description}}', array('post' => $post));
 			$this->assertEquals('Sixteenth President', $str);
 		}

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -4,14 +4,14 @@
 
 		function testInitWithID(){
 			$uid = $this->factory->user->create(array('display_name' => 'Baberaham Lincoln'));
-			$user = new TimberUser($uid);
+			$user = new Timber\User($uid);
 			$this->assertEquals('Baberaham Lincoln', $user->name);
 			$this->assertEquals($uid, $user->id);
 		}
 
 		function testInitWithSlug(){
 			$uid = $this->factory->user->create(array('display_name' => 'Tito Bottitta', 'user_login' => 'mbottitta'));
-			$user = new TimberUser('mbottitta');
+			$user = new Timber\User('mbottitta');
 			$this->assertEquals('Tito Bottitta', $user->name);
 			$this->assertEquals($uid, $user->id);
 		}
@@ -19,7 +19,7 @@
 		function testDescription() {
 			$uid = $this->factory->user->create(array('display_name' => 'Baberaham Lincoln', 'user_login' => 'blincoln'));
 			update_user_meta($uid, 'description', 'Sixteenth President');
-			$user = new TimberUser($uid);
+			$user = new Timber\User($uid);
 			$this->assertEquals('Sixteenth President', $user->description);
 			$pid = $this->factory->post->create(array('post_author' => $uid));
 			$post = new Timber\Post($pid);
@@ -29,14 +29,14 @@
 
 		function testInitShouldUnsetPassword() {
 			$uid = $this->factory->user->create(array('display_name' => 'Tom Riddle'));
-			$user = new TimberUser($uid );
+			$user = new Timber\User($uid );
 			$this->assertFalse(property_exists( $user, 'user_pass'));
 		}
 
 		function testInitWithObject(){
 			$uid = $this->factory->user->create(array('display_name' => 'Baberaham Lincoln'));
 			$uid = get_user_by('id', $uid);
-			$user = new TimberUser($uid);
+			$user = new Timber\User($uid);
 			$this->assertEquals('Baberaham Lincoln', $user->name);
 		}
 
@@ -44,7 +44,7 @@
 			$this->setPermalinkStructure('/blog/%year%/%monthnum%/%postname%/');
 			$uid = $this->factory->user->create(array('display_name' => 'Baberaham Lincoln', 'user_login' => 'lincoln'));
 			$uid = get_user_by('id', $uid);
-			$user = new TimberUser($uid);
+			$user = new Timber\User($uid);
 			$this->assertEquals('http://example.org/blog/author/lincoln/', trailingslashit($user->link()) );
 			$this->assertEquals('/blog/author/lincoln/', trailingslashit($user->path()) );
 			$user->president = '16th';

--- a/tests/test-timber-wpml.php
+++ b/tests/test-timber-wpml.php
@@ -24,7 +24,7 @@ class TestTimberWPML extends Timber_UnitTestCase {
 		$built_menu_id = $built_menu['term_id'];
 
 		TestTimberMenu::buildMenu('Zappy', $items);
-		$theme = new TimberTheme();
+		$theme = new Timber\Theme();
 		$data = array('nav_menu_locations' => array('header-menu' => 0, 'extra-menu' => $built_menu_id, 'bonus' => 0));
 		update_option('theme_mods_'.$theme->slug, $data);
 		register_nav_menus(

--- a/tests/test-timber-wpml.php
+++ b/tests/test-timber-wpml.php
@@ -34,7 +34,7 @@ class TestTimberWPML extends Timber_UnitTestCase {
 				'bonus' => 'The Bonus'
 		    )
 		);
-		$menu = new TimberMenu('extra-menu');
+		$menu = new Timber\Menu('extra-menu');
 		$this->assertEquals('Ziggy', $menu->name);
 	}
 

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -196,7 +196,7 @@ class TestTimber extends Timber_UnitTestCase {
 
     function testTimberRenderString() {
     	$pid = $this->factory->post->create(array('post_title' => 'Zoogats'));
-        $post = new TimberPost($pid);
+        $post = new Timber\Post($pid);
         ob_start();
         Timber::render_string('<h2>{{post.title}}</h2>', array('post' => $post));
        	$data = ob_get_contents();
@@ -206,7 +206,7 @@ class TestTimber extends Timber_UnitTestCase {
 
     function testTimberRender() {
     	$pid = $this->factory->post->create(array('post_title' => 'Foobar'));
-        $post = new TimberPost($pid);
+        $post = new Timber\Post($pid);
         ob_start();
         Timber::render('assets/single-post.twig', array('post' => $post));
        	$data = ob_get_contents();

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -147,7 +147,7 @@ class TestTimber extends Timber_UnitTestCase {
 
 		$context = Timber::get_context();
 		$this->assertArrayHasKey( 'user', $context );
-		$this->assertInstanceOf( 'TimberUser', $context['user'] );
+		$this->assertInstanceOf( 'Timber\User', $context['user'] );
 	}
 
 	function testQueryPostsInContext(){

--- a/tests/testX-timber-image-isolated.php
+++ b/tests/testX-timber-image-isolated.php
@@ -24,7 +24,7 @@ class TestTimberImageIsolated extends Timber_UnitTestCase {
 		$file_loc = self::copyTestImage( 'eastern.jpg' );
 		$upload_dir = wp_upload_dir();
 		$url_src = $upload_dir['url'].'/eastern.jpg';
-		$filename = TimberImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
+		$filename = Timber\ImageHelper::get_resize_file_url( $url_src, 300, 500, 'default' );
 		$this->assertEquals($upload_dir['url'].'/eastern-300x500-c-default.jpg', $filename );
 	}
 }


### PR DESCRIPTION
**Ticket**: #1580 

**Issue**

Non-namespaced class names are still used throughout the codebase and documentation.

**Solution**

Replace non-namespaced class names with namespaced class names.

The function names in Twig remain the same. There, we still use `TimberPost`,  `TimberTerm`, etc.

**Impact**

None, hopefully.

**Usage Changes**

None.

**Testing**

I ran tests, should be fine.
