### PR TITLE
Documentation: Use relative links for linking between doc pages

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -66,4 +66,4 @@ Make sure you select the Timber-enabled theme **after** you activate the plugin.
 
 ### 3. Let’s write our theme!
 
-Continue ahead in [part 2 about Theming](https://timber.github.io/docs/getting-started/theming/).
+Continue ahead in [part 2 about Theming](/getting-started/theming/).

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -7,7 +7,7 @@ menu:
 
 Timber makes it damn easy to use an image in a tag.
 
-Automatically, Timber will interpret images attached to a post’s thumbnail field ("Featured Image" in the admin) and treat them as instances of [Timber\Image](https://timber.github.io/docs/reference/timber-image/). Then, in your Twig templates, you can access them via `{{ post.thumbnail }}`. 
+Automatically, Timber will interpret images attached to a post’s thumbnail field ("Featured Image" in the admin) and treat them as instances of [Timber\Image](/reference/timber-image/). Then, in your Twig templates, you can access them via `{{ post.thumbnail }}`. 
 
 ## Basic image stuff
 

--- a/docs/guides/cookbook-text.md
+++ b/docs/guides/cookbook-text.md
@@ -78,4 +78,4 @@ Twig template:
 <p class="entry-meta">{{ function('twentytwelve_entry_meta') }}</p>
 ```
 
-You can read more about using functions in the [Functions](https://timber.github.io/docs/guides/functions/) guide.
+You can read more about using functions in the [Functions](/guides/functions/) guide.

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -92,7 +92,7 @@ In Timber versions lower than 1.3, you could use `function_wrapper` to make func
 
 The concept of Timber (and templating engines like Twig in general) is to prepare all the data before you pass it to a template. Some functions in WordPress echo their output directly. We don’t want this, because the output of this function would be echoed before we call `Timber:render()` and appear before every else on your website. There are two ways to work around this:
 
-- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](https://timber.github.io/docs/reference/timber-helper/#ob-function).
+- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](/reference/timber-helper/#ob-function).
 - If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) you can use `FunctionWrapper`:
 
 ```php

--- a/docs/guides/internationalization.md
+++ b/docs/guides/internationalization.md
@@ -52,7 +52,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 <p class="entry-meta">{{ __('Posted on %s', 'my-text-domain')|format(posted_on_date) }}</p>
 ```
 
-If you want to use the `sprintf` function in Twig, you have to [add it yourself](https://timber.github.io/docs/guides/functions/#make-functions-available-in-twig).
+If you want to use the `sprintf` function in Twig, you have to [add it yourself](/guides/functions/#make-functions-available-in-twig).
 
 ## Generating localization files
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -18,7 +18,7 @@ You can still use plugins like [W3 Total Cache](https://wordpress.org/plugins/w3
 
 ## Cache the Entire Twig File and Data
 
-When rendering, use the `$expires` argument in [`Timber::render`](https://timber.github.io/docs/reference/timber/#render). For example:
+When rendering, use the `$expires` argument in [`Timber::render`](/reference/timber/#render). For example:
 
 ```php
 <?php
@@ -32,7 +32,7 @@ This method is very effective, but crude - the whole template is cached. So if y
 
 ### Set cache mode
 
-As a fourth parameter for [Timber::render()](https://timber.github.io/docs/reference/timber/#render), you can set the `$cache_mode`.
+As a fourth parameter for [Timber::render()](/reference/timber/#render), you can set the `$cache_mode`.
 
 ```php
 <?php

--- a/docs/guides/wp-integration.md
+++ b/docs/guides/wp-integration.md
@@ -73,7 +73,7 @@ Please note the argument count that WordPress requires for `add_action`.
 
 ## Filters
 
-Timber already comes with a [set of useful filters](https://timber.github.io/docs/guides/filters/). If you have your own filters that you want to apply, you can use `apply_filters`.
+Timber already comes with a [set of useful filters](/guides/filters/). If you have your own filters that you want to apply, you can use `apply_filters`.
 
 ```twig
 {{ post.content|apply_filters('my_filter') }}


### PR DESCRIPTION
#### Issue

The upcoming documentation will be versioned for v1 and v2 of Timber. The latest documentation can always be found under <https://timber.github.io/docs/>. The documentation for v1 will live under `https://timber.github.io/docs/v1/`. The links used to link between documentation are absolute now, so links under `/v1` would always point to the latest versions of the docs, instead of v1.

#### Solution

This pull request makes the links relative, so that links between documentation works as intended.