### PR TITLE
2.x Deprecate non-namespaced functions in Twig

### DIFF
--- a/docs/guides/acf-cookbook.md
+++ b/docs/guides/acf-cookbook.md
@@ -27,7 +27,7 @@ You can retrieve an image from a custom field, then use it in a Twig template. T
 ### The quick way (for most situations)
 
 ```twig
-<img src="{{TimberImage(post.get_field('hero_image')).src}}" />
+<img src="{{ Image(post.get_field('hero_image')).src }}" />
 ```
 
 ### The long way (for some special situations)
@@ -60,7 +60,7 @@ You can now use all the above functions to transform your custom images in the s
 
 ```twig
 {% for image in post.get_field('gallery') %}
-    <img src="{{ TimberImage(image) }}" />
+    <img src="{{ Image(image) }}" />
 {% endfor %}
 ```
 
@@ -78,7 +78,7 @@ You can access repeater fields within twig files:
 		<div class="item">
 			<h4>{{item.name}}</h4>
 			<h6>{{item.info}}</h6>
-			<img src="{{TimberImage(item.picture).src}}" />
+			<img src="{{ Image(item.picture).src }}" />
 		</div>
 	{% endfor %}
 </div>
@@ -134,8 +134,8 @@ Similar to repeaters, get the field by the name of the flexible content field:
 ```twig
 {% for media_item in post.get_field('media_set') %}
 	{% if media_item.acf_fc_layout == 'image_set' %}
-		<img src="{{TimberImage(media_item.image).src}}" />
-		<p class="caption">{{TimberImage(media_item.image).caption}}</p>
+		<img src="{{ Image(media_item.image).src }}" />
+		<p class="caption">{{ Image(media_item.image).caption }}</p>
 		<aside class="notes">{{media_item.notes}}</aside>
 	{% elseif media_item.acf_fc_layout == 'video_set' %}
 		<iframe width="560" height="315" src="http://www.youtube.com/embed/{{media_item.youtube_id}}" frameborder="0" allowfullscreen></iframe>

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -98,7 +98,7 @@ When setting up your custom fields you’ll want to save the `image_id` to the f
 ### The quick way (for most situations)
 
 ```twig
