### PR TITLE
WP filters return object

### DIFF
--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -65,6 +65,7 @@ If you have functions that you use a lot and want to improve readability of your
  */
 add_filter( 'timber/twig', function( \Twig_Environment $twig ) {
 	$twig->addFunction( new Timber\Twig_Function( 'edit_post_link', 'edit_post_link' ) );
+	return $twig;
 } );
 ```
 


### PR DESCRIPTION
#### Issue
Under some configuration, adding a filter like the one below:
```php
add_filter( 'timber/twig', function( \Twig_Environment $twig ) {
    $twig->addFilter( new Twig_SimpleFilter( 'bar', function ( $value ) { return "foo"; } ) );
} );
```
Fails with `Call to a member function addFunction() on null`

#### Solution
WordPress filters return an object otherwise NULL is assumed what would replace the `$twig` object.


#### Impact
Fix documentation and respect WP best practices.
