### PR TITLE
Fixed URLHelper on https as no port is needed

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -11,7 +11,7 @@ class URLHelper {
 	 */
 	public static function get_current_url() {
 		$pageURL = self::get_scheme()."://";
-		if ( isset($_SERVER["SERVER_PORT"]) && $_SERVER["SERVER_PORT"] && $_SERVER["SERVER_PORT"] != "80" ) {
+		if ( isset($_SERVER["SERVER_PORT"]) && $_SERVER["SERVER_PORT"] && $_SERVER["SERVER_PORT"] != "80" && $_SERVER["SERVER_PORT"] != "443") {
 			$pageURL .= self::get_host().":".$_SERVER["SERVER_PORT"].$_SERVER["REQUEST_URI"];
 		} else {
 			$pageURL .= self::get_host().$_SERVER["REQUEST_URI"];


### PR DESCRIPTION
#### Issue
The URL Helper adds the port 443 if the website is served via https


#### Solution
I added a condition to not include the port if the page is served via https


#### Impact
Should have none


#### Usage Changes
No
