### PR TITLE
Remove sniff that deviates from WordPress Coding Standards

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -66,11 +66,4 @@
         </properties>
     </rule>
 
-    <rule ref="PEAR.Functions.FunctionCallSignature">
-        <properties>
-            <property name="requiredSpacesAfterOpen" value="0" />
-            <property name="requiredSpacesBeforeClose" value="0"/>
-        </properties>
-    </rule>
-
 </ruleset>


### PR DESCRIPTION
**Ticket**: #1603 

#### Issue

Taking up the discussion about coding style and personal preferences in https://github.com/timber/timber/pull/1603. I propose to remove these rules, my reasoning can be found here: https://github.com/timber/timber/pull/1603#issuecomment-354163527. Sorry for being a little pedantic about this.

#### Solution

Remove sniffs that deviate from the WordPress Coding Standards without a strong reason that would justify that they stay.