### PR TITLE
Fix depth parameter of comment in reply_link()

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -330,7 +330,7 @@ class Comment extends Core implements CoreInterface {
 			'add_below' => 'comment',
 			'respond_id' => 'respond',
 			'reply_text' => $reply_text,
-			'depth' => 1,
+			'depth' => $this->depth(),
 			'max_depth' => $max_depth,
 		);
 


### PR DESCRIPTION
#### Issue
`{{ comment.reply_link() }}` function always returns link, even if `max_depth` of comments is reached. This is due to `depth` parameter always set to `1`, which is wrong behavior. For child comments, this parameter should be set to its real depth level, not `1`.

In result, current usage of `{{ comment.reply_link() }}` ignores `max_depth` level set in Wordpress settings, as this level is never reached.

#### Solution
Pass current depth value instead of always `1` to Wordpress built-in `get_comment_reply_link()` function.

#### Impact
No impact.

#### Usage Changes
No changes.