### PR TITLE
2.x Streamline method and filter names for getting meta data

### DIFF
--- a/docs/guides/acf-cookbook.md
+++ b/docs/guides/acf-cookbook.md
@@ -14,7 +14,7 @@ While data saved by ACF is available via `{{post.my_acf_field}}` you will often 
 ```twig
 <h3>{{post.title}}</h3>
 <div class="intro-text">
-     {{post.get_field('my_wysiwyg_field')}}
+     {{post.meta('my_wysiwyg_field')}}
 </div>
 ```
 
@@ -27,7 +27,7 @@ You can retrieve an image from a custom field, then use it in a Twig template. T
 ### The quick way (for most situations)
 
 ```twig
-<img src="{{TimberImage(post.get_field('hero_image')).src}}" />
+<img src="{{TimberImage(post.meta('hero_image')).src}}" />
 ```
 
 ### The long way (for some special situations)
@@ -59,7 +59,7 @@ You can now use all the above functions to transform your custom images in the s
 ## Gallery field
 
 ```twig
-{% for image in post.get_field('gallery') %}
+{% for image in post.meta('gallery') %}
     <img src="{{ TimberImage(image) }}" />
 {% endfor %}
 ```

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -124,7 +124,7 @@ class Comment extends Core implements CoreInterface {
 		$this->import($comment_data);
 		$this->ID = $this->comment_ID;
 		$this->id = $this->comment_ID;
-		$comment_meta_data = $this->get_meta_fields($this->ID);
+		$comment_meta_data = $this->get_meta_values($this->ID);
 		$this->import($comment_meta_data);
 	}
 
@@ -333,12 +333,22 @@ class Comment extends Core implements CoreInterface {
 	}
 
 	/**
+	 * Gets a comment meta value.
+	 *
 	 * @api
-	 * @param string $field_name
-	 * @return mixed
+	 * @deprecated 2.0.0, use `{{ comment.meta('field_name) }}` instead
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name ) {
-		return $this->get_meta_field($field_name);
+	public function get_meta_field( $field_name ) {
+		Helper::deprecated(
+			"{{ comment.get_meta_field('field_name') }}",
+			"{{ comment.meta('field_name') }}",
+			'2.0.0'
+		);
+
+		return $this->meta($field_name);
 	}
 
 	/**
@@ -354,7 +364,7 @@ class Comment extends Core implements CoreInterface {
 	 * @param int $comment_id
 	 * @return mixed
 	 */
