### PR TITLE
Fix double instantiation of post class in Timber::get_post

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -142,7 +142,7 @@ class PostGetter {
 			return $post_class_use;
 		}
 
-		if ( !class_exists($post_class_use) || !is_subclass_of($post_class_use, '\Timber\Post')  ) {
+		if ( !class_exists($post_class_use) || !is_subclass_of($post_class_use, '\Timber\Post') ) {
 			Helper::error_log('Class '.$post_class_use.' either does not exist or implement \Timber\Post');
 			return '\Timber\Post';
 		}

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -142,7 +142,7 @@ class PostGetter {
 			return $post_class_use;
 		}
 
-		if ( !class_exists($post_class_use) || !is_a(new $post_class_use, '\Timber\Post') ) {
+		if ( !class_exists($post_class_use) || !is_subclass_of($post_class_use, '\Timber\Post')  ) {
 			Helper::error_log('Class '.$post_class_use.' either does not exist or implement \Timber\Post');
 			return '\Timber\Post';
 		}


### PR DESCRIPTION
Do not instantiate a new instance of $post_class_use

**Ticket**: #1660 

#### Issue
This solves the double-instantiation of the post class wrapper from Timber::get_post


#### Solution
Instead of checking is_a on an instantiated object, I am checking is_subclass_of


#### Impact
Should be backwards compatible, slight performance improvement if the Post Class wrapper's constructor is heavy.

#### Usage Changes
None

#### Considerations
None

#### Testing
Existing test cases should cover
