### PR TITLE
2.x Introduce target method for MenuItem

### DIFF
--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -49,7 +49,7 @@ Optionally, you can send additional options to `Timber\Menu`. Current only `dept
 
 ```php
 $args = array(
-	'depth' => 2,
+    'depth' => 2,
 );
 $menu = new Timber\Menu( 'primary', $args );
 ```
@@ -99,12 +99,13 @@ In your Twig file, you can loop over the menu items like normal arrays. You’re
     <ul class="nav-main">
         {% for item in menu.items %}
             <li class="nav-main-item {{ item.classes|join(' ') }}">
-                <a class="nav-main-link" href="{{ item.link }}">{{ item.title }}</a>
+                <a class="nav-main-link" href="{{ item.link }}" {{ item.is_target_blank ? 'target="_blank"' }}>{{ item.title }}</a>
+
                 {% if item.children %}
                     <ul class="nav-drop">
                         {% for child in item.children %}
                             <li class="nav-drop-item">
-                                <a href="{{ child.link }}">{{ child.title }}</a>
+                                <a href="{{ child.link }}" {{ item.is_target_blank ? 'target="_blank"' }}>{{ child.title }}</a>
                             </li>
                         {% endfor %}
                     </ul>
@@ -135,6 +136,34 @@ Here’s an example to display child menu items only if it’s the menu item is 
 ```
 
 Other properties that are available are `current_item_parent` for direct parents of a menu item and `current_item_ancestor` for when you have deeper nesting.
+
+## Menu item targets
+
+To get the target for a menu item, you can use `item.target`:
+
+```twig
+<a href="{{ item.link }}" target="{{ item.target }}">
+```
+
+In the menu edit screen, WordPress offers a checkbox for each menu item that lets the administrator decide whether to open a menu item in a new tab. The `item.target` function will return `_blank` if that checkbox is ticked, and `_self` if it’s not ticked.
+
+You might not need a value `_self` for the target attribute, because `_self` is the default value, which opens a link in the same tab/window. If you want to add `target="_blank"` only if it’s really needed, then you can use the conditional function `item.is_target_blank` :
+
+```twig
+<a href="{{ item.link }}" {{ item.is_target_blank ? 'target="_blank"' }}>
+```
+
+What about **external links**? If your site is `example.org`, then `google.com/whatever` is an external link. Whether it makes sense to open links in new tabs is not the topic to discuss here. If you still decide that you want that, you can check whether an item link is external with `item.is_external`:
+
+```twig
+<a href="{{ item.link }}" {{ item.is_external ? 'target="_blank"' }}">
+```
+
+You could also use it in combination with `item.is_target_blank`:
+
+```twig
+<a href="{{ item.link }}" {{ item.is_target_blank or item.is_external ? 'target="_blank"' }}>
+```
 
 ## Tips
 

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -247,7 +247,8 @@ class MenuItem extends Core implements CoreInterface {
 	 * Checks to see if the menu item is an external link.
 	 *
 	 * If your site is `example.org`, then `google.com/whatever` is an external link. This is
-	 * helpful when you want to create rules for the target of a link.
+	 * helpful when you want to style external links differently or create rules for the target of a
+	 * link.
 	 *
 	 * @api
 	 * @example

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -298,6 +298,30 @@ class MenuItem extends Core implements CoreInterface {
 	}
 
 	/**
+	 * Gets the target of a menu item according to the «Open in new tab» option in the menu item
+	 * options.
+	 *
+	 * This function return `_blank` when the option to open a menu item in a new tab is checked in
+	 * the WordPress backend, and `_self` if the option is not checked. Beware `_self` is the
+	 * default value for the target attribute, which means you could leave it out. You can use
+	 * `item.is_target_blank` if you want to use a conditional.
+	 *
+	 * @example
+	 * ```twig
+	 * <a href="{{ item.link }}" target="{{ item.target }}">
+	 * ```
+	 *
+	 * @return string
+	 */
+	public function target() {
+		if ( $this->is_target_blank() ) {
+			return '_blank';
+		}
+
+		return '_self';
+	}
+
+	/**
 	 * Get the type of the menu item.
 	 *
 	 * Depending on what is the menu item links to. Can be `post_type` for posts, pages and custom

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -174,6 +174,24 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertFalse( $item->is_target_blank() );
 	}
 
+	function testMenuItemTarget() {
+		self::_createTestMenu();
+		$menu = new Timber\Menu();
+		$items = $menu->get_items();
+
+		// Menu item without _menu_item_target set
+		$item = $items[0];
+		$this->assertEquals( '_self', $item->target() );
+
+		// Menu item with _menu_item_target set to '_blank'
+		$item = $items[1];
+		$this->assertEquals( '_blank', $item->target() );
+
+		// Menu item with _menu_item_target set to ''
+		$item = $items[2];
+		$this->assertFalse( '_self', $item->target() );
+	}
+
 	function testMenuMeta() {
 		self::_createTestMenu();
 		$menu = new Timber\Menu();


### PR DESCRIPTION
**Ticket**: #1629 and #1701

#### Issue

Picking up on the discussion that we had in #1701 whether it would make sense to have an `item.target` method.

#### Solution

- Added a new method `item.target` for menu items that can be used instead of `item.is_target_blank` and adds a little more flexibility for developers.
- Updated documentation for menu items. See the updates to the menu guide for what’s possible.

#### Impact

None.

#### Usage Changes

Makes handling menu item targets more versatile.

#### Testing

Yes. I added tests, they ran successfully.
