### PR TITLE
2x/1634

### DIFF
--- a/lib/Archives.php
+++ b/lib/Archives.php
@@ -75,7 +75,7 @@ class Archives extends Core {
 	 */
 	public function init( $args = null, $base = '' ) {
 		$this->base = $base;
-		$this->items = $this->get_items($args);
+		$this->items = $this->items($args);
 		$this->args = $args;
 	}
 

--- a/lib/Archives.php
+++ b/lib/Archives.php
@@ -181,10 +181,14 @@ class Archives extends Core {
 	}
 
 	/**
-	 * @deprecated since 2.0 use Archives::items instead
+	 * @api
+	 * @deprecated 2.0.0, use `{{ archives.items }}` instead.
+	 * @see \Timber\Archives::items()
 	 * @return array|string
 	 */
 	public function get_items( $args = null ) {
+		Helper::warn( '{{ archives.get_items }} is deprecated. Use {{ archives.items }} instead.' );
+
 		return $this->items($args);
 	}
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -244,11 +244,18 @@ class Helper {
 	}
 
 	/**
-	 * @param string $message that you want to output
-	 * @return boolean
+	 * Trigger a warning.
+	 *
+	 * @param string $message The warning that you want to output.
+	 *
+	 * @return void
 	 */
 	public static function warn( $message ) {
-		return trigger_error($message, E_USER_WARNING);
+		if ( ! WP_DEBUG ) {
+			return;
+		}
+
+		trigger_error( $message, E_USER_WARNING );
 	}
 
 	/**

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -259,6 +259,47 @@ class Helper {
 	}
 
 	/**
+	 * Trigger a deprecation warning.
+	 *
+	 * @param string $message The warning that you want to output.
+	 *
+	 * @return void
+	 */
+	public static function deprecated( $function, $replacement, $version ) {
+		if ( ! WP_DEBUG ) {
+			return;
+		}
+
+		 do_action( 'deprecated_function_run', $function, $replacement, $version );
+ 
+	    /**
+	     * Filters whether to trigger an error for deprecated functions.
+	     *
+	     * @since 2.5.0
+	     *
+	     * @param bool $trigger Whether to trigger the error for deprecated functions. Default true.
+	     */
+	    if ( WP_DEBUG && apply_filters( 'deprecated_function_trigger_error', true ) ) {
+	        if ( function_exists( '__' ) ) {
+	            if ( ! is_null( $replacement ) ) {
+	                /* translators: 1: PHP function name, 2: version number, 3: alternative function name */
+	                trigger_error( sprintf( __('%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.'), $function, $version, $replacement ) );
+	            } else {
+	                /* translators: 1: PHP function name, 2: version number */
+	                trigger_error( sprintf( __('%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.'), $function, $version ) );
+	            }
+	        } else {
+	            if ( ! is_null( $replacement ) ) {
+	                trigger_error( sprintf( '%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.', $function, $version, $replacement ) );
+	            } else {
+	                trigger_error( sprintf( '%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.', $function, $version ) );
+	            }
+	        }
+	    }
+	}
+
+
+	/**
 	 *
 	 *
 	 * @param string  $separator

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -214,11 +214,11 @@ class Loader {
 	}
 
 	/**
-	 * @param string $name
-	 * @return bool
 	 * @deprecated 1.3.5 No longer used internally
 	 * @todo remove in 2.x
 	 * @codeCoverageIgnore
+	 * @param string $name
+	 * @return bool
 	 */
 	protected function template_exists( $name ) {
 		return $this->get_loader()->exists($name);

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -388,7 +388,7 @@ class MenuItem extends Core implements CoreInterface {
 	 * Get the featured image of the post associated with the menu item.
 	 *
 	 * @api
-	 * @deprecated since 1.5.2 to be removed in v2.0
+	 * @deprecated 1.5.2, to be removed in v2.0
 	 * @example
 	 * ```twig
 	 * {% for item in menu.items %}

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -315,15 +315,17 @@ class MenuItem extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Check if a link is external.
+	 * Checks to see if the menu item is an external link.
 	 *
-	 * This is helpful when creating rules for the target of a link.
-	 *
-	 * @internal
+	 * @api
+	 * @deprecated 2.0.0, use `{{ item.is_external }}`
 	 * @see \Timber\MenuItem::is_external()
+	 *
 	 * @return bool Whether the link is external or not.
 	 */
 	public function external() {
+		Helper::warn( '{{ item.external }} is deprecated. Use {{ item.is_external }} instead.' );
+
 		return $this->is_external();
 	}
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -362,29 +362,47 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @return PostPreview
+	 * Get a preview (excerpt) of your post.
+	 *
+	 * If you an excerpt is set on the post, the excerpt will be used. Otherwise it will try to pull
+	 * from a preview from `post_content`. If there’s a `<!-- more -->` tag in the post content,
+	 * it will use that to mark where to pull through.
+	 *
+	 * @see \Timber\PostPreview
+	 *
+	 * @return \Timber\PostPreview
 	 */
 	public function preview() {
 		return new PostPreview($this);
 	}
 
 	/**
-	 * get a preview of your post, if you have an excerpt it will use that,
-	 * otherwise it will pull from the post_content.
-	 * If there's a <!-- more --> tag it will use that to mark where to pull through.
-	 * @deprecated since 1.3.1, use {{ post.preview }} instead
-	 * @example
-	 * ```twig
-	 * <p>{{post.get_preview(50)}}</p>
-	 * ```
-	 * @param int $len The number of words that WP should use to make the tease. (Isn't this better than [this mess](http://wordpress.org/support/topic/changing-the-default-length-of-the_excerpt-1?replies=14)?). If you've set a post_excerpt on a post, we'll use that for the preview text; otherwise the first X words of the post_content
-	 * @param bool $force What happens if your custom post excerpt is longer then the length requested? By default (`$force = false`) it will use the full `post_excerpt`. However, you can set this to true to *force* your excerpt to be of the desired length
-	 * @param string $readmore The text you want to use on the 'readmore' link
-	 * @param bool|string $strip true for default, false for none, string for list of custom attributes
-	 * @param string $end The text to end the preview with (defaults to ...)
-	 * @return string of the post preview
+	 * Get a preview (excerpt) of your post.
+	 *
+	 * @api
+	 * @deprecated 1.3.1, use `{{ post.preview }}` instead.
+	 * @see        \Timber\Post::preview()
+	 *
+	 * @param int         $len      The number of words that WordPress should use to make the
+	 *                              preview.
+	 *                              (Isn’t this better than [this
+	 *                              mess](http://wordpress.org/support/topic/changing-the-default-length-of-the_excerpt-1?replies=14)?).
+	 *                              If you’ve set a post excerpt on a post, we’ll use that for the
+	 *                              preview text; otherwise the first X words of `post_content`.
+	 * @param bool        $force    What happens if your custom post excerpt is longer then the
+	 *                              length requested? By default (`$force = false`) it will use the
+	 *                              full `post_excerpt`. However, you can set this to `true` to
+	 *                              *force* your excerpt to be of the desired length.
+	 * @param string      $readmore The text you want to use for the 'readmore' link.
+	 * @param bool|string $strip    `true` for default, `false` for none, a string for a list of
+	 *                              custom attributes.
+	 * @param string      $end      The text to end the preview with. Default `...`.
+	 *
+	 * @return string The post preview.
 	 */
 	public function get_preview( $len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = '&hellip;' ) {
+		Helper::warn( '{{ post.get_preview }} is deprecated. Use {{ post.preview }} instead.' );
+
 		$pp = new PostPreview($this);
 
 		/** This filter is documented in PostPreview.php */
@@ -825,7 +843,7 @@ class Post extends Core implements CoreInterface {
 	 *
 	 * @internal
 	 * @param string $class additional classes you want to add.
-	 * @see Timber\Post::$_css_class
+	 * @see \Timber\Post::$_css_class
 	 * @example
 	 * ```twig
 	 * <article class="{{ post.class }}">
@@ -929,7 +947,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Get the categoires on a particular post
+	 * Get the categories on a particular post
 	 *
 	 * @api
 	 * @return array of Timber\Term objects

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -401,8 +401,7 @@ class Post extends Core implements CoreInterface {
 	 * @return string The post preview.
 	 */
 	public function get_preview( $len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = '&hellip;' ) {
-		Helper::warn( '{{ post.get_preview }} is deprecated. Use {{ post.preview }} instead.' );
-
+		Helper::deprecated('{{ post.get_preview }}', '{{ post.preview }}', '1.3.1');
 		$pp = new PostPreview($this);
 
 		/** This filter is documented in PostPreview.php */

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -247,19 +247,6 @@ class Site extends Core implements CoreInterface {
 		return $this->url;
 	}
 
-	/**
-	 * @api
-	 * @deprecated 0.21.9, use `{{ site.link }}` instead.
-	 * @see \Timber\Site::link()
-	 * @internal
-	 * @return string
-	 */
-	public function get_link() {
-		Helper::warn( '{{ site.get_link }} is deprecated. Use {{ site.link }} instead.' );
-
-		return $this->link();
-	}
-
 
 	/**
 	 * @ignore
@@ -315,21 +302,9 @@ class Site extends Core implements CoreInterface {
 	 * @return string
 	 */
 	public function url() {
-		Helper::warn( '{{ site.url }} is deprecated. Use {{ site.link }} instead.' );
-
+		Helper::deprecated('{{ site.url }}', '{{ site.link }}', '1.0.4');
 		return $this->link();
 	}
 
-	/**
-	 * @api
-	 * @deprecated 0.21.9, use `{{ site.link }}` instead.
-     * @see \Timber\Site::link()
-	 * @return string
-	 */
-	public function get_url() {
-		Helper::warn( '{{ site.get_url }} is deprecated. Use {{ site.link }} instead.' );
-
-		return $this->link();
-	}
 
 }

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -248,12 +248,15 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @deprecated 0.21.9
+	 * @api
+	 * @deprecated 0.21.9, use `{{ site.link }}` instead.
+	 * @see \Timber\Site::link()
 	 * @internal
 	 * @return string
 	 */
 	public function get_link() {
-		Helper::warn('{{site.get_link}} is deprecated, use {{site.link}}');
+		Helper::warn( '{{ site.get_link }} is deprecated. Use {{ site.link }} instead.' );
+
 		return $this->link();
 	}
 
@@ -306,21 +309,26 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @deprecated 1.0.4
-	 * @see Timber\Site::link
+	 * @api
+	 * @deprecated 1.0.4, use `{{ site.link }}` instead.
+	 * @see \Timber\Site::link()
 	 * @return string
 	 */
 	public function url() {
+		Helper::warn( '{{ site.url }} is deprecated. Use {{ site.link }} instead.' );
+
 		return $this->link();
 	}
 
 	/**
-	 * @deprecated 0.21.9
-	 * @internal
+	 * @api
+	 * @deprecated 0.21.9, use `{{ site.link }}` instead.
+     * @see \Timber\Site::link()
 	 * @return string
 	 */
 	public function get_url() {
-		Helper::warn('{{site.get_url}} is deprecated, use {{site.link}} instead');
+		Helper::warn( '{{ site.get_url }} is deprecated. Use {{ site.link }} instead.' );
+
 		return $this->link();
 	}
 

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -234,40 +234,18 @@ class Term extends Core implements CoreInterface {
 	 * @return string
 	 */
 	public function get_edit_url() {
-		Helper::warn( '{{ term.get_edit_url }} is deprecated. Use `{{ term.edit_link }}` instead.' );
-
+		Helper::deprecated('{{ term.get_edit_url }}', '{{ term.edit_link }}', '2.0.0');
 		return $this->edit_link();
 	}
 
 	/**
 	 * @internal
+	 * @deprecated 2.0.0, use `{{ term.meta("my_field") }}` instead.
 	 * @param string $field_name
 	 * @return string
 	 */
 	public function get_meta_field( $field_name ) {
 		return $this->meta($field_name);
-	}
-
-	/**
-	 * @api
-	 * @deprecated 1.0.0, use `{{ term.path }}` instead.
-	 * @return string
-	 */
-	public function get_path() {
-		Helper::warn( '{{ term.get_path }} is deprecated. Use {{ term.path }} instead.' );
-
-		return $this->path();
-	}
-
-	/**
-	 * @api
-	 * @deprecated 1.0.0, use `{{ term.link }}` instead.
-	 * @return string
-	 */
-	public function get_link() {
-		Helper::warn( '{{ term.get_link }} is deprecated. Use {{ term.link }} instead.' );
-
-		return $this->link();
 	}
 
 
@@ -525,7 +503,7 @@ class Term extends Core implements CoreInterface {
 	/**
 	 * Get Posts that have been "tagged" with the particular term
 	 *
-	 * @deprecated 2.0 use Term::posts() instead
+	 * @deprecated 2.0.0 use `{{ term.posts }}` instead
 	 * @internal
 	 * @param int $numberposts
 	 * @param string $post_type
@@ -533,6 +511,7 @@ class Term extends Core implements CoreInterface {
 	 * @return array|bool|null
 	 */
 	public function get_posts( $numberposts = 10, $post_type = 'any', $PostClass = '' ) {
+		Helper::deprecated('{{ term.get_posts }}', '{{ term.posts }}', '2.0.0')
 		return $this->posts($numberposts, $post_type, $PostClass);
 	}
 
@@ -541,7 +520,7 @@ class Term extends Core implements CoreInterface {
 	 * @return array
 	 */
 	public function get_children() {
-		Helper::warn( '{{ term.get_children }} is deprecated. Use {{ term.children }} instead.' );
+		Helper::deprecated('{{ term.get_children }}', '{{ term.children }}', '2.0.0');
 
 		return $this->children();
 	}
@@ -549,7 +528,7 @@ class Term extends Core implements CoreInterface {
 
 	/**
 	 *
-	 * @deprecated since 2.0
+	 * @deprecated 2.0.0 with no replacement
 	 * @param string  $key
 	 * @param mixed   $value
 	 */

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -240,14 +240,11 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @api
-	 * @deprecated 2.0.0, use `{{ term.meta }}` instead.
+	 * @internal
 	 * @param string $field_name
 	 * @return string
 	 */
 	public function get_meta_field( $field_name ) {
-		Helper::warn( '{{ term.get_meta_field }} is deprecated. Use {{ term.meta }} instead.' );
-
 		return $this->meta($field_name);
 	}
 

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -235,6 +235,31 @@ class Term extends Core implements CoreInterface {
 		return $this->meta($field_name);
 	}
 
+	/**
+	 * @api
+	 * @deprecated 1.0.0, use `{{ term.path }}` instead.
+	 * @return string
+	 */
+	public function get_path() {
+		Helper::warn( '{{ term.get_path }} is deprecated. Use {{ term.path }} instead.' );
+
+		return $this->path();
+	}
+
+	/**
+	 * @api
+	 * @deprecated 1.0.0, use `{{ term.link }}` instead.
+	 * @return string
+	 */
+	public function get_link() {
+		Helper::warn( '{{ term.get_link }} is deprecated. Use {{ term.link }} instead.' );
+
+		return $this->link();
+	}
+
+
+	/* Alias
+	====================== */
 
 	/**
 	 * @api
@@ -490,7 +515,7 @@ class Term extends Core implements CoreInterface {
 	/**
 	 * Get Posts that have been "tagged" with the particular term
 	 *
-	 * @deprecated since 2.0 use Term::posts() instead
+	 * @deprecated 2.0 use Term::posts() instead
 	 * @internal
 	 * @param int $numberposts
 	 * @param string $post_type

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -225,13 +225,29 @@ class Term extends Core implements CoreInterface {
 	}
 
 
+	/* Public methods
+	===================== */
+
 	/**
-	 * @internal
-   	 * @deprecated since 2.0.0 use Term::meta() insteaad
+	 * @api
+	 * @deprecated 2.0.0, use `{{ term.edit_link }}` instead.
+	 * @return string
+	 */
+	public function get_edit_url() {
+		Helper::warn( '{{ term.get_edit_url }} is deprecated. Use `{{ term.edit_link }}` instead.' );
+
+		return $this->edit_link();
+	}
+
+	/**
+	 * @api
+	 * @deprecated 2.0.0, use `{{ term.meta }}` instead.
 	 * @param string $field_name
 	 * @return string
 	 */
 	public function get_meta_field( $field_name ) {
+		Helper::warn( '{{ term.get_meta_field }} is deprecated. Use {{ term.meta }} instead.' );
+
 		return $this->meta($field_name);
 	}
 
@@ -257,9 +273,6 @@ class Term extends Core implements CoreInterface {
 		return $this->link();
 	}
 
-
-	/* Alias
-	====================== */
 
 	/**
 	 * @api
@@ -527,23 +540,15 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
-	 * @deprecated since 2.0.0 use Term::children() instead
-	 * @internal
+	 * @deprecated 2.0.0, use `{{ term.children }}` instead.
 	 * @return array
 	 */
 	public function get_children() {
+		Helper::warn( '{{ term.get_children }} is deprecated. Use {{ term.children }} instead.' );
+
 		return $this->children();
 	}
 
-	/**
-	 * @internal
-   	 * @deprecated since 2.0.0 use Term::edit_link() instead
-	 * @return string
-	 */
-	public function get_edit_url() {
-		return get_edit_term_link($this->ID, $this->taxonomy);
-	}
 
 	/**
 	 *

--- a/lib/User.php
+++ b/lib/User.php
@@ -336,21 +336,26 @@ class User extends Core implements CoreInterface {
 	 */
 
 	/**
-	 * @deprected since 2.0
+	 * @api
+	 * @deprecated 2.0.0, use `{{ user.meta }}` instead.
 	 * @param string $field_name
 	 * @return mixed
 	 */
 	public function get_meta_field( $field_name ) {
+		Helper::warn( '{{ user.get_meta_field() }} is deprecated. Use {{ user.meta() }} instead.' );
+
 		return $this->meta($field_name);
 	}
 
 	/**
-	 * @deprected since 2.0
-	 * @internal
+	 * @api
+	 * @deprecated 2.0.0, use `{{ user.meta }}` instead.
 	 * @param string $field_name
 	 * @return null
 	 */
 	public function get_meta( $field_name ) {
+		Helper::warn( '{{ user.get_meta() }} is deprecated. Use {{ user.meta() }} instead.' );
+
 		return $this->get_meta_field($field_name);
 	}
 }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -147,7 +147,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[1];
-		$this->assertTrue( $item->external() );
+		$this->assertTrue( $item->is_external() );
 		$struc = get_option( 'permalink_structure' );
 		$this->assertEquals( 'http://upstatement.com', $item->url );
 		$this->assertEquals( 'http://upstatement.com', $item->link() );

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -2,6 +2,9 @@
 
 	class TestTimberPostPreview extends Timber_UnitTestCase {
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testDoubleEllipsis(){
 			$post_id = $this->factory->post->create();
 			$post = new Timber\Post($post_id);
@@ -10,6 +13,9 @@
 			$this->assertEquals(1, substr_count($prev, '&hellip;'));
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testReadMoreClassFilter() {
 			add_filter('timber/post/get_preview/read_more_class', function($class) {
 				return $class . ' and-foo';
@@ -20,6 +26,9 @@
 			$this->assertContains('and-foo', (string) $text);
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testPreviewTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 			$post = new Timber\Post($post_id);
@@ -27,6 +36,9 @@
 			$this->assertNotContains('</p>', (string) $text);
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testGetPreview() {
 			global $wp_rewrite;
 			$struc = false;
@@ -64,7 +76,7 @@
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [mythang]', 'post_excerpt' => '') );
 			$post = new Timber\Post( $pid );
-			$this->assertEquals('jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
+			$this->assertEquals('jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
 		function testShortcodesInPreviewFromContentWithMoreTag() {
@@ -73,27 +85,39 @@
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [duck] <!--more--> joojoo', 'post_excerpt' => '') );
 			$post = new Timber\Post( $pid );
-			$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
+			$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testPreviewWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = new Timber\Post( $pid );
 			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true));
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testPreviewWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = new Timber\Post( $pid );
 			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testPreviewWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = new Timber\Post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->get_preview());
 		}
 
+		/**
+		 * @expectedDeprecated {{ post.get_preview }}
+		 */
 		function testPreviewWithCustomEnd() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck', 'post_excerpt' => '') );
 			$post = new Timber\Post( $pid );
@@ -101,7 +125,7 @@
 		}
 
 		/**
-		 * @group failing
+		 * @expectedDeprecated {{ post.get_preview }}
 		 */
 		function testPreviewWithCustomStripTags() {
 			$pid = $this->factory->post->create(array(


### PR DESCRIPTION
**Ticket**: #1634 

Builds on #1634 to use WP's PHPUnit functionality for `@expectedDeprecated` this resolves the errors with the `TestTimberPostPreview` tests by way of a handy new `Helper::deprecated` method:

```php
Helper::deprecated('{{ term.get_link }}', '{{ term.link }}', '2.0.0');
```
