### PR TITLE
2.x Update methods to retrieve site option

### DIFF
--- a/lib/Site.php
+++ b/lib/Site.php
@@ -229,18 +229,57 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @param string  $field
-	 * @return mixed
+	 * Get the value for a site option.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * Published on: {{ post.date|date(site.date_format) }}
+	 * ```
+	 *
+	 * @param string $option The name of the option to get the value for.
+	 *
+	 * @return mixed The option value.
 	 */
-	public function __get( $field ) {
-		if ( !isset($this->$field) ) {
+	public function __get( $option ) {
+		if ( ! isset( $this->$option ) ) {
 			if ( is_multisite() ) {
-				$this->$field = get_blog_option($this->ID, $field);
+				$this->$option = get_blog_option( $this->ID, $option );
 			} else {
-				$this->$field = get_option($field);
+				$this->$option = get_option( $option );
 			}
 		}
-		return $this->$field;
+
+		return $this->$option;
+	}
+
+	/**
+	 * Get the value for a site option.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * Published on: {{ post.date|date(site.option('date_format')) }}
+	 * ```
+	 *
+	 * @param string $option The name of the option to get the value for.
+	 *
+	 * @return mixed The option value.
+	 */
+	public function option( $option ) {
+		return $this->__get( $option );
+	}
+
+	/**
+	 * Get the value for a site option.
+	 *
+	 * @api
+	 * @deprecated 2.0.0, use `{{ site.option }}` instead
+	 */
+	public function meta( $option ) {
+		Helper::deprecated( '{{ site.meta() }}', '{{ site.option() }}', '2.0.0' );
+
+		return $this->__get( $option );
 	}
 
 	/**
@@ -288,14 +327,6 @@ class Site extends Core implements CoreInterface {
 	 */
 	public function link() {
 		return $this->url;
-	}
-
-
-	/**
-	 * @internal
-	 */
-	public function meta( $field ) {
-		return $this->__get($field);
 	}
 
 	/**

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -57,10 +57,19 @@ class TestTimberSite extends Timber_UnitTestCase {
 		$this->assertEquals( 'bar', $site->foo );
 	}
 
+	/**
+	 * @expectedDeprecated {{ site.meta() }}
+	 */
 	function testSiteMeta() {
 		$ts = new Timber\Site();
 		update_option('foo', 'magoo');
 		$this->assertEquals('magoo', $ts->meta('foo'));
+	}
+
+	function testSiteOption() {
+		$ts = new Timber\Site();
+		update_option('date_format', 'j. F Y');
+		$this->assertEquals('j. F Y', $ts->option('date_format'));
 	}
 
 	function setUp() {


### PR DESCRIPTION
**Ticket**: #1580 

#### Issue

Up until now, site option values could be retrieved through `{{ site.option_name }}` or `{{ site.meta('option_name') }}`. The term `meta` doesn’t fit very well for a site option, because the value doesn’t live in a meta database table, but in `wp_options`. It would be more intuitive to have the following methods available for retrieving site options:

- `{{ site.option_name }}` (leave as is)
- `{{ site.option('option_name') }}`

#### Solution

- Add `option()` method that retrieves a site option through `__get()`.
- Deprecate `meta()` method in favor of `option()`.
- Update DocBlocks.

#### Testing

- Added test for new `option()` method.
- Updated test for `meta()` to catch deprecation.