-<img src="{{ TimberImage(post.hero_image).src }}" />
+<img src="{{ Image(post.hero_image).src }}" />
 ```
 
 ### The long way (for some special situations)

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -99,28 +99,28 @@ class Twig {
 		$twig->addFunction( new Twig_Function(
 			'TimberPost',
 			function( $pid, $PostClass = 'Timber\Post' ) {
-				Helper::deprecated( '{{ TimberPost() }}', 'Post', '2.0.0' );
+				Helper::deprecated( '{{ TimberPost() }}', '{{ Post() }}', '2.0.0' );
 			}
 		) );
 
 		$twig->addFunction( new Twig_Function(
 			'TimberImage',
 			function( $pid = false, $ImageClass = 'Timber\Image' ) {
-				Helper::deprecated( '{{ TimberImage() }}', 'Image', '2.0.0' );
+				Helper::deprecated( '{{ TimberImage() }}', '{{ Image() }}', '2.0.0' );
 			}
 		) );
 
 		$twig->addFunction( new Twig_Function(
 			'TimberTerm',
 			function( $tid, $taxonomy = '', $TermClass = 'Timber\Term' ) {
-				Helper::deprecated( '{{ TimberTerm() }}', 'Term', '2.0.0' );
+				Helper::deprecated( '{{ TimberTerm() }}', '{{ Term() }}', '2.0.0' );
 			}
 		) );
 
 		$twig->addFunction( new Twig_Function(
 			'TimberUser',
 			function( $pid, $UserClass = 'Timber\User' ) {
-				Helper::deprecated( '{{ TimberUser() }}', 'User', '2.0.0' );
+				Helper::deprecated( '{{ TimberUser() }}', '{{ User() }}', '2.0.0' );
 			}
 		) );
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -54,39 +54,10 @@ class Twig {
 
 		$twig->addFunction(new Twig_Function('shortcode', 'do_shortcode'));
 
-		/* TimberObjects */
-		$twig->addFunction(new Twig_Function('TimberPost', function( $pid, $PostClass = 'Timber\Post' ) {
-					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
-						foreach ( $pid as &$p ) {
-							$p = new $PostClass($p);
-						}
-						return $pid;
-					}
-					return new $PostClass($pid);
-				} ));
-		$twig->addFunction(new Twig_Function('TimberImage', function( $pid = false, $ImageClass = 'Timber\Image' ) {
-					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
-						foreach ( $pid as &$p ) {
-							$p = new $ImageClass($p);
-						}
-						return $pid;
-					}
-					return new $ImageClass($pid);
-				} ));
+		/**
+		 * Timber object functions.
+		 */
 
-		$twig->addFunction(new Twig_Function('TimberTerm', array($this, 'handle_term_object')));
-
-		$twig->addFunction(new Twig_Function('TimberUser', function( $pid, $UserClass = 'Timber\User' ) {
-					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
-						foreach ( $pid as &$p ) {
-							$p = new $UserClass($p);
-						}
-						return $pid;
-					}
-					return new $UserClass($pid);
-				} ));
-
-		/* TimberObjects Alias */
 		$twig->addFunction(new Twig_Function('Post', function( $pid, $PostClass = 'Timber\Post' ) {
 					if ( is_array($pid) && !Helper::is_array_assoc($pid) ) {
 						foreach ( $pid as &$p ) {
@@ -120,6 +91,38 @@ class Twig {
 					}
 					return new $UserClass($pid);
 				} ));
+
+		/**
+		 * Deprecated Timber object functions.
+		 */
+
+		$twig->addFunction( new Twig_Function(
+			'TimberPost',
+			function( $pid, $PostClass = 'Timber\Post' ) {
+				Helper::deprecated( '{{ TimberPost() }}', 'Post', '2.0.0' );
+			}
+		) );
+
+		$twig->addFunction( new Twig_Function(
+			'TimberImage',
+			function( $pid = false, $ImageClass = 'Timber\Image' ) {
+				Helper::deprecated( '{{ TimberImage() }}', 'Image', '2.0.0' );
+			}
+		) );
+
+		$twig->addFunction( new Twig_Function(
+			'TimberTerm',
+			function( $tid, $taxonomy = '', $TermClass = 'Timber\Term' ) {
+				Helper::deprecated( '{{ TimberTerm() }}', 'Term', '2.0.0' );
+			}
+		) );
+
+		$twig->addFunction( new Twig_Function(
+			'TimberUser',
+			function( $pid, $UserClass = 'Timber\User' ) {
+				Helper::deprecated( '{{ TimberUser() }}', 'User', '2.0.0' );
+			}
+		) );
 
 		/* bloginfo and translate */
 		$twig->addFunction(new Twig_Function('bloginfo', function( $show = '', $filter = 'raw' ) {

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -761,7 +761,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$photo = $this->copyTestImage();
 		$photo = Timber\URLHelper::get_rel_path($photo);
 		update_post_meta($pid, 'custom_photo', '/'.$photo);
-		$str = '{{TimberImage(post.custom_photo).width}}';
+		$str = '{{ Image(post.custom_photo).width }}';
 		$post = new Timber\Post($pid);
 		$rendered = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals( 1500, $rendered );
@@ -947,7 +947,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$image = $post->thumbnail();
 		$post = get_post($post->ID);
 
-		$str = '{{ TimberImage(post).src }}';
+		$str = '{{ Image(post).src }}';
 		$result = Timber::compile_string( $str, array('post' => $post) );
 
 		$this->assertEquals($image->src(), $result);
@@ -956,7 +956,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testTimberImageFromTimberImage() {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
-		$str = '{{ TimberImage(post).src }}';
+		$str = '{{ Image(post).src }}';
 		$post = new Timber\Image($image);
 		$result = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals($image->src(), $result);
@@ -965,7 +965,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testTimberImageFromTimberImageID() {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
-		$str = '{{ TimberImage(post).src }}';
+		$str = '{{ Image(post).src }}';
 		$post = new Timber\Image($image->ID);
 		$result = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals($image->src(), $result);
@@ -975,7 +975,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$post = $this->get_post_with_image();
 		$image = $post->thumbnail();
 		$post = $image->ID;
-		$str = '{{ TimberImage(post).src }}';
+		$str = '{{ Image(post).src }}';
 		$result = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals($image->src(), $result);
 	}
@@ -984,7 +984,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$iid = self::get_image_attachment();
 		$image = new Timber\Image($iid);
 		$post = get_post($iid);
-		$str = '{{ TimberImage(post).src }}';
+		$str = '{{ Image(post).src }}';
 		$result = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals($image->src(), $result);
 	}
@@ -993,7 +993,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 	function testTimberImageFromDocument() {
 		$pid = $this->factory->post->create();
 		$iid = self::get_image_attachment($pid, 'dummy-pdf.pdf');
-		$str = '{{ TimberImage(post).src }}';
+		$str = '{{ Image(post).src }}';
 		$attachment = new Timber\Image($iid);
 		$result = Timber::compile_string( $str, array('post' => $iid) );
 		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/dummy-pdf.pdf', $result);

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -12,7 +12,7 @@
 			$string = Timber::compile_string($template);
 			$this->assertEquals('Zong post_tag', $string);
 
-			$template = '{% set zp_term = TimberTerm('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
+			$template = '{% set zp_term = Term('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
 			$string = Timber::compile_string($template);
 			$this->assertEquals('Zebra', $string);
 		}
@@ -27,7 +27,7 @@
 			$string = Timber::compile_string($template);
 			$this->assertEquals('Zong arts', $string);
 
-			$template = '{% set zp_term = TimberTerm('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
+			$template = '{% set zp_term = Term('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
 			$string = Timber::compile_string($template);
 			$this->assertEquals('Zebra', $string);
 		}
@@ -38,7 +38,7 @@
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
 			$term = new Timber\Term($term_id, 'arts');
 			$this->assertEquals('Zong', $term->name());
-			$template = '{% set zp_term = TimberTerm("'.$term->ID.'", "arts") %}{{ zp_term.name }}';
+			$template = '{% set zp_term = Term("'.$term->ID.'", "arts") %}{{ zp_term.name }}';
 			$string = Timber::compile_string($template);
 			$this->assertEquals('Zong', $string);
 		}

--- a/tests/test-timber-twig-objects.php
+++ b/tests/test-timber-twig-objects.php
@@ -2,139 +2,163 @@
 
 use Timber\Timber;
 
-	class TestTimberTwigObjects extends Timber_UnitTestCase {
+class TestTimberTwigObjects extends Timber_UnitTestCase {
 
-		function testTimberImageInTwig() {
-			$iid = TestTimberImage::get_image_attachment();
-			$str = '{{TimberImage('.$iid.').src}}';
-			$compiled = Timber::compile_string($str);
-			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpg', $compiled);
-		}
-
-		function testImageInTwig() {
-			$iid = TestTimberImage::get_image_attachment();
-			$str = '{{Image('.$iid.').src}}';
-			$compiled = Timber::compile_string($str);
-			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpg', $compiled);
-		}
-
-		function testImagesInTwig() {
-			$images = array();
-			$images[] = TestTimberImage::get_image_attachment( 0, 'arch.jpg' );
-			$images[] = TestTimberImage::get_image_attachment( 0, 'city-museum.jpg' );
-			$str = '{% for image in Image(images) %}{{image.src}}{% endfor %}';
-			$compiled = Timber::compile_string($str, array('images' => $images));
-			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpghttp://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/city-museum.jpg', $compiled);
-		}
-
-		function testTimberImagesInTwig() {
-			$images = array();
-			$images[] = TestTimberImage::get_image_attachment( 0, 'arch.jpg' );
-			$images[] = TestTimberImage::get_image_attachment( 0, 'city-museum.jpg' );
-			$str = '{% for image in TimberImage(images) %}{{image.src}}{% endfor %}';
-			$compiled = Timber::compile_string($str, array('images' => $images));
-			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpghttp://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/city-museum.jpg', $compiled);
-		}
-
-		function testTimberImageInTwigToString() {
-			$iid = TestTimberImage::get_image_attachment();
-			$str = '{{TimberImage('.$iid.')}}';
-			$compiled = Timber::compile_string($str);
-			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpg', $compiled);
-		}
-
-		function testTimberPostInTwig(){
-			$pid = $this->factory->post->create(array('post_title' => 'Foo'));
-			$str = '{{TimberPost('.$pid.').title}}';
-			$this->assertEquals('Foo', Timber::compile_string($str));
-		}
-
-		function testPostInTwig(){
-			$pid = $this->factory->post->create(array('post_title' => 'Foo'));
-			$str = '{{Post('.$pid.').title}}';
-			$this->assertEquals('Foo', Timber::compile_string($str));
-		}
-
-		function testTimberPostsInTwig(){
-			$pids[] = $this->factory->post->create(array('post_title' => 'Foo'));
-			$pids[] = $this->factory->post->create(array('post_title' => 'Bar'));
-			$str = '{% for post in TimberPost(pids) %}{{post.title}}{% endfor %}';
-			$this->assertEquals('FooBar', Timber::compile_string($str, array('pids' => $pids)));
-		}
-
-		function testPostsInTwig(){
-			$pids[] = $this->factory->post->create(array('post_title' => 'Foo'));
-			$pids[] = $this->factory->post->create(array('post_title' => 'Bar'));
-			$str = '{% for post in Post(pids) %}{{post.title}}{% endfor %}';
-			$this->assertEquals('FooBar', Timber::compile_string($str, array('pids' => $pids)));
-		}
-
-		function testPostQueryWithStringInTwig(){
-			$pids[] = $this->factory->post->create( array( 'post_title' => 'Foo' ) );
-			$pids[] = $this->factory->post->create( array( 'post_title' => 'Bar' ) );
-			$str    = "{% for post in PostQuery('post_type=post&posts_per_page=-1&order=ASC') %}{{ post.title }}{% endfor %}";
-
-			$this->assertEquals( 'FooBar', Timber::compile_string( $str, array( 'pids' => $pids ) ) );
-		}
-
-		function testPostQueryWithArgsInTwig(){
-			$pids[] = $this->factory->post->create( array( 'post_title' => 'Foo' ) );
-			$pids[] = $this->factory->post->create( array( 'post_title' => 'Bar' ) );
-			$str    = "{% for post in PostQuery({ post_type: 'post', posts_per_page: -1, order: 'ASC'}) %}{{ post.title }}{% endfor %}";
-
-			$this->assertEquals( 'FooBar', Timber::compile_string( $str, array( 'pids' => $pids ) ) );
-		}
-
-		function testTimberUserInTwig(){
-			$uid = $this->factory->user->create(array('display_name' => 'Pete Karl'));
-			$str = '{{TimberUser('.$uid.').name}}';
-			$this->assertEquals('Pete Karl', Timber::compile_string($str));
-		}
-
-		function testUsersInTwig(){
-			$uids[] = $this->factory->user->create(array('display_name' => 'Mark Watabe'));
-			$uids[] = $this->factory->user->create(array('display_name' => 'Austin Tzou'));
-			$str = '{% for user in User(uids) %}{{user.name}} {% endfor %}';
-			$this->assertEquals('Mark Watabe Austin Tzou', trim(Timber::compile_string($str, array('uids' => $uids))));
-		}
-
-		function testUserInTwig(){
-			$uid = $this->factory->user->create(array('display_name' => 'Nathan Hass'));
-			$str = '{{User('.$uid.').name}}';
-			$this->assertEquals('Nathan Hass', Timber::compile_string($str));
-		}
-
-		function testTimberUsersInTwig() {
-			$uids[] = $this->factory->user->create(array('display_name' => 'Estelle Getty'));
-			$uids[] = $this->factory->user->create(array('display_name' => 'Bea Arthur'));
-			$str = '{% for user in TimberUser(uids) %}{{user.name}} {% endfor %}';
-			$this->assertEquals('Estelle Getty Bea Arthur', trim(Timber::compile_string($str, array('uids' => $uids))));
-		}
-
-		function testTimberTermInTwig(){
-			$tid = $this->factory->term->create(array('name' => 'Golden Girls'));
-			$str = '{{TimberTerm(tid).title}}';
-			$this->assertEquals('Golden Girls', Timber::compile_string($str, array('tid' => $tid)));
-		}
-
-		function testTermInTwig(){
-			$tid = $this->factory->term->create(array('name' => 'Mythbusters'));
-			$str = '{{Term(tid).title}}';
-			$this->assertEquals('Mythbusters', Timber::compile_string($str, array('tid' => $tid)));
-		}
-
-		function testTimberTermsInTwig(){
-			$tids[] = $this->factory->term->create(array('name' => 'Foods'));
-			$tids[] = $this->factory->term->create(array('name' => 'Cars'));
-			$str = '{% for term in TimberTerm(tids) %}{{term.title}} {% endfor %}';
-			$this->assertEquals('Foods Cars ', Timber::compile_string($str, array('tids' => $tids)));
-		}
-
-		function testTermsInTwig(){
-			$tids[] = $this->factory->term->create(array('name' => 'Animals'));
-			$tids[] = $this->factory->term->create(array('name' => 'Germans'));
-			$str = '{% for term in Term(tids) %}{{term.title}} {% endfor %}';
-			$this->assertEquals('Animals Germans ', Timber::compile_string($str, array('tids' => $tids)));
-		}
-
+	/**
+	 * @expectedDeprecated {{ TimberImage() }}
+	 */
+	function testTimberImageInTwig() {
+		$iid = TestTimberImage::get_image_attachment();
+		$str = '{{ TimberImage('.$iid.').src }}';
+		$compiled = Timber::compile_string($str);
+		$this->assertEmpty($compiled);
 	}
+
+	function testImageInTwig() {
+		$iid = TestTimberImage::get_image_attachment();
+		$str = '{{Image('.$iid.').src}}';
+		$compiled = Timber::compile_string($str);
+		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpg', $compiled);
+	}
+
+	function testImagesInTwig() {
+		$images = array();
+		$images[] = TestTimberImage::get_image_attachment( 0, 'arch.jpg' );
+		$images[] = TestTimberImage::get_image_attachment( 0, 'city-museum.jpg' );
+		$str = '{% for image in Image(images) %}{{image.src}}{% endfor %}';
+		$compiled = Timber::compile_string($str, array('images' => $images));
+		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpghttp://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/city-museum.jpg', $compiled);
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberImage() }}
+	 */
+	function testTimberImagesInTwig() {
+		$images = array();
+		$images[] = TestTimberImage::get_image_attachment( 0, 'arch.jpg' );
+		$images[] = TestTimberImage::get_image_attachment( 0, 'city-museum.jpg' );
+		$str = '{% for image in TimberImage(images) %}{{image.src}}{% endfor %}';
+		$compiled = Timber::compile_string($str, array('images' => $images));
+		$this->assertEmpty($compiled);
+	}
+
+	function testTimberImageInTwigToString() {
+		$iid = TestTimberImage::get_image_attachment();
+		$str = '{{Image('.$iid.')}}';
+		$compiled = Timber::compile_string($str);
+		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpg', $compiled);
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberPost() }}
+	 */
+	function testTimberPostInTwig(){
+		$pid = $this->factory->post->create(array('post_title' => 'Foo'));
+		$str = '{{ TimberPost('.$pid.').title }}';
+		$this->assertEmpty(Timber::compile_string($str));
+	}
+
+	function testPostInTwig(){
+		$pid = $this->factory->post->create(array('post_title' => 'Foo'));
+		$str = '{{Post('.$pid.').title}}';
+		$this->assertEquals('Foo', Timber::compile_string($str));
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberPost() }}
+	 */
+	function testTimberPostsInTwig(){
+		$pids[] = $this->factory->post->create(array('post_title' => 'Foo'));
+		$pids[] = $this->factory->post->create(array('post_title' => 'Bar'));
+		$str = '{% for post in TimberPost(pids) %}{{post.title}}{% endfor %}';
+		$this->assertEmpty(Timber::compile_string($str, array('pids' => $pids)));
+	}
+
+	function testPostsInTwig(){
+		$pids[] = $this->factory->post->create(array('post_title' => 'Foo'));
+		$pids[] = $this->factory->post->create(array('post_title' => 'Bar'));
+		$str = '{% for post in Post(pids) %}{{post.title}}{% endfor %}';
+		$this->assertEquals('FooBar', Timber::compile_string($str, array('pids' => $pids)));
+	}
+
+	function testPostQueryWithStringInTwig(){
+		$pids[] = $this->factory->post->create( array( 'post_title' => 'Foo' ) );
+		$pids[] = $this->factory->post->create( array( 'post_title' => 'Bar' ) );
+		$str    = "{% for post in PostQuery('post_type=post&posts_per_page=-1&order=ASC') %}{{ post.title }}{% endfor %}";
+
+		$this->assertEquals( 'FooBar', Timber::compile_string( $str, array( 'pids' => $pids ) ) );
+	}
+
+	function testPostQueryWithArgsInTwig(){
+		$pids[] = $this->factory->post->create( array( 'post_title' => 'Foo' ) );
+		$pids[] = $this->factory->post->create( array( 'post_title' => 'Bar' ) );
+		$str    = "{% for post in PostQuery({ post_type: 'post', posts_per_page: -1, order: 'ASC'}) %}{{ post.title }}{% endfor %}";
+
+		$this->assertEquals( 'FooBar', Timber::compile_string( $str, array( 'pids' => $pids ) ) );
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberUser() }}
+	 */
+	function testTimberUserInTwig(){
+		$uid = $this->factory->user->create(array('display_name' => 'Pete Karl'));
+		$str = '{{ TimberUser('.$uid.').name }}';
+		$this->assertEmpty(Timber::compile_string($str));
+	}
+
+	function testUsersInTwig(){
+		$uids[] = $this->factory->user->create(array('display_name' => 'Mark Watabe'));
+		$uids[] = $this->factory->user->create(array('display_name' => 'Austin Tzou'));
+		$str = '{% for user in User(uids) %}{{user.name}} {% endfor %}';
+		$this->assertEquals('Mark Watabe Austin Tzou', trim(Timber::compile_string($str, array('uids' => $uids))));
+	}
+
+	function testUserInTwig(){
+		$uid = $this->factory->user->create(array('display_name' => 'Nathan Hass'));
+		$str = '{{User('.$uid.').name}}';
+		$this->assertEquals('Nathan Hass', Timber::compile_string($str));
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberUser() }}
+	 */
+	function testTimberUsersInTwig() {
+		$uids[] = $this->factory->user->create(array('display_name' => 'Estelle Getty'));
+		$uids[] = $this->factory->user->create(array('display_name' => 'Bea Arthur'));
+		$str = '{% for user in TimberUser(uids) %}{{user.name}} {% endfor %}';
+		$this->assertEmpty(trim(Timber::compile_string($str, array('uids' => $uids))));
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberTerm() }}
+	 */
+	function testTimberTermInTwig(){
+		$tid = $this->factory->term->create(array('name' => 'Golden Girls'));
+		$str = '{{ TimberTerm(tid).title }}';
+		$this->assertEmpty(Timber::compile_string($str, array('tid' => $tid)));
+	}
+
+	function testTermInTwig(){
+		$tid = $this->factory->term->create(array('name' => 'Mythbusters'));
+		$str = '{{Term(tid).title}}';
+		$this->assertEquals('Mythbusters', Timber::compile_string($str, array('tid' => $tid)));
+	}
+
+	/**
+	 * @expectedDeprecated {{ TimberTerm() }}
+	 */
+	function testTimberTermsInTwig(){
+		$tids[] = $this->factory->term->create(array('name' => 'Foods'));
+		$tids[] = $this->factory->term->create(array('name' => 'Cars'));
+		$str = '{% for term in TimberTerm(tids) %}{{term.title}} {% endfor %}';
+		$this->assertEmpty(Timber::compile_string($str, array('tids' => $tids)));
+	}
+
+	function testTermsInTwig(){
+		$tids[] = $this->factory->term->create(array('name' => 'Animals'));
+		$tids[] = $this->factory->term->create(array('name' => 'Germans'));
+		$str = '{% for term in Term(tids) %}{{term.title}} {% endfor %}';
+		$this->assertEquals('Animals Germans ', Timber::compile_string($str, array('tids' => $tids)));
+	}
+
+}


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1580#issuecomment-360980331

#### Issue

In Twig, the following functions still exist: `TimberPost`, `TimberImage`, `TimberTerm`, `TimberUser`. For PHP, we replaced all those instances of non-namespaced functions. To make it more consistent, let’s deprecate these in Twig as well. The shorter versions that work perfectly fine (even without Timber\ as a prefix) already exist: `Post`, `Image`, `Term`, `User`. We can leave them as they are.

#### Solution

- Deprecated `TimberPost`, `TimberImage`, `TimberTerm`, `TimberUser` in Twig. They don’t return anything.
- Updated tests.
- Updated guides where some of these function names were still used.

#### Testing

Yes.