### PR TITLE
when Imagick isn't available we should return false

### DIFF
--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -51,27 +51,29 @@ class Resize extends ImageOperation {
 		}
 		$result = $src_filename.'-'.$w.'x'.$h.'-c-'.($this->crop ? $this->crop : 'f'); // Crop will be either user named or f (false)
 		if ( $src_extension ) {
-			$result .= '.'.$src_extension;
+			$result .= '.' . $src_extension;
 		}
 		return $result;
 	}
 
 	/**
-	 * @param string $load_filename
-	 * @param string $save_filename
-	 * @param \WP_Image_Editor $editor
+	 * Run a resize as animated GIF (if the server supports it)
+	 *
+	 * @param string           $load_filename the name of the file to resize.
+	 * @param string           $save_filename the desired name of the file to save.
+	 * @param \WP_Image_Editor $editor the image editor we're using.
 	 * @return bool
 	 */
 	protected function run_animated_gif( $load_filename, $save_filename, \WP_Image_Editor $editor ) {
 		$w = $this->w;
 		$h = $this->h;
-		if ( !class_exists('Imagick') || ( defined('TEST_NO_IMAGICK') &&  TEST_NO_IMAGICK )) {
-			Helper::warn( 'Cannot resize GIF, Imagick is not installed' );
+		if ( ! class_exists('Imagick') || ( defined('TEST_NO_IMAGICK') && TEST_NO_IMAGICK ) ) {
+			Helper::warn('Cannot resize GIF, Imagick is not installed');
 			return false;
 		}
 		$image = new \Imagick($load_filename);
 		$image = $image->coalesceImages();
-		$crop = self::get_target_sizes($editor);
+		$crop  = self::get_target_sizes($editor);
 		foreach ( $image as $frame ) {
 			$frame->cropImage($crop['src_w'], $crop['src_h'], $crop['x'], $crop['y']);
 			$frame->thumbnailImage($w, $h);

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -64,8 +64,9 @@ class Resize extends ImageOperation {
 	protected function run_animated_gif( $load_filename, $save_filename, \WP_Image_Editor $editor ) {
 		$w = $this->w;
 		$h = $this->h;
-		if ( !class_exists('Imagick') ) {
+		if ( !class_exists('Imagick') || ( defined('TEST_NO_IMAGICK') &&  TEST_NO_IMAGICK )) {
 			Helper::error_log( 'Can not resize GIF, Imagick is not installed' );
+			return;
 		}
 		$image = new \Imagick($load_filename);
 		$image = $image->coalesceImages();
@@ -172,9 +173,7 @@ class Resize extends ImageOperation {
 		if ( !is_wp_error($image) ) {
 			//should be resized by gif resizer
 			if ( ImageHelper::is_animated_gif($load_filename) ) {
-				//attempt to resize
-				//return if successful
-				//proceed if not
+				//attempt to resize, return if successful proceed if not
 				$gif = self::run_animated_gif($load_filename, $save_filename, $image);
 				if ( $gif ) {
 					return true;

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -66,7 +66,7 @@ class Resize extends ImageOperation {
 		$w = $this->w;
 		$h = $this->h;
 		if ( !class_exists('Imagick') || ( defined('TEST_NO_IMAGICK') &&  TEST_NO_IMAGICK )) {
-			Helper::error_log( 'Can not resize GIF, Imagick is not installed' );
+			Helper::warn( 'Cannot resize GIF, Imagick is not installed' );
 			return false;
 		}
 		$image = new \Imagick($load_filename);

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -60,13 +60,14 @@ class Resize extends ImageOperation {
 	 * @param string $load_filename
 	 * @param string $save_filename
 	 * @param \WP_Image_Editor $editor
+	 * @return bool
 	 */
 	protected function run_animated_gif( $load_filename, $save_filename, \WP_Image_Editor $editor ) {
 		$w = $this->w;
 		$h = $this->h;
 		if ( !class_exists('Imagick') || ( defined('TEST_NO_IMAGICK') &&  TEST_NO_IMAGICK )) {
 			Helper::error_log( 'Can not resize GIF, Imagick is not installed' );
-			return;
+			return false;
 		}
 		$image = new \Imagick($load_filename);
 		$image = $image->coalesceImages();

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 - Please add bullet points here with your PR. The heading for this section will get the correct version number once released.
+- Fixed some issues with animated gif resizing when Imagick isn't available #1653
 
 **Changes for Theme Developers**
 - Please add any usage changes here so theme developers are informed of changes.

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -265,24 +265,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertFalse( TimberImageHelper::is_animated_gif('notreal.gif') );
 	}
 
-	/**
-     * @runInSeparateProcess
-     * @expectedException Twig_Error_Runtime
-     */
-	function testAnimagedGifResizeWithoutImagick() {
-		define('TEST_NO_IMAGICK', true);
-		$image = self::copyTestImage('robocop.gif');
-		$data = array('crop' => 'default');
-		$data['size'] = array('width' => 90, 'height' => 90);
-		$upload_dir = wp_upload_dir();
-		$url = $upload_dir['url'].'/robocop.gif';
-		$data['test_image'] = $url;
-		$str = Timber::compile( 'assets/image-test.twig', $data );
-		$resized_path = $upload_dir['path'].'/robocop-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.gif';
-		$this->addFile( $resized_path );
-		$this->assertFileExists( $resized_path );
-		$this->assertFalse(TimberImageHelper::is_animated_gif($resized_path));
-	}
+
 
 	/**
 	 * @group maybeSkipped
@@ -1080,6 +1063,24 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$data['url'] = $data['baseurl'];
 
 		return $data;
+	}
+
+	/**
+     * @expectedException Twig_Error_Runtime
+     */
+	function testAnimagedGifResizeWithoutImagick() {
+		define('TEST_NO_IMAGICK', true);
+		$image = self::copyTestImage('robocop.gif');
+		$data = array('crop' => 'default');
+		$data['size'] = array('width' => 90, 'height' => 90);
+		$upload_dir = wp_upload_dir();
+		$url = $upload_dir['url'].'/robocop.gif';
+		$data['test_image'] = $url;
+		$str = Timber::compile( 'assets/image-test.twig', $data );
+		$resized_path = $upload_dir['path'].'/robocop-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.gif';
+		$this->addFile( $resized_path );
+		$this->assertFileExists( $resized_path );
+		$this->assertFalse(TimberImageHelper::is_animated_gif($resized_path));
 	}
 
 }

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -81,6 +81,30 @@ class TestTimberImage extends TimberImage_UnitTestCase {
  * Tests
  ---------------- */
 
+ 	function testInitFromID() {
+		$pid = $this->factory->post->create();
+		$filename = self::copyTestImage( 'arch.jpg' );
+		$attachment = array( 'post_title' => 'The Arch', 'post_content' => '' );
+		$iid = wp_insert_attachment( $attachment, $filename, $pid );
+		$image = new TimberImage( $iid );
+		$this->assertEquals( 1500, $image->width() );
+	}
+
+ 	/**
+     * @runInSeparateProcess
+     */
+	function testWithOutputBuffer() {
+		ob_start();
+		$post = $this->get_post_with_image();
+		$str = '<img src="{{ post.thumbnail.src|resize(510, 280) }}" />';
+		Timber::render_string($str, array('post' => $post));
+		$result = ob_get_contents();
+		ob_end_clean();
+		$m = date('m');
+		$y = date('Y');
+		$this->assertEquals('<img src="http://example.org/wp-content/uploads/'.$y.'/'.$m.'/arch-510x280-c-default.jpg" />', $result);
+	}
+
  	function testReplacedImage() {
  		$pid = $this->factory->post->create(array('post_type' => 'post'));
  		$attach_id = self::get_image_attachment($pid, 'arch.jpg');
@@ -149,6 +173,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals( 1.5, $image->aspect() );
 	}
 
+	/**
+	 * @group maybeSkipped
+	 */
 	function testExternalImageResize() {
 		if ( !self::is_connected() ) {
 			$this->markTestSkipped('Cannot test external images when not connected to internet');
@@ -241,6 +268,27 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertFalse( TimberImageHelper::is_animated_gif('notreal.gif') );
 	}
 
+	/**
+     * @runInSeparateProcess
+     */
+	function testAnimagedGifResizeWithoutImagick() {
+		define('TEST_NO_IMAGICK', true);
+		$image = self::copyTestImage('robocop.gif');
+		$data = array('crop' => 'default');
+		$data['size'] = array('width' => 90, 'height' => 90);
+		$upload_dir = wp_upload_dir();
+		$url = $upload_dir['url'].'/robocop.gif';
+		$data['test_image'] = $url;
+		Timber::compile( 'assets/image-test.twig', $data );
+		$resized_path = $upload_dir['path'].'/robocop-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.gif';
+		$this->addFile( $resized_path );
+		$this->assertFileExists( $resized_path );
+		$this->assertFalse(TimberImageHelper::is_animated_gif($resized_path));
+	}
+
+	/**
+	 * @group maybeSkipped
+	 */
 	function testAnimatedGifResize() {
 		if ( ! extension_loaded( 'imagick' ) ) {
 			self::markTestSkipped( 'Animated GIF resizing test requires Imagick extension' );
@@ -277,6 +325,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	}
 
+	/**
+	 * @group maybeSkipped
+	 */
 	function testResizeTallImage() {
 		$data = array();
 		$data['size'] = array( 'width' => 600 );
@@ -311,15 +362,6 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$image = new TimberImage( $filename );
 		$this->assertStringStartsWith('/wp-content', $image->path());
 		$this->assertStringEndsWith('.jpg', $image->path());
-	}
-
-	function testInitFromID() {
-		$pid = $this->factory->post->create();
-		$filename = self::copyTestImage( 'arch.jpg' );
-		$attachment = array( 'post_title' => 'The Arch', 'post_content' => '' );
-		$iid = wp_insert_attachment( $attachment, $filename, $pid );
-		$image = new TimberImage( $iid );
-		$this->assertEquals( 1500, $image->width() );
 	}
 
 	function testInitFromFilePath() {
@@ -504,6 +546,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		return ImageOperation::rgbhex($r, $g, $b);
 	}
 
+	/**
+	 * @group maybeSkipped
+	 */
 	function testPNGtoJPG() {
 		if ( ! extension_loaded( 'gd' ) ) {
 			self::markTestSkipped( 'PNG to JPEG conversion test requires GD extension' );
@@ -669,6 +714,10 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertFileNotExists( $resized_500_file );
 	}
 
+	/**
+	 *
+	 * @group maybeSkipped
+	 */
 	function testLetterboxImageDeletion() {
 		if ( ! extension_loaded( 'gd' ) ) {
 			self::markTestSkipped( 'Letterbox image test requires GD extension' );
@@ -741,6 +790,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		return $path;
 	}
 
+	/**
+	 * @group maybeSkipped
+	 */
 	function testThemeImageLetterbox() {
 		$theme_url = get_theme_root_uri().'/'.get_stylesheet();
 		if ( ! extension_loaded( 'gd' ) ) {
@@ -767,17 +819,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals( 1500, $rendered );
 	}
 
-	function testWithOutputBuffer() {
-		ob_start();
-		$post = $this->get_post_with_image();
-		$str = '<img src="{{ post.thumbnail.src|resize(510, 280) }}" />';
-		Timber::render_string($str, array('post' => $post));
-		$result = ob_get_contents();
-		ob_end_clean();
-		$m = date('m');
-		$y = date('Y');
-		$this->assertEquals('<img src="http://example.org/wp-content/uploads/'.$y.'/'.$m.'/arch-510x280-c-default.jpg" />', $result);
-	}
+
 
 	function testResizeNamed() {
 		add_image_size('timber-testResizeNamed', $width = 600, $height = 400, $crop = true);
@@ -892,6 +934,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals('<img src="'.$upload_dir['url'].'/'.$image->sizes['medium']['file'].'" />', trim($result));
 	}
 
+	/**
+	 * @group maybeSkipped
+	 */
 	function testGifToJpg() {
 		if ( ! extension_loaded( 'gd' ) ) {
 			self::markTestSkipped( 'JPEG conversion test requires GD extension' );
@@ -909,6 +954,9 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertTrue($helper);
 	}
 
+	/**
+	 * @group maybeSkipped
+	 */
 	function testResizeGif() {
 		if ( ! extension_loaded( 'imagick' ) ) {
 			self::markTestSkipped( 'Animated GIF resizing test requires Imagick extension' );

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -90,9 +90,6 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$this->assertEquals( 1500, $image->width() );
 	}
 
- 	/**
-     * @runInSeparateProcess
-     */
 	function testWithOutputBuffer() {
 		ob_start();
 		$post = $this->get_post_with_image();
@@ -270,6 +267,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 
 	/**
      * @runInSeparateProcess
+     * @expectedException Twig_Error_Runtime
      */
 	function testAnimagedGifResizeWithoutImagick() {
 		define('TEST_NO_IMAGICK', true);
@@ -279,7 +277,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$upload_dir = wp_upload_dir();
 		$url = $upload_dir['url'].'/robocop.gif';
 		$data['test_image'] = $url;
-		Timber::compile( 'assets/image-test.twig', $data );
+		$str = Timber::compile( 'assets/image-test.twig', $data );
 		$resized_path = $upload_dir['path'].'/robocop-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.gif';
 		$this->addFile( $resized_path );
 		$this->assertFileExists( $resized_path );


### PR DESCRIPTION
#### Issue
Currently the code in `Resize.php` checks for Imagick for resizing animated GIFs and gives a warning, but then proceeds to process with Imagick — even though it's already determined it's not there.

#### Solution
Return false when`Imagick` isn't there so we know no animated gif was created

#### Impact
Should resolve errors on existing installations. Tested on a real-life site with this issue.

#### Usage Changes
Nope

#### Testing
Added a testing modification so that we can simulate when Imagick isn't available; this involves creating a constant that the method tests for