### PR TITLE
#1709 break $MenuItemClass instantiation into own method

### DIFF
--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -223,7 +223,7 @@ class Menu extends Core {
 					$old_menu_item = $item;
 					$item = new $this->PostClass($item);
 				}
-				$menu_item = new $this->MenuItemClass($item);
+				$menu_item = $this->create_menu_item($item);
 				if ( isset($old_menu_item) ) {
 					$menu_item->import_classes($old_menu_item);
 				}
@@ -238,6 +238,15 @@ class Menu extends Core {
 			}
 		}
 		return $menu;
+	}
+
+	/**
+	 * @internal
+	 * @param object $item the WP menu item object to wrap
+	 * @return mixed an instance of the user-configured $MenuItemClass
+	 */
+	protected function create_menu_item($item) {
+		return new $this->MenuItemClass($item);
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: #1709 

#### Issue

I'd like to make the instantiation of `$MenuItemClass` instances more modular and overrideable in subclasses of `Menu`.

#### Solution

Create a new protected method, `create_menu_item`, that is solely responsible for instantiating Timber-flavored menu items.

Refactor `order_children` to call `create_menu_item` instead of instantiating directly.

#### Impact

All the polymorphism.

#### Usage Changes

If I've done everything right, this should be a pure refactor with no effect on behavior.

#### Considerations

This PR is literally the pinnacle of perfection and there is no possible way to improve it.

srsly tho idk, p simple

#### Testing

If this breaks any unit tests, I'll buy someone a beer.