### PR TITLE
2.x Prepare structural elements for usage with phpDocumentor

### DIFF
--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -2,6 +2,9 @@
 
 namespace Timber;
 
+/**
+ * Class Admin
+ */
 class Admin {
 
 	public static function init() {
@@ -101,11 +104,10 @@ class Admin {
 	 *
 	 * @codeCoverageIgnore
 	 *
-	 * @type    function
 	 * @date    4/22/16
 	 *
-	 * @param   {array}	 $plugin_data
-	 * @param   {object} $r
+	 * @param array  $plugin_data
+	 * @param object $r
 	 */
 	public static function in_plugin_update_message( $plugin_data, $r ) {
 		$current_version = $plugin_data['Version'];

--- a/lib/Archives.php
+++ b/lib/Archives.php
@@ -6,8 +6,13 @@ use Timber\Core;
 use Timber\URLHelper;
 
 /**
- * The Timber\Archives class is used to generate a menu based on the date archives of your posts. The [Nieman Foundation News site](http://nieman.harvard.edu/news/) has an example of how the output can be used in a real site ([screenshot](https://cloud.githubusercontent.com/assets/1298086/9610076/3cdca596-50a5-11e5-82fd-acb74c09c482.png)).
+ * Class Archive
  *
+ * The `Timber\Archives` class is used to generate a menu based on the date archives of your posts.
+ * The [Nieman Foundation News site](http://nieman.harvard.edu/news/) has an example of how the
+ * output can be used in a real site ([screenshot](https://cloud.githubusercontent.com/assets/1298086/9610076/3cdca596-50a5-11e5-82fd-acb74c09c482.png)).
+ *
+ * @api
  * @example
  * ```php
  * $context['archives'] = new Timber\Archives( $args );
@@ -38,29 +43,39 @@ use Timber\URLHelper;
  * ```
  */
 class Archives extends Core {
-
+	/**
+	 * URL prefix.
+	 *
+	 * @api
+	 * @var string
+	 */
 	public $base = '';
+
 	/**
 	 * @api
-	 * @var array the items of the archives to iterate through and markup for your page
+	 * @var array The items of the archives to iterate through and markup for your page.
 	 */
+	public $items;
 
 	/**
 	 * Build an Archives menu
 	 *
 	 * @api
-	 * @param array  $args of arguments {
-	 *     @type bool show_year => false
-	 *     @type string
-	 *     @type string type => 'monthly-nested'
-	 *     @type int limit => -1
-	 *     @type bool show_post_count => false
-	 *     @type string order => 'DESC'
-	 *     @type string post_type => 'post'
-	 *     @type bool show_year => false
-	 *     @type bool nested => false
-	 * };
-	 * @param string $base any additional paths that need to be prepended to the URLs that are generated, for example: "tags".
+	 * @param array  $args {
+	 *      Array of arguments.
+	 *
+	 *      @type bool $show_year => false
+	 *      @type string
+	 *      @type string $type => 'monthly-nested'
+	 *      @type int $limit => -1
+	 *      @type bool $show_post_count => false
+	 *      @type string $order => 'DESC'
+	 *      @type string $post_type => 'post'
+	 *      @type bool $show_year => false
+	 *      @type bool $nested => false
+	 * }
+	 * @param string $base Any additional paths that need to be prepended to the URLs that are
+	 *                     generated, for example: "tags". Default ''.
 	 */
 	public function __construct( $args = null, $base = '' ) {
 		$this->init($args, $base);

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -7,7 +7,13 @@ use Timber\Core;
 use Timber\CoreInterface;
 
 /**
- * The Timber\Comment class is used to view the output of comments. 99% of the time this will be in the context of the comments on a post. However you can also fetch a comment directly using its comment ID.
+ * Class Comment
+ *
+ * The `Timber\Comment` class is used to view the output of comments. 99% of the time this will be
+ * in the context of the comments on a post. However you can also fetch a comment directly using its
+ * comment ID.
+ *
+ * @api
  * @example
  * ```php
  * $comment = new Timber\Comment($comment_id);
@@ -32,26 +38,76 @@ class Comment extends Core implements CoreInterface {
 
 	public static $representation = 'comment';
 
+	/**
+	 * @api
+	 * @var int
+	 */
 	public $ID;
+
+	/**
+	 * @api
+	 * @var int
+	 */
 	public $id;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $comment_author_email;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $comment_content;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $comment_date;
+
+	/**
+	 * @api
+	 * @var int
+	 */
 	public $comment_ID;
+
+	/**
+	 * @api
+	 * @var int
+	 */
 	public $user_id;
+
+	/**
+	 * @api
+	 * @var int
+	 */
 	public $post_id;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $comment_author;
+
 	public $_depth = 0;
 
 	protected $children = array();
 
 	/**
+	 * @api
 	 * @param int $cid
 	 */
 	public function __construct( $cid ) {
 		$this->init($cid);
 	}
 
+	/**
+	 * @api
+	 * @return string
+	 */
 	public function __toString() {
 		return $this->content();
 	}
@@ -108,7 +164,8 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Fetches the Gravatar
+	 * Fetches the Gravatar.
+	 *
 	 * @api
 	 * @example
 	 * ```twig
@@ -168,6 +225,7 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param Comment $child_comment;
 	 */
 	public function add_child( Comment $child_comment ) {
@@ -178,6 +236,7 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param int $depth
 	 */
 	public function update_depth( $depth = 0 ) {
@@ -246,7 +305,7 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
-	 * What time was the commetn posted?
+	 * What time was the comment posted?
 	 *
 	 * @api
 	 * @example
@@ -274,6 +333,7 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param string $field_name
 	 * @return mixed
 	 */
@@ -359,7 +419,6 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
 	 * @internal
 	 * @param string $field_name
 	 * @return mixed
@@ -430,8 +489,8 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Enqueue the WP threaded comments javascript,
-	 * and fetch the reply link for various comments.
+	 * Enqueue the WP threaded comments JavaScript, and fetch the reply link for various comments.
+	 *
 	 * @api
 	 * @return string
 	 */

--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -4,6 +4,9 @@ namespace Timber;
 
 use Timber\Comment;
 
+/**
+ * Class CommentThread
+ */
 class CommentThread extends \ArrayObject {
 
 	var $CommentClass = 'Timber\Comment';
@@ -86,7 +89,7 @@ class CommentThread extends \ArrayObject {
 			}
 		}
 
-		
+
 
 		foreach ( $children as &$comment ) {
 			$parent_id = $comment->comment_parent;

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -2,6 +2,9 @@
 
 namespace Timber;
 
+/**
+ * Class Core
+ */
 abstract class Core {
 
 	public $id;

--- a/lib/CoreInterface.php
+++ b/lib/CoreInterface.php
@@ -2,6 +2,9 @@
 
 namespace Timber;
 
+/**
+ * Interface CoreInterface
+ */
 interface CoreInterface {
 
 	public function __call( $field, $args );

--- a/lib/FunctionWrapper.php
+++ b/lib/FunctionWrapper.php
@@ -5,11 +5,12 @@ namespace Timber;
 use Timber\Helper;
 
 /**
- * FunctionWrapper Class.
+ * Class FunctionWrapper
  *
- * With Timber, we want to prepare all the data before we echo content through a render function. Some functionality in WordPress directly echoes output instead of returning it. This class makes it easier to store the results of an echoing function by using ob_start() and ob_end_clean() behind the scenes.
- *
- * @package Timber
+ * With Timber, we want to prepare all the data before we echo content through a render function.
+ * Some functionality in WordPress directly echoes output instead of returning it. This class makes
+ * it easier to store the results of an echoing function by using ob_start() and ob_end_clean()
+ * behind the scenes.
  */
 class FunctionWrapper {
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -6,12 +6,15 @@ use Timber\FunctionWrapper;
 use Timber\URLHelper;
 
 /**
- * As the name suggests these are helpers for Timber (and you!) when developing. You can find additional (mainly internally-focused helpers) in Timber\URLHelper
+ * Class Helper
+ *
+ * As the name suggests these are helpers for Timber (and you!) when developing. You can find additional
+ * (mainly internally-focused helpers) in Timber\URLHelper.
  */
 class Helper {
-
 	/**
-	 * A utility for a one-stop shop for Transients
+	 * A utility for a one-stop shop for transients.
+	 *
 	 * @api
 	 * @example
 	 * ```php
@@ -52,7 +55,10 @@ class Helper {
 	}
 
 	/**
-	 * Does the dirty work of locking the transient, running the callback and unlocking
+	 * Does the dirty work of locking the transient, running the callback and unlocking.
+	 *
+	 * @internal
+	 *
 	 * @param string 	$slug
 	 * @param callable 	$callback
 	 * @param integer  	$transient_time Expiration of transients in seconds
@@ -158,7 +164,8 @@ class Helper {
 	/* These are for measuring page render time */
 
 	/**
-	 * For measuring time, this will start a timer
+	 * For measuring time, this will start a timer.
+	 *
 	 * @api
 	 * @return float
 	 */
@@ -170,13 +177,16 @@ class Helper {
 	}
 
 	/**
-	 * For stopping time and getting the data
+	 * For stopping time and getting the data.
+	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * $start = Timber\Helper::start_timer();
 	 * // do some stuff that takes awhile
 	 * echo Timber\Helper::stop_timer( $start );
 	 * ```
+	 *
 	 * @param int     $start
 	 * @return string
 	 */
@@ -193,7 +203,10 @@ class Helper {
 	======================== */
 
 	/**
-	 * Calls a function with an output buffer. This is useful if you have a function that outputs text that you want to capture and use within a twig template.
+	 * Calls a function with an output buffer. This is useful if you have a function that outputs
+	 * text that you want to capture and use within a twig template.
+	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * function the_form() {
@@ -213,9 +226,10 @@ class Helper {
 	 * <h1>Apply to my contest!</h1>
 	 * <form action="form.php"><input type="text" /><input type="submit /></form>
 	 * ```
-	 * @api
+	 *
 	 * @param callback $function
 	 * @param array   $args
+	 *
 	 * @return string
 	 */
 	public static function ob_function( $function, $args = array(null) ) {
@@ -227,7 +241,7 @@ class Helper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param mixed $arg that you want to error_log
 	 * @return void
@@ -246,6 +260,8 @@ class Helper {
 	/**
 	 * Trigger a warning.
 	 *
+	 * @api
+	 *
 	 * @param string $message The warning that you want to output.
 	 *
 	 * @return void
@@ -261,7 +277,7 @@ class Helper {
 	/**
 	 * Trigger a deprecation warning.
 	 *
-	 * @param string $message The warning that you want to output.
+	 * @api
 	 *
 	 * @return void
 	 */
@@ -271,7 +287,7 @@ class Helper {
 		}
 
 		 do_action( 'deprecated_function_run', $function, $replacement, $version );
- 
+
 	    /**
 	     * Filters whether to trigger an error for deprecated functions.
 	     *
@@ -300,7 +316,7 @@ class Helper {
 
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param string  $separator
 	 * @param string  $seplocation
@@ -326,22 +342,24 @@ class Helper {
 		return trim(wp_title($separator, false, $seplocation));
 	}
 
-
 	/**
+	 * Sorts object arrays by properties.
 	 *
+	 * @api
 	 *
-	 * @param array   $array
-	 * @param string  $prop
+	 * @param array  $array The array of objects to sort.
+	 * @param string $prop  The property to sort by.
+	 *
 	 * @return void
 	 */
 	public static function osort( &$array, $prop ) {
 		usort($array, function( $a, $b ) use ($prop) {
-				return $a->$prop > $b->$prop ? 1 : -1;
-			} );
+			return $a->$prop > $b->$prop ? 1 : -1;
+		} );
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param array   $arr
 	 * @return bool
@@ -354,7 +372,7 @@ class Helper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param array   $array
 	 * @return \stdClass
@@ -372,7 +390,7 @@ class Helper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param array   $array
 	 * @param string  $key
@@ -399,13 +417,13 @@ class Helper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param array   $array
 	 * @param string  $key
 	 * @param mixed   $value
 	 * @return array|null
-	 * @throws Exception
+	 * @throws \Exception
 	 */
 	public static function get_object_by_property( $array, $key, $value ) {
 		if ( is_array($array) ) {
@@ -421,7 +439,7 @@ class Helper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param array   $array
 	 * @param int     $len
@@ -438,7 +456,7 @@ class Helper {
 	======================== */
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param mixed   $value
 	 * @return bool
@@ -458,6 +476,8 @@ class Helper {
 	/**
 	 * Is the number even? Let's find out.
 	 *
+	 * @api
+	 *
 	 * @param int $i number to test.
 	 * @return bool
 	 */
@@ -468,6 +488,8 @@ class Helper {
 	/**
 	 * Is the number odd? Let's find out.
 	 *
+	 * @api
+	 *
 	 * @param int $i number to test.
 	 * @return bool
 	 */
@@ -477,8 +499,13 @@ class Helper {
 
 	/**
 	 * Plucks the values of a certain key from an array of objects
-	 * @param array $array
+	 *
+	 * @api
+	 *
+	 * @param array  $array
 	 * @param string $key
+	 *
+	 * @return array
 	 */
 	public static function pluck( $array, $key ) {
 		$return = array();
@@ -497,8 +524,10 @@ class Helper {
 	/**
 	 * Filters a list of objects, based on a set of key => value arguments.
 	 *
+	 * @api
 	 * @since 1.5.3
 	 * @ticket #1594
+	 *
 	 * @param array        $list to filter.
 	 * @param string|array $filter to search for.
 	 * @param string       $operator to use (AND, NOT, OR).
@@ -516,5 +545,4 @@ class Helper {
 		$util = new \WP_List_Util( $list );
 		return $util->filter( $args, $operator );
 	}
-
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -7,10 +7,13 @@ use Timber\Helper;
 use Timber\Post;
 use Timber\URLHelper;
 
-
 /**
- * If Timber\Post is the class you're going to spend the most time, Timber\Image is the class you're going to have the most fun with.
+ * Class Image
  *
+ * If Timber\Post is the class you're going to spend the most time, Timber\Image is the class you're
+ * going to have the most fun with.
+ *
+ * @api
  * @example
  * ```php
  * $context = Timber::get_context();
@@ -50,43 +53,69 @@ class Image extends Post implements CoreInterface {
 
 	protected $_can_edit;
 	protected $_dimensions;
-	public $abs_url;
-	/**
-	 * @var string $object_type what does this class represent in WordPress terms?
-	 */
-	public $object_type = 'image';
-	/**
-	 * @var string $representation what does this class represent in WordPress terms?
-	 */
-	public static $representation = 'image';
-	/**
-	 * @var array of supported relative file types
-	 */
-	private $file_types = array('jpg', 'jpeg', 'png', 'svg', 'bmp', 'ico', 'gif', 'tiff', 'pdf');
+
 	/**
 	 * @api
-	 * @var string $file_loc the location of the image file in the filesystem (ex: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
+	 * @var string
+	 */
+	public $abs_url;
+
+	/**
+	 * @api
+	 * @var string What does this class represent in WordPress terms?
+	 */
+	public $object_type = 'image';
+
+	/**
+	 * @api
+	 * @var string What does this class represent in WordPress terms?
+	 */
+	public static $representation = 'image';
+
+	/**
+	 * @var array Array of supported relative file types.
+	 */
+	private $file_types = array('jpg', 'jpeg', 'png', 'svg', 'bmp', 'ico', 'gif', 'tiff', 'pdf');
+
+	/**
+	 * @api
+	 * @var string The location of the image file in the filesystem (ex: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
 	 */
 	public $file_loc;
+
+	/**
+	 * @api
+	 * @var mixed
+	 */
 	public $file;
+
 	/**
 	 * @api
 	 * @var integer the ID of the image (which is a WP_Post)
 	 */
 	public $id;
-	public $sizes = array();
+
 	/**
 	 * @api
-	 * @var string $caption the string stored in the WordPress database
+	 * @var array
+	 */
+	public $sizes = array();
+
+	/**
+	 * @api
+	 * @var string The string stored in the WordPress database
 	 */
 	public $caption;
+
 	/**
-	 * @var $_wp_attached_file the file as stored in the WordPress database
+	 * @var array The file as stored in the WordPress database
 	 */
 	protected $_wp_attached_file;
 
 	/**
 	 * Creates a new Timber\Image object
+	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * // You can pass it an ID number
@@ -104,6 +133,8 @@ class Image extends Post implements CoreInterface {
 	/**
 	 * The src of the image
 	 *
+	 * @api
+	 *
 	 * @return string the src of the file
 	 */
 	public function __toString() {
@@ -112,6 +143,8 @@ class Image extends Post implements CoreInterface {
 
 	/**
 	 * Get a PHP array with pathinfo() info from the file
+	 *
+	 * @api
 	 *
 	 * @return array
 	 */
@@ -207,6 +240,8 @@ class Image extends Post implements CoreInterface {
 
 	/**
 	 * Returns the `wp_upload_dir` and saves result to static var
+	 *
+	 * @api
 	 *
 	 * @return array of data https://developer.wordpress.org/reference/functions/wp_upload_dir/
 	 */
@@ -405,7 +440,7 @@ class Image extends Post implements CoreInterface {
 
 	/**
 	 * @api
-	 * @return bool|Timber\Post
+	 * @return bool|\Timber\Post
 	 */
 	public function parent() {
 		if ( !$this->post_parent ) {
@@ -430,7 +465,6 @@ class Image extends Post implements CoreInterface {
 	}
 
 	/**
-	 * @param string $size a size known to WordPress (like "medium")
 	 * @api
 	 * @example
 	 * ```twig
@@ -440,6 +474,8 @@ class Image extends Post implements CoreInterface {
 	 * ```html
 	 * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" />
 	 * ```
+	 *
+	 * @param string $size a size known to WordPress (like "medium")
 	 * @return bool|string
 	 */
 	public function src( $size = 'full' ) {

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -11,6 +11,8 @@ use Timber\Image\Operation\Letterbox;
 use Timber\URLHelper;
 
 /**
+ * Class ImageHelper
+ *
  * Implements the Twig image filters:
  * https://timber.github.io/docs/guides/cookbook-images/#arbitrary-resizing-of-images
  * - resize
@@ -22,6 +24,8 @@ use Timber\URLHelper;
  * - public static functions provide the methods that are called by the filter
  * - most of the work is common to all filters (URL analysis, directory gymnastics, file caching, error management) and done by private static functions
  * - the specific part (actual image processing) is delegated to dedicated subclasses of TimberImageOperation
+ *
+ * @api
  */
 class ImageHelper {
 
@@ -43,6 +47,7 @@ class ImageHelper {
 	 * New dimensions are achieved by cropping to maintain ratio.
 	 *
 	 * @api
+	 *
 	 * @param string  		$src an URL (absolute or relative) to the original image
 	 * @param int|string	$w target width(int) or WordPress image size (WP-set or user-defined).
 	 * @param int     		$h target height (ignored if $w is WP image size). If not set, will ignore and resize based on $w only.
@@ -71,7 +76,9 @@ class ImageHelper {
 	}
 
 	/**
-	 * Find the sizes of an image based on a defined image size
+	 * Find the sizes of an image based on a defined image size.
+	 *
+	 * @internal
 	 * @param  string $size the image size to search for
 	 *                      can be WordPress-defined ("medium")
 	 *                      or user-defined ("my-awesome-size")
@@ -98,6 +105,8 @@ class ImageHelper {
 	/**
 	 * Generates a new image with increased size, for display on Retina screens.
 	 *
+	 * @api
+	 *
 	 * @param string  $src of the file to read from.
 	 * @param float   $multiplier
 	 * @param boolean $force require process to run even if the file exists.
@@ -111,6 +120,8 @@ class ImageHelper {
 
 	/**
 	 * Checks to see if the given file is an aimated gif
+	 *
+	 * @api
 	 *
 	 * @param string $file local filepath to a file, not a URL.
 	 * @return boolean true if it's an animated gif, false if not.
@@ -145,6 +156,8 @@ class ImageHelper {
 	 * Generate a new image with the specified dimensions.
 	 * New dimensions are achieved by adding colored bands to maintain ratio.
 	 *
+	 * @api
+	 *
 	 * @param string  $src
 	 * @param int     $w
 	 * @param int     $h
@@ -159,6 +172,8 @@ class ImageHelper {
 
 	/**
 	 * Generates a new image by converting the source GIF or PNG into JPG
+	 *
+	 * @api
 	 *
 	 * @param string  $src   a url or path to the image (http://example.org/wp-content/uploads/2014/image.jpg) or (/wp-content/uploads/2014/image.jpg)
 	 * @param string  $bghex
@@ -583,6 +598,9 @@ class ImageHelper {
 
 // -- the below methods are just used for unit testing the URL generation code
 //
+	/**
+	 * @internal
+	 */
 	public static function get_letterbox_file_url( $url, $w, $h, $color ) {
 		$au = self::analyze_url($url);
 		$op = new Image\Operation\Letterbox($w, $h, $color);
@@ -595,6 +613,9 @@ class ImageHelper {
 		return $new_url;
 	}
 
+	/**
+	 * @internal
+	 */
 	public static function get_letterbox_file_path( $url, $w, $h, $color ) {
 		$au = self::analyze_url($url);
 		$op = new Image\Operation\Letterbox($w, $h, $color);
@@ -606,6 +627,9 @@ class ImageHelper {
 		return $new_path;
 	}
 
+	/**
+	 * @internal
+	 */
 	public static function get_resize_file_url( $url, $w, $h, $crop ) {
 		$au = self::analyze_url($url);
 		$op = new Image\Operation\Resize($w, $h, $crop);
@@ -618,6 +642,9 @@ class ImageHelper {
 		return $new_url;
 	}
 
+	/**
+	 * @internal
+	 */
 	public static function get_resize_file_path( $url, $w, $h, $crop ) {
 		$au = self::analyze_url($url);
 		$op = new Image\Operation\Resize($w, $h, $crop);

--- a/lib/Integrations.php
+++ b/lib/Integrations.php
@@ -3,8 +3,9 @@
 namespace Timber;
 
 /**
+ * Class Integrations
+ *
  * This is for integrating external plugins into timber
- * @package  timber
  */
 class Integrations {
 
@@ -14,7 +15,7 @@ class Integrations {
 	public function __construct() {
 		$this->init();
 	}
-    
+
 	public function init() {
 		add_action('init', array($this, 'maybe_init_integrations'));
 

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -5,6 +5,11 @@ namespace Timber;
 use Timber\Core;
 use Timber\Post;
 
+/**
+ * Class Menu
+ *
+ * @api
+ */
 class Menu extends Core {
 
 	public $MenuItemClass = 'Timber\MenuItem';
@@ -18,19 +23,19 @@ class Menu extends Core {
 
 	/**
 	 * @api
-	 * @var integer The ID of the menu, corresponding to the wp_terms table.
+	 * @var int The ID of the menu, corresponding to the wp_terms table.
 	 */
 	public $id;
 
 	/**
 	 * @api
-	 * @var integer The ID of the menu, corresponding to the wp_terms table.
+	 * @var int The ID of the menu, corresponding to the wp_terms table.
 	 */
 	public $ID;
 
 	/**
 	 * @api
-	 * @var integer The ID of the menu, corresponding to the wp_terms table.
+	 * @var int The ID of the menu, corresponding to the wp_terms table.
 	 */
 	public $term_id;
 
@@ -48,6 +53,8 @@ class Menu extends Core {
 
 	/**
 	 * Initialize a menu.
+	 *
+	 * @api
 	 *
 	 * @param int|string $slug A menu slug, the term ID of the menu, the full name from the admin
 	 *                         menu, the slug of theregistered location or nothing. Passing nothing

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -7,6 +7,11 @@ use Timber\CoreInterface;
 
 use Timber\URLHelper;
 
+/**
+ * Class MenuItem
+ *
+ * @api
+ */
 class MenuItem extends Core implements CoreInterface {
 	/**
 	 * @api
@@ -165,6 +170,8 @@ class MenuItem extends Core implements CoreInterface {
 	/**
 	 * Add a new `Timber\MenuItem` object as a child of this menu item.
 	 *
+	 * @api
+	 *
 	 * @param \Timber\MenuItem $item The menu item to add.
 	 */
 	public function add_child( $item ) {
@@ -277,11 +284,11 @@ class MenuItem extends Core implements CoreInterface {
 	 * Plugins like Advanced Custom Fields allow you to set custom fields for menu items. With this
 	 * method you can retrieve the value of these.
 	 *
+	 * @api
 	 * @example
 	 * ```twig
 	 * <a class="icon-{{ item.meta('icon') }}" href="{{ item.link }}">{{ item.title }}</a>
 	 * ```
-	 * @api
 	 * @param string $key The meta key to get the value for.
 	 * @return mixed Whatever value is stored in the database.
 	 */

--- a/lib/Pagination.php
+++ b/lib/Pagination.php
@@ -2,6 +2,11 @@
 
 namespace Timber;
 
+/**
+ * Class Pagination
+ *
+ * @api
+ */
 class Pagination {
 
 	public $current;
@@ -10,12 +15,21 @@ class Pagination {
 	public $next;
 	public $prev;
 
+	/**
+	 * Pagination constructor.
+	 *
+	 * @api
+	 *
+	 * @param array $prefs
+	 * @param null  $wp_query
+	 */
 	public function __construct( $prefs = array(), $wp_query = null ) {
 		$this->init($prefs, $wp_query);
 	}
 
 	/**
 	 * Get pagination.
+	 *
 	 * @api
 	 * @param array   $prefs
 	 * @return array mixed
@@ -148,7 +162,7 @@ class Pagination {
 				$dots = true;
 			} else {
 				if ( $args['show_all'] || ($n <= $args['end_size'] || ($args['current'] && $n >= $args['current'] - $args['mid_size'] && $n <= $args['current'] + $args['mid_size']) || $n > $args['total'] - $args['end_size']) ) {
-					
+
 					$link = str_replace('%_%', 1 == $n ? '' : $args['format'], $args['base']);
 					$link = str_replace('%#%', $n, $link);
 
@@ -192,16 +206,16 @@ class Pagination {
 		}
 		return $add_args;
 	}
-	
+
 	protected static function sanitize_args( $args ) {
 
 		$format_args = array();
-		
+
 		$format = explode('?', str_replace('%_%', $args['format'], $args['base']));
 		$format_query = isset($format[1]) ? $format[1] : '';
 
 		wp_parse_str($format_query, $format_args);
-		
+
 		// Remove the format argument from the array of query arguments, to avoid overwriting custom format.
 		foreach ( $format_args as $format_arg => $format_arg_value ) {
 			unset($args['add_args'][urlencode_deep($format_arg)]);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -16,7 +16,14 @@ use Timber\PostType;
 use WP_Post;
 
 /**
- * This is the object you use to access or extend WordPress posts. Think of it as Timber's (more accessible) version of WP_Post. This is used throughout Timber to represent posts retrieved from WordPress making them available to Twig templates. See the PHP and Twig examples for an example of what it's like to work with this object in your code.
+ * Class Post
+ *
+ * This is the object you use to access or extend WordPress posts. Think of it as Timber's (more
+ * accessible) version of WP_Post. This is used throughout Timber to represent posts retrieved from
+ * WordPress making them available to Twig templates. See the PHP and Twig examples for an example
+ * of what it’s like to work with this object in your code.
+ *
+ * @api
  * @example
  * ```php
  * // single.php, see connected twig example
@@ -43,139 +50,150 @@ use WP_Post;
  *     </div>
  * </article>
  * ```
- *
- * @package Timber
  */
 class Post extends Core implements CoreInterface {
 
 	/**
-	 * @var string $ImageClass the name of the class to handle images by default
+	 * @var string The name of the class to handle images by default
 	 */
 	public $ImageClass = 'Timber\Image';
 
 	/**
-	 * @var string $PostClass the name of the class to handle posts by default
+	 * @var string The name of the class to handle posts by default
 	 */
 	public $PostClass = 'Timber\Post';
 
 	/**
-	 * @var string $TermClass the name of the class to handle terms by default
+	 * @var string The name of the class to handle terms by default
 	 */
 	public $TermClass = 'Timber\Term';
 
 	/**
-	 * @var string $object_type what does this class represent in WordPress terms?
+	 * @var string What does this class represent in WordPress terms?
 	 */
 	public $object_type = 'post';
 
 	/**
-	 * @var array $custom stores custom meta data
+	 * @api
+	 * @var array Stores custom meta data
 	 */
 	public $custom = array();
 
 	/**
-	 * @var string $representation what does this class represent in WordPress terms?
+	 * @var string What does this class represent in WordPress terms?
 	 */
 	public static $representation = 'post';
 
 	/**
 	 * @internal
-	 * @var string $_content stores the processed content internally
+	 * @var string Stores the processed content internally
 	 */
 	protected $_content;
 
 	/**
-	 * @var string $_permalink the returned permalink from WP's get_permalink function
+	 * @var string The returned permalink from WP's get_permalink function
 	 */
 	protected $_permalink;
 
 	/**
-	 * @var array $_next stores the results of the next Timber\Post in a set inside an array (in order to manage by-taxonomy)
+	 * @var array Stores the results of the next Timber\Post in a set inside an array (in order to manage by-taxonomy)
 	 */
 	protected $_next = array();
 
 	/**
-	 * @var array $_prev stores the results of the previous Timber\Post in a set inside an array (in order to manage by-taxonomy)
+	 * @var array Stores the results of the previous Timber\Post in a set inside an array (in order to manage by-taxonomy)
 	 */
 	protected $_prev = array();
 
 	/**
-	 * @var string $class stores the CSS classes for the post (ex: "post post-type-book post-123")
+	 * @var string Stores the CSS classes for the post (ex: "post post-type-book post-123")
 	 */
 	protected $_css_class;
 
 	/**
 	 * @api
-	 * @var string $id the numeric WordPress id of a post
+	 * @var string The numeric WordPress id of a post.
 	 */
 	public $id;
 
 	/**
-	 * @var string 	$ID 			the numeric WordPress id of a post, capitalized to match WP usage
+	 * @api
+	 * @var string The numeric WordPress id of a post, capitalized to match WordPress usage.
 	 */
 	public $ID;
 
 	/**
-	 * @var int 	$post_author 	the numeric ID of the a post's author corresponding to the wp_user dtable
+	 * @api
+	 * @var int The numeric ID of the a post's author corresponding to the wp_user database table
 	 */
 	public $post_author;
 
 	/**
-	 * @var string 	$post_content 	the raw text of a WP post as stored in the database
+	 * @api
+	 * @var string The raw text of a WP post as stored in the database
 	 */
 	public $post_content;
 
 	/**
-	 * @var string 	$post_date 		the raw date string as stored in the WP database, ex: 2014-07-05 18:01:39
+	 * @api
+	 * @var string The raw date string as stored in the WP database, ex: 2014-07-05 18:01:39
 	 */
 	public $post_date;
 
 	/**
-	 * @var string 	$post_excerpt 	the raw text of a manual post excerpt as stored in the database
+	 * @api
+	 * @var string The raw text of a manual post excerpt as stored in the database
 	 */
 	public $post_excerpt;
 
 	/**
-	 * @var int 		$post_parent 	the numeric ID of a post's parent post
+	 * @api
+	 * @var int The numeric ID of a post's parent post
 	 */
 	public $post_parent;
 
 	/**
 	 * @api
-	 * @var string 		$post_status 	the status of a post ("draft", "publish", etc.)
+	 * @var string The status of a post ("draft", "publish", etc.)
 	 */
 	public $post_status;
 
 	/**
-	 * @var string 	$post_title 	the raw text of a post's title as stored in the database
+	 * @api
+	 * @var string The raw text of a post's title as stored in the database
 	 */
 	public $post_title;
 
 	/**
 	 * @api
-	 * @var string 	$post_type 		the name of the post type, this is the machine name (so "my_custom_post_type" as opposed to "My Custom Post Type")
+	 * @var string The name of the post type, this is the machine name (so "my_custom_post_type" as
+	 *      opposed to "My Custom Post Type")
 	 */
 	public $post_type;
 
 	/**
 	 * @api
-	 * @var string 	$slug 		the URL-safe slug, this corresponds to the poorly-named "post_name" in the WP database, ex: "hello-world"
+	 * @var string The URL-safe slug, this corresponds to the poorly-named "post_name" in the WP
+	 *      database, ex: "hello-world"
 	 */
 	public $slug;
 
 	/**
-	 * @var PostType $_type stores the PostType object for the Post
+	 * @var string Stores the PostType object for the Post
 	 */
 	protected $__type;
 
 	/**
-	 * If you send the constructor nothing it will try to figure out the current post id based on being inside The_Loop
+	 * If you send the constructor nothing it will try to figure out the current post id based on
+	 * being inside The_Loop.
 	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * $post = new Timber\Post();
 	 * $other_post = new Timber\Post($random_post_id);
 	 * ```
+	 *
 	 * @param mixed $pid
 	 */
 	public function __construct( $pid = null ) {
@@ -184,8 +202,13 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * This is helpful for twig to return properties and methods see: https://github.com/fabpot/Twig/issues/2
-	 * This is also here to ensure that {{ post.class }} remains usable
+	 * This is helpful for twig to return properties and methods see:
+	 * https://github.com/fabpot/Twig/issues/2
+	 *
+	 * This is also here to ensure that {{ post.class }} remains usable.
+	 *
+	 * @api
+	 *
 	 * @return mixed
 	 */
 	public function __get( $field ) {
@@ -197,8 +220,13 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * This is helpful for twig to return properties and methods see: https://github.com/fabpot/Twig/issues/2
+	 * This is helpful for twig to return properties and methods see:
+	 * https://github.com/fabpot/Twig/issues/2
+	 *
 	 * This is also here to ensure that {{ post.class }} remains usable
+	 *
+	 * @api
+	 *
 	 * @return mixed
 	 */
 	public function __call( $field, $args ) {
@@ -257,6 +285,8 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * Outputs the title of the post if you do something like `<h1>{{post}}</h1>`
+	 *
+	 * @api
 	 * @return string
 	 */
 	public function __toString() {
@@ -346,8 +376,8 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Helps you find the post id regardless of whether you send a string or whatever.
 	 *
-	 * @param integer $pid number to check against.
 	 * @internal
+	 * @param integer $pid number to check against.
 	 * @return integer ID number of a post
 	 */
 	protected function check_post_id( $pid ) {
@@ -368,6 +398,7 @@ class Post extends Core implements CoreInterface {
 	 * from a preview from `post_content`. If there’s a `<!-- more -->` tag in the post content,
 	 * it will use that to mark where to pull through.
 	 *
+	 * @api
 	 * @see \Timber\PostPreview
 	 *
 	 * @return \Timber\PostPreview
@@ -517,6 +548,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @internal
 	 * @param int $i
 	 * @return string
 	 */
@@ -555,6 +587,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Gets the comment form for use on a single article page
 	 *
+	 * @api
 	 * @param array $args this $args thing is a fucking mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form).
 	 * @return string of HTML for the form
 	 */
@@ -565,7 +598,8 @@ class Post extends Core implements CoreInterface {
 
 
 	/**
-	 * Get the terms associated with the post
+	 * Get the terms associated with the post.
+	 *
 	 * This goes across all taxonomies by default
 	 *
 	 * @api
@@ -592,9 +626,11 @@ class Post extends Core implements CoreInterface {
 	 *   </div>
 	 * </section>
 	 * ```
+	 *
 	 * @param string|array $tax What taxonom(y|ies) to pull from. Defaults to all registered taxonomies for the post type. You can use custom ones, or built-in WordPress taxonomies (category, tag). Timber plays nice and figures out that tag/tags/post_tag are all the same (and categories/category), for custom taxonomies you're on your own.
 	 * @param bool         $merge Should the resulting array be one big one (true)? Or should it be an array of sub-arrays for each taxonomy (false)?.
 	 * @param string       $TermClass what the Timber class to use for Terms.
+	 *
 	 * @return array
 	 */
 	public function terms( $tax = '', $merge = true, $TermClass = '' ) {
@@ -628,7 +664,7 @@ class Post extends Core implements CoreInterface {
 			$terms = wp_get_post_terms($this->ID, $taxonomy);
 
 			if ( is_wp_error($terms) ) {
-				/* @var $terms WP_Error */
+				/* @var \WP_Error $terms */
 				Helper::error_log("Error retrieving terms for taxonomy '$taxonomy' on a post in timber-post.php");
 				Helper::error_log('tax = '.print_r($tax, true));
 				Helper::error_log('WP_Error: '.$terms->get_error_message());
@@ -651,6 +687,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param string|int $term_name_or_id
 	 * @param string $taxonomy
 	 * @return bool
@@ -671,7 +708,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
+	 * @api
 	 * @return int the number of comments on a post
 	 */
 	public function comment_count() {
@@ -680,7 +717,7 @@ class Post extends Core implements CoreInterface {
 
 
 	/**
-	 *
+	 * @api
 	 * @param string $field_name
 	 * @return boolean
 	 */
@@ -720,7 +757,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
+	 * @api
 	 * @param string $field_name
 	 * @return mixed
 	 */
@@ -798,6 +835,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Import field data onto this object
 	 *
+	 * @api
 	 * @deprecated since 2.0.0
 	 * @param string $field_name
 	 */
@@ -806,7 +844,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Get the CSS classes for a post without cache. 
+	 * Get the CSS classes for a post without cache.
 	 * For usage you should use `{{post.class}}`
 	 *
 	 * @internal
@@ -909,6 +947,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Got more than one author? That's cool, but you'll need Co-Authors plus or another plugin to access any data
 	 *
+	 * @api
 	 * @return array
 	 */
 	public function authors() {
@@ -931,6 +970,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Get the author (WordPress user) who last modified the post
 	 *
+	 * @api
 	 * @example
 	 * ```twig
 	 * Last updated by {{ post.modified_author.name }}
@@ -1011,12 +1051,8 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * Gets the comments on a Timber\Post and returns them as an array of `Timber\Comment` objects (or whatever comment class you set).
+	 *
 	 * @api
-	 * @param int $count Set the number of comments you want to get. `0` is analogous to "all"
-	 * @param string $order use ordering set in WordPress admin, or a different scheme
-	 * @param string $type For when other plugins use the comments table for their own special purposes, might be set to 'liveblog' or other depending on what's stored in yr comments table
-	 * @param string $status Could be 'pending', etc.
-	 * @param string $CommentClass What class to use when returning Comment objects. As you become a Timber pro, you might find yourself extending Timber\Comment for your site or app (obviously, totally optional)
 	 * @example
 	 * ```twig
 	 * {# single.twig #}
@@ -1028,6 +1064,12 @@ class Post extends Core implements CoreInterface {
 	 * 	</div>
 	 * {% endfor %}
 	 * ```
+	 *
+	 * @param int $count Set the number of comments you want to get. `0` is analogous to "all"
+	 * @param string $order use ordering set in WordPress admin, or a different scheme
+	 * @param string $type For when other plugins use the comments table for their own special purposes, might be set to 'liveblog' or other depending on what's stored in yr comments table
+	 * @param string $status Could be 'pending', etc.
+	 * @param string $CommentClass What class to use when returning Comment objects. As you become a Timber pro, you might find yourself extending Timber\Comment for your site or app (obviously, totally optional)
 	 * @return bool|array
 	 */
 	public function comments( $count = null, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'Timber\Comment' ) {
@@ -1158,6 +1200,7 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * Get the date to use in your template!
+	 *
 	 * @api
 	 * @example
 	 * ```twig
@@ -1209,6 +1252,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Returns the post_type object with labels and other info
 	 *
+	 * @api
 	 * @since 1.0.4
 	 * @example
 	 *
@@ -1234,6 +1278,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Returns the edit URL of a post if the user has access to it
 	 *
+	 * @api
 	 * @return bool|string the edit URL of a post in the WordPress admin
 	 */
 	public function edit_link() {
@@ -1277,6 +1322,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param string $field_name
 	 * @return mixed
 	 */
@@ -1289,6 +1335,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @return string
 	 */
 	public function name() {
@@ -1296,7 +1343,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
+	 * @api
 	 * @param string $date_format
 	 * @return string
 	 */
@@ -1307,6 +1354,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param string $time_format
 	 * @return string
 	 */
@@ -1344,7 +1392,9 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Get a data array of pagination so you can navigate to the previous/next for a paginated post
+	 * Get a data array of pagination so you can navigate to the previous/next for a paginated post.
+	 *
+	 * @api
 	 * @return array
 	 */
 	public function pagination() {
@@ -1377,6 +1427,8 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * Finds any WP_Post objects and converts them to Timber\Posts
+	 *
+	 * @api
 	 * @param array|WP_Post $data
 	 * @param string $class
 	 */
@@ -1400,13 +1452,15 @@ class Post extends Core implements CoreInterface {
 
 
 	/**
-	 * Gets the parent (if one exists) from a post as a Timber\Post object (or whatever is set in Timber\Post::$PostClass)
+	 * Gets the parent (if one exists) from a post as a Timber\Post object (or whatever is set in
+	 * Timber\Post::$PostClass)
+	 *
 	 * @api
 	 * @example
 	 * ```twig
 	 * Parent page: <a href="{{ post.parent.link }}">{{ post.parent.title }}</a>
 	 * ```
-	 * @return bool|Timber\Post
+	 * @return bool|\Timber\Post
 	 */
 	public function parent() {
 		if ( !$this->post_parent ) {
@@ -1415,10 +1469,10 @@ class Post extends Core implements CoreInterface {
 		return new $this->PostClass($this->post_parent);
 	}
 
-
 	/**
 	 * Gets the relative path of a WP Post, so while link() will return http://example.org/2015/07/my-cool-post
 	 * this will return just /2015/07/my-cool-post
+	 *
 	 * @api
 	 * @example
 	 * ```twig
@@ -1480,7 +1534,7 @@ class Post extends Core implements CoreInterface {
 	 * ```twig
 	 * <img src="{{ post.thumbnail.src }}" />
 	 * ```
-	 * @return Timber/Image|null of your thumbnail
+	 * @return \Timber\Image|null of your thumbnail
 	 */
 	public function thumbnail() {
 		$tid = get_post_thumbnail_id($this->ID);

--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -10,10 +10,18 @@ use Timber\Post;
  *
  * PostCollections are internal objects used to hold a collection of posts.
  *
- * @package Timber
+ * @api
  */
 class PostCollection extends \ArrayObject {
 
+	/**
+	 * PostCollection constructor.
+	 *
+	 * @api
+	 *
+	 * @param array  $posts
+	 * @param string $post_class
+	 */
 	public function __construct( $posts = array(), $post_class = '\Timber\Post' ) {
 		$returned_posts = self::init($posts, $post_class);
 
@@ -83,7 +91,10 @@ class PostCollection extends \ArrayObject {
 		return self::maybe_set_preview($returned_posts);
 	}
 
-
+	/**
+	 * @api
+	 * @return array
+	 */
 	public function get_posts() {
 		return $this->getArrayCopy();
 	}

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -5,6 +5,9 @@ namespace Timber;
 use Timber\PostCollection;
 use Timber\QueryIterator;
 
+/**
+ * Class PostGetter
+ */
 class PostGetter {
 
 	/**

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -3,8 +3,11 @@
 namespace Timber;
 
 /**
- * An object that lets a user easily modify the post preview to their
- * liking
+ * Class PostPreview
+ *
+ * An object that lets a user easily modify the post preview to their liking.
+ *
+ * @api
  * @since 1.0.4
 */
 class PostPreview {
@@ -19,6 +22,7 @@ class PostPreview {
 	protected $destroy_tags = array('script', 'style');
 
 	/**
+	 * @api
 	 * @param Post $post
 	 */
 	public function __construct( $post ) {
@@ -30,6 +34,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @api
 	 * @param integer $length (in words) of the target preview
 	 */
 	public function length( $length = 50 ) {
@@ -38,6 +43,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @api
 	 * @param integer $char_length (in characters) of the target preview
 	 */
 	public function chars( $char_length = false ) {
@@ -46,6 +52,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @api
 	 * @param string $end how should the text in the preview end
 	 */
 	public function end( $end = '&hellip;' ) {
@@ -54,6 +61,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @api
 	 * @param boolean $force If the editor wrote a manual excerpt longer than the set length, should it be "forced" to the size specified?
 	 */
 	public function force( $force = true ) {
@@ -62,6 +70,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @api
 	 * @param string $readmore What the text displays as to the reader inside of the <a> tag
 	 */
 	public function read_more( $readmore = 'Read More' ) {
@@ -70,6 +79,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @api
 	 * @param boolean|string $strip strip the tags or what? You can also provide a list of allowed tags
 	 */
 	public function strip( $strip = true ) {
@@ -78,6 +88,7 @@ class PostPreview {
 	}
 
 	/**
+	 * @internal
 	 * @param string $text
 	 * @param array|booelan $readmore_matches
 	 * @param boolean $trimmed was the text trimmed?

--- a/lib/PostQuery.php
+++ b/lib/PostQuery.php
@@ -7,6 +7,8 @@ use Timber\Post;
 use Timber\PostGetter;
 
 /**
+ * Class PostQuery
+ *
  * Query for a collection of WordPress posts.
  *
  * This is the equivalent of using `WP_Query` in normal WordPress development.
@@ -15,7 +17,6 @@ use Timber\PostGetter;
  * retrieve meta information about it.
  *
  * @api
- * @package Timber
  */
 class PostQuery extends PostCollection {
 
@@ -35,6 +36,7 @@ class PostQuery extends PostCollection {
 	 * [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/) for a list of all
 	 * the arguments that can be used for the `$query` parameter.
 	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * // Get posts from default query
@@ -90,6 +92,7 @@ class PostQuery extends PostCollection {
 	 *
 	 * Optionally could be used to get pagination with custom preferences.
 	 *
+	 * @api
 	 * @example
 	 * ```twig
 	 * {% if posts.pagination.prev %}

--- a/lib/PostsIterator.php
+++ b/lib/PostsIterator.php
@@ -4,15 +4,13 @@ namespace Timber;
 
 /**
  * Class PostsIterator
- *
- * @package Timber
  */
 class PostsIterator extends \ArrayIterator {
-	
+
 	public function current() {
 		global $post;
 		$post = parent::current();
 		return $post;
 	}
-	
+
 }

--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -10,12 +10,13 @@ if ( !defined('ABSPATH') ) {
 	exit;
 }
 
+/**
+ * Class QueryIterator
+ */
 class QueryIterator implements \Iterator, \Countable {
 
 	/**
-	 *
-	 *
-	 * @var WP_Query
+	 * @var \WP_Query
 	 */
 	private $_query = null;
 	private $_posts_class = 'Timber\Post';

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -6,6 +6,8 @@ use Timber\Core;
 use Timber\CoreInterface;
 
 /**
+ * Class Request
+ *
  * Timber\Request exposes $_GET and $_POST to the context
  */
 class Request extends Core implements CoreInterface {

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -9,7 +9,12 @@ use Timber\Theme;
 use Timber\Helper;
 
 /**
- * Timber\Site gives you access to information you need about your site. In Multisite setups, you can get info on other sites in your network.
+ * Class Site
+ *
+ * `Timber\Site` gives you access to information you need about your site. In Multisite setups, you
+ * can get info on other sites in your network.
+ *
+ * @api
  * @example
  * ```php
  * $context = Timber::get_context();
@@ -28,10 +33,16 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 * @api
-	 * @var string the admin email address set in the WP admin panel
+	 * @var string The admin email address set in the WP admin panel
 	 */
 	public $admin_email;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $blogname;
+
 	/**
 	 * @api
 	 * @var string
@@ -43,16 +54,19 @@ class Site extends Core implements CoreInterface {
 	 * @var string
 	 */
 	public $description;
+
 	/**
 	 * @api
 	 * @var int the ID of a site in multisite
 	 */
 	public $id;
+
 	/**
 	 * @api
 	 * @var string the language setting ex: en-US
 	 */
 	public $language;
+
 	/**
 	 * @api
 	 * @var bool true if multisite, false if plain ole' WordPress
@@ -65,23 +79,46 @@ class Site extends Core implements CoreInterface {
 	 */
 	public $name;
 
-	/** @api
+	/**
+	 * @api
 	 * @var string for people who like trackback spam
 	 */
 	public $pingback_url;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $siteurl;
+
 	/**
 	 * @api
 	 * @var \Timber\Theme
 	 */
 	public $theme;
+
 	/**
 	 * @api
 	 * @var string
 	 */
 	public $title;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $url;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $home_url;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $site_url;
 
 	/**
@@ -96,6 +133,8 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 * Constructs a Timber\Site object
+	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * //multisite setup
@@ -120,6 +159,7 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 * Switches to the blog requested in the request
+	 *
 	 * @param string|integer|null $site_name_or_id
 	 * @return integer with the ID of the new blog
 	 */
@@ -180,7 +220,6 @@ class Site extends Core implements CoreInterface {
 		$this->pingback = $this->pingback_url = get_bloginfo('pingback_url');
 	}
 
-
 	/**
 	 * Returns the language attributes that you're looking for
 	 * @return string
@@ -190,8 +229,6 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
-	 *
 	 * @param string  $field
 	 * @return mixed
 	 */
@@ -206,6 +243,10 @@ class Site extends Core implements CoreInterface {
 		return $this->$field;
 	}
 
+	/**
+	 * @api
+	 * @return null|\Timber\Image
+	 */
 	public function icon() {
 		if ( is_multisite() ) {
 			return $this->icon_multisite($this->ID);
@@ -229,6 +270,8 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 * Returns the link to the site's home.
+	 *
+	 * @api
 	 * @example
 	 * ```twig
 	 * <a href="{{ site.link }}" title="Home">
@@ -240,7 +283,7 @@ class Site extends Core implements CoreInterface {
 	 * 	  <img src="/wp-content/uploads/logo.png" alt="Logo for some stupid thing" />
 	 * </a>
 	 * ```
-	 * @api
+	 *
 	 * @return string
 	 */
 	public function link() {
@@ -249,7 +292,7 @@ class Site extends Core implements CoreInterface {
 
 
 	/**
-	 * @ignore
+	 * @internal
 	 */
 	public function meta( $field ) {
 		return $this->__get($field);
@@ -257,7 +300,7 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 *
-	 * @ignore
+	 * @internal
 	 * @param string  $key
 	 * @param mixed   $value
 	 */
@@ -305,6 +348,5 @@ class Site extends Core implements CoreInterface {
 		Helper::deprecated('{{ site.url }}', '{{ site.link }}', '1.0.4');
 		return $this->link();
 	}
-
 
 }

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -10,9 +10,12 @@ use Timber\Helper;
 use Timber\URLHelper;
 
 /**
- * Terms: WordPress has got 'em, you want 'em. Categories. Tags. Custom
- * Taxonomies. You don't care, you're a fiend. Well let's get this under control:
+ * Class Term
  *
+ * Terms: WordPress has got 'em, you want 'em. Categories. Tags. Custom Taxonomies. You don't care,
+ * you're a fiend. Well let's get this under control:
+ *
+ * @api
  * @example
  * ```php
  * //Get a term by its ID
@@ -51,11 +54,13 @@ class Term extends Core implements CoreInterface {
 	public static $representation = 'term';
 
 	public $_children;
+
 	/**
 	 * @api
 	 * @var string the human-friendly name of the term (ex: French Cuisine)
 	 */
 	public $name;
+
 	/**
 	 * @api
 	 * @var string the WordPress taxonomy slug (ex: `post_tag` or `actors`)
@@ -63,6 +68,7 @@ class Term extends Core implements CoreInterface {
 	public $taxonomy;
 
 	/**
+	 * @api
 	 * @param int $tid
 	 * @param string $tax
 	 */
@@ -79,6 +85,7 @@ class Term extends Core implements CoreInterface {
 	/**
 	 * The string the term will render as by default
 	 *
+	 * @api
 	 * @return string
 	 */
 	public function __toString() {
@@ -86,6 +93,8 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
+	 *
 	 * @param $tid
 	 * @param $taxonomy
 	 *
@@ -288,15 +297,15 @@ class Term extends Core implements CoreInterface {
 		return get_edit_term_link($this->ID, $this->taxonomy);
 	}
 
-
 	/**
-	 * Returns a full link to the term archive page like
-	 * `http://example.com/category/news`
+	 * Returns a full link to the term archive page like `http://example.com/category/news`
+	 *
 	 * @api
 	 * @example
 	 * ```twig
 	 * See all posts in: <a href="{{ term.link }}">{{ term.name }}</a>
 	 * ```
+	 *
 	 * @return string
 	 */
 	public function link() {
@@ -336,7 +345,6 @@ class Term extends Core implements CoreInterface {
 	 * required.
 	 *
 	 * @api
-	 * @param string $field_name
 	 * @example
 	 * ```twig
 	 * <div class="location-info">
@@ -344,6 +352,8 @@ class Term extends Core implements CoreInterface {
 	 *   <p>{{ term.meta('address') }}</p>
 	 * </div>
 	 * ```
+	 *
+	 * @param string $field_name
 	 * @return string
 	 */
 	public function meta( $field_name ) {
@@ -386,8 +396,8 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Returns a relative link (path) to the term archive page like
-	 * `/category/news`
+	 * Returns a relative link (path) to the term archive page like `/category/news`
+	 *
 	 * @api
 	 * @example
 	 * ```twig
@@ -429,9 +439,6 @@ class Term extends Core implements CoreInterface {
 
 	/**
 	 * @api
-	 * @param int $numberposts_or_args
-	 * @param string $post_type_or_class
-	 * @param string $post_class
 	 * @example
 	 * ```twig
 	 * <h4>Recent posts in {{ term.name }}</h4>
@@ -441,6 +448,10 @@ class Term extends Core implements CoreInterface {
 	 * {% endfor %}
 	 * </ul>
 	 * ```
+	 *
+	 * @param int $numberposts_or_args
+	 * @param string $post_type_or_class
+	 * @param string $post_class
 	 * @return \Timber\PostQuery
 	 */
 	public function posts( $numberposts_or_args = 10, $post_type_or_class = 'any', $post_class = '' ) {
@@ -503,8 +514,9 @@ class Term extends Core implements CoreInterface {
 	/**
 	 * Get Posts that have been "tagged" with the particular term
 	 *
+	 * @api
 	 * @deprecated 2.0.0 use `{{ term.posts }}` instead
-	 * @internal
+	 *
 	 * @param int $numberposts
 	 * @param string $post_type
 	 * @param string $PostClass
@@ -516,7 +528,9 @@ class Term extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @deprecated 2.0.0, use `{{ term.children }}` instead.
+	 *
 	 * @return array
 	 */
 	public function get_children() {
@@ -525,10 +539,10 @@ class Term extends Core implements CoreInterface {
 		return $this->children();
 	}
 
-
 	/**
-	 *
+	 * @api
 	 * @deprecated 2.0.0 with no replacement
+	 *
 	 * @param string  $key
 	 * @param mixed   $value
 	 */

--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -5,6 +5,9 @@ namespace Timber;
 use Timber\Term;
 use Timber\Helper;
 
+/**
+ * Class TermGetter
+ */
 class TermGetter {
 	/**
 	 * @param int|WP_Term|object $term

--- a/lib/TextHelper.php
+++ b/lib/TextHelper.php
@@ -3,19 +3,23 @@
 namespace Timber;
 
 /**
- * Class provides different text-related functions
- * commonly used in WordPress development
+ * Class TextHelper
+ *
+ * Class provides different text-related functions commonly used in WordPress development
+ *
+ * @api
  */
 class TextHelper {
-
     /**
      * Trims text to a certain number of characters.
      * This function can be useful for excerpt of the post
      * As opposed to wp_trim_words trims characters that makes text to
      * take the same amount of space in each post for example
      *
+     * @api
      * @since   1.2.0
      * @author  @CROSP
+     *
      * @param   string $text      Text to trim.
      * @param   int    $num_chars Number of characters. Default is 60.
      * @param   string|null $more      Optional. What to append if $text needs to be trimmed. Default '&hellip;'.
@@ -31,8 +35,7 @@ class TextHelper {
     }
 
     /**
-     *
-     *
+     * @api
      * @param string  $text
      * @param int     $num_words
      * @param string|null|false  $more text to appear in "Read more...". Null to use default, false to hide
@@ -87,11 +90,20 @@ class TextHelper {
         return apply_filters('wp_trim_words', $text, $num_words, $more, $original_text);
     }
 
+	/**
+	 * @api
+	 *
+	 * @param       $string
+	 * @param array $tags
+	 *
+	 * @return null|string|string[]
+	 */
     public static function remove_tags( $string, $tags = array() ) {
         return preg_replace('#<(' . implode( '|', $tags) . ')(?:[^>]+)?>.*?</\1>#s', '', $string);
     }
 
     /**
+     * @api
      * @param string $haystack
      * @param string $needle
      * @return boolean
@@ -104,7 +116,7 @@ class TextHelper {
     }
 
     /**
-     *
+     * @api
      *
      * @param string  $html
      * @return string

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -3,12 +3,16 @@
 namespace Timber;
 
 use Timber\Core;
-use Timber\Theme;
 use Timber\URLHelper;
 
 /**
- * Need to display info about your theme? Well you've come to the right place. By default info on the current theme comes for free with what's fetched by `Timber::get_context()` in which case you can access it your theme like so:
+ * Class Theme
  *
+ * Need to display info about your theme? Well you've come to the right place. By default info on
+ * the current theme comes for free with what's fetched by `Timber::get_context()` in which case you
+ * can access it your theme like so:
+ *
+ * @api
  * @example
  * ```php
  * <?php
@@ -22,7 +26,6 @@ use Timber\URLHelper;
  * ```html
  * <script src="http://example.org/wp-content/themes/my-theme/static/js/all.js"></script>
  * ```
- * @package Timber
  */
 class Theme extends Core {
 
@@ -63,16 +66,25 @@ class Theme extends Core {
 	 * @var string the slug of the theme (ex: `my-super-theme`)
 	 */
 	public $slug;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $uri;
 
 	/**
-	 * @var WP_Theme the underlying WordPress native Theme object
+	 * @var \WP_Theme the underlying WordPress native Theme object
 	 */
 	private $theme;
 
 	/**
-	 * Constructs a new Timber\Theme object. NOTE the Timber\Theme object of the current theme comes in the default `Timber::get_context()` call. You can access this in your twig template via `{{site.theme}}.
-	 * @param string $slug
+	 * Constructs a new `Timber\Theme` object.
+	 *
+	 * The `Timber\Theme` object of the current theme comes in the default `Timber::get_context()`
+	 * call. You can access this in your twig template via `{{site.theme}}`.
+	 *
+	 * @api
 	 * @example
 	 * ```php
 	 * <?php
@@ -87,6 +99,8 @@ class Theme extends Core {
 	 * ```html
 	 * We are currently using the My Theme theme.
 	 * ```
+	 *
+	 * @param string $slug
 	 */
 	public function __construct( $slug = null ) {
 		$this->init($slug);
@@ -129,6 +143,7 @@ class Theme extends Core {
 	}
 
 	/**
+	 * @api
 	 * @param string $name
 	 * @param bool $default
 	 * @return string
@@ -138,6 +153,7 @@ class Theme extends Core {
 	}
 
 	/**
+	 * @api
 	 * @return array
 	 */
 	public function theme_mods() {

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -17,10 +17,11 @@ use Timber\User;
 use Timber\Loader;
 
 /**
- * Timber Class.
+ * Class Timber
  *
  * Main class called Timber for this plugin.
  *
+ * @api
  * @example
  * ```php
  * $posts = new Timber\PostQuery();
@@ -67,7 +68,6 @@ class Timber {
 	/**
 	 * Tests whether we can use Timber
 	 * @codeCoverageIgnore
-	 * @return
 	 */
 	protected function test_compatibility() {
 		if ( is_admin() || $_SERVER['PHP_SELF'] == '/wp-login.php' ) {
@@ -509,7 +509,7 @@ class Timber {
 	 * ```
 	 * @param string $string A string with Twig variables.
 	 * @param array  $data   Optional. An array of data to use in Twig template.
-	 * @return  bool|string
+	 * @return bool|string
 	 */
 	public static function compile_string( $string, $data = array() ) {
 		$dummy_loader = new Loader();
@@ -660,11 +660,9 @@ class Timber {
 	 *
 	 * @api
 	 * @param array $prefs an array of preference data.
-	 * @return array mixed
+	 * @return array|mixed
 	 */
 	public static function get_pagination( $prefs = array() ) {
 		return Pagination::get_pagination($prefs);
 	}
-
-
 }

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -10,7 +10,9 @@ use Timber\Term;
 use Timber\Image;
 use Timber\User;
 
-
+/**
+ * Class Twig
+ */
 class Twig {
 
 	public static $dir_name;

--- a/lib/Twig_Function.php
+++ b/lib/Twig_Function.php
@@ -3,9 +3,9 @@
 namespace Timber;
 
 /**
-  * Temporary fix for conflicts between Twig_Function and Twig_SimpleFunction
-  * in different versions of Twig (1.* and 2.*)
-  */
+ * Temporary fix for conflicts between Twig_Function and Twig_SimpleFunction
+ * in different versions of Twig (1.* and 2.*)
+ */
 if ( version_compare(\Twig_Environment::VERSION, '2.0.0', '>=') ) {
 
   class Twig_Function extends \Twig_Function { }
@@ -13,5 +13,5 @@ if ( version_compare(\Twig_Environment::VERSION, '2.0.0', '>=') ) {
 } else {
 
   class Twig_Function extends \Twig_SimpleFunction { }
-  
+
 }

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -2,11 +2,17 @@
 
 namespace Timber;
 
+/**
+ * Class URLHelper
+ *
+ * @api
+ */
 class URLHelper {
 
 	/**
 	 * Get the current URL of the page
 	 *
+	 * @api
 	 * @return string
 	 */
 	public static function get_current_url() {
@@ -22,6 +28,7 @@ class URLHelper {
 	/**
 	 * Get url scheme
 	 *
+	 * @api
 	 * @return string
 	 */
 	public static function get_scheme() {
@@ -33,6 +40,7 @@ class URLHelper {
 	 * Because it's a URL we don't care about protocol (HTTP vs HTTPS)
 	 * Or case (so it's cAsE iNsEnSeTiVe)
 	 *
+	 * @api
 	 * @return boolean
 	 */
 	public static function starts_with( $haystack, $starts_with ) {
@@ -46,8 +54,7 @@ class URLHelper {
 
 
 	/**
-	 *
-	 *
+	 * @api
 	 * @param string $url
 	 * @return bool
 	 */
@@ -63,8 +70,7 @@ class URLHelper {
 	}
 
 	/**
-	 *
-	 *
+	 * @api
 	 * @return string
 	 */
 	public static function get_path_base() {
@@ -80,8 +86,7 @@ class URLHelper {
 	}
 
 	/**
-	 *
-	 *
+	 * @api
 	 * @param string $url
 	 * @param bool   $force
 	 * @return string
@@ -108,7 +113,9 @@ class URLHelper {
 	/**
 	 * Some setups like HTTP_HOST, some like SERVER_NAME, it's complicated
 	 *
+	 * @api
 	 * @link http://stackoverflow.com/questions/2297403/http-host-vs-server-name
+	 *
 	 * @return string the HTTP_HOST or SERVER_NAME
 	 */
 	public static function get_host() {
@@ -122,7 +129,7 @@ class URLHelper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param string $url
 	 * @return bool
@@ -136,7 +143,7 @@ class URLHelper {
 	}
 
 	/**
-	 *
+	 * @api
 	 *
 	 * @param string $src
 	 * @return string
@@ -152,6 +159,8 @@ class URLHelper {
 	 * Takes a url and figures out its place based in the file system based on path
 	 * NOTE: Not fool-proof, makes a lot of assumptions about the file path
 	 * matching the URL path
+	 *
+	 * @api
 	 *
 	 * @param string $url
 	 * @return string
@@ -191,6 +200,7 @@ class URLHelper {
 	}
 
 	/**
+	 * @api
 	 * @param string $fs
 	 */
 	public static function file_system_to_url( $fs ) {
@@ -232,6 +242,8 @@ class URLHelper {
 	 * Get the path to the content directory relative to the site.
 	 * This replaces the WP_CONTENT_SUBDIR constant
 	 *
+	 * @api
+	 *
 	 * @return string (ex: /wp-content or /content)
 	 */
 	public static function get_content_subdir() {
@@ -264,8 +276,7 @@ class URLHelper {
 	}
 
 	/**
-	 *
-	 *
+	 * @api
 	 * @param string $src
 	 * @return string
 	 */
@@ -281,6 +292,7 @@ class URLHelper {
 	/**
 	 * Look for accidental slashes in a URL and remove them
 	 *
+	 * @api
 	 * @param  string $url to process (ex: http://nytimes.com//news/article.html)
 	 * @return string the result (ex: http://nytimes.com/news/article.html)
 	 */
@@ -298,6 +310,7 @@ class URLHelper {
 	/**
 	 * Add something to the start of the path in an URL
 	 *
+	 * @api
 	 * @param  string $url a URL that you want to manipulate (ex: 'https://nytimes.com/news/article.html').
 	 * @param  string $path the path you want to insert ('/2017').
 	 * @return string the result (ex 'https://nytimes.com/2017/news/article.html')
@@ -331,6 +344,7 @@ class URLHelper {
 	/**
 	 * Add slash (if not already present) to a path
 	 *
+	 * @api
 	 * @param  string $path to process.
 	 * @return string
 	 */
@@ -344,6 +358,7 @@ class URLHelper {
 	/**
 	 * Remove slashes (if found) from a path
 	 *
+	 * @api
 	 * @param  string $path to process.
 	 * @return string
 	 */
@@ -367,6 +382,7 @@ class URLHelper {
 	 * an image hosted on the same domain BUT on a different site than the
 	 * WordPress install will be reported as external content.
 	 *
+	 * @api
 	 * @param  string $url a URL to evaluate against
 	 * @return boolean if $url points to an external location returns true
 	 */
@@ -394,9 +410,15 @@ class URLHelper {
 	}
 
 	/**
-	 * Determines if URL is an external url. True if $path is an external url or subdomain (http://cdn.example.org = true). False if relative or local true if it's a subdomain
+	 * Determines if URL is an external URL.
+	 *
+	 * True if $path is an external url or subdomain (http://cdn.example.org = true). False if
+	 * relative or local true if it's a subdomain
+	 *
+	 * @api
 	 *
 	 * @param  string $url to evalute.
+	 *
 	 * @return bool
 	 */
 	public static function is_external( $url ) {
@@ -411,6 +433,7 @@ class URLHelper {
 	/**
 	 * Pass links through untrailingslashit unless they are a single /
 	 *
+	 * @api
 	 * @param  string $link the URL to process.
 	 * @return string
 	 */
@@ -424,8 +447,10 @@ class URLHelper {
 	/**
 	 * Removes the subcomponent of a URL regardless of protocol
 	 *
+	 * @api
 	 * @since  1.3.3
 	 * @author jarednova
+	 *
 	 * @param  string $haystack ex: http://example.org/wp-content/uploads/dog.jpg.
 	 * @param  string $needle ex: http://example.org/wp-content.
 	 * @return string
@@ -440,8 +465,10 @@ class URLHelper {
 	/**
 	 * Swaps whatever protocol of a URL is sent. http becomes https and vice versa
 	 *
+	 * @api
 	 * @since  1.3.3
 	 * @author jarednova
+	 *
 	 * @param  string $url ex: http://example.org/wp-content/uploads/dog.jpg.
 	 * @return string ex: https://example.org/wp-content/uploads/dog.jpg
 	 */
@@ -458,9 +485,10 @@ class URLHelper {
 	/**
 	 * Pass links through user_trailingslashit handling query strings properly
 	 *
+	 * @api
 	 * @param  string $link the URL to process.
 	 * @return string
-	 * */
+	 */
 	public static function user_trailingslashit( $link ) {
 		$link_parts = wp_parse_url($link);
 
@@ -478,11 +506,16 @@ class URLHelper {
 	}
 
 	/**
-	 * Returns the url parameters, for example for url http://example.org/blog/post/news/2014/whatever
-	 * this will return array('blog', 'post', 'news', '2014', 'whatever');
-	 * OR if sent an integer like: Timber\URLHelper::get_params(2); this will return 'news';
+	 * Returns the url parameters
+	 *
+	 * For example, for URL `http://example.org/blog/post/news/2014/whatever` this will return
+	 * `array('blog', 'post', 'news', '2014', 'whatever');` OR if sent an integer like:
+	 * `Timber\URLHelper::get_params(2);` this will return `news`.
+	 *
+	 * @api
 	 *
 	 * @param int $i the position of the parameter to grab.
+	 *
 	 * @return array|string
 	 */
 	public static function get_params( $i = false ) {

--- a/lib/User.php
+++ b/lib/User.php
@@ -10,7 +10,12 @@ use Timber\URLHelper;
 use Timber\Image;
 
 /**
- * This is used in Timber to represent users retrived from WordPress. You can call `$my_user = new Timber\User(123);` directly, or access it through the `{{ post.author }}` method.
+ * Class User
+ *
+ * This is used in Timber to represent users retrived from WordPress. You can call
+ * `$my_user = new Timber\User(123);` directly, or access it through the `{{ post.author }}` method.
+ *
+ * @api
  * @example
  * ```php
  * $context['current_user'] = new Timber\User();
@@ -38,6 +43,11 @@ class User extends Core implements CoreInterface {
 	 * @var string The description from WordPress
 	 */
 	public $description;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $display_name;
 
 	/**
@@ -48,13 +58,13 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * @api
-	 * @var  string The first name of the user
+	 * @var string The first name of the user
 	 */
 	public $first_name;
 
 	/**
 	 * @api
-	 * @var  string The last name of the user
+	 * @var string The last name of the user
 	 */
 	public $last_name;
 
@@ -63,9 +73,15 @@ class User extends Core implements CoreInterface {
 	 * @var int The ID from WordPress
 	 */
 	public $id;
+
+	/**
+	 * @api
+	 * @var string
+	 */
 	public $user_nicename;
 
 	/**
+	 * @api
 	 * @param object|int|bool $uid
 	 */
 	public function __construct( $uid = false ) {
@@ -73,6 +89,7 @@ class User extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @example
 	 * ```twig
 	 * This post is by {{ post.author }}
@@ -230,6 +247,7 @@ class User extends Core implements CoreInterface {
 	}
 
 	/**
+	 * @api
 	 * @param string $field_name
 	 * @return mixed
 	 */


### PR DESCRIPTION
#### Issue

The new documentation parser will use phpDocumentor to generate a Markdown documentation. Classes, properties and methods will only be included if they have an `@api` tag. This will make it easier to use the CLI when generating the documentation.

This pull request adds missing `@api` tags and fixes some other issues. It’s "a quick sweep" to bring v2 of the docs on the same level as v1 in terms of what will be included. A more thorough run through the DocBlocks will be required later to add missing summaries, descriptions and tags.

#### Testing

None, because only inline documentation was changed.