### PR TITLE
ref #1657 -- added test and using WP's quality filters

### DIFF
--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -191,6 +191,8 @@ class Resize extends ImageOperation {
 							$crop['target_w'],
 							$crop['target_h']
 			);
+			$quality = apply_filters( 'wp_editor_set_quality', 82, 'image/jpeg');
+			$image->set_quality($quality);
 			$result = $image->save($save_filename);
 			if ( is_wp_error($result) ) {
 				// @codeCoverageIgnoreStart

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -162,8 +162,9 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		$resized = str_replace('http://example.org', '', $resized);
 		$resized = TimberUrlHelper::url_to_file_system( $resized );
 
-		$fileSizeBig = filesize($resized);
-		$this->assertEquals(43136, $fileSizeBig);
+		$fileSizeDefault = filesize($resized);
+		$this->assertGreaterThan(20000, $fileSizeDefault);
+		$this->assertLessThan(75000, $fileSizeDefault);
 	}
 
 	function testJPEGQualityHigh() {

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -155,4 +155,43 @@ class TestTimberImageResize extends Timber_UnitTestCase {
 		
 	}
 
+	function testJPEGQualityDefault() {
+		//make image at best quality
+		$arch = TestTimberImage::copyTestImage('arch.jpg');
+		$resized = Timber\ImageHelper::resize($arch, 500, 500, 'default', true);
+		$resized = str_replace('http://example.org', '', $resized);
+		$resized = TimberUrlHelper::url_to_file_system( $resized );
+
+		$fileSizeBig = filesize($resized);
+		$this->assertEquals(43136, $fileSizeBig);
+	}
+
+	function testJPEGQualityHigh() {
+		//make image at best quality
+		add_filter('wp_editor_set_quality', function(){
+			return 100;
+		});
+		$arch = TestTimberImage::copyTestImage('arch.jpg');
+		$resized = Timber\ImageHelper::resize($arch, 500, 500, 'default', true);
+		$resized = str_replace('http://example.org', '', $resized);
+		$resized = TimberUrlHelper::url_to_file_system( $resized );
+
+		$fileSizeBig = filesize($resized);
+		$this->assertGreaterThan(43136, $fileSizeBig);
+	}
+
+	function testJPEGQualityLow() {
+		//make image at best quality
+		add_filter('wp_editor_set_quality', function(){
+			return 1;
+		});
+		$arch = TestTimberImage::copyTestImage('arch.jpg');
+		$resized = Timber\ImageHelper::resize($arch, 500, 500, 'default', true);
+		$resized = str_replace('http://example.org', '', $resized);
+		$resized = TimberUrlHelper::url_to_file_system( $resized );
+
+		$fileSizeSmall = filesize($resized);
+		$this->assertLessThan(43136, $fileSizeSmall);
+	}
+
 }


### PR DESCRIPTION
**Ticket**: #1657 #857 

This takes @gchtr's recommendations in #857 and implements a starting point for quality manipulation using WP's tools (the `wp_editor_set_quality` filter). There are also tests to verify the behavior.

I'm partial to the concerns about the number of args we're currently asking `resize` to handle. We're now on to arg number 5. I'm torn about the best way to proceed, but I do want to at least move ahead with coverage and handling WP preferences