### PR TITLE
Alias Twig_Function from Twig 2.4.0

### DIFF
--- a/lib/Twig_Function.php
+++ b/lib/Twig_Function.php
@@ -3,15 +3,24 @@
 namespace Timber;
 
 /**
-  * Temporary fix for conflicts between Twig_Function and Twig_SimpleFunction
-  * in different versions of Twig (1.* and 2.*)
-  */
-if ( version_compare(\Twig_Environment::VERSION, '2.0.0', '>=') ) {
+ * Handle TwigFunction among Twig versions
+ *
+ * From Twig 2.4.0, extending Twig_Function is deprecated, will be final in 3.0
+ *
+ * Temporary fix for conflicts between Twig_Function and Twig_SimpleFunction
+ * in different versions of Twig (1.* and 2.*)
+ */
 
-  class Twig_Function extends \Twig_Function { }
+if ( version_compare(\Twig_Environment::VERSION, '2.4.0', '>=') ) {
+
+	class_alias('\Twig\TwigFunction', '\Timber\Twig_Function');
+
+} elseif ( version_compare(\Twig_Environment::VERSION, '2.0.0', '>=') ) {
+
+	class Twig_Function extends \Twig_Function { }
 
 } else {
 
-  class Twig_Function extends \Twig_SimpleFunction { }
-  
+	class Twig_Function extends \Twig_SimpleFunction { }
+
 }

--- a/lib/Twig_Function.php
+++ b/lib/Twig_Function.php
@@ -6,7 +6,7 @@ namespace Timber;
  * Handle TwigFunction among Twig versions
  *
  * From Twig 2.4.0, extending Twig_Function is deprecated, will be final in 3.0
- *
+ * @ticket #1641
  * Temporary fix for conflicts between Twig_Function and Twig_SimpleFunction
  * in different versions of Twig (1.* and 2.*)
  */

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -810,7 +810,7 @@
 			$pid = $this->factory->post->create(array('post_content' => $quote));
 			$post = new TimberPost($pid);
 			$expected = array(
-				'<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>',
+				'<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
 			);
 
 			$this->assertEquals($expected, $post->video());


### PR DESCRIPTION
**Ticket**: #1632

#### Issue
From 2.4.0, Twig does not allow `Twig_Function` class to be extended. Triggers PHP notices if using Twig ^2.4.0

#### Solution
Alias class and map it to new Twig class `\Twig\TwigFunction`.

#### Impact

Locally tested with Twig ^1.0|2.3.0|^2.4.0, looks fine.

#### Usage Changes

None.

#### Considerations

Require Twig ^2.4.0. PHP 7+ is now available on any decent hosting provider.

#### Testing

Sorry, no. I don't know how to deal with multiple versions of a package with `phpunit`.