-	protected function get_meta_fields( $comment_id = null ) {
+	protected function get_meta_values( $comment_id = null ) {
 		if ( $comment_id === null ) {
 			$comment_id = $this->ID;
 		}
@@ -373,16 +383,25 @@ class Comment extends Core implements CoreInterface {
 		 * @param int             $comment_id    The comment ID.
 		 * @param \Timber\Comment $comment       The comment object.
 		 */
-		$comment_metas = apply_filters( 'timber/comment/pre_get_meta_fields', $comment_metas, $comment_id, $this );
+		$comment_metas = apply_filters( 'timber/comment/pre_get_meta_values',
+			$comment_metas,
+			$comment_id,
+			$this
+		);
 
 		/**
 		 * Fires before comment meta data is imported into the object.
 		 *
-		 * @deprecated 2.0.0
-		 * @since      0.15.4
+		 * @deprecated 2.0.0, use `timber/comment/pre_get_meta_values`
 		 * @since      0.19.1 Switched from filter to action functionality.
+		 * @since      0.15.4
 		 */
-		do_action_deprecated( 'timber_comment_get_meta_pre', array( $comment_metas, $comment_id ), '2.0.0', 'timber/comment/pre_get_meta_fields' );
+		do_action_deprecated(
+			'timber_comment_get_meta_pre',
+			array( $comment_metas, $comment_id ),
+			'2.0.0',
+			'timber/comment/pre_get_meta_values'
+		);
 
 		if ( ! is_array( $comment_metas ) || empty( $comment_metas ) ) {
 			$comment_metas = get_comment_meta($comment_id);
@@ -405,25 +424,40 @@ class Comment extends Core implements CoreInterface {
 		 * @param int             $comment_id    The comment ID.
 		 * @param \Timber\Comment $comment       The comment object.
 		 */
-		$comment_metas = apply_filters( 'timber/comment/get_meta_fields', $comment_metas, $comment_id, $this );
+		$comment_metas = apply_filters(
+			'timber/comment/get_meta_values',
+			$comment_metas,
+			$comment_id,
+			$this
+		);
 
 		/**
 		 * Filters comment meta data.
 		 *
-		 * @deprecated 2.0.0, use `timber/comment/get_meta_fields`
-         * @since 0.15.4
+		 * @deprecated 2.0.0, use `timber/comment/get_meta_values`
+		 * @since 0.15.4
 		 */
-		$comment_metas = apply_filters_deprecated( 'timber_comment_get_meta', array( $comment_metas, $comment_id ), '2.0.0', 'timber/comment/get_meta_fields' );
+		$comment_metas = apply_filters_deprecated(
+			'timber_comment_get_meta',
+			array( $comment_metas, $comment_id ),
+			'2.0.0',
+			'timber/comment/get_meta_values'
+		);
 
 		return $comment_metas;
 	}
 
 	/**
-	 * @internal
-	 * @param string $field_name
-	 * @return mixed
+	 * Gets a comment meta value.
+	 *
+	 * Returns a meta value for a comment that’s saved in the comment meta database table.
+	 *
+	 * @api
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
-	protected function get_meta_field( $field_name ) {
+	public function meta( $field_name ) {
 		/**
 		 * Filters the value for a comment meta field before it is fetched from the database.
 		 *
@@ -432,24 +466,24 @@ class Comment extends Core implements CoreInterface {
 		 * @since 2.0.0
 		 *
 		 * @param string          $value      Passing a non-null value will short-circuit
-		 *                                    `Comment::get_meta_field()`, returning the value instead.
+		 *                                    `Comment::meta()`, returning the value instead.
 		 *                                    Default null.
 		 * @param int             $comment_id The comment ID.
 		 * @param string          $field_name The name of the meta field to get the value for.
 		 * @param \Timber\Comment $comment    The comment object.
 		 */
-		$value = apply_filters( 'timber/comment/pre_get_meta_field', null, $this->ID, $field_name, $this);
+		$value = apply_filters( 'timber/comment/pre_meta', null, $this->ID, $field_name, $this );
 
 		/**
 		 * Filters the value for a comment meta field before it is fetched from the database.
 		 *
-		 * @deprecated 2.0.0, use `timber/comment/pre_get_meta_field`
+		 * @deprecated 2.0.0, use `timber/comment/pre_meta`
 		 */
 		$value = apply_filters_deprecated(
 			'timber_comment_get_meta_field_pre',
-			array( $value, $this->ID, $field_name, $this),
+			array( $value, $this->ID, $field_name, $this ),
 			'2.0.0',
-			'timber/comment/pre_get_meta_field'
+			'timber/comment/pre_meta'
 		);
 
 		// Short-circuit
@@ -471,18 +505,18 @@ class Comment extends Core implements CoreInterface {
 		 * @param string          $field_name The name of the meta field to get the value for.
 		 * @param \Timber\Comment $comment    The comment object.
 		 */
-		$value = apply_filters( 'timber/comment/get_meta_field', $value, $this->ID, $field_name, $this);
+		$value = apply_filters( 'timber/comment/get_meta', $value, $this->ID, $field_name, $this );
 
 		/**
 		 * Filters the value for a comment meta field.
 		 *
-		 * @deprecated 2.0.0, use `timber/comment/get_meta_field`
+		 * @deprecated 2.0.0, use `timber/comment/get_meta`
 		 */
 		$value = apply_filters_deprecated(
 			'timber_comment_get_meta_field',
 			array( $value, $this->ID, $field_name, $this ),
 			'2.0.0',
-			'timber/comment/get_meta_field'
+			'timber/comment/get_meta'
 		);
 
 		return $value;

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -188,7 +188,7 @@ class Image extends Post implements CoreInterface {
 	/**
 	 * @return array
 	 */
-	protected function get_post_custom( $iid ) {
+	protected function get_meta_values( $iid ) {
 		$pc = get_post_custom($iid);
 		if ( is_bool($pc) ) {
 			return array();
@@ -207,7 +207,7 @@ class Image extends Post implements CoreInterface {
 			if ( ! is_array($image_info) ) {
 				$image_info = array();
 			}
-			$image_custom = self::get_post_custom($iid);
+			$image_custom = self::get_meta_values($iid);
 			$basic        = get_post($iid);
 			if ( $basic ) {
 				if ( isset($basic->post_excerpt) ) {
@@ -325,7 +325,7 @@ class Image extends Post implements CoreInterface {
 			$this->ID = $iid;
 		}
 		if ( isset($this->ID) ) {
-			$custom = self::get_post_custom($this->ID);
+			$custom = self::get_meta_values($this->ID);
 			foreach ( $custom as $key => $value ) {
 				$this->$key = $value[0];
 			}

--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -7,18 +7,22 @@
 
 namespace Timber\Integrations;
 
+use Timber\Helper;
+
 /**
  * Class used to handle integration with Advanced Custom Fields
  */
 class ACF {
 
 	public function __construct() {
-		add_filter('timber/post/get_meta', array( $this, 'post_get_meta' ), 10, 2);
-		add_filter('timber/post/get_meta_field', array( $this, 'post_get_meta_field' ), 10, 3);
+		add_filter('timber/post/get_meta_values', array( $this, 'post_get_meta' ), 10, 2);
+		add_filter('timber/post/get_meta', array( $this, 'post_get_meta_field' ), 10, 3);
 		add_filter('timber/post/meta_object_field', array( $this, 'post_meta_object' ), 10, 3);
-		add_filter('timber/term/meta', array( $this, 'term_get_meta' ), 10, 3);
-		add_filter('timber/term/meta/field', array( $this, 'term_get_meta_field' ), 10, 4);
-		add_filter('timber/user/pre_get_meta_field', array( $this, 'user_get_meta_field' ), 10, 3);
+		add_filter('timber/term/get_meta_values', array( $this, 'term_get_meta' ), 10, 3);
+		add_filter('timber/term/meta', array( $this, 'term_get_meta_field' ), 10, 4);
+		add_filter('timber/user/pre_meta', array( $this, 'user_get_meta_field' ), 10, 3);
+
+		// Deprecated
 		add_filter('timber/term/meta/set', array( $this, 'term_set_meta' ), 10, 4);
 	}
 
@@ -39,6 +43,11 @@ class ACF {
 		return get_field($field_name, $searcher);
 	}
 
+	/**
+	 * @deprecated 2.0.0, with no replacement
+	 *
+	 * @return mixed
+	 */
 	public function term_set_meta( $value, $field, $term_id, $term ) {
 		$searcher = $term->taxonomy . '_' . $term->ID;
 		update_field($field, $value, $searcher);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -768,7 +768,7 @@ class Post extends Core implements CoreInterface {
 	 * @param string $field_name The field name for which you want to get the value.
 	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name ) {
+	public function meta( $field_name = null ) {
 		/**
 		 * Filters the value for a post meta field before it is fetched from the database.
 		 *

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -467,7 +467,7 @@ class Post extends Core implements CoreInterface {
 	 * @param integer $pid a post ID number
 	 */
 	public function import_custom( $pid ) {
-		$customs = $this->get_post_custom($pid);
+		$customs = $this->get_meta_values($pid);
 		$this->import($customs);
 	}
 
@@ -475,10 +475,12 @@ class Post extends Core implements CoreInterface {
 	 * Used internally to fetch the metadata fields (wp_postmeta table)
 	 * and attach them to our Timber\Post object
 	 * @internal
+	 *
 	 * @param int $pid
+	 *
 	 * @return array
 	 */
-	protected function get_post_custom( $pid ) {
+	protected function get_meta_values( $pid ) {
 		$customs = array();
 
 		/**
@@ -492,18 +494,18 @@ class Post extends Core implements CoreInterface {
 		 * @param int          $pid     The post ID.
 		 * @param \Timber\Post $post    The post object.
 		 */
-		$customs = apply_filters( 'timber/post/pre_get_meta', $customs, $pid, $this );
+		$customs = apply_filters( 'timber/post/pre_get_meta_values', $customs, $pid, $this );
 
 		/**
 		 * Fires before post meta data is imported into the object.
 		 *
-		 * @deprecated 2.0.0, use `timber/post/pre_get_meta`
+		 * @deprecated 2.0.0, use `timber/post/pre_get_meta_values`
 		 */
 		do_action_deprecated(
 			'timber_post_get_meta_pre',
 			array( $customs, $pid, $this ),
 			'2.0.0',
-			'timber/post/pre_get_meta'
+			'timber/post/pre_get_meta_values'
 		);
 
 		if ( !is_array($customs) || empty($customs) ) {
@@ -530,18 +532,18 @@ class Post extends Core implements CoreInterface {
 		 * @param int          $pid     The post ID.
 		 * @param \Timber\Post $post    The post object.
 		 */
-		$customs = apply_filters( 'timber/post/get_meta', $customs, $pid, $this );
+		$customs = apply_filters( 'timber/post/get_meta_values', $customs, $pid, $this );
 
 		/**
 		 * Filters post meta data.
 		 *
-		 * @deprecated 2.0.0, use `timber/post/get_meta`
+		 * @deprecated 2.0.0, use `timber/post/get_meta_values`
 		 */
 		$customs = apply_filters_deprecated(
 			'timber_post_get_meta',
 			array( $customs, $pid, $this ),
 			'2.0.0',
-			'timber/post/get_meta'
+			'timber/post/get_meta_values'
 		);
 
 		return $customs;
@@ -578,7 +580,7 @@ class Post extends Core implements CoreInterface {
 		$post->status = $post->post_status;
 		$post->id = $post->ID;
 		$post->slug = $post->post_name;
-		$customs = $this->get_post_custom($post->ID);
+		$customs = $this->get_meta_values($post->ID);
 		$post->custom = $customs;
 		//$post = (object) array_merge((array) $customs, (array) $post);
 		return $post;
@@ -722,7 +724,7 @@ class Post extends Core implements CoreInterface {
 	 * @return boolean
 	 */
 	public function has_field( $field_name ) {
-		return (!$this->get_field($field_name)) ? false : true;
+		return (!$this->meta($field_name)) ? false : true;
 	}
 
 	/**
@@ -757,11 +759,16 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * Gets a post meta value.
+	 *
+	 * Returns a meta value for a post that’s saved in the post meta database table.
+	 *
 	 * @api
-	 * @param string $field_name
-	 * @return mixed
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
-	public function get_field( $field_name ) {
+	public function meta( $field_name ) {
 		/**
 		 * Filters the value for a post meta field before it is fetched from the database.
 		 *
@@ -775,18 +782,18 @@ class Post extends Core implements CoreInterface {
 		 * @param string       $field_name The name of the meta field to get the value for.
 		 * @param \Timber\Post $post       The post object.
 		 */
-		$value = apply_filters( 'timber/post/pre_get_meta_field', null, $this->ID, $field_name, $this );
+		$value = apply_filters( 'timber/post/pre_meta', null, $this->ID, $field_name, $this );
 
 		/**
 		 * Filters the value for a post meta field before it is fetched from the database.
 		 *
-		 * @deprecated 2.0.0, use `timber/post/pre_get_meta_field`
+		 * @deprecated 2.0.0, use `timber/post/pre_meta`
 		 */
 		$value = apply_filters_deprecated(
 			'timber_post_get_meta_field_pre',
 			array( $value, $this->ID, $field_name, $this ),
 			'2.0.0',
-			'timber/post/pre_get_meta_field'
+			'timber/post/pre_meta'
 		);
 
 		if ( $value === null ) {
@@ -814,18 +821,18 @@ class Post extends Core implements CoreInterface {
 		 * @param string       $field_name The name of the meta field to get the value for.
 		 * @param \Timber\Post $post       The post object.
 		 */
-		$value = apply_filters( 'timber/post/get_meta_field', $value, $this->ID, $field_name, $this );
+		$value = apply_filters( 'timber/post/meta', $value, $this->ID, $field_name, $this );
 
 		/**
 		 * Filters the value for a post meta field.
 		 *
-		 * @deprecated 2.0.0, use `timber/post/get_meta_field`
+		 * @deprecated 2.0.0, use `timber/post/meta`
 		 */
 		$value = apply_filters_deprecated(
 			'timber_post_get_meta_field',
 			array( $value, $this->ID, $field_name, $this ),
 			'2.0.0',
-			'timber/post/get_meta_field'
+			'timber/post/meta'
 		);
 
 		$value = $this->convert($value, __CLASS__);
@@ -840,7 +847,7 @@ class Post extends Core implements CoreInterface {
 	 * @param string $field_name
 	 */
 	public function import_field( $field_name ) {
-		$this->$field_name = $this->get_field($field_name);
+		$this->$field_name = $this->meta($field_name);
 	}
 
 	/**
@@ -1322,16 +1329,27 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * Gets a post meta value.
+	 *
 	 * @api
-	 * @param string $field_name
-	 * @return mixed
+	 * @deprecated 2.0.0, use `{{ post.meta('field_name') }}` instead.
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name = null ) {
+	public function get_field( $field_name = null ) {
+		Helper::deprecated(
+			"{{ post.get_field('field_name') }}",
+			"{{ post.meta('field_name' }}",
+			'2.0.0'
+		);
+
 		if ( $field_name === null ) {
 			//on the off-chance the field is actually named meta
 			$field_name = 'meta';
 		}
-		return $this->get_field($field_name);
+
+		return $this->meta( $field_name );
 	}
 
 	/**

--- a/lib/User.php
+++ b/lib/User.php
@@ -154,7 +154,7 @@ class User extends Core implements CoreInterface {
 		$this->id = $this->ID;
 		$this->name = $this->name();
 		$this->avatar = new Image(get_avatar_url($this->id));
-		$this->custom = $this->get_custom();
+		$this->custom = $this->get_meta_values();
 		$this->import($this->custom, false, true);
 	}
 
@@ -165,7 +165,7 @@ class User extends Core implements CoreInterface {
 	 * @internal
 	 * @return array|null
 	 */
-	protected function get_custom() {
+	protected function get_meta_values() {
 		if ( $this->ID ) {
 			$um = array();
 
@@ -180,18 +180,18 @@ class User extends Core implements CoreInterface {
 			 * @param int          $user_id   The user ID.
 			 * @param \Timber\User $user      The user object.
 			 */
-			$um = apply_filters( 'timber/user/pre_get_meta', $um, $this->ID, $this );
+			$um = apply_filters( 'timber/user/pre_get_meta_values', $um, $this->ID, $this );
 
 			/**
 			 * Filters user meta data before it is fetched from the database.
 			 *
-			 * @deprecated 2.0.0, use `timber/user/pre_get_meta`
+			 * @deprecated 2.0.0, use `timber/user/pre_get_meta_values`
 			 */
 			$um = apply_filters_deprecated(
 				'timber_user_get_meta_pre',
 				array( $um, $this->ID, $this ),
 				'2.0.0',
-				'timber/user/pre_get_meta'
+				'timber/user/pre_get_meta_values'
 			);
 
 			if ( empty($um) ) {
@@ -214,18 +214,18 @@ class User extends Core implements CoreInterface {
 			 * @param int          $user_id   The user ID.
 			 * @param \Timber\User $user      The user object.
 			 */
-			$custom = apply_filters( 'timber/user/get_meta', $custom, $this->ID, $this );
+			$custom = apply_filters( 'timber/user/get_meta_values', $custom, $this->ID, $this );
 
 			/**
 			 * Filters user meta data fetched from the database.
 			 *
-			 * @deprecated 2.0.0, use `timber/user/get_meta`
+			 * @deprecated 2.0.0, use `timber/user/get_meta_values`
 			 */
 			$custom = apply_filters_deprecated(
 				'timber_user_get_meta',
 				array( $custom, $this->ID, $this ),
 				'2.0.0',
-				'timber/user/get_meta'
+				'timber/user/get_meta_values'
 			);
 
 			return $custom;
@@ -247,9 +247,14 @@ class User extends Core implements CoreInterface {
 	}
 
 	/**
+	 * Gets a user meta value.
+	 *
+	 * Returns a meta value for a user that’s saved in the user meta database table.
+	 *
 	 * @api
-	 * @param string $field_name
-	 * @return mixed
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
 	public function meta( $field_name ) {
 		$value = null;
@@ -267,18 +272,18 @@ class User extends Core implements CoreInterface {
 		 * @param string       $field_name The name of the meta field to get the value for.
 		 * @param \Timber\User $user       The user object.
 		 */
-		$value = apply_filters( 'timber/user/pre_get_meta_field', $value, $this->ID, $field_name, $this );
+		$value = apply_filters( 'timber/user/pre_meta', $value, $this->ID, $field_name, $this );
 
 		/**
 		 * Filters a user meta field before it is fetched from the database.
 		 *
-		 * @deprecated 2.0.0, use `timber/user/pre_get_meta_field`
+		 * @deprecated 2.0.0, use `timber/user/pre_meta`
 		 */
 		$value = apply_filters_deprecated(
 			'timber_user_get_meta_field_pre',
 			array( $value, $this->ID, $field_name, $this ),
 			'2.0.0',
-			'timber/user/pre_get_meta_field'
+			'timber/user/pre_meta'
 		);
 
 		if ( null === $value ) {
@@ -296,18 +301,18 @@ class User extends Core implements CoreInterface {
 		 * @param string       $field_name The name of the meta field to get the value for.
 		 * @param \Timber\User $user       The user object.
 		 */
-		$value = apply_filters( 'timber/user/get_meta_field', $value, $this->ID, $field_name, $this );
+		$value = apply_filters( 'timber/user/meta', $value, $this->ID, $field_name, $this );
 
 		/**
 		 * Filters the value for a user meta field.
 		 *
-		 * @deprecated 2.0.0, use `timber/user/get_meta_field`
+		 * @deprecated 2.0.0, use `timber/user/meta`
 		 */
 		$value = apply_filters_deprecated(
 			'timber_user_get_meta_field',
 			array( $value, $this->ID, $field_name, $this ),
 			'2.0.0',
-			'timber/user/get_meta_field'
+			'timber/user/meta'
 		);
 
 		return $value;
@@ -354,26 +359,40 @@ class User extends Core implements CoreInterface {
 	 */
 
 	/**
+	 * Gets a user meta value.
+	 *
 	 * @api
-	 * @deprecated 2.0.0, use `{{ user.meta }}` instead.
-	 * @param string $field_name
-	 * @return mixed
+	 * @deprecated 2.0.0, use `{{ user.meta('field_name') }}` instead.
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
 	public function get_meta_field( $field_name ) {
-		Helper::warn( '{{ user.get_meta_field() }} is deprecated. Use {{ user.meta() }} instead.' );
+		Helper::deprecated(
+			"{{ user.get_meta_field('field_name') }}",
+			"{{ user.meta('field_name') }}",
+			'2.0.0'
+		);
 
-		return $this->meta($field_name);
+		return $this->meta( $field_name );
 	}
 
 	/**
+	 * Gets a user meta value.
+	 *
 	 * @api
-	 * @deprecated 2.0.0, use `{{ user.meta }}` instead.
-	 * @param string $field_name
-	 * @return null
+	 * @deprecated 2.0.0, use `{{ user.meta('field_name') }}` instead.
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
 	 */
 	public function get_meta( $field_name ) {
-		Helper::warn( '{{ user.get_meta() }} is deprecated. Use {{ user.meta() }} instead.' );
+		Helper::deprecated(
+			"{{ user.get_meta('field_name') }}",
+			"{{ user.meta('field_name') }}",
+			'2.0.0'
+		);
 
-		return $this->get_meta_field($field_name);
+		return $this->meta( $field_name );
 	}
 }

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -6,9 +6,9 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		update_post_meta( $post_id, 'Frank', 'Drebin' );
 		$tp = new Timber\Post( $post_id );
-		add_filter( 'timber/post/get_meta_field', array( $this, 'filter_timber_post_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/post/meta', array( $this, 'filter_timber_post_get_meta_field' ), 10, 4 );
 		$this->assertEquals( 'Drebin', $tp->meta( 'Frank' ) );
-		remove_filter( 'timber/post/get_meta_field', array( $this, 'filter_timber_post_get_meta_field' ) );
+		remove_filter( 'timber/post/meta', array( $this, 'filter_timber_post_get_meta_field' ) );
 	}
 
 	function filter_timber_post_get_meta_field( $value, $pid, $field_name, $timber_post ) {
@@ -23,9 +23,9 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 		$comment = new Timber\Comment( $comment_id );
 		$comment->update( 'ghost', 'busters' );
-		add_filter( 'timber/comment/get_meta_field', array( $this, 'filter_timber_comment_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/comment/meta', array( $this, 'filter_timber_comment_get_meta_field' ), 10, 4 );
 		$this->assertEquals( $comment->meta( 'ghost' ), 'busters' );
-		remove_filter( 'timber/comment/get_meta_field', array( $this, 'filter_timber_comment_get_meta_field' ) );
+		remove_filter( 'timber/comment/meta', array( $this, 'filter_timber_comment_get_meta_field' ) );
 	}
 
 	function filter_timber_comment_get_meta_field( $value, $cid, $field_name, $timber_comment ) {
@@ -39,9 +39,9 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		$uid = $this->factory->user->create();
 		$user = new Timber\User( $uid );
 		$user->update( 'jared', 'novack' );
-		add_filter( 'timber/user/get_meta_field', array( $this, 'filter_timber_user_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ), 10, 4 );
 		$this->assertEquals( $user->meta( 'jared' ), 'novack' );
-		remove_filter( 'timber/user/get_meta_field', array( $this, 'filter_timber_user_get_meta_field' ) );
+		remove_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ) );
 	}
 
 	function filter_timber_user_get_meta_field( $value, $uid, $field_name, $timber_user ) {
@@ -54,10 +54,10 @@ class TestTimberFilters extends Timber_UnitTestCase {
 	function testTermMetaFilter() {
 		$tid = $this->factory->term->create();
 		$term = new Timber\Term( $tid );
-		add_filter( 'timber/term/meta/field', array( $this, 'filter_timber_term_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/term/meta', array( $this, 'filter_timber_term_get_meta_field' ), 10, 4 );
 
 		$term->meta( 'panic', 'oh yeah' );
-		remove_filter( 'timber/term/meta/field', array( $this, 'filter_timber_term_get_meta_field' ) );
+		remove_filter( 'timber/term/meta', array( $this, 'filter_timber_term_get_meta_field' ) );
 	}
 
 	function filter_timber_term_get_meta_field( $value, $tid, $field_name, $timber_term ) {

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -16,7 +16,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testACFGetFieldPost() {
 		$pid = $this->factory->post->create();
 		update_field( 'subhead', 'foobar', $pid );
-		$str = '{{post.get_field("subhead")}}';
+		$str = '{{post.meta("subhead")}}';
 		$post = new Timber\Post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals( 'foobar', $str );
@@ -67,7 +67,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$tid = $this->factory->term->create();
 		update_field( 'color', 'blue', 'post_tag_'.$tid );
 		$term = new Timber\Term( $tid );
-		$str = '{{term.get_field("color")}}';
+		$str = '{{term.meta("color")}}';
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -32,7 +32,7 @@
 			$iid = wp_insert_attachment( $attachment, $filename, $post_id );
 			update_post_meta($post_id, 'landmark', $iid);
 			$post = new Timber\Post($post_id);
-			$image = $post->get_field('landmark');
+			$image = $post->meta('landmark');
 			$image = new Timber\Image($image);
 			$this->assertEquals('The Arch', $image->title());
 		}

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -412,25 +412,56 @@
 		}*/
 
 		/**
-		 * This tests was created to catch what happens when you
-		 * do weird things to {{ post.meta }}, like with a custom field
-		 * actually named "meta"
-		 * This seems like an edge case that's best to let error-out so it can be resovled
-		 * instead of creating unexpected behavior
+		 * This tests was created to catch what happens when you do weird things to {{ post.meta }}, 
+		 * like calling it when nothing's assigned and trying to output as a string.
 		 * 
 		 * @expectedException Twig_Error_Runtime
 		 */
 		function testPostMetaMetaException(){
 			$post_id = $this->factory->post->create();
 			$post = new Timber\Post($post_id);
-			$string = Timber::compile_string('My {{post.meta}}', array('post' => $post));
-			$this->assertEquals('My', trim($string));
+			$string = Timber::compile_string('My {{ post.meta }}', array('post' => $post));
+			$this->assertEquals('My ', trim($string));
+		}
+
+		/**
+		 * This tests was created to catch what happens when you do weird things to {{ post.meta }}, 
+		 * like calling it when nothing's assigned and trying to output a default property as a string.
+		 * 
+		 */
+		function testPostMetaMetaArrayProperty(){
+			$post_id = $this->factory->post->create();
+			$post = new Timber\Post($post_id);
+			$string = Timber::compile_string('My {{ post.meta._pingme[0] }}', array('post' => $post));
+			$this->assertEquals('My 1', trim($string));
+		}
+
+		/**
+		 * This tests was created to catch what happens when you do weird things to {{ post.meta }}, 
+		 * like calling it when nothing's assigned and trying to output as a string. (Even when 
+		 * something's assigned)
+		 * 
+		 * @expectedException Twig_Error_Runtime
+		 */
+		function testPostMetaMetaAssignedException() {
+			$post_id = $this->factory->post->create();
 			update_post_meta($post_id, 'meta', 'steak');
 			$post = new Timber\Post($post_id);
-			$string = Timber::compile_string('My {{post.custom.meta}}', array('post' => $post));
-			//sorry you can't over-write methods now
+			$string = Timber::compile_string('My {{ post.meta }}', array('post' => $post));
+			$this->assertEquals('My ', trim($string));
+		}
+
+		function testPostMetaMetaOnCustom() {
+			$post_id = $this->factory->post->create();
+			$post = new Timber\Post($post_id);
+			update_post_meta($post_id, 'meta', 'steak');
+			$post = new Timber\Post($post_id);
+			$string = Timber::compile_string('My {{ post.custom.meta }}', array('post' => $post));
+			// We're cool with this, but it's still a bad idea.
 			$this->assertEquals('My steak', trim($string));
 		}
+
+		
 
 		function testPostParent(){
 			$parent_id = $this->factory->post->create();

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -411,6 +411,15 @@
 			//$this->assertEquals($post->the_field_name_flat, 'the-value');
 		}*/
 
+		/**
+		 * This tests was created to catch what happens when you
+		 * do weird things to {{ post.meta }}, like with a custom field
+		 * actually named "meta"
+		 * This seems like an edge case that's best to let error-out so it can be resovled
+		 * instead of creating unexpected behavior
+		 * 
+		 * @expectedException Twig_Error_Runtime
+		 */
 		function testPostMetaMetaException(){
 			$post_id = $this->factory->post->create();
 			$post = new Timber\Post($post_id);


### PR DESCRIPTION
**Ticket**: #1580, picking up on #1621

## Issue

Streamline filter and function names.

Consider the following functions, which each have two newly added filters, adapted from their old (underscored) filter names:

### Get all custom fields

**Post::get_post_custom()**

- `timber/post/pre_get_meta`
- `timber/post/get_meta`

**Term::get_term_meta**

- `timber/term/meta`

**User::get_custom()**

- `timber/user/pre_get_meta`
- `timber/user/get_meta`

**Comment::get_meta_fields()**

- `timber/comment/pre_get_meta_fields`
- `timber/comment/get_meta_fields`

### Get value for one custom field

**Post::get_field()**

- `timber/post/pre_get_meta_field`
- `timber/post/get_meta_field`

**Term::meta()**

- `timber/term/meta/field`

**User::meta()**

- `timber/user/pre_get_meta_field`
- `timber/user/get_meta_field`

**Comment::get_meta_field()**

- `timber/comment/pre_get_meta_field`
- `timber/comment/get_meta_field`

### What could be improved

1. The functions practically all do the same, but they are called differently. We should streamline these. And, in addition, `Post::meta()` currently calls `Post::get_field()`. But couldn’t it be the other way around, that `get_field()` is an alias of `meta()`?
2. The filter names are not streamlined as well. I think they should match the function names.

## Solution

### Streamline method names to get all custom field values

- `Post::get_meta_values()`
    - `timber/post/pre_get_meta_values`
    - `timber/post/get_meta_values`
- `Term::get_meta_values()`
    - `timber/term/get_meta_values`
- `User::get_meta_values()`
    - `timber/user/pre_get_meta_values`
    - `timber/user/get_meta_values`
- `Comment::get_meta_values()`
    - `timber/comment/pre_get_meta_values`
    - `timber/comment/get_meta_values`

### Streamline method names to get value for one custom field:

- `Post::meta()`
    - `timber/post/pre_meta`
    - `timber/post/meta`
- `Term::meta()`
    - `timber/term/meta`
- `User::meta()`
    - `timber/user/pre_meta`
    - `timber/user/meta`
- `Comment::meta()`
    - `timber/comment/pre_meta`
    - `timber/comment/meta`

### Deprecate namespaced filters

Where a a namespaced filter was already used (introduced in 0.21.x), I deprecated these as well.

- `timber/term/meta` in `Term::get_meta_values`
- `timber/term/meta/field` in `Term::meta`

The filter `timber/term/meta` in `Term::get_meta_values` was removed instead of being deprecated through `apply_filters_deprecated`, because there’s now a filter `timber/term/meta` in `Timber::meta()`. This might lead to weird behavior where `timber/term/meta` is still used in a theme.

### Improve DocBlocks

- Added summary, description and descriptions for parameter and return values for the `meta()` methods.

### Deprecation warnings

Added calls to `Helper::deprecated()` in the following deprecated methods:

- `Post::get_field()`
- `Term::get_meta_field()`
- `User::get_meta_field()`
- `User::get_meta()`
- `Comment::get_meta_field()`

## Testing

- I updated tests where they were failing.
- There’s an error in `TestTimberPost::testPostMetaMetaException`, but I’m not really sure what the test is supposed to be doing.
- Do we need to write new tests for something that’s changed here?
