### PR TITLE
Update public langage in Helper.php and Docs.php

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -451,8 +451,8 @@ class Helper {
 	 *
 	 * Gets the comment form for use on a single article page
 	 * @deprecated 0.21.8 use `{{ function('comment_form') }}` instead
-	 * @param int     $post_id which post_id should the form be tied to?
-	 * @param array   $args this $args thing is a fucking mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
+	 * @param int $post_id which post_id should the form be tied to?
+	 * @param array The $args thing is a mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
 	 * @return string
 	 */
 	public static function get_comment_form( $post_id = null, $args = array() ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -546,7 +546,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 *
 	 * Gets the comment form for use on a single article page
-	 * @param array   $args this $args thing is a fucking mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
+	 * @param array This $args array thing is a mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
 	 * @return string of HTML for the form
 	 */
 	public function comment_form( $args = array() ) {


### PR DESCRIPTION
#### Issue
Documentation generated from doc-blocks includes profanity on public facing page. Lets clean it up 🛀 

#### Solution
Updating doc-blocks to improve online documentation.

#### Impact
Docs probably need to be re-generated and deployed. No impact other than a re-wording of two doc-blocks.

#### Usage Changes
None

#### Considerations
Personal values and opinions aside. It just looks better for open source projects to use friendly language on public facing documents.

#### Testing
N/A

#### Comments
Thanks guys! Loving using twig inside WP. Honestly without the comments helper templates you've created I would never ship on time. I even agree with the language I'm changing here, the `$args` array is the messiest thing I've ever worked with.