### PR TITLE
Add Menu::get_current_item() helper

### DIFF
--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -136,6 +136,28 @@ Here’s an example to display child menu items only if it’s the menu item is 
 
 Other properties that are available are `current_item_parent` for direct parents of a menu item and `current_item_ancestor` for when you have deeper nesting.
 
+### Getting the current menu item outside the loop
+
+Say you want to display sibling menu items of the current page, for example in
+a sidebar. You can use the `get_current_item()` helper to achieve this:
+
+**Twig**
+
+```twig
+<div class="sidebar">
+  <a href="{{ menu.get_current_item.link }}">
+    {{ menu.get_current_item.title }}
+  </a>
+  <ul>
+    {% for child in menu.get_current_item.get_children %}
+      <li>
+        <a href="{{ child.link }}">{{ child.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+```
+
 ## Tips
 
 - [Add items dynamically](https://github.com/jarednova/timber/issues/200)

--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -158,6 +158,37 @@ a sidebar. You can use the `get_current_item()` helper to achieve this:
 </div>
 ```
 
+### Getting a current menu ancestor
+
+You can limit the traversal depth of the tree when looking for the current
+item by passing a `$depth` parameter to `get_current_item`.
+Going off the previous example, say you wanted the root node of your sidebar
+to be the _second_ level of the main menu tree. In that case, you could
+specify a depth of 2:
+
+**Twig**
+
+```twig
+<div class="sidebar secondary-nav">
+  <a href="{{ menu.get_current_item(2).link }}">
+    {{ menu.get_current_item(2).title }}
+  </a>
+  <ul class="third-level-nav-items">
+    {% for child in menu.get_current_item(2).get_children %}
+      <li>
+        <a href="{{ child.link }}">{{ child.title }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+```
+
+### Getting the current top-level item
+
+For getting the top-level (that is, level-1) item corresponding to the
+current post, you can call `get_current_top_level_item()`. This method
+takes no arguments and is just an alias for `get_current_item(1)`.
+
 ## Tips
 
 - [Add items dynamically](https://github.com/jarednova/timber/issues/200)

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -348,6 +348,14 @@ class Menu extends Core {
           // we found an ancestor,
           // but keep looking for a more precise match
           $this->current_item = $item;
+
+          // we're in the right subtree, so go deeper
+          if ( $item->get_children() ) {
+            // reset the counter, since we're at a new level
+            $items = $item->get_children();
+            $i = 0;
+            continue;
+          }
         }
 
         $i++;

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -320,11 +320,15 @@ class Menu extends Core {
 	 *   </ul>
 	 * </div>
 	 * ```
+	 * @param int $depth the maximum depth to traverse the menu tree to find the
+	 * current item. Defaults to -1, meaning no maximum. 1-based, meaning the
+	 * top level is 1.
 	 * @return MenuItem the current `Timber\MenuItem` object, i.e. the menu item
 	 * corresponding to the current post.
 	 */
-	public function get_current_item() {
+	public function get_current_item( $depth = -1 ) {
 		if ( false === $this->current_item ) {
+			// I TOLD YOU BEFORE.
 			return false;
 		}
 
@@ -334,7 +338,16 @@ class Menu extends Core {
 		}
 
 		if ( ! isset($this->current_item) ) {
-			$this->current_item = $this->traverse_items_for_current($this->items);
+			$current = $this->traverse_items_for_current(
+				$this->items,
+				$depth
+			);
+
+			if ( $depth < 1 ) {
+				$this->current_item = $current;
+			} else {
+				return $current;
+			}
 		}
 
 		return $this->current_item;
@@ -347,9 +360,10 @@ class Menu extends Core {
 	 * @internal
 	 * @param array $items the items to traverse.
 	 */
-	private function traverse_items_for_current( $items ) {
-		$current = false;
-		$i       = 0;
+	private function traverse_items_for_current( $items, $depth ) {
+		$current 			= false;
+		$currentDepth = 1;
+		$i       			= 0;
 
 		while ( isset($items[ $i ]) ) {
 			$item = $items[ $i ];
@@ -364,11 +378,17 @@ class Menu extends Core {
 				// but keep looking for a more precise match.
 				$current = $item;
 
+				if ( $currentDepth === $depth ) {
+					// we're at max traversal depth.
+					return $current;
+				}
+
 				// we're in the right subtree, so go deeper.
 				if ( $item->get_children() ) {
 					// reset the counter, since we're at a new level.
 					$items = $item->get_children();
 					$i     = 0;
+					$currentDepth++;
 					continue;
 				}
 			}

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -325,11 +325,11 @@ class Menu extends Core {
    */
   public function get_current_item() {
     if ( false === $this->current_item ) {
-      return null;
+      return false;
     }
 
     if ( empty( $this->items ) ) {
-      return null;
+      return $this->current_item = false;
     }
 
     if ( !isset( $this->current_item ) ) {

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -334,40 +334,48 @@ class Menu extends Core {
 		}
 
 		if ( ! isset($this->current_item) ) {
-			$items = $this->items;
-			$i     = 0;
-
-			while ( isset($items[ $i ]) ) {
-				$item = $items[ $i ];
-
-				if ( $item->current ) {
-					// cache this item for subsequent calls.
-					$this->current_item = $item;
-					// stop looking.
-					break;
-				} elseif ( $item->current_item_ancestor ) {
-					// we found an ancestor,
-					// but keep looking for a more precise match.
-					$this->current_item = $item;
-
-					// we're in the right subtree, so go deeper.
-					if ( $item->get_children() ) {
-						// reset the counter, since we're at a new level.
-						$items = $item->get_children();
-						$i     = 0;
-						continue;
-					}
-				}
-
-				$i++;
-			}
-		}
-
-		if ( ! isset($this->current_item) ) {
-			// indicate that we know we won't find current_item here.
-			$this->current_item = false;
+			$this->current_item = $this->traverse_items_for_current($this->items);
 		}
 
 		return $this->current_item;
+	}
+
+
+	/**
+	 * Traverse an array of MenuItems in search of the current item.
+	 *
+	 * @internal
+	 * @param array $items the items to traverse.
+	 */
+	private function traverse_items_for_current( $items ) {
+		$current = false;
+		$i       = 0;
+
+		while ( isset($items[ $i ]) ) {
+			$item = $items[ $i ];
+
+			if ( $item->current ) {
+				// cache this item for subsequent calls.
+				$current = $item;
+				// stop looking.
+				break;
+			} elseif ( $item->current_item_ancestor ) {
+				// we found an ancestor,
+				// but keep looking for a more precise match.
+				$current = $item;
+
+				// we're in the right subtree, so go deeper.
+				if ( $item->get_children() ) {
+					// reset the counter, since we're at a new level.
+					$items = $item->get_children();
+					$i     = 0;
+					continue;
+				}
+			}
+
+			$i++;
+		}
+
+		return $current;
 	}
 }

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -58,6 +58,11 @@ class Menu extends Core {
 	 */
 	public $title;
 
+  /**
+   * @var MenuItem the current menu item
+   */
+  private $current_item;
+
 
 
 	/**
@@ -293,4 +298,42 @@ class Menu extends Core {
 
 		return array();
 	}
+
+  /**
+   * Get the current MenuItem based on the WP context
+   *
+   * @see _wp_menu_item_classes_by_context()
+   * @example
+   * Say you want to render the sub-tree of the main menu that corresponds
+   * to the menu item for the current page, such as in a context-aware sidebar:
+   * ```twig
+   * <div class="sidebar">
+   *   <a href="{{ menu.get_current_item.link }}">
+   *     {{ menu.get_current_item.title }}
+   *   </a>
+   *   <ul>
+   *     {% for child in menu.get_current_item.get_children %}
+   *       <li>
+   *         <a href="{{ child.link }}">{{ child.title }}</a>
+   *       </li>
+   *     {% endfor %}
+   *   </ul>
+   * </div>
+   * ```
+   * @return MenuItem the current `Timber\MenuItem` object, i.e. the menu item
+   * corresponding to the current post.
+   */
+  public function get_current_item() {
+    if ( !isset( $this->current_item ) ) {
+      foreach ( $this->items as $item ) {
+        if ( $item->current ) {
+          // cache this item for subsequent calls
+          $this->current_item = $item;
+          break;
+        }
+      }
+    }
+
+    return $this->current_item;
+  }
 }

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -58,10 +58,10 @@ class Menu extends Core {
 	 */
 	public $title;
 
-  /**
-   * @var MenuItem the current menu item
-   */
-  private $current_item;
+	/**
+	 * @var MenuItem the current menu item
+	 */
+	private $current_item;
 
 
 
@@ -299,74 +299,75 @@ class Menu extends Core {
 		return array();
 	}
 
-  /**
-   * Get the current MenuItem based on the WP context
-   *
-   * @see _wp_menu_item_classes_by_context()
-   * @example
-   * Say you want to render the sub-tree of the main menu that corresponds
-   * to the menu item for the current page, such as in a context-aware sidebar:
-   * ```twig
-   * <div class="sidebar">
-   *   <a href="{{ menu.get_current_item.link }}">
-   *     {{ menu.get_current_item.title }}
-   *   </a>
-   *   <ul>
-   *     {% for child in menu.get_current_item.get_children %}
-   *       <li>
-   *         <a href="{{ child.link }}">{{ child.title }}</a>
-   *       </li>
-   *     {% endfor %}
-   *   </ul>
-   * </div>
-   * ```
-   * @return MenuItem the current `Timber\MenuItem` object, i.e. the menu item
-   * corresponding to the current post.
-   */
-  public function get_current_item() {
-    if ( false === $this->current_item ) {
-      return false;
-    }
+	/**
+	 * Get the current MenuItem based on the WP context
+	 *
+	 * @see _wp_menu_item_classes_by_context()
+	 * @example
+	 * Say you want to render the sub-tree of the main menu that corresponds
+	 * to the menu item for the current page, such as in a context-aware sidebar:
+	 * ```twig
+	 * <div class="sidebar">
+	 *   <a href="{{ menu.get_current_item.link }}">
+	 *     {{ menu.get_current_item.title }}
+	 *   </a>
+	 *   <ul>
+	 *     {% for child in menu.get_current_item.get_children %}
+	 *       <li>
+	 *         <a href="{{ child.link }}">{{ child.title }}</a>
+	 *       </li>
+	 *     {% endfor %}
+	 *   </ul>
+	 * </div>
+	 * ```
+	 * @return MenuItem the current `Timber\MenuItem` object, i.e. the menu item
+	 * corresponding to the current post.
+	 */
+	public function get_current_item() {
+		if ( false === $this->current_item ) {
+			return false;
+		}
 
-    if ( empty( $this->items ) ) {
-      return $this->current_item = false;
-    }
+		if ( empty($this->items) ) {
+			$this->current_item = false;
+			return $this->current_item;
+		}
 
-    if ( !isset( $this->current_item ) ) {
-      $items = $this->items;
-      $i = 0;
+		if ( ! isset($this->current_item) ) {
+			$items = $this->items;
+			$i     = 0;
 
-      while ( isset( $items[$i] ) ) {
-        $item = $items[$i];
+			while ( isset($items[ $i ]) ) {
+				$item = $items[ $i ];
 
-        if ( $item->current ) {
-          // cache this item for subsequent calls
-          $this->current_item = $item;
-          // stop looking
-          break;
-        } elseif ( $item->current_item_ancestor ) {
-          // we found an ancestor,
-          // but keep looking for a more precise match
-          $this->current_item = $item;
+				if ( $item->current ) {
+					// cache this item for subsequent calls.
+					$this->current_item = $item;
+					// stop looking.
+					break;
+				} elseif ( $item->current_item_ancestor ) {
+					// we found an ancestor,
+					// but keep looking for a more precise match.
+					$this->current_item = $item;
 
-          // we're in the right subtree, so go deeper
-          if ( $item->get_children() ) {
-            // reset the counter, since we're at a new level
-            $items = $item->get_children();
-            $i = 0;
-            continue;
-          }
-        }
+					// we're in the right subtree, so go deeper.
+					if ( $item->get_children() ) {
+						// reset the counter, since we're at a new level.
+						$items = $item->get_children();
+						$i     = 0;
+						continue;
+					}
+				}
 
-        $i++;
-      }
-    }
+				$i++;
+			}
+		}
 
-    if ( !isset( $this->current_item ) ) {
-      // indicate that we know we won't find current_item here
-      $this->current_item = false;
-    }
+		if ( ! isset($this->current_item) ) {
+			// indicate that we know we won't find current_item here.
+			$this->current_item = false;
+		}
 
-    return $this->current_item;
-  }
+		return $this->current_item;
+	}
 }

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -353,6 +353,15 @@ class Menu extends Core {
 		return $this->current_item;
 	}
 
+	/**
+	 * Alias for get_current_top_level_item(1).
+	 *
+	 * @return MenuItem the current top-level `Timber\MenuItem` object.
+	 */
+	public function get_current_top_level_item() {
+		return $this->get_current_item( 1 );
+	}
+
 
 	/**
 	 * Traverse an array of MenuItems in search of the current item.

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -324,14 +324,28 @@ class Menu extends Core {
    * corresponding to the current post.
    */
   public function get_current_item() {
+    if ( false === $this->current_item ) {
+      return null;
+    }
+
     if ( !isset( $this->current_item ) ) {
       foreach ( $this->items as $item ) {
         if ( $item->current ) {
           // cache this item for subsequent calls
           $this->current_item = $item;
+          // stop looking
           break;
+        } elseif ( $item->current_item_ancestor ) {
+          // we found an ancestor,
+          // but keep looking for a more precise match
+          $this->current_item = $item;
         }
       }
+    }
+
+    if ( !isset( $this->current_item ) ) {
+      // indicate that we know we won't find current_item here
+      $this->current_item = false;
     }
 
     return $this->current_item;

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -328,8 +328,17 @@ class Menu extends Core {
       return null;
     }
 
+    if ( empty( $this->items ) ) {
+      return null;
+    }
+
     if ( !isset( $this->current_item ) ) {
-      foreach ( $this->items as $item ) {
+      $items = $this->items;
+      $i = 0;
+
+      while ( isset( $items[$i] ) ) {
+        $item = $items[$i];
+
         if ( $item->current ) {
           // cache this item for subsequent calls
           $this->current_item = $item;
@@ -340,6 +349,8 @@ class Menu extends Core {
           // but keep looking for a more precise match
           $this->current_item = $item;
         }
+
+        $i++;
       }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,10 @@ _Twig is the template language powering Timber; if you need a little background 
 **Changes for Theme Developers**
 - Please add any usage changes here so theme developers are informed of changes.
 
+= 2.0.0 =
+**Fixes and improvements**
+- Added Menu::get_current_item() helper method #1704
+
 = 1.7.0 =
 **Fixes and improvements**
 - Fixed some issues with animated gif resizing when Imagick isn't available #1653

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -703,4 +703,49 @@ class TestTimberMenu extends Timber_UnitTestCase {
     $this->assertFalse($menu->get_current_item());
   }
 
+  function testGetCurrentItemWithDepth() {
+    self::_createTestMenu();
+    $menu = new TimberMenu();
+
+    // pick a grandchild to inherit the great responsibility of current affairs
+    $parent = $menu->items[0];
+    $parent->current_item_ancestor = true;
+
+    // although grandchild is current, we expect this one because of $depth
+    $child = $parent->children[0];
+    $child->current_item_ancestor = true;
+
+    // mark grandchild as current, so when we get child back,
+    // we can reason that the traversal was depth-limited
+    $grandchild = $child->children[1];
+    $grandchild->current = true;
+
+    $current = $menu->get_current_item(2);
+    $this->assertEquals( $child->link(), $current->link() );
+  }
+
+  function testGetCurrentItemSequence() {
+    // make sure we're not caching current_item too eagerly
+    // when calling get_current_item with $depth
+    self::_createTestMenu();
+    $menu = new TimberMenu();
+
+    // we'll expect parent first, but expect grandchild on subsequent calls
+    // with no arguments
+    $parent = $menu->items[0];
+    $parent->current_item_ancestor = true;
+
+    $child = $parent->children[0];
+    $child->current = true;
+
+    $this->assertEquals(
+      $parent->link(),
+      $menu->get_current_item(1)->link()
+    );
+    $this->assertEquals(
+      $child->link(),
+      $menu->get_current_item()->link()
+    );
+  }
+
 }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -669,4 +669,22 @@ class TestTimberMenu extends Timber_UnitTestCase {
     $this->assertEquals( '/grandpa', $current->link() );
   }
 
+  function testGetCurrentItemWithComplexAncestry() {
+    self::_createTestMenu();
+    $menu = new TimberMenu();
+
+    // pick a grandchild to inherit the great responsibility of current affairs
+    $parent = $menu->items[0];
+    $parent->current_item_ancestor = true;
+
+    $child = $parent->children[0];
+    $child->current_item_ancestor = true;
+
+    $grandchild = $child->children[1];
+    $grandchild->current = true;
+
+    $current = $menu->get_current_item();
+    $this->assertEquals( $grandchild->link(), $current->link() );
+  }
+
 }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -681,7 +681,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
     $this->buildMenu('The Zazziest Menu', $items);
 
-    $menu = new TimberMenu('The Zazziest Menu');
+    $menu = new Timber\Menu('The Zazziest Menu');
 
     // force a specific MenuItem to be the current one,
     // and put it on the Zazz Train to Zazzville
@@ -700,7 +700,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
     $this->buildMenu('Ancestry.com Main Menu', $items);
 
-    $menu = new TimberMenu('Ancestry.com Main Menu');
+    $menu = new Timber\Menu('Ancestry.com Main Menu');
 
     // force a MenuItem of olde to be the current one,
     // and listen reverently to its stories
@@ -712,7 +712,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
   function testGetCurrentItemWithComplexAncestry() {
     self::_createTestMenu();
-    $menu = new TimberMenu();
+    $menu = new Timber\Menu();
 
     // pick a grandchild to inherit the great responsibility of current affairs
     $parent = $menu->items[0];

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -748,4 +748,20 @@ class TestTimberMenu extends Timber_UnitTestCase {
     );
   }
 
+  function testGetCurrentTopLevelItem() {
+    self::_createTestMenu();
+    $menu = new TimberMenu();
+
+    // we want this one
+    $parent = $menu->items[0];
+    $parent->current_item_ancestor = true;
+
+    // although grandchild is current, we expect this one because of $depth
+    $child = $parent->children[0];
+    $child->current = true;
+
+    $top = $menu->get_current_top_level_item();
+    $this->assertEquals( $parent->link(), $top->link() );
+  }
+
 }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -730,7 +730,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
   function testGetCurrentItemAntiClimactic() {
     self::_createTestMenu();
-    $menu = new TimberMenu();
+    $menu = new Timber\Menu();
 
     // nothing marked as current
     // womp womp
@@ -738,7 +738,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
   }
 
   function testGetCurrentItemWithEmptyMenu() {
-    $menu = new TimberMenu();
+    $menu = new Timber\Menu();
 
     // ain't nothin there
     $this->assertFalse($menu->get_current_item());
@@ -746,7 +746,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
   function testGetCurrentItemWithDepth() {
     self::_createTestMenu();
-    $menu = new TimberMenu();
+    $menu = new Timber\Menu();
 
     // pick a grandchild to inherit the great responsibility of current affairs
     $parent = $menu->items[0];
@@ -769,7 +769,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
     // make sure we're not caching current_item too eagerly
     // when calling get_current_item with $depth
     self::_createTestMenu();
-    $menu = new TimberMenu();
+    $menu = new Timber\Menu();
 
     // we'll expect parent first, but expect grandchild on subsequent calls
     // with no arguments
@@ -791,7 +791,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
   function testGetCurrentTopLevelItem() {
     self::_createTestMenu();
-    $menu = new TimberMenu();
+    $menu = new Timber\Menu();
 
     // we want this one
     $parent = $menu->items[0];

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -644,10 +644,29 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
     // force a specific MenuItem to be the current one,
     // and put it on the Zazz Train to Zazzville
+    $menu->items[0]->current_item_ancestor = true;
     $menu->items[1]->current = true;
 
     $current = $menu->get_current_item();
     $this->assertEquals( '/zazzy', $current->link() );
+  }
+
+  function testGetCurrentItemWithAncestor() {
+    $items = array();
+    $items[] = (object) array('type' => 'link', 'link' => '/');
+    $items[] = (object) array('type' => 'link', 'link' => '/grandpa');
+    $items[] = (object) array('type' => 'link', 'link' => '/joe-shmoe');
+
+    $this->buildMenu('Ancestry.com Main Menu', $items);
+
+    $menu = new TimberMenu('Ancestry.com Main Menu');
+
+    // force a MenuItem of olde to be the current one,
+    // and listen reverently to its stories
+    $menu->items[1]->current_item_ancestor = true;
+
+    $current = $menu->get_current_item();
+    $this->assertEquals( '/grandpa', $current->link() );
   }
 
 }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -632,4 +632,22 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals( 3, count($menu->get_items()) );
 	}
 
+  function testGetCurrentItem() {
+    $items = array();
+    $items[] = (object) array('type' => 'link', 'link' => '/');
+    $items[] = (object) array('type' => 'link', 'link' => '/zazzy');
+    $items[] = (object) array('type' => 'link', 'link' => '/stuffy');
+
+    $this->buildMenu('The Zazziest Menu', $items);
+
+    $menu = new TimberMenu('The Zazziest Menu');
+
+    // force a specific MenuItem to be the current one,
+    // and put it on the Zazz Train to Zazzville
+    $menu->items[1]->current = true;
+
+    $current = $menu->get_current_item();
+    $this->assertEquals( '/zazzy', $current->link() );
+  }
+
 }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -687,4 +687,20 @@ class TestTimberMenu extends Timber_UnitTestCase {
     $this->assertEquals( $grandchild->link(), $current->link() );
   }
 
+  function testGetCurrentItemAntiClimactic() {
+    self::_createTestMenu();
+    $menu = new TimberMenu();
+
+    // nothing marked as current
+    // womp womp
+    $this->assertFalse($menu->get_current_item());
+  }
+
+  function testGetCurrentItemWithEmptyMenu() {
+    $menu = new TimberMenu();
+
+    // ain't nothin there
+    $this->assertFalse($menu->get_current_item());
+  }
+
 }


### PR DESCRIPTION
**Ticket**: #1704 

#### Issue

Current solutions for getting the current menu item outside the main nav loop involve looping over all menu items explicitly. This is clunky.

#### Solution

Add a `Menu::get_current_item()` method that returns the current item, or the closest ancestor.

#### Impact

Timber is more awesome now.

#### Usage Changes

No breaking changes; strictly new code. I did add a note to the changelog for 2.0. Oh and MOAR DOCS. :)

#### Considerations

It'd be nice to add a `$depth` parameter in the future, to limit the depth of the tree traversal: e.g. calling `get_current_item(1)` (or 0?) would only scan the top menu level for the current/ancestor item. (I think the `depth` constructor option is 1-based? In any case it should be consistent with that.)

Once we have that it'd be trivial to implement a `get_current_top_level_item` helper, which is a use-case I encounter all the time. It might also be nice to add a `get_current_item_parent` helper.

#### Testing

https://www.daedtech.com/wp-content/uploads/2012/12/TestAllTheThings.jpg