### PR TITLE
Previewing changes made to ACF fields

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -252,11 +252,11 @@ class Post extends Core implements CoreInterface {
 			$pid = $pid_from_loop;
 		}
 		if (
-			isset($wp_query->queried_object_id)
-			&& ($wp_query->queried_object_id === $pid || (is_object($pid) && $wp_query->queried_object_id === $pid->ID))
-			&& isset($_GET['preview'])
+			isset($_GET['preview'])
 			&& isset($_GET['preview_nonce'])
 			&& wp_verify_nonce($_GET['preview_nonce'], 'post_preview_'.$wp_query->queried_object_id)
+			&& isset($wp_query->queried_object_id)
+			&& ($wp_query->queried_object_id === $pid || (is_object($pid) && $wp_query->queried_object_id === $pid->ID))
 		) {
 			$pid = $this->get_post_preview_id($wp_query);
 		}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -251,6 +251,15 @@ class Post extends Core implements CoreInterface {
 		if ( $pid === null && ($pid_from_loop = PostGetter::loop_to_id()) ) {
 			$pid = $pid_from_loop;
 		}
+		if (
+			isset($wp_query->queried_object_id)
+			&& ($wp_query->queried_object_id === $pid || (is_object($pid) && $wp_query->queried_object_id === $pid->ID))
+			&& isset($_GET['preview'])
+			&& isset($_GET['preview_nonce'])
+			&& wp_verify_nonce($_GET['preview_nonce'], 'post_preview_'.$wp_query->queried_object_id)
+		) {
+			$pid = $this->get_post_preview_id($wp_query);
+		}
 		return $pid;
 	}
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -336,6 +336,44 @@
 			$this->assertEquals('I am the one', $post->post_content);
 		}
 
+
+		function testCustomFieldPreviewRevision(){
+			global $current_user;
+			global $wp_query;
+
+			$post_id = $this->factory->post->create(array(
+				'post_author' => 5,
+			));
+			update_field('test_field', 'The custom field content', $post_id);
+
+			$assertCustomFieldVal = 'This has been revised';
+			$revision_id = $this->factory->post->create(array(
+				'post_type' => 'revision',
+				'post_status' => 'inherit',
+				'post_parent' => $post_id,
+			));
+			update_field('test_field', $assertCustomFieldVal, $revision_id);
+
+			$uid = $this->factory->user->create(array(
+				'user_login' => 'timber',
+				'user_pass' => 'timber',
+			));
+			$user = wp_set_current_user($uid);
+			$user->add_role('administrator');
+
+			$wp_query->queried_object_id = $post_id;
+			$wp_query->queried_object = get_post($post_id);
+			$_GET['preview'] = true;
+			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
+			$post = new TimberPost($post_id);
+
+			$str_direct = Timber::compile_string('{{post.test_field}}', array('post' => $post));
+			$str_getfield = Timber::compile_string('{{post.get_field(\'test_field\')}}', array('post' => $post));
+
+			$this->assertEquals( $assertCustomFieldVal, $str_direct );
+			$this->assertEquals( $assertCustomFieldVal, $str_getfield );
+		}
+
 		function testContent(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();


### PR DESCRIPTION
**Related to Ticket**: #836  <!-- Ignore this if not relevant -->

#### Issue
When previewing a post that utilizes ACF fields, it appears that Timber is inconsistently handling the revision ID when populating the custom field values in the `TimberPost` class. To get ACF fields to show up properly when previewing a post, you need to use `{{ post.get_field('custom_field') }}`, as using `{{ post.custom_field }}` won't output the previewed value.


#### Solution
In [PR 876](https://github.com/timber/timber/pull/876) some code was added to check if the user is previewing a post, and then returning the ID of the revision that is used as the preview. However, this check was only happening if no post ID was passed to the `TimberPost` instance.

Adding another check to the `determine_id()` method to see if the user is previewing a post, regardless of whether or not the ID was passed, seems to fix the issue.

Worth noting is that this check will also only run if the current `queried_object_id` is the same as the determined `$pid` in the logic above. This will prevent this code from running on *all* calls to the `TimberPost` class that happen on a previewed page.


#### Impact
Shouldn't be much...if the user is not previewing a page then this additional code won't run.


#### Usage Changes
None.


#### Considerations
It's possible (probable?) that the preview check in the first `if` clause in the `determine_id()` method can be removed entirely. I'm thinking it can but I just don't know enough of the codebase to know for sure.


#### Testing
Unit test has been added.