### PR TITLE
#1704 fix current_* helper refs in Menu docs

### DIFF
--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -140,17 +140,17 @@ Other properties that are available are `current_item_parent` for direct parents
 ### Getting the current menu item outside the loop
 
 Say you want to display sibling menu items of the current page, for example in
-a sidebar. You can use the `get_current_item()` helper to achieve this:
+a sidebar. You can use the `current_item()` helper to achieve this:
 
 **Twig**
 
 ```twig
 <div class="sidebar">
-  <a href="{{ menu.get_current_item.link }}">
-    {{ menu.get_current_item.title }}
+  <a href="{{ menu.current_item.link }}">
+    {{ menu.current_item.title }}
   </a>
   <ul>
-    {% for child in menu.get_current_item.get_children %}
+    {% for child in menu.current_item.get_children %}
       <li>
         <a href="{{ child.link }}">{{ child.title }}</a>
       </li>
@@ -162,7 +162,7 @@ a sidebar. You can use the `get_current_item()` helper to achieve this:
 ### Getting a current menu ancestor
 
 You can limit the traversal depth of the tree when looking for the current
-item by passing a `$depth` parameter to `get_current_item`.
+item by passing a `$depth` parameter to `current_item`.
 Going off the previous example, say you wanted the root node of your sidebar
 to be the _second_ level of the main menu tree. In that case, you could
 specify a depth of 2:
@@ -171,11 +171,11 @@ specify a depth of 2:
 
 ```twig
 <div class="sidebar secondary-nav">
-  <a href="{{ menu.get_current_item(2).link }}">
-    {{ menu.get_current_item(2).title }}
+  <a href="{{ menu.current_item(2).link }}">
+    {{ menu.current_item(2).title }}
   </a>
   <ul class="third-level-nav-items">
-    {% for child in menu.get_current_item(2).get_children %}
+    {% for child in menu.current_item(2).get_children %}
       <li>
         <a href="{{ child.link }}">{{ child.title }}</a>
       </li>
@@ -187,8 +187,8 @@ specify a depth of 2:
 ### Getting the current top-level item
 
 For getting the top-level (that is, level-1) item corresponding to the
-current post, you can call `get_current_top_level_item()`. This method
-takes no arguments and is just an alias for `get_current_item(1)`.
+current post, you can call `current_top_level_item()`. This method
+takes no arguments and is just an alias for `current_item(1)`.
 
 ## Menu item targets
 


### PR DESCRIPTION
**Ticket**: #1704 

Just a quick follow-up to #1716 and #1724 fixing the helper method names in the docs.

Thanks!