### PR TITLE
Them::path() use `force = true` to work with specifying the port

### DIFF
--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -114,7 +114,9 @@ class Theme extends Core {
 	 * @return  string the relative path to the theme (ex: `/wp-content/themes/my-timber-theme`)
 	 */
 	public function path() {
-		return URLHelper::get_rel_url($this->link());
+		// force = true to work with specifying the port
+		// @see https://github.com/timber/timber/issues/1739
+		return URLHelper::get_rel_url($this->link(), true); 
 	}
 
 	/**


### PR DESCRIPTION
#### Issue
https://github.com/timber/timber/issues/1739

#### Solution
In order to turn off the `parse_url()['host'] `and `self::get_host()` check, we pass ` force = true`, so that `Timber::path ()` works correctly when the site is opened with the port number ,

#### Impact
It should not be, because in `URLHelper::get_rel_url()` it is passed `Theme::link()`

#### Usage Changes
No changes