### PR TITLE
add optional extra parameter to resize method

### DIFF
--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -17,14 +17,14 @@ use Timber\Image\Operation as ImageOperation;
  */
 class Resize extends ImageOperation {
 
-   private $w, $h, $crop;
+   private $w, $h, $crop, $quality;
 
 	/**
 	 * @param int    $w    width of new image
 	 * @param int    $h    height of new image
 	 * @param string $crop cropping method, one of: 'default', 'center', 'top', 'bottom', 'left', 'right', 'top-center', 'bottom-center'.
 	 */
-	public function __construct( $w, $h, $crop ) {
+	public function __construct( $w, $h, $crop, $quality ) {
 		$this->w = $w;
 		$this->h = $h;
 		// Sanitize crop position
@@ -33,6 +33,7 @@ class Resize extends ImageOperation {
 			$crop = $allowed_crop_positions[0];
 		}
 		$this->crop = $crop;
+		$this->quality = $quality;
 	}
 
 	/**
@@ -191,6 +192,7 @@ class Resize extends ImageOperation {
 							$crop['target_w'],
 							$crop['target_h']
 			);
+			$image->set_quality($this->quality);
 			$result = $image->save($save_filename);
 			if ( is_wp_error($result) ) {
 				// @codeCoverageIgnoreStart

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -20,9 +20,10 @@ class Resize extends ImageOperation {
    private $w, $h, $crop, $quality;
 
 	/**
-	 * @param int    $w    width of new image
-	 * @param int    $h    height of new image
-	 * @param string $crop cropping method, one of: 'default', 'center', 'top', 'bottom', 'left', 'right', 'top-center', 'bottom-center'.
+	 * @param int    $w       width of new image
+	 * @param int    $h       height of new image
+	 * @param string $crop    cropping method, one of: 'default', 'center', 'top', 'bottom', 'left', 'right', 'top-center', 'bottom-center'.
+	 * @param int    $quality compression quality 0-100 if image format is jpeg
 	 */
 	public function __construct( $w, $h, $crop, $quality ) {
 		$this->w = $w;

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -48,6 +48,7 @@ class ImageHelper {
 	 * @param int     		$h target height (ignored if $w is WP image size). If not set, will ignore and resize based on $w only.
 	 * @param string  		$crop your choices are 'default', 'center', 'top', 'bottom', 'left', 'right'
 	 * @param bool    		$force
+	 * @param int     		$quality compression quality 0-100 if image format is jpeg
 	 * @example
 	 * ```twig
 	 * <img src="{{ image.src | resize(300, 200, 'top') }}" />

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -584,7 +584,7 @@ class ImageHelper {
 		return $new_path;
 	}
 
-	public static function get_resize_file_url( $url, $w, $h, $crop, $quality ) {
+	public static function get_resize_file_url( $url, $w, $h, $crop, $quality = 60 ) {
 		$au = self::analyze_url($url);
 		$op = new Image\Operation\Resize($w, $h, $crop, $quality);
 		$new_url = self::_get_file_url(
@@ -596,7 +596,7 @@ class ImageHelper {
 		return $new_url;
 	}
 
-	public static function get_resize_file_path( $url, $w, $h, $crop, $quality ) {
+	public static function get_resize_file_path( $url, $w, $h, $crop, $quality = 60 ) {
 		$au = self::analyze_url($url);
 		$op = new Image\Operation\Resize($w, $h, $crop, $quality);
 		$new_path = self::_get_file_path(

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -66,7 +66,7 @@ class ImageHelper {
 				return $src;
 			}
 		}
-		$op = new Image\Operation\Resize($w, $h, $crop);
+		$op = new Image\Operation\Resize($w, $h, $crop, $quality);
 		return self::_operate($src, $op, $force);
 	}
 

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -584,9 +584,9 @@ class ImageHelper {
 		return $new_path;
 	}
 
-	public static function get_resize_file_url( $url, $w, $h, $crop ) {
+	public static function get_resize_file_url( $url, $w, $h, $crop, $quality ) {
 		$au = self::analyze_url($url);
-		$op = new Image\Operation\Resize($w, $h, $crop);
+		$op = new Image\Operation\Resize($w, $h, $crop, $quality);
 		$new_url = self::_get_file_url(
 			$au['base'],
 			$au['subdir'],
@@ -596,9 +596,9 @@ class ImageHelper {
 		return $new_url;
 	}
 
-	public static function get_resize_file_path( $url, $w, $h, $crop ) {
+	public static function get_resize_file_path( $url, $w, $h, $crop, $quality ) {
 		$au = self::analyze_url($url);
-		$op = new Image\Operation\Resize($w, $h, $crop);
+		$op = new Image\Operation\Resize($w, $h, $crop, $quality);
 		$new_path = self::_get_file_path(
 			$au['base'],
 			$au['subdir'],

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -57,7 +57,7 @@ class ImageHelper {
 	 * ```
 	 * @return string (ex: )
 	 */
-	public static function resize( $src, $w, $h = 0, $crop = 'default', $force = false ) {
+	public static function resize( $src, $w, $h = 0, $crop = 'default', $force = false, $quality = 60 ) {
 		if ( !is_numeric($w) && is_string($w) ) {
 			if ( $sizes = self::find_wp_dimensions($w) ) {
 				$w = $sizes['w'];


### PR DESCRIPTION
add optional extra parameter to `resize` method of the `ImageHelper` class to customize jpeg compression quality of image being generated

**Related Ticket**: # [857](https://github.com/timber/timber/issues/857)

#### Issue
The default setting `set_quality` method of Wordpress' [WP_Image_Editor class](https://codex.wordpress.org/Class_Reference/WP_Image_Editor) is 90%, which is not a very desirable quality for jpeg compression for web use. Also, it would just be a really nice feature to have implemented to be able to customize what compression quality `resize()` puts out.

#### Solution
Add a new optional parameter to resize() call to customize jpeg quality, 0-100. Personal suggestion for a default setting if nothing passed: 60 (as reflected in my code).

#### Impact
Since it's an optional extra parameter added to the end of the current parameters, it should be backwards compatible.

#### Usage Changes
`{{ image.src | resize( 300, 200, 'top', false, 50 ) }}` (would produce 50% jpeg quality)

#### Considerations
- Would also maybe help to throw error if user passes something other than the accepted 0-100 integer.
- Would need to update [Timber docs](https://timber.github.io/docs/reference/timber-imagehelper/#resize).