### PR TITLE
2.x Introduce is_target_blank method for MenuItem

### DIFF
--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -264,6 +264,27 @@ class MenuItem extends Core implements CoreInterface {
 	}
 
 	/**
+	 * Checks whether the «Open in new tab» option checked in the menu item options.
+	 *
+	 * @example
+	 * ```twig
+	 * <a href="{{ item.link }}" {{ item.is_target_blank ? 'target="_blank"' }}>
+	 * ```
+	 *
+	 * In combination with `is_external()`
+	 *
+	 * ```twig
+	 * <a href="{{ item.link }}" {{ item.is_target_blank or item.is_external ? 'target="_blank"' }}>
+	 * ```
+	 *
+	 * @return bool Whether the menu item has the «Open in new tab» option checked in the menu item
+	 *              options.
+	 */
+	public function is_target_blank() {
+		return '_blank' === $this->meta( '_menu_item_target' );
+	}
+
+	/**
 	 * Get the type of the menu item.
 	 *
 	 * Depending on what is the menu item links to. Can be `post_type` for posts, pages and custom

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -254,6 +254,19 @@ class MenuItem extends Core implements CoreInterface {
 	 * ```twig
 	 * <a href="{{ item.link }}" target="{{ item.is_external ? '_blank' : '_self' }}">
 	 * ```
+	 *
+	 * Or when you only want to add a target attribute if it is really needed:
+	 *
+	 * ```twig
+	 * <a href="{{ item.link }}" {{ item.is_external ? 'target="_blank"' }}">
+	 * ```
+	 *
+	 * In combination with `is_target_blank()`:
+	 *
+	 * ```twig
+	 * <a href="{{ item.link }}" {{ item.is_external or item.is_target_blank ? 'target="_blank"' }}">
+	 * ```
+	 *
 	 * @return bool Whether the link is external or not.
 	 */
 	public function is_external() {

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -290,7 +290,7 @@ class MenuItem extends Core implements CoreInterface {
 	 * <a class="icon-{{ item.meta('icon') }}" href="{{ item.link }}">{{ item.title }}</a>
 	 * ```
 	 * @param string $key The meta key to get the value for.
-	 * @return mixed Whatever value is stored in the database.
+	 * @return mixed Whatever value is stored in the database. Null if no value could be found.
 	 */
 	public function meta( $key ) {
 		if ( is_object($this->menu_object) && method_exists($this->menu_object, 'meta') ) {
@@ -299,6 +299,8 @@ class MenuItem extends Core implements CoreInterface {
 		if ( isset($this->$key) ) {
 			return $this->$key;
 		}
+
+		return null;
 	}
 
 	/* Aliases */

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -156,6 +156,24 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals( 'http://upstatement.com', $item->link() );
 	}
 
+	function testMenuItemIsTargetBlank() {
+		self::_createTestMenu();
+		$menu = new Timber\Menu();
+		$items = $menu->get_items();
+
+		// Menu item without _menu_item_target set
+		$item = $items[0];
+		$this->assertFalse( $item->is_target_blank() );
+
+		// Menu item with _menu_item_target set to '_blank'
+		$item = $items[1];
+		$this->assertTrue( $item->is_target_blank() );
+
+		// Menu item with _menu_item_target set to ''
+		$item = $items[2];
+		$this->assertFalse( $item->is_target_blank() );
+	}
+
 	function testMenuMeta() {
 		self::_createTestMenu();
 		$menu = new Timber\Menu();
@@ -346,6 +364,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $link_id, '_menu_item_url', 'http://upstatement.com' );
 		update_post_meta( $link_id, '_menu_item_xfn', '' );
 		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
+		update_post_meta( $link_id, '_menu_item_target', '_blank' );
 
 		/* make a child page */
 		$child_id = wp_insert_post( array(
@@ -365,6 +384,8 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $child_menu_item, '_menu_item_object_id', $child_id );
 		update_post_meta( $child_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $child_menu_item, '_menu_item_url', '' );
+		update_post_meta( $child_menu_item, '_menu_item_target', '' );
+
 		$post = new Timber\Post( $child_menu_item );
 		$menu_items[] = $child_menu_item;
 


### PR DESCRIPTION
**Ticket**: #1629

#### Issue

There is no easy way to check whether the «Open link in new tab» option is checked on a menu item in the backend.

#### Solution

- Introduce a new method `MenuItem::is_target_blank()` that checks whether the post meta entry `_menu_item_target` is set to "blank".
- Add fallback return value of `null` for `MenuItem::meta()`.
- Add documentation for `is_target_blank()` and `is_external()` to use them in combination.

#### Impact

None.

#### Usage Changes

Item targets can now be checked with

```twig
<a href="{{ item.link }}" {{ item.is_target_blank ? 'target="_blank"' }}>
```

And in combination with `MenuItem::is_external()`:

```twig
<a href="{{ item.link }}" {{ item.is_target_blank or item.is_external ? 'target="_blank"' }}>
```

#### Testing

I added a test to check for the different states:

- No `_menu_item_target` meta value set on a menu item
- Meta value "blank" for `_menu_item_target`.
- Meta value "" for `_menu_item_target`.