### PR TITLE
composer: type = wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "timber/timber",
-  "type": "library",
+  "type": "wordpress-plugin",
   "description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
   "keywords": [
     "timber",


### PR DESCRIPTION
#### Issue
When using bedrock it common to set custom plugin path according to package "type" like so:
```
    "extra": {
	"installer-paths": {
	    "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
	    "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
	    "web/app/themes/{$name}/": ["type:wordpress-theme"]
	}
    }
```
This work when using wpackagist, but not directly using (GitHub-based) upstream, especially when intending to use `dev-master`

#### Solution
Timber is a "wordpress-plugin". Just use that as its type.

#### Impact
None, hopefully.
