### PR TITLE
2.x Remove backwards compatibility for non-namespaced class names

### DIFF
--- a/lib/PostCollection.php
+++ b/lib/PostCollection.php
@@ -133,6 +133,3 @@ class PostCollection extends \ArrayObject {
 		return $posts;
 	}
 }
-
-class_alias('Timber\PostCollection', 'Timber\PostsCollection');
-class_alias('Timber\PostCollection', 'TimberPostsCollection');

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -59,7 +59,6 @@ class Timber {
 		}
 		if ( class_exists('\WP') && !defined('TIMBER_LOADED') ) {
 			$this->test_compatibility();
-			$this->backwards_compatibility();
 			$this->init_constants();
 			self::init();
 		}
@@ -81,28 +80,6 @@ class Timber {
 		}
 	}
 
-	/**
-	 * @codeCoverageIgnore
-	 */
-	private function backwards_compatibility() {
-		if ( class_exists('TimberArchives') ) {
-			//already run, so bail
-			return;
-		}
-		$names = array('Archives', 'Comment', 'Core', 'FunctionWrapper', 'Helper', 'Image', 'ImageHelper', 'Integrations', 'Loader', 'Menu', 'MenuItem', 'Post', 'PostGetter', 'PostCollection', 'QueryIterator', 'Request', 'Site', 'Term', 'TermGetter', 'Theme', 'Twig', 'URLHelper', 'User', 'Integrations\Command', 'Integrations\ACF');
-		foreach ( $names as $name ) {
-			$old_class_name = 'Timber'.str_replace('Integrations\\', '', $name);
-			$new_class_name = 'Timber\\'.$name;
-			if ( class_exists($new_class_name) ) {
-				class_alias($new_class_name, $old_class_name);
-			}
-		}
-		class_alias(get_class($this), 'Timber');
-		if ( class_exists('Timber\\'.'Integrations\Timber_WP_CLI_Command') ) {
-			class_alias('Timber\\'.'Integrations\Timber_WP_CLI_Command', 'Timber_WP_CLI_Command');
-		}
-	}
-
 	public function init_constants() {
 		defined("TIMBER_LOC") or define("TIMBER_LOC", realpath(dirname(__DIR__)));
 	}
@@ -116,6 +93,15 @@ class Timber {
 			ImageHelper::init();
 			Admin::init();
 			new Integrations();
+
+			/**
+			 * Make an alias for the Timber class.
+			 *
+			 * This way, developers can use Timber::render() instead of Timber\Timber::render, which
+			 * is more user-friendly.
+			 */
+			class_alias( 'Timber\Timber', 'Timber' );
+
 			define('TIMBER_LOADED', true);
 		}
 	}

--- a/tests/test-timber-post-collection.php
+++ b/tests/test-timber-post-collection.php
@@ -4,14 +4,9 @@ class TestTimberPostQuery extends Timber_UnitTestCase {
 
 	function setUp() {
 		global $wpdb;
-		$wpdb->query("TRUNCATE TABLE $wpdb->posts"); 
+		$wpdb->query("TRUNCATE TABLE $wpdb->posts");
 		$wpdb->query("ALTER TABLE $wpdb->posts AUTO_INCREMENT = 1");
 		parent::setUp();
-	}
-
-	function testBackwards() {
-		$pc = new TimberPostsCollection();
-		$pc = new Timber\PostsCollection();
 	}
 
 	function testBasicCollection() {
@@ -52,7 +47,7 @@ class TestTimberPostQuery extends Timber_UnitTestCase {
 	}
 
 	function IgnoretestBasicCollectionWithPaginationAndBlankQuery() {
-		
+
 		$pids = $this->factory->post->create_many(130);
 		$this->go_to('/');
 		$pc = new Timber\PostQuery();


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1580#issuecomment-360980331

#### Issue

Since namespaced classes were introduced in 1.x, we’re trying to promote the use of the namespaced classes. Until now, there was backwards compatibility through class aliases. Version 2.x would be a good moment to ditch this.

However, one alias would make sense for ease-of-use: `Timber` as an alias for `Timber\Timber`. This is useful because we won’t have to write `Timber\Timber::render()`, but can still use `Timber::render()`.

#### Solution

- Remove method `Timber::backwards_compatibility()`. Move alias for `Timber\Timber` to `Timber::init()`.
- Remove class aliases for `Timber\PostCollection`.

#### Impact

There will be fatal errors for developers who use non-namespaced class names in PHP. A section in the upgrade guide that will be added in a separate pull request can help.

#### Testing

I ran tests and removed `TestTimberPostCollection::testBackwards()`, because there’s no backwards compatibility anymore.
