### PR TITLE
2.x Refactor context and improve compatibility with third party plugins

### DIFF
--- a/docs/getting-started/theming.md
+++ b/docs/getting-started/theming.md
@@ -139,7 +139,7 @@ Let’s crack open **index.php** and see what’s inside:
 
 ```php
 <?php
-$context = Timber::get_context();
+$context = Timber::context();
 $context['posts'] = new Timber\PostQuery();
 
 Timber::render( 'index.twig', $context );
@@ -151,7 +151,7 @@ This is where we are going to handle the logic that powers our index file. Let�
 
 ```php
 <?php
-$context = Timber::get_context();
+$context = Timber::context();
 ```
 
 This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you’ll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.

--- a/docs/guides/acf-cookbook.md
+++ b/docs/guides/acf-cookbook.md
@@ -41,7 +41,7 @@ $post = new Timber\Post();
 if (isset($post->hero_image) && strlen($post->hero_image)){
 	$post->hero_image = new Timber\Image($post->hero_image);
 }
-$data = Timber::get_context();
+$data = Timber::context();
 $data['post'] = $post;
 Timber::render('single.twig', $data);
 ```

--- a/docs/guides/cheatsheet.md
+++ b/docs/guides/cheatsheet.md
@@ -5,10 +5,10 @@ menu:
     parent: "guides"
 ---
 
-Here are some helpful conversions for functions you’re probably well familiar with in WordPress and their Timber equivalents. These assume a PHP file with the `Timber::get_context();` function at the top. For example:
+Here are some helpful conversions for functions you’re probably well familiar with in WordPress and their Timber equivalents. These assume a PHP file with the `Timber::context();` function at the top. For example:
 
 ```php
-$context = Timber::get_context();
+$context = Timber::context();
 $context['post'] = new Timber\Post();
 Timber::render( 'single.twig', $context );
 ```

--- a/docs/guides/cheatsheet.md
+++ b/docs/guides/cheatsheet.md
@@ -9,7 +9,7 @@ Here are some helpful conversions for functions you’re probably well familiar 
 
 ```php
 $context = Timber::context();
-$context['post'] = new Timber\Post();
+
 Timber::render( 'single.twig', $context );
 ```
 

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -7,7 +7,7 @@ menu:
 
 The context is one of the most important concepts to understand in Timber. Think of the context as the set of variables that are passed to your Twig template.
 
-In the following example, `$data` is an array of values. Each of the values will be available in the Twig template with the key of the value as a variable name.
+In the following example, `$data` is an associative array of values. Each of the values will be available in the Twig template with the key as a variable name.
 
 **single.php**
 
@@ -29,7 +29,7 @@ Timber::render( 'single.twig', $data );
 <p>{{ message }}</p>
 ```
 
-Of course you don’t have to figure all the variables you need for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`. 
+Of course you don’t have to figure out all the variables you need for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`. 
 
 **single.php**
 
@@ -41,7 +41,7 @@ $context = Timber::context();
 Timber::render( 'single.twig', $context );
 ```
 
-Follow this guide to get an overview of what’s in the context, or use `var_dump( $context );` in PHP or `{{ dump() }}` in Twig to display the contents right on your site.
+Follow this guide to get an overview of what’s in the context, or use `var_dump( $context );` in PHP or `{{ dump() }}` in Twig to display the contents in your browser.
 
 ## Global context
 
@@ -49,45 +49,22 @@ The global context is the context that is always set when you load it through `T
 
 ### Global context variables
 
-#### site
+Among others, the following variables will be available:
 
-The `site` variable is a `Timber\Site` object which will make it easier for you to retrieve site info. If you’re used to using `blog_info( 'sitename' )` in PHP, you can use `{{ site.name }}` in Twig instead.
+- **site** – The `site` variable is a [Timber\Site](/docs/reference/timber-site/) object which will make it easier for you to retrieve site info. If you’re used to using `blog_info( 'sitename' )` in PHP, you can use `{{ site.name }}` in Twig instead.
+- **request** - The `request` variable is a `Timber\Request` object, which will make it easier for you to access `$_GET` and `$_POST` variables in your context. Please be aware that you should always be very careful about using `$_GET` and `$_POST` variables in your templates directly. Read more about this in the Escaping Guide.
+- **theme** - The `theme` variable is [Timber\Theme](/docs/reference/timber-theme/) object and contains info about your theme.
+- **user** - The `user` variable will be a [`Timber\User`](/docs/reference/timber-user/) object if a user/visitor is currently logged in and otherwise it will just be `false`.
 
-#### request
-
-The `request` variable is a `Timber\Request` object, which will make it easier for you to access `$_GET` and `$_POST` variables in your context. Please be aware that you should always be very careful about using `$_GET` and `$_POST` variables in your templates directly. Read more about this in the [Escaping Guide]().
-
-#### theme
-
-The `theme` variable contains useful info about your theme.
-
-#### user
-
-The `user` variable will be a `Timber\User` object if a user/visitor is currently logged in and otherwise it will just be `false`. This will make it possible for you to check if a user is logged by checking for `user` instead of calling `is_user_logged_in()` in your Twig templates:
-
-```twig
-{% if user %}
-	Hello {{ user.name }}
-{% endif %}
-```
-
-#### http_host
-
-…
-
-#### wp_title
-
-…
-
-#### body_class
-
-…
+For a full list of variables, go have a look at the reference for [`Timber::context()`](/docs/reference/timber-timber/#context).
 
 ### Hook into the global context
 
-In your theme, you probably have elements that you use on every page, like a navigation menu, or a postal address or phone number. You don’t want to set these variables every time you call `Timber::render()` or `Timber::compile()`. And you don’t have to! You can use the `timber/context` filter to add your own data that will always be available.
+In your theme, you probably have elements that you use on every page, like a navigation menu, or a postal address or phone number. You don’t want to add these variables to the context every time you call `Timber::render()` or `Timber::compile()`. And you don’t have to! You can use the `timber/context` filter to add your own data that will always be available.
 
 Here’s an example for how you could **add a navigation menu** to your context, so that it becomes available in every template you use:
+
+**functions.php**
 
 ```php
 // Example: Add a menu to the global context.
@@ -98,13 +75,13 @@ add_filter( 'timber/context', function( $context ) {
 } );
 ```
 
-For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus).
+For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus). Please be aware that the [global context will be cached](#context-cache). That’s why you need to define your `timber/context` filter before using `Timber::context()` for the first time.
 
 ## Template contexts
 
 The context can change based on what template is displayed. Timber will always set `post` or `posts` in the context, if it can. But sometimes this is not what you want. Sometimes you need to change some arguments when fetching posts, or write your own posts query. In that case, it’s important to tell Timber about your change. Otherwise it will perform a separate query in the back, which might affect the performance of your page load. Since version 2.0 of Timber, you have more control over this process.
 
-### post
+### Singular templates
 
 The `post` variable will be available in singular templates ([is_singular()](https://developer.wordpress.org/reference/functions/is_singular/)), like posts or pages. It will contain a `Timber\Post` object of the currently displayed post.
 
@@ -132,7 +109,7 @@ $context = Timber::context( array(
 Timber::render( 'single.twig', $context );
 ```
 
-Of course you can pass in a `Timber\Post` object instead of just an ID, too.
+Of course you can also pass in a `Timber\Post` object instead of just an ID.
 
 **single.php**
 
@@ -145,7 +122,7 @@ $context = Timber::context( array(
 Timber::render( 'single.twig', $context );
 ```
 
-This is also the way to go if you want to use [your own post class](https://timber.github.io/docs/guides/extending-timber/). In that case, you could pass a post object directly.
+This is also the way to go if you want to use [your own post class](/docs/guides/extending-timber/). In that case, you could pass a post object directly.
 
 **single.php**
 
@@ -158,15 +135,13 @@ $context = Timber::context( array(
 Timber::render( 'single.twig', $context );
 ```
 
-### posts
+### Archive templates
 
-The `posts` variable will be available in archive templates ([is_archive()](https://developer.wordpress.org/reference/functions/is_archive/)), like your posts index page, category or tag archives, date based or author archives. It will contain the posts that are fetched with `Timber\PostQuery` with the arguments of WordPress’ default query.
+The `posts` variable will be available in archive templates ([is_archive()](https://developer.wordpress.org/reference/functions/is_archive/)), like your posts index page, category or tag archives, date based or author archives. It will contain the posts that are fetched with `Timber\PostQuery` with the arguments that WordPress uses for the default query of the currently displayed page.
 
 #### Change arguments for default query
 
-You can change arguments for the default query that WordPress will use to fetch posts by passing a `posts` argument array to the `context()` function. You might be used to using the [`pre_get_posts` filter](https://developer.wordpress.org/reference/hooks/pre_get_posts/), but here’s a way that might be more convenient for you.
-
-For example, if you’d want to change the default query to only show pages that have no parents, you can set the `post_parent` argument:
+You can change arguments for the default query that WordPress will use to fetch posts by passing a `posts` argument array to the `context()` function. For example, if you’d want to change the default query to *only show pages that have no parents*, you could pass in a `post_parent` argument:
 
 **archive.php**
 
@@ -180,11 +155,11 @@ $context = Timber::context( array(
 Timber::render( 'archive.twig', $context );
 ```
 
-You `$context` will then contain a `posts` entry with a posts collection fetched by the default query.
+Your `$context` will then contain a `posts` entry with a posts collection fetched by the default query. This is practically the same as using [`pre_get_posts` filter](https://developer.wordpress.org/reference/hooks/pre_get_posts/) in a default WordPress project, but it might be a little more convenient.
 
 #### Overwrite default query
 
-To **overwrite the default query** that WordPress uses, there’s a parameter `cancel_default_query` that you can use in combination with the arguments array that you pass to `context()`:
+You may not want to use the default query that WordPress uses. Sometimes you want to write your own query from scratch. To **overwrite the default query** that WordPress uses, there’s a parameter `cancel_default_query` that you can use in combination with the arguments array that you pass to `context()`:
 
 **archive.php**
 
@@ -204,7 +179,7 @@ $context['posts'] = new Timber\PostQuery( array(
 Timber::render( 'archive.twig', $context );
 ```
 
-Now, to make it easier to write, you can also pass in the arguments directly through the `posts` parameter.
+For a more compact way of writing this, you can also pass in the arguments directly through the `posts` parameter. If `cancel_default_query` is set to `true`, the arguments that you pass in `posts` will be used to perform a query that will then be present in `$context['posts']`.
 
 **archive.php**
 
@@ -219,8 +194,6 @@ Timber::render( 'archive.twig', Timber::context( array(
 ) ) );
 ```
 
-If `cancel_default_query` is set to `true`, the arguments that you pass in `posts` will be used to perform a query that will then be present in `$context['posts']`.
-
 ### Disable template contexts
 
 Automatic template contexts might not be what you want. In that case, you can disable them by using the `timber/context/args` filter:
@@ -230,10 +203,10 @@ Automatic template contexts might not be what you want. In that case, you can di
 ```php
 // Disable `post` and `posts` in context
 add_filter( 'timber/context/args', function( $args ) {
-	$args['post'] = false;
-	$args['posts'] = false;
+    $args['post'] = false;
+    $args['posts'] = false;
 
-	return $args;
+    return $args;
 } );
 ```
 
@@ -264,10 +237,13 @@ Sometimes you also need your context in other places, for example when you compi
  * Shortcode for address inside a WYSIWG field
  */
 add_shortcode( 'company_address', function() {
-    return Timber::compile( 'shortcode/company-address.twig', Timber::context_global() );
+    return Timber::compile(
+        'shortcode/company-address.twig',
+        Timber::context_global()
+    );
 } );
 ```
 
 Inside `shortcode/company-address.twig`, you will then have access to all the global variables that you can use in your normal template files as well. When you only need the global context, you can use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
 
-Timber will cache the global context for you, but it won’t cache template contexts. If you’re using the `timber/context` filter, make sure you run it before you call `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data.
+Timber will **cache the global context**, but it won’t cache template contexts. If you’re using the `timber/context` filter, make sure you run it before you call `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data.

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -1,0 +1,243 @@
+---
+title: "Context"
+menu:
+  main:
+    parent: "guides"
+---
+
+The context is one of the most important concepts to understand in Timber. Think of the context as the set of variables that are passed to your Twig template.
+
+In the following example, `$data` is an array of values. Each of the values will be available in the Twig template with the key of the value as a variable name.
+
+**single.php**
+
+```php
+<?php
+
+$data = array(
+    'message' => 'This can be any variable you want',
+    'author'  => 'Tom',
+);
+
+Timber::render( 'single.twig', $data );
+```
+
+**single.twig**
+
+```twig
+<h3>Message by {{ author }}</h3>
+<p>{{ message }}</p>
+```
+
+Of course you don’t have to figure all the variables you need for yourself. Timber will provide with a set of useful variables when you call `Timber::context()`.
+
+```php
+<?php
+
+$context = Timber::context();
+
+Timber::render( 'single.twig', $context );
+```
+
+Follow this guide to get an overview of what’s in the context, or use `var_dump( $context );` in PHP or `{{ dump() }}` in Twig to display the contents right on your site.
+
+## Global context
+
+The global context is the context that is always set when you load it through `Timber::context()`.
+
+### Global context variables
+
+#### site
+
+The `site` variable is a `Timber\Site` object which will make it easier for you to retrieve site info. If you’re used to using `blog_info( 'sitename' )` in PHP, you can use `{{ site.name }}` in Twig instead.
+
+#### request
+
+The `request` variable is a `Timber\Request` object, which will make it easier for you to access `$_GET` and `$_POST` variables in your context. Please be aware that you should always be very careful about using `$_GET` and `$_POST` variables in your templates directly. Read more about this in the [Escaping Guide]().
+
+#### theme
+
+The `theme` variable contains useful info about your theme.
+
+#### user
+
+The `user` variable will be a `Timber\User` object if a user/visitor is currently logged in and otherwise it will just be `false`.
+
+#### http_host
+
+…
+
+#### wp_title
+
+…
+
+#### body_class
+
+…
+
+### Hook into the global context
+
+In your theme, you probably have elements that you use on every page, like a navigation menu, an address or phone number. You don’t want to set these variables whenever you call `Timber::render()` or `Timber::compile()`. And you don’t have to! You can use the `timber/context` filter to add your own data.
+
+Here’s an example for how you could add a menu to your context, so that it becomes available in every template you use:
+
+```php
+add_filter( 'timber/context', function( $context ) {
+    // Example: Add a menu to the global context.
+    $context['menu'] = new Timber\Menu( 'primary-menu' );
+
+    return $context;
+} );
+```
+
+For menus to work, you’d first need to [register them](https://codex.wordpress.org/Navigation_Menus).
+
+## Template contexts
+
+The context can change based on what template is displayed. Timber will always set `post` or `posts` in the context, if it can. But sometimes this is not what you want. Sometimes you need to change some arguments when fetching posts, or write your own posts query. In that case, it’s important to tell Timber of your change. Otherwise it will perform a separate query in the back, which might affect performance. Since version 2.0 of Timber, you have more control over this process.
+
+### post
+
+The `post` variable will be available in singular templates ([is_singular()](https://developer.wordpress.org/reference/functions/is_singular/)) like posts or pages. It will contain a `Timber\Post` object of the currently displayed post.
+
+This means that the most basic singular template might look like this:
+
+**single.php**
+
+```php
+<?php
+
+Timber::render( 'single.twig', Timber::context() );
+```
+
+If you want to use a different post than the default post, you can do that with the `post` parameter. In the following example, we’re passing a post ID directly.
+
+**single.php**
+
+```php
+<?php
+
+$context = Timber::context( array(
+    'post' => 85,
+) );
+
+Timber::render( 'single.twig', $context );
+```
+
+Of course you can pass in a `Timber\Post` object, too.
+
+**single.php**
+
+```php
+<?php
+$post = new Timber\Post( 85 );
+
+$context = Timber::context( array(
+    'post' => $post,
+) );
+
+Timber::render( 'single.twig', $context );
+```
+
+This is also the way to go if you want to use [your own post class](https://timber.github.io/docs/guides/extending-timber/). In that case, you could pass a post object directly.
+
+### posts
+
+The `posts` variable will be available in archive templates ([is_archive()](https://developer.wordpress.org/reference/functions/is_archive/)), like your posts index page, category or tag archives, date based or author archives. It will contain the posts that are fetched with `Timber\PostQuery` with the arguments of the default query.
+
+#### Change arguments for default query
+
+You can change arguments for the default query by passing a `posts` argument to the `context()` function or by using a filter.
+
+For example, if you’d want to change the default query to only show pages that have no parents, you can set the `post_parent` argument.
+
+```php
+$context = Timber::context( array(
+    'posts' => array(
+        'post_parent' => 0,
+    ),
+) );
+
+Timber::render( 'archive.twig', $context );
+```
+
+This way, `$context` will contain a `posts` array.
+
+#### Overwrite default query
+
+To overwrite the default query, there’s a parameter `cancel_default_query` that you can use with the arguments array that you pass to `context()`:
+
+```php
+// Cancel default query for a small performance improvement
+$context = Timber::context( array(
+    'cancel_default_query' => true,
+) );
+
+$context['posts'] = new Timber\PostQuery( array(
+    'post_type'      => 'book',
+    'posts_per_page' => -1,
+    'post_status'    => 'publish',
+) );
+
+Timber::render( 'archive.twig', $context );
+```
+
+Now, to make it easier to write, you can also pass in the arguments directly through the `posts` parameter.
+
+```php
+$context = Timber::context( array(
+    'cancel_default_query' => true,
+    'posts'                => array(
+        'post_type'      => 'book',
+        'posts_per_page' => -1,
+        'post_status'    => 'publish',
+    ),
+) );
+
+Timber::render( 'archive.twig', $context );
+```
+
+If `cancel_default_query` is set to `true`, the arguments that you pass in `posts` will be used to perform a query that will then be present in `$context['posts']`.
+
+### Disable template contexts
+
+Automatic template contexts might not be what you want. In that case, you can disable them by using the `timber/context/args` filter:
+
+```php
+// Disable `post` and `posts` in context
+add_filter( 'timber/context/args', function( $args ) {
+	$args['post'] = false;
+	$args['posts'] = false;
+
+	return $args;
+} );
+```
+
+You can also directly pass `false` to either the `post` and/or the `posts` parameter when you call `context()`:
+
+```php
+$context = Timber::context( array(
+    'post'  => false,
+    'posts' => false,
+) );
+```
+
+## Context cache
+
+Sometimes you also need your context in other places, for example when you compile the template for a shortcode:
+
+```php
+/**
+ * Shortcode for address inside a WYSIWG field
+ */
+add_shortcode( 'address', function() {
+    return Timber::compile( 'shortcode/address.twig', Timber::context() );
+} );
+```
+
+Inside `shortcode/address.twig`, you will then have access to all the variables that you can use in your normal template files as well. You can call the `context()` function multiple times without losing performance. Timber will cache the context for your first call and will return the cache when you call it again.
+
+- The global context will always be cached. That’s why it’s important that you add your `timber/context` filters before you call `context()` for the first time.
+- The template contexts will be cached, except when you pass different parameters than in a previous call.
+
+## timber/context/args filter

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -29,7 +29,9 @@ Timber::render( 'single.twig', $data );
 <p>{{ message }}</p>
 ```
 
-Of course you don’t have to figure all the variables you need for yourself. Timber will provide with a set of useful variables when you call `Timber::context()`.
+Of course you don’t have to figure all the variables you need for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`. 
+
+**single.php**
 
 ```php
 <?php
@@ -61,7 +63,13 @@ The `theme` variable contains useful info about your theme.
 
 #### user
 
-The `user` variable will be a `Timber\User` object if a user/visitor is currently logged in and otherwise it will just be `false`.
+The `user` variable will be a `Timber\User` object if a user/visitor is currently logged in and otherwise it will just be `false`. This will make it possible for you to check if a user is logged by checking for `user` instead of calling `is_user_logged_in()` in your Twig templates:
+
+```twig
+{% if user %}
+	Hello {{ user.name }}
+{% endif %}
+```
 
 #### http_host
 
@@ -77,28 +85,28 @@ The `user` variable will be a `Timber\User` object if a user/visitor is currentl
 
 ### Hook into the global context
 
-In your theme, you probably have elements that you use on every page, like a navigation menu, an address or phone number. You don’t want to set these variables whenever you call `Timber::render()` or `Timber::compile()`. And you don’t have to! You can use the `timber/context` filter to add your own data.
+In your theme, you probably have elements that you use on every page, like a navigation menu, or a postal address or phone number. You don’t want to set these variables every time you call `Timber::render()` or `Timber::compile()`. And you don’t have to! You can use the `timber/context` filter to add your own data that will always be available.
 
-Here’s an example for how you could add a menu to your context, so that it becomes available in every template you use:
+Here’s an example for how you could **add a navigation menu** to your context, so that it becomes available in every template you use:
 
 ```php
+// Example: Add a menu to the global context.
 add_filter( 'timber/context', function( $context ) {
-    // Example: Add a menu to the global context.
     $context['menu'] = new Timber\Menu( 'primary-menu' );
 
     return $context;
 } );
 ```
 
-For menus to work, you’d first need to [register them](https://codex.wordpress.org/Navigation_Menus).
+For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus).
 
 ## Template contexts
 
-The context can change based on what template is displayed. Timber will always set `post` or `posts` in the context, if it can. But sometimes this is not what you want. Sometimes you need to change some arguments when fetching posts, or write your own posts query. In that case, it’s important to tell Timber of your change. Otherwise it will perform a separate query in the back, which might affect performance. Since version 2.0 of Timber, you have more control over this process.
+The context can change based on what template is displayed. Timber will always set `post` or `posts` in the context, if it can. But sometimes this is not what you want. Sometimes you need to change some arguments when fetching posts, or write your own posts query. In that case, it’s important to tell Timber about your change. Otherwise it will perform a separate query in the back, which might affect the performance of your page load. Since version 2.0 of Timber, you have more control over this process.
 
 ### post
 
-The `post` variable will be available in singular templates ([is_singular()](https://developer.wordpress.org/reference/functions/is_singular/)) like posts or pages. It will contain a `Timber\Post` object of the currently displayed post.
+The `post` variable will be available in singular templates ([is_singular()](https://developer.wordpress.org/reference/functions/is_singular/)), like posts or pages. It will contain a `Timber\Post` object of the currently displayed post.
 
 This means that the most basic singular template might look like this:
 
@@ -124,16 +132,14 @@ $context = Timber::context( array(
 Timber::render( 'single.twig', $context );
 ```
 
-Of course you can pass in a `Timber\Post` object, too.
+Of course you can pass in a `Timber\Post` object instead of just an ID, too.
 
 **single.php**
 
 ```php
 <?php
-$post = new Timber\Post( 85 );
-
 $context = Timber::context( array(
-    'post' => $post,
+    'post' => new Timber\Post( 85 ),
 ) );
 
 Timber::render( 'single.twig', $context );
@@ -141,15 +147,28 @@ Timber::render( 'single.twig', $context );
 
 This is also the way to go if you want to use [your own post class](https://timber.github.io/docs/guides/extending-timber/). In that case, you could pass a post object directly.
 
+**single.php**
+
+```php
+<?php
+$context = Timber::context( array(
+    'post' => new Extended_Post(),
+) );
+
+Timber::render( 'single.twig', $context );
+```
+
 ### posts
 
-The `posts` variable will be available in archive templates ([is_archive()](https://developer.wordpress.org/reference/functions/is_archive/)), like your posts index page, category or tag archives, date based or author archives. It will contain the posts that are fetched with `Timber\PostQuery` with the arguments of the default query.
+The `posts` variable will be available in archive templates ([is_archive()](https://developer.wordpress.org/reference/functions/is_archive/)), like your posts index page, category or tag archives, date based or author archives. It will contain the posts that are fetched with `Timber\PostQuery` with the arguments of WordPress’ default query.
 
 #### Change arguments for default query
 
-You can change arguments for the default query by passing a `posts` argument to the `context()` function or by using a filter.
+You can change arguments for the default query that WordPress will use to fetch posts by passing a `posts` argument array to the `context()` function. You might be used to using the [`pre_get_posts` filter](https://developer.wordpress.org/reference/hooks/pre_get_posts/), but here’s a way that might be more convenient for you.
 
-For example, if you’d want to change the default query to only show pages that have no parents, you can set the `post_parent` argument.
+For example, if you’d want to change the default query to only show pages that have no parents, you can set the `post_parent` argument:
+
+**archive.php**
 
 ```php
 $context = Timber::context( array(
@@ -161,11 +180,13 @@ $context = Timber::context( array(
 Timber::render( 'archive.twig', $context );
 ```
 
-This way, `$context` will contain a `posts` array.
+You `$context` will then contain a `posts` entry with a posts collection fetched by the default query.
 
 #### Overwrite default query
 
-To overwrite the default query, there’s a parameter `cancel_default_query` that you can use with the arguments array that you pass to `context()`:
+To **overwrite the default query** that WordPress uses, there’s a parameter `cancel_default_query` that you can use in combination with the arguments array that you pass to `context()`:
+
+**archive.php**
 
 ```php
 // Cancel default query for a small performance improvement
@@ -173,6 +194,7 @@ $context = Timber::context( array(
     'cancel_default_query' => true,
 ) );
 
+// Write your own query
 $context['posts'] = new Timber\PostQuery( array(
     'post_type'      => 'book',
     'posts_per_page' => -1,
@@ -184,17 +206,17 @@ Timber::render( 'archive.twig', $context );
 
 Now, to make it easier to write, you can also pass in the arguments directly through the `posts` parameter.
 
+**archive.php**
+
 ```php
-$context = Timber::context( array(
+Timber::render( 'archive.twig', Timber::context( array(
     'cancel_default_query' => true,
     'posts'                => array(
         'post_type'      => 'book',
         'posts_per_page' => -1,
         'post_status'    => 'publish',
     ),
-) );
-
-Timber::render( 'archive.twig', $context );
+) ) );
 ```
 
 If `cancel_default_query` is set to `true`, the arguments that you pass in `posts` will be used to perform a query that will then be present in `$context['posts']`.
@@ -202,6 +224,8 @@ If `cancel_default_query` is set to `true`, the arguments that you pass in `post
 ### Disable template contexts
 
 Automatic template contexts might not be what you want. In that case, you can disable them by using the `timber/context/args` filter:
+
+**functions.php**
 
 ```php
 // Disable `post` and `posts` in context
@@ -215,9 +239,18 @@ add_filter( 'timber/context/args', function( $args ) {
 
 You can also directly pass `false` to either the `post` and/or the `posts` parameter when you call `context()`:
 
+**single.php**
+
 ```php
 $context = Timber::context( array(
     'post'  => false,
+) );
+```
+
+**archive.php**
+
+```php
+$context = Timber::context( array(
     'posts' => false,
 ) );
 ```
@@ -230,14 +263,11 @@ Sometimes you also need your context in other places, for example when you compi
 /**
  * Shortcode for address inside a WYSIWG field
  */
-add_shortcode( 'address', function() {
-    return Timber::compile( 'shortcode/address.twig', Timber::context() );
+add_shortcode( 'company_address', function() {
+    return Timber::compile( 'shortcode/company-address.twig', Timber::context_global() );
 } );
 ```
 
-Inside `shortcode/address.twig`, you will then have access to all the variables that you can use in your normal template files as well. You can call the `context()` function multiple times without losing performance. Timber will cache the context for your first call and will return the cache when you call it again.
+Inside `shortcode/company-address.twig`, you will then have access to all the global variables that you can use in your normal template files as well. When you only need the global context, you can use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
 
-- The global context will always be cached. That’s why it’s important that you add your `timber/context` filters before you call `context()` for the first time.
-- The template contexts will be cached, except when you pass different parameters than in a previous call.
-
-## timber/context/args filter
+Timber will cache the global context for you, but it won’t cache template contexts. If you’re using the `timber/context` filter, make sure you run it before you call `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data.

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -196,21 +196,23 @@ Timber::render( 'archive.twig', Timber::context( array(
 
 ### Disable template contexts
 
-Automatic template contexts might not be what you want. In that case, you can disable them by using the `timber/context/args` filter:
+Automatic template contexts might not be what you want. In that case, you can disable them.
 
-**functions.php**
+#### Disable archive context
+
+You can also directly pass `false` to the `posts` argument when you call `context()`:
+
+**archive.php**
 
 ```php
-// Disable `post` and `posts` in context
-add_filter( 'timber/context/args', function( $args ) {
-    $args['post'] = false;
-    $args['posts'] = false;
-
-    return $args;
-} );
+$context = Timber::context( array(
+    'posts' => false,
+) );
 ```
 
-You can also directly pass `false` to either the `post` and/or the `posts` parameter when you call `context()`:
+#### Disable singular context
+
+You can directly pass `false` to the `post` argument when you call `context()`:
 
 **single.php**
 
@@ -220,12 +222,36 @@ $context = Timber::context( array(
 ) );
 ```
 
-**archive.php**
+If you disable `post` in the context, you should pass your new post through `Timber::context_post()`.
+
+**single.php**
 
 ```php
-$context = Timber::context( array(
-    'posts' => false,
-) );
+<?php
+// If you need to set post yourself, use `context_post()` to improve compatibility.
+
+$context         = Timber::context( array( 'post' => false ) );
+$context['post'] = Timber::context_post( new Extended_Post() );
+
+Timber::render( 'single.twig', $context );
+```
+
+The `Timber::context_post()` function is needed **for better compatibility with third party plugins**. Through this function, Timber will set `$wp->query->in_the_loop` to `true`, will call the `loop_start` action and will call `$wp_query->setup_postdata()`, which in turn will call the `the_post` action.
+
+### Disable template context with a filter
+
+If you want to globally disable template contexts, you can use the `timber/context/args` filter:
+
+**functions.php**
+
+```php
+// Disable `post` and/or `posts` in context
+add_filter( 'timber/context/args', function( $args ) {
+    $args['post'] = false;
+    $args['posts'] = false;
+
+    return $args;
+} );
 ```
 
 ## Context cache

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -75,11 +75,31 @@ add_filter( 'timber/context', function( $context ) {
 } );
 ```
 
-For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus). Please be aware that the [global context will be cached](#context-cache). That’s why you need to define your `timber/context` filter before using `Timber::context()` for the first time.
+For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus).
+
+## Context cache
+
+The global context will be cached. That’s why you need to define your `timber/context` filter before using `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data. Having a cached global context can be useful if you need the context in other places. For example if you compile the template for a shortcode:
+
+```php
+/**
+ * Shortcode for address inside a WYSIWG field
+ */
+add_shortcode( 'company_address', function() {
+    return Timber::compile(
+        'shortcode/company-address.twig',
+        Timber::context_global()
+    );
+} );
+```
+
+Inside `shortcode/company-address.twig`, you will have access to all the global variables that you can use in your normal template files as well. Whenever you only need the global context, you can use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
 
 ## Template contexts
 
 The context can change based on what template is displayed. Timber will always set `post` or `posts` in the context, if it can. But sometimes this is not what you want. Sometimes you need to change some arguments when fetching posts, or write your own posts query. In that case, it’s important to tell Timber about your change. Otherwise it will perform a separate query in the back, which might affect the performance of your page load. Since version 2.0 of Timber, you have more control over this process.
+
+Timber won’t cache template contexts.
 
 ### Singular templates
 
@@ -253,23 +273,3 @@ add_filter( 'timber/context/args', function( $args ) {
     return $args;
 } );
 ```
-
-## Context cache
-
-Sometimes you also need your context in other places, for example when you compile the template for a shortcode:
-
-```php
-/**
- * Shortcode for address inside a WYSIWG field
- */
-add_shortcode( 'company_address', function() {
-    return Timber::compile(
-        'shortcode/company-address.twig',
-        Timber::context_global()
-    );
-} );
-```
-
-Inside `shortcode/company-address.twig`, you will then have access to all the global variables that you can use in your normal template files as well. When you only need the global context, you can use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
-
-Timber will **cache the global context**, but it won’t cache template contexts. If you’re using the `timber/context` filter, make sure you run it before you call `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data.

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -115,7 +115,7 @@ if ( isset( $post->hero_image ) && strlen( $post->hero_image ) ) {
     $post->hero_image = new Timber\Image( $post->hero_image );
 }
 
-$data = Timber::get_context();
+$data = Timber::context();
 $data['post'] = $post;
 Timber::render( 'single.twig', $data );
 ```

--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -76,14 +76,14 @@ function add_to_context( $context ) {
 }
 ```
 
-Now, when you call `Timber::get_context()`, your menu will already be set in the context. You don’t need to initialize the menu in all your template files.
+Now, when you call `Timber::context()`, your menu will already be set in the context. You don’t need to initialize the menu in all your template files.
 
 **index.php**
 
 ```php
 <?php
 
-$context = Timber::get_context();
+$context = Timber::context();
 
 Timber::render( 'index.twig', $context );
 ```

--- a/docs/guides/pagination.md
+++ b/docs/guides/pagination.md
@@ -13,7 +13,7 @@ This will only work in a php file with an active query (like `archive.php` or `h
 
 ```php
 	<?php
-	$context = Timber::get_context();
+	$context = Timber::context();
 	$context['posts'] = new Timber\PostQuery();
 	Timber::render('archive.twig', $context);
 ```
@@ -50,7 +50,7 @@ You can then markup the output like so  (of course, the exact markup is up to YO
 	if (!isset($paged) || !$paged){
 		$paged = 1;
 	}
-	$context = Timber::get_context();
+	$context = Timber::context();
 	$args = array(
 		'post_type' => 'event',
 		'posts_per_page' => 5,
@@ -77,7 +77,7 @@ In your archive.php or home.php template:
 
 ```php
 	<?php
-	$context = Timber::get_context();
+	$context = Timber::context();
 	$context['posts'] = new Timber\PostQuery();
 	Timber::render('archive.twig', $context);
 ```

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -119,7 +119,7 @@ You can also use some [syntactic sugar](http://en.wikipedia.org/wiki/Syntactic_s
 ```php
 <?php
 
-$context = Timber::get_context();
+$context = Timber::context();
 
 $context['main_stories'] = TimberHelper::transient( 'main_stories', function(){
     $posts = new Timber\PostQuery();
@@ -156,7 +156,7 @@ Timber provides some quick shortcuts to measure page timing. Here’s an example
 // This generates a starting time
 $start = Timber\Helper::start_timer();
 
-$context = Timber::get_context();
+$context = Timber::context();
 $context['post'] = new Timber\Post();
 $context['whatever'] = get_my_foo();
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -157,7 +157,6 @@ Timber provides some quick shortcuts to measure page timing. Here’s an example
 $start = Timber\Helper::start_timer();
 
 $context = Timber::context();
-$context['post'] = new Timber\Post();
 $context['whatever'] = get_my_foo();
 
 Timber::render( 'single.twig', $context, 600 );

--- a/docs/guides/sidebars.md
+++ b/docs/guides/sidebars.md
@@ -61,16 +61,25 @@ In this example, you would populate your sidebar from your main PHP file (home.p
 ```php
 <?php
 /* single.php */
-$context = Timber::context();
-$post = new Timber\Post();
-$post_cat = $post->get_terms('category');
-$post_cat = $post_cat[0]->ID;
-$context['post'] = $post;
 
-$sidebar_context = array();
-$sidebar_context['related'] = new Timber\PostQuery('cat='.$post_cat);
-$context['sidebar'] = Timber::get_sidebar('sidebar-related.twig', $sidebar_context);
-Timber::render('single.twig', $context);
+$post     = new Timber\Post();
+$post_cat = $post->get_terms( 'category' );
+$post_cat = $post_cat[0]->ID;
+
+$sidebar_context = array(
+	'related' => new Timber\PostQuery( 'cat=' . $post_cat ),
+);
+
+$context = Timber::context( array(
+	'post' => $post,
+) );
+
+$context['sidebar'] = Timber::get_sidebar(
+	'sidebar-related.twig',
+	$sidebar_context
+);
+
+Timber::render( 'single.twig', $context );
 ```
 * In the final twig file, make sure you have spot for your sidebar:
 

--- a/docs/guides/sidebars.md
+++ b/docs/guides/sidebars.md
@@ -26,7 +26,7 @@ Timber::render('sidebar.twig', $context);
 ```php
 <?php
 /* single.php */
-$context = Timber::get_context();
+$context = Timber::context();
 $context['sidebar'] = Timber::get_sidebar('sidebar.php');
 Timber::render('single.twig', $context);
 ```
@@ -61,7 +61,7 @@ In this example, you would populate your sidebar from your main PHP file (home.p
 ```php
 <?php
 /* single.php */
-$context = Timber::get_context();
+$context = Timber::context();
 $post = new Timber\Post();
 $post_cat = $post->get_terms('category');
 $post_cat = $post_cat[0]->ID;

--- a/docs/guides/woocommerce.md
+++ b/docs/guides/woocommerce.md
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Timber' ) ){
     return;
 }
 
-$context            = Timber::get_context();
+$context            = Timber::context();
 $context['sidebar'] = Timber::get_widgets( 'shop-sidebar' );
 
 if ( is_singular( 'product' ) ) {

--- a/docs/guides/woocommerce.md
+++ b/docs/guides/woocommerce.md
@@ -21,7 +21,7 @@ $context            = Timber::context();
 $context['sidebar'] = Timber::get_widgets( 'shop-sidebar' );
 
 if ( is_singular( 'product' ) ) {
-    $context['post']    = new Timber\Post();
+    $context['post']    = Timber::context_post( new Timber\Post() );
     $product            = wc_get_product( $context['post']->ID );
     $context['product'] = $product;
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -18,7 +18,7 @@ class Helper {
 	 * @api
 	 * @example
 	 * ```php
-	 * $context = Timber::get_context();
+	 * $context = Timber::context();
 	 * $context['favorites'] = Timber\Helper::transient('user-' .$uid. '-favorites', function() use ($uid) {
 	 *  	//some expensive query here that's doing something you want to store to a transient
 	 *  	return $favorites;
@@ -213,7 +213,7 @@ class Helper {
 	 *     echo '<form action="form.php"><input type="text" /><input type="submit /></form>';
 	 * }
 	 *
-	 * $context = Timber::get_context();
+	 * $context = Timber::context();
 	 * $context['post'] = new Timber\Post();
 	 * $context['my_form'] = Timber\Helper::ob_function('the_form');
 	 * Timber::render('single-form.twig', $context);
@@ -545,5 +545,5 @@ class Helper {
 		$util = new \WP_List_Util( $list );
 		return $util->filter( $args, $operator );
 	}
-  
+
 }

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -214,7 +214,6 @@ class Helper {
 	 * }
 	 *
 	 * $context = Timber::context();
-	 * $context['post'] = new Timber\Post();
 	 * $context['my_form'] = Timber\Helper::ob_function('the_form');
 	 * Timber::render('single-form.twig', $context);
 	 * ```

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -16,9 +16,10 @@ use Timber\URLHelper;
  * @api
  * @example
  * ```php
- * $context = Timber::context();
  * $post = new Timber\Post();
- * $context['post'] = $post;
+ *
+ * $context         = Timber::context();
+ * $context['post'] = Timber::context_post( $post );
  *
  * // lets say you have an alternate large 'cover image' for your post stored in a custom field which returns an image ID
  * $cover_image_id = $post->cover_image;

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -16,7 +16,7 @@ use Timber\URLHelper;
  * @api
  * @example
  * ```php
- * $context = Timber::get_context();
+ * $context = Timber::context();
  * $post = new Timber\Post();
  * $context['post'] = $post;
  *

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -598,8 +598,6 @@ class Post extends Core implements CoreInterface {
 			return null;
 		}
 
-		do_action_ref_array('the_post', array(&$post, &$GLOBALS['wp_query']));
-
 		$post->status = $post->post_status;
 		$post->id = $post->ID;
 		$post->slug = $post->post_name;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -27,7 +27,7 @@ use WP_Post;
  * @example
  * ```php
  * // single.php, see connected twig example
- * $context = Timber::get_context();
+ * $context = Timber::context();
  * $context['post'] = new Timber\Post(); // It's a new Timber\Post object, but an existing post from WordPress.
  * Timber::render('single.twig', $context);
  * ?>
@@ -242,7 +242,7 @@ class Post extends Core implements CoreInterface {
 	 * Determined whether or not an admin/editor is looking at the post in "preview mode" via the
 	 * WordPress admin
 	 * @internal
-	 * @return bool 
+	 * @return bool
 	 */
 	protected static function is_previewing() {
 		global $wp_query;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -19,25 +19,28 @@ use WP_Post;
  * Class Post
  *
  * This is the object you use to access or extend WordPress posts. Think of it as Timber's (more
- * accessible) version of WP_Post. This is used throughout Timber to represent posts retrieved from
- * WordPress making them available to Twig templates. See the PHP and Twig examples for an example
- * of what it’s like to work with this object in your code.
+ * accessible) version of `WP_Post`. This is used throughout Timber to represent posts retrieved
+ * from WordPress making them available to Twig templates. See the PHP and Twig examples for an
+ * example of what it’s like to work with this object in your code.
  *
  * @api
  * @example
+ *
+ * **single.php**
+ *
  * ```php
- * // single.php, see connected twig example
  * $context = Timber::context();
- * $context['post'] = new Timber\Post(); // It's a new Timber\Post object, but an existing post from WordPress.
- * Timber::render('single.twig', $context);
- * ?>
+ *
+ * Timber::render( 'single.twig', $context );
  * ```
+ *
+ * **single.twig**
+ *
  * ```twig
- * {# single.twig #}
  * <article>
- *     <h1 class="headline">{{post.title}}</h1>
+ *     <h1 class="headline">{{ post.title }}</h1>
  *     <div class="body">
- *         {{post.content}}
+ *         {{ post.content }}
  *     </div>
  * </article>
  * ```
@@ -46,7 +49,9 @@ use WP_Post;
  * <article>
  *     <h1 class="headline">The Empire Strikes Back</h1>
  *     <div class="body">
- *         It is a dark time for the Rebellion. Although the Death Star has been destroyed, Imperial troops have driven the Rebel forces from their hidden base and pursued them across the galaxy.
+ *         It is a dark time for the Rebellion. Although the Death Star has been
+ *         destroyed, Imperial troops have driven the Rebel forces from their
+ *         hidden base and pursued them across the galaxy.
  *     </div>
  * </article>
  * ```

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -17,7 +17,7 @@ use Timber\Helper;
  * @api
  * @example
  * ```php
- * $context = Timber::get_context();
+ * $context = Timber::context();
  * $other_site_id = 2;
  * $context['other_site'] = new Timber\Site($other_site_id);
  * Timber::render('index.twig', $context);

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -9,14 +9,14 @@ use Timber\URLHelper;
  * Class Theme
  *
  * Need to display info about your theme? Well you've come to the right place. By default info on
- * the current theme comes for free with what's fetched by `Timber::get_context()` in which case you
+ * the current theme comes for free with what's fetched by `Timber::context()` in which case you
  * can access it your theme like so:
  *
  * @api
  * @example
  * ```php
  * <?php
- * $context = Timber::get_context();
+ * $context = Timber::context();
  * Timber::render('index.twig', $context);
  * ?>
  * ```
@@ -81,7 +81,7 @@ class Theme extends Core {
 	/**
 	 * Constructs a new `Timber\Theme` object.
 	 *
-	 * The `Timber\Theme` object of the current theme comes in the default `Timber::get_context()`
+	 * The `Timber\Theme` object of the current theme comes in the default `Timber::context()`
 	 * call. You can access this in your twig template via `{{site.theme}}`.
 	 *
 	 * @api
@@ -141,7 +141,7 @@ class Theme extends Core {
 	public function path() {
 		// force = true to work with specifying the port
 		// @see https://github.com/timber/timber/issues/1739
-		return URLHelper::get_rel_url($this->link(), true); 
+		return URLHelper::get_rel_url($this->link(), true);
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -273,7 +273,7 @@ class Timber {
 	 * @param array $args {
 	 *     Optional. An array of arguments for the context.
 	 *
-	 *     @type false|null|\Timber\Post        $post                 A post ID, a WP_Post object, a `Timber\Post`
+	 *     @type null|false|\Timber\Post        $post                 A post ID, a WP_Post object, a `Timber\Post`
 	 *                                                                object or a class instance that inherits from
 	 *                                                                `Timber\Post`. If set to `false`, Timber will not
 	 *                                                                set `post` in the context. Default `null`.
@@ -320,7 +320,7 @@ class Timber {
 		$context = self::context_global();
 
 		// Context for singular templates.
-		$context_post = self::context_post( $args );
+		$context_post = self::context_post( $args['post'] );
 
 		if ( $context_post ) {
 			$context['post'] = $context_post;
@@ -435,15 +435,21 @@ class Timber {
 	/**
 	 * Gets post context for a singular template.
 	 *
+	 * Mimicks WordPress behavior for singular templates to improve compatibility with third party
+	 * plugins.
+	 *
 	 * @api
 	 * @since 2.0.0
 	 *
-	 * @param array $args An array of arguments from `Timber::context()`.
+	 * @param null|false|\Timber\Post $post_arg Optional. A post ID, a WP_Post object, a
+	 *                                          `Timber\Post` object or a class instance that
+	 *                                          inherits from `Timber\Post`. Defaults to global
+	 *                                          `$post`. Default `null`.
 	 *
 	 * @return null|\Timber\Post A `Timber\Post` object. Null if not applicable in the current
 	 *                           context.
 	 */
-	public static function context_post( $args = array() ) {
+	public static function context_post( $post_arg = null ) {
 		global $post;
 		global $wp_query;
 
@@ -452,15 +458,16 @@ class Timber {
 		 * - A post shouldn’t be set in the context
 		 * - We don’t have a singular template
 		 */
-		if ( false === $args['post'] || ! is_singular() ) {
+		if ( false === $post_arg || ! is_singular() ) {
 			return null;
 		}
 
+		// Use post global as the default.
 		$context_post = $post;
 
 		// Arguments that are passed directly to the context will always overwrite the default post.
-		if ( ! empty( $args['post'] ) ) {
-			$context_post = $args['post'];
+		if ( ! empty( $post_arg ) ) {
+			$context_post = $post_arg;
 		}
 
 		/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -32,7 +32,7 @@ use Timber\Loader;
  * ) );
  * $posts = new Timber\PostQuery( array( 23, 24, 35, 67 ), 'InkwellArticle' );
  *
- * $context = Timber::get_context();
+ * $context = Timber::context();
  * $context['posts'] = $posts;
  *
  * Timber::render( 'index.twig', $context );
@@ -231,7 +231,7 @@ class Timber {
 
 	/**
 	 * Gets the context.
-	 * 
+	 *
 	 * @api
 	 * @deprecated 2.0.0, use `Timber::context()` instead.
 	 *
@@ -372,13 +372,13 @@ class Timber {
 			 *
 			 * By using this filter, you can add custom data to the global Timber context, which
 			 * means that this data will be available on every page that is initialized with
-			 * `Timber::get_context()`.
+			 * `Timber::context()`.
 			 *
 			 * Be aware that data will be cached as soon as you call `Timber::get_context()` for the
 			 * first time. That’s why you should add this filter before you call
 			 * `Timber::context()`.
 			 *
-			 * @see \Timber\Timber::get_context()
+			 * @see \Timber\Timber::context()
 			 * @since 0.21.7
 			 * @example
 			 * ```php
@@ -761,7 +761,7 @@ class Timber {
 	 * @api
 	 * @example
 	 * ```php
-	 * $context = Timber::get_context();
+	 * $context = Timber::context();
 	 *
 	 * Timber::render( 'index.twig', $context );
 	 * ```

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -350,7 +350,10 @@ class Timber {
 	 * @example
 	 * ```php
 	 * add_shortcode( 'global_address', function() {
-     *    return Timber::compile( 'global_address.twig', Timber::context_global() );
+	 *     return Timber::compile(
+	 *         'global_address.twig',
+	 *         Timber::context_global()
+	 *     );
 	 * } );
 	 * ```
 	 *

--- a/lib/User.php
+++ b/lib/User.php
@@ -31,7 +31,7 @@ use Timber\Image;
  *
  * ```php
  * $context = Timber::context();
- * $context['post'] = new Timber\Post();
+ *
  * Timber::render( 'single.twig', $context );
  * ```
  * ```twig

--- a/lib/User.php
+++ b/lib/User.php
@@ -12,23 +12,37 @@ use Timber\Image;
 /**
  * Class User
  *
- * This is used in Timber to represent users retrived from WordPress. You can call
- * `$my_user = new Timber\User(123);` directly, or access it through the `{{ post.author }}` method.
+ * A user object represents a WordPress user.
+ *
+ * The currently logged-in user will be available as `{{ user }}` in your Twig files through the
+ * global context. If a user is not logged in, it will be `false`. This will make it possible for
+ * you to check if a user is logged by checking for `user` instead of calling `is_user_logged_in()`
+ * in your Twig templates.
  *
  * @api
  * @example
+ * ```twig
+ * {% if user %}
+ *     Hello {{ user.name }}
+ * {% endif %}
+ * ```
+ *
+ * The difference between a logged-in user and a post author:
+ *
  * ```php
- * $context['current_user'] = new Timber\User();
+ * $context = Timber::context();
  * $context['post'] = new Timber\Post();
- * Timber::render('single.twig', $context);
+ * Timber::render( 'single.twig', $context );
  * ```
  * ```twig
- * <p class="current-user-info">Your name is {{ current_user.name }}</p>
- * <p class="article-info">This article is called "{{ post.title }}" and it's by {{ post.author.name }}
+ * <p class="current-user-info">Your name is {{ user.name }}</p>
+ * <p class="article-info">This article is called "{{ post.title }}"
+ *     and it’s by {{ post.author.name }}</p>
  * ```
  * ```html
  * <p class="current-user-info">Your name is Jesse Eisenberg</p>
- * <p class="article-info">This article is called "Consider the Lobster" and it's by David Foster Wallace
+ * <p class="article-info">This article is called "Consider the Lobster"
+ *     and it’s by David Foster Wallace</p>
  * ```
  */
 class User extends Core implements CoreInterface {

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -1,19 +1,211 @@
 <?php
 
 class TestTimberContext extends Timber_UnitTestCase {
-
 	/**
 	 * This throws an infite loop if memorization isn't working
 	 */
 	function testContextLoop() {
-		add_filter('timber/context', function($context) {
-			$context = Timber::get_context();
+		add_filter( 'timber/context', function( $context ) {
+			$context          = Timber::context();
 			$context['zebra'] = 'silly horse';
+
 			return $context;
-		});
-		$context = Timber::get_context();
-		$this->assertEquals('http://example.org', $context['http_host']);
+		} );
+
+		$context = Timber::context();
+
+		$this->assertEquals( 'http://example.org', $context['http_host'] );
 	}
 
+	function testPostContextSimple() {
+		$post_id = $this->factory->post->create();
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$context = Timber::context();
+		$post    = new Timber\Post( $post_id );
+
+		$this->assertEquals( $post, $context['post'] );
+	}
+
+	function testPostContextWithID() {
+		$post_id1 = $this->factory->post->create();
+		$post_id2 = $this->factory->post->create();
+
+		$this->go_to( get_permalink( $post_id1 ) );
+
+		$context = Timber::context( array(
+			'post' => $post_id2,
+		) );
+
+		$this->assertEquals( $post_id2, $context['post']->ID );
+	}
+
+	function testPostContextWithExtendedPost() {
+		require_once(__DIR__.'/php/timber-post-subclass.php');
+
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$context = Timber::context( array(
+			'post' => new TimberPostSubclass(),
+		) );
+
+		$this->assertInstanceOf( 'TimberPostSubclass', $context['post'] );
+	}
+
+	function testPostsContextSimple() {
+		update_option( 'show_on_front', 'posts' );
+		$this->factory->post->create_many( 3 );
+		$this->go_to( '/' );
+
+		$context = Timber::context();
+
+		$this->assertInstanceOf( 'Timber\PostQuery', $context['posts'] );
+		$this->assertCount( 3, $context['posts']->get_posts() );
+	}
+
+	function testChangeDefaultQueryArgument() {
+		update_option( 'show_on_front', 'posts' );
+		$this->factory->post->create_many( 3, array( 'post_type' => 'page' ) );
+		$this->go_to( '/' );
+
+		$context = Timber::context( array(
+			'posts' => array(
+				'post_type' => 'page',
+		        'posts_per_page' => 2,
+			),
+		) );
+
+		$this->assertInstanceOf( 'Timber\PostQuery', $context['posts'] );
+		$this->assertCount( 2, $context['posts']->get_posts() );
+		$this->assertEquals( 'page', $context['posts'][0]->post_type );
+	}
+
+	function testCancelDefaultQueryPosts() {
+		update_option( 'show_on_front', 'posts' );
+		$this->factory->post->create_many( 3 );
+		$this->go_to( '/' );
+
+		$context = Timber::context( array(
+			'cancel_default_query' => true
+		) );
+
+		$this->assertArrayNotHasKey( 'posts', $context );
+	}
+
+	function testCancelDefaultQueryPostsWithPostArgs() {
+		update_option( 'show_on_front', 'posts' );
+		$this->factory->post->create_many( 3 );
+
+		$this->go_to( '/' );
+
+		$context = Timber::context( array(
+			'cancel_default_query' => true,
+			'posts' => array(
+				'posts_per_page' => 2,
+			),
+		) );
+
+		$this->assertArrayHasKey( 'posts', $context );
+		$this->assertCount( 2, $context['posts']->get_posts() );
+	}
+
+	function testDisableDefaultQueryByArgsPost() {
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$context = Timber::context( array(
+		    'post'  => false,
+		) );
+
+		$this->assertArrayNotHasKey( 'post', $context );
+	}
+
+	function testDisableDefaultQueryByArgsPosts() {
+		update_option( 'show_on_front', 'posts' );
+		$this->factory->post->create_many( 3 );
+		$this->go_to( '/' );
+
+		$context = Timber::context( array(
+		    'posts'  => false,
+		) );
+
+		$this->assertArrayNotHasKey( 'posts', $context );
+	}
+
+	function testDisableDefaultQueryByFilterPost() {
+		add_filter( 'timber/context/args', function( $args ) {
+			$args['post'] = false;
+
+			return $args;
+		} );
+
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$context = Timber::context();
+
+		$this->assertArrayNotHasKey( 'post', $context );
+	}
+
+	function testDisableDefaultQueryByFilterPosts() {
+		add_filter( 'timber/context/args', function( $args ) {
+			$args['posts'] = false;
+
+			return $args;
+		} );
+
+		$this->factory->post->create_many( 3 );
+		$this->go_to( get_post_type_archive_link( 'post' ) );
+
+		$context = Timber::context();
+
+		$this->assertArrayNotHasKey( 'posts', $context );
+	}
+
+	function testIfInTheLoopIsSetToTrueInSingularTemplates() {
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		global $wp_query;
+
+		$this->assertFalse( $wp_query->in_the_loop );
+
+		Timber::context();
+
+		$this->assertTrue( $wp_query->in_the_loop );
+	}
+
+	function testLoopStartHookInSingularTemplates() {
+		add_action( 'loop_start', function( $wp_query ) {
+			$wp_query->touched_loop_start = true;
+		} );
+
+		$post_id = $this->factory->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		Timber::context();
+
+		global $wp_query;
+		$this->assertTrue( $wp_query->touched_loop_start );
+	}
+
+	/**
+	 * Tests whether 'the_post' action is called when a singular template is displayed.
+	 *
+	 * @see TestTimberPost::testPostConstructorAndThePostHook()
+	 */
+	function testIfThePostHookIsRunInSingularTemplates() {
+		add_action( 'the_post', function( $post ) {
+			add_filter( 'touched_the_post_action', '__return_true' );
+		} );
+
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		Timber::context();
+
+		$this->assertTrue( apply_filters( 'touched_the_post_action', false ) );
+	}
 
 }

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -1,5 +1,8 @@
 <?php
 
+use Timber\Timber;
+use Timber\Post;
+
 class TestTimberContext extends Timber_UnitTestCase {
 	/**
 	 * This throws an infite loop if memorization isn't working
@@ -23,8 +26,9 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 
 		$context = Timber::context();
-		$post    = new Timber\Post( $post_id );
+		$post    = new Post( $post_id );
 
+		$this->assertArrayNotHasKey( 'posts', $context );
 		$this->assertEquals( $post, $context['post'] );
 	}
 
@@ -42,7 +46,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 	}
 
 	function testPostContextWithExtendedPost() {
-		require_once(__DIR__.'/php/timber-post-subclass.php');
+		require_once( __DIR__ . '/php/timber-post-subclass.php' );
 
 		$post_id = $this->factory->post->create();
 		$this->go_to( get_permalink( $post_id ) );
@@ -61,6 +65,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 
 		$context = Timber::context();
 
+		$this->assertArrayNotHasKey( 'post', $context );
 		$this->assertInstanceOf( 'Timber\PostQuery', $context['posts'] );
 		$this->assertCount( 3, $context['posts']->get_posts() );
 	}

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -39,13 +39,13 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 	}
 
 	function testWPHead() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string('{{ function("wp_head") }}', $context);
 		$this->assertRegexp('/<title>Test Blog/', trim($str));
 	}
 
 	function testFunctionInTemplate() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ function('my_boo') }}", $context);
 		$this->assertEquals('bar!', trim($str));
 	}
@@ -66,7 +66,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 			$twig->addFunction(new Timber\Twig_Function('your_boo', array($this, 'your_boo')) );
 			return $twig;
 		});
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ your_boo() }}", $context);
 		$this->assertEquals('yourboo', trim($str));
 	}

--- a/tests/test-timber-gettext.php
+++ b/tests/test-timber-gettext.php
@@ -3,28 +3,28 @@
 class TestTimberGettext extends Timber_UnitTestCase {
 
 	function test__() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ __('my_boo') }}", $context);
 		$this->assertEquals(__('my_boo'), trim($str));
 	}
 
 	function testTranslate() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ translate('my_boo') }}", $context);
 		$this->assertEquals(translate('my_boo'), trim($str));
 	}
-  
+
 	function test_e() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ _e('my_boo') }}", $context);
-    ob_start(); 
+    ob_start();
     _e('my_boo');
     $_e = ob_get_clean();
 		$this->assertEquals($_e, trim($str));
 	}
-  
+
 	function test_n() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ _n('foo', 'foos', 1 ) }}", $context);
 		$this->assertEquals(_n('foo', 'foos', 1 ), trim($str));
 		$str = Timber::compile_string("{{ _n('foo', 'foos', 2 ) }}", $context);
@@ -32,26 +32,26 @@ class TestTimberGettext extends Timber_UnitTestCase {
 	}
 
 	function test_x() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ _x('boo', 'my') }}", $context);
 		$this->assertEquals(_x('boo', 'my'), trim($str));
 	}
-  
+
 	function test_ex() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ _ex('boo', 'my') }}", $context);
-    ob_start(); 
+    ob_start();
     _ex('boo', 'my');
     $_ex = ob_get_clean();
 		$this->assertEquals($_ex, trim($str));
 	}
 
 	function test_nx() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string("{{ _nx('boo', 'boos', 1, 'my' ) }}", $context);
 		$this->assertEquals(_nx('boo', 'boos', 1, 'my' ), trim($str));
 		$str = Timber::compile_string("{{ _nx('boo', 'boos', 2, 'my' ) }}", $context);
 		$this->assertEquals(_nx('boo', 'boos', 2, 'my' ), trim($str));
 	}
-    
+
 }

--- a/tests/test-timber-hooks.php
+++ b/tests/test-timber-hooks.php
@@ -7,7 +7,7 @@
 				$context['person'] = "Nathan Hass";
 				return $context;
 			});
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$this->assertEquals('Nathan Hass', $context['person']);
 		}
 	}

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -118,7 +118,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 	function testMenuTwig() {
 		self::setPermalinkStructure();
-		$context = Timber::get_context();
+		$context = Timber::context();
 		self::_createTestMenu();
 		$this->go_to( home_url( '/child-page' ) );
 		$context['menu'] = new Timber\Menu();
@@ -132,7 +132,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		self::setPermalinkStructure();
 		self::_createTestMenu();
 		$this->go_to( home_url( '/home' ) );
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$context['menu'] = new Timber\Menu();
 		$str = Timber::compile( 'assets/menu-classes.twig', $context );
 		$str = trim( $str );
@@ -465,7 +465,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $root_url_link_id, '_menu_item_xfn', '' );
 		update_post_meta( $root_url_link_id, '_menu_item_menu_item_parent', 0 );
 		update_post_meta( $root_url_link_id, '_menu_item_target', '' );
-		
+
 		$link_id = wp_insert_post(
 			array(
 				'post_title' => 'People',

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -337,17 +337,17 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 	}
 
 	/**
-	 * Make sure that the_post action is called when we loop over a collection of posts.
+	 * Make sure that the_post action is not called when we loop over a collection of posts.
 	 */
 	function testThePostHook() {
 		add_action( 'the_post', function( $post ) {
-			$post->touched_the_post_action = true;
+			add_filter( 'touched_the_post_action', '__return_true' );
 		} );
 
 		$posts = new Timber\PostQuery( $this->factory->post->create_many( 3 ) );
 
 		foreach ( $posts as $post ) {
-			$this->assertEquals( true, $post->touched_the_post_action );
+			$this->assertFalse( apply_filters( 'touched_the_post_action', false ) );
 		}
 	}
 }

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -1,7 +1,6 @@
 <?php
 
 class TestTimberPostGetter extends Timber_UnitTestCase {
-
 	/**
 	 * @group wp_query_hacks
 	 */
@@ -337,6 +336,20 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$this->assertEquals(4, count($personPostsString));
 	}
 
+	/**
+	 * Make sure that the_post action is called when we loop over a collection of posts.
+	 */
+	function testThePostHook() {
+		add_action( 'the_post', function( $post ) {
+			$post->touched_the_post_action = true;
+		} );
+
+		$posts = new Timber\PostQuery( $this->factory->post->create_many( 3 ) );
+
+		foreach ( $posts as $post ) {
+			$this->assertEquals( true, $post->touched_the_post_action );
+		}
+	}
 }
 
 class MyState {

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -402,7 +402,7 @@
 
 			$wp_query->queried_object_id = $post_id;
 			$wp_query->queried_object = get_post($post_id);
-			
+
 			$post = new \Timber\Post($post_id);
 
 			$str_direct = Timber::compile_string('{{post.test_field}}', array('post' => $post));
@@ -485,9 +485,9 @@
 		}*/
 
 		/**
-		 * This tests was created to catch what happens when you do weird things to {{ post.meta }}, 
+		 * This tests was created to catch what happens when you do weird things to {{ post.meta }},
 		 * like calling it when nothing's assigned and trying to output as a string.
-		 * 
+		 *
 		 * @expectedException Twig_Error_Runtime
 		 */
 		function testPostMetaMetaException(){
@@ -498,9 +498,9 @@
 		}
 
 		/**
-		 * This tests was created to catch what happens when you do weird things to {{ post.meta }}, 
+		 * This tests was created to catch what happens when you do weird things to {{ post.meta }},
 		 * like calling it when nothing's assigned and trying to output a default property as a string.
-		 * 
+		 *
 		 * @expectedException Twig_Error_Runtime
 		 */
 		function testPostMetaMetaArrayProperty(){
@@ -511,10 +511,10 @@
 		}
 
 		/**
-		 * This tests was created to catch what happens when you do weird things to {{ post.meta }}, 
-		 * like calling it when nothing's assigned and trying to output as a string. (Even when 
+		 * This tests was created to catch what happens when you do weird things to {{ post.meta }},
+		 * like calling it when nothing's assigned and trying to output as a string. (Even when
 		 * something's assigned)
-		 * 
+		 *
 		 * @expectedException Twig_Error_Runtime
 		 */
 		function testPostMetaMetaAssignedException() {
@@ -535,7 +535,7 @@
 			$this->assertEquals('My steak', trim($string));
 		}
 
-		
+
 
 		function testPostParent(){
 			$parent_id = $this->factory->post->create();
@@ -990,4 +990,22 @@
 			//
 		}
 
+		/**
+		 * Tests whether 'the_post' action is called when a post is fetched through the Post constructor.
+		 *
+		 * The 'the_post' action should only be called when a singular template file is called, and
+		 * only on the main post, but not when Timber creates post objects in a loop.
+		 *
+		 * @ticket 1639
+		 */
+		function testPostConstructorAndThePostHook() {
+			add_action( 'the_post', function( $post ) {
+				$post->touched_the_post_action = true;
+			} );
+
+			$post_id = $this->factory()->post->create();
+			$post = new Timber\Post( $post_id );
+
+			$this->assertEquals( false, $post->touched_the_post_action );
+		}
 	}

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -997,15 +997,16 @@
 		 * only on the main post, but not when Timber creates post objects in a loop.
 		 *
 		 * @ticket 1639
+		 * @see TestTimberContext::testIfThePostHookIsRunInSingularTemplates()
 		 */
 		function testPostConstructorAndThePostHook() {
 			add_action( 'the_post', function( $post ) {
-				$post->touched_the_post_action = true;
+				add_filter( 'touched_the_post_action', '__return_true' );
 			} );
 
 			$post_id = $this->factory()->post->create();
-			$post = new Timber\Post( $post_id );
+			new Timber\Post( $post_id );
 
-			$this->assertEquals( false, $post->touched_the_post_action );
+			$this->assertFalse( apply_filters( 'touched_the_post_action', false ) );
 		}
 	}

--- a/tests/test-timber-request.php
+++ b/tests/test-timber-request.php
@@ -5,15 +5,15 @@ class TestTimberRequest extends Timber_UnitTestCase {
 	function testPostData() {
 		$_POST['foo'] = 'bar';
 		$template = '{{request.post.foo}}';
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string($template, $context);
 		$this->assertEquals('bar', $str);
 	}
-	
+
 	function testGetData() {
 		$_GET['foo'] = 'bar';
 		$template = '{{request.get.foo}}';
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$str = Timber::compile_string($template, $context);
 		$this->assertEquals('bar', $str);
 	}

--- a/tests/test-timber-sidebar.php
+++ b/tests/test-timber-sidebar.php
@@ -3,7 +3,7 @@
 	class TestTimberSidebar extends Timber_UnitTestCase {
 
 		function testTwigSidebar(){
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$sidebar_post = $this->factory->post->create(array('post_title' => 'Sidebar post content'));
 			$sidebar_context = array();
 			$sidebar_context['post'] = new Timber\Post($sidebar_post);
@@ -17,7 +17,7 @@
 				$context['sidebar'] = Timber::get_sidebar('assets/my-sidebar.php');
 				return $context;
 			});
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$result = Timber::compile('assets/main-w-sidebar-php.twig', $context);
 			$this->assertEquals("A Fever You Can't Sweat Out by Panic! at the Disco from 2005", trim($result));
 

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -21,13 +21,13 @@ class TestTimberSite extends Timber_UnitTestCase {
 
 	function testThemeFromContext() {
 		switch_theme( 'twentyfifteen' );
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$this->assertEquals( 'twentyfifteen', $context['theme']->slug );
 	}
 
 	function testThemeFromSiteContext() {
 		switch_theme( 'twentyfifteen' );
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$this->assertEquals( 'twentyfifteen', $context['site']->theme->slug );
 	}
 

--- a/tests/test-timber-theme.php
+++ b/tests/test-timber-theme.php
@@ -21,7 +21,7 @@
 		}
 
 		function testPath() {
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$theme = $context['site']->theme;
 			$output = Timber::compile_string('{{site.theme.path}}', $context);
 			$this->assertEquals('/wp-content/themes/'.$theme->slug, $output);
@@ -50,14 +50,14 @@
 
 		function testPathOnSubdirectoryInstall() {
 			update_option( 'siteurl', 'http://example.org/wordpress', true );
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$theme = $context['site']->theme;
 			$output = Timber::compile_string('{{site.theme.path}}', $context);
 			$this->assertEquals('/wp-content/themes/'.$theme->slug, $output);
 		}
 
 		function testLink() {
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$theme = $context['site']->theme;
 			$output = Timber::compile_string('{{site.theme.link}}', $context);
 			$this->assertEquals('http://example.org/wp-content/themes/'.$theme->slug, $output);
@@ -65,7 +65,7 @@
 
 		function testLinkOnSubdirectoryInstall() {
 			update_option( 'siteurl', 'http://example.org/wordpress', true );
-			$context = Timber::get_context();
+			$context = Timber::context();
 			$theme = $context['site']->theme;
 			$output = Timber::compile_string('{{site.theme.link}}', $context);
 			$this->assertEquals('http://example.org/wp-content/themes/'.$theme->slug, $output);

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -169,7 +169,7 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 	}
 
 	function testUserInContextAnon() {
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$this->assertArrayHasKey( 'user', $context );
 		$this->assertFalse($context['user']);
 	}
@@ -181,13 +181,13 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		));
 		$user = wp_set_current_user($uid);
 
-		$context = Timber::get_context();
+		$context = Timber::context();
 		$this->assertArrayHasKey( 'user', $context );
 		$this->assertInstanceOf( 'Timber\User', $context['user'] );
 	}
 
 	function testQueryPostsInContext(){
-        $context = Timber::get_context();
+        $context = Timber::context();
         $this->assertArrayHasKey( 'posts', $context );
         $this->assertInstanceOf( 'Timber\PostCollection', $context['posts'] );
 	}

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -186,12 +186,6 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->assertInstanceOf( 'Timber\User', $context['user'] );
 	}
 
-	function testQueryPostsInContext(){
-        $context = Timber::context();
-        $this->assertArrayHasKey( 'posts', $context );
-        $this->assertInstanceOf( 'Timber\PostCollection', $context['posts'] );
-	}
-
 	/* Terms */
 	function testGetTerms(){
 		$posts = $this->factory->post->create_many(15, array( 'post_type' => 'post' ) );


### PR DESCRIPTION
**Ticket**: #1639

This pull request refactors Timber’s context and improves compatibility with third party plugins.

## Improving compatibility for third party plugins

As lined out in #1639, Timber’s current behaviour can lead to compatibility problems with plugins such as BuddyPress or WooCommerce, because…

- `the_post` hook is called whenever a `Timber\Post` object is instantiated.
- Loop variables are not set for singular templates.

I figured that a way to fix both problems would be to use Timber’s context function, because that’s the function we always call in a template. Using a WordPress hook like `template_redirect` could be tricky, because developers probably will set different posts as the main post for singular templates.

That’s why I added the necessary logic to mimick WordPress’s behavior for singular templates:

- Sets `$wp->query->in_the_loop = true`.
- Calls the `loop_start` hook.
- Calls `$wp_query->setup_postdata()`.

And I removed the call to `the_post` inside `Timber\Post::get_info()` and moved it to a context function.

## A context guide

I added a new Context Guide in `docs/guides/context.md` that will explain the concept of the context in Timber. It’s probably best to read through it in addition to what is written here.

## Rename function to `context()`

To be consistent with the naming that we applied in the rest of Timber’s classes, I renamed the `get_context()` function to `context()`. The `get_context()` function will be marked as deprecated.

## New functions

Next to `Timber::context()`, I added three functions to better handle the different context caches.

- `Timber::context_global()` – Used for getting the global context.
- `Timber::context_post()` - Used for getting the context for a singular post.
- `Timber::context_posts()` – Used for getting the context a post collection for an archive.

## Template based contexts

The context changes based on which template is displayed. For singular templates, it will set `post` in the context, and for archive templates it will set `posts` in the context.

This way, Timber will make assumptions about what you’re gonna do in your template. Instead of setting up your template like this:

**archive.php**

```php
<?php
$context          = Timber::get_context();
$context['posts'] = new Timber\PostQuery();

Timber::render( 'archive.twig', $context );
```

You could now set it up like this:

**archive.php**

```php
<?php
// Minimal style
Timber::render( 'archive.twig', Timber::get_context() );
```

(Little known fact: You wouldn’t have to use `$context['posts'] = new Timber\PostQuery();` in the current version of Timber either. Timber did always set `posts` in the context.)

Of course there are a lot of cases where we need to adapt the default. That’s where context arguments are coming in.

## Arguments for the context

The context now accepts an arguments array. Currently, there are three arguments supported: `post`, `posts` and `cancel_default_query`.

### posts

The `posts` argument can be an array of posts, a `Timber\PostQuery` or an array of arguments that will be passed to `Timber\PostQuery`. If it’s set to `false`, Timber will not set `posts` in the context.

**archive.php**

```php
$context = Timber::context( array(
    'posts' => array(
        'post_parent' => 0,
    ),
) );

Timber::render( 'archive.twig', $context );
```

Up until now, there was no easy way to *adapt the default WordPress template query*. Now, if `posts` is an array of arguments, it will **merge** this array with the default arguments that WordPress uses for its template query. So, in the example above, you will get the default list of posts for an archive, just without child posts.

It’s also possible to pass a `Timber\PostQuery` object to `posts`. Then, no merging will happen.

### cancel_default_query

By default, parameters passed with `posts` will merge with the default WordPress post query. If the `cancel_default_query` parameter is set to `true`, merging will be disabled. Instead, the default query will be overwritten with the parameters passed in `posts`.

### post

This can be a post ID, a `WP_Post` object, a `Timber\Post` object or a class instance that inherits from `Timber\Post`.

**single.php**

```php
<?php

// Use a custom class for post.
Timber::render( 'single.twig', Timber::context(
    'post' => new Extended_Post(),
) );
```

You now might be tempted to try something like this:

```php
<?php
// Don’t do this!

$context         = Timber::context( array( 'post' => false ) );
$context['post'] = new Extended_Post();

Timber::render( 'single.twig', $context );
```

While this might seem fine, it’s probably **not a good idea**. Setting `post` after running `Timber::context()` will not set up the necessary globals for compatibility with third party plugins.

As outlined in #1639, we can’t set up the globals inside `Timber\Post`, because that leads to other problems. It’s important to tell Timber for which post it should set up globals, in case a different post ID is used.

But how do we ensure that developers won’t use the example above, because it has become so prevalent in most Timber examples? And what if figuring out the post to display depends on what the context returns?

The only solution I can come up with now could be to use `Timber::context_post()` separately:

```php
<?php
$context         = Timber::context( array( 'post' => false ) );
$context['post'] = Timber::context_post( array( 'post' => new Extended_Post() ) );

Timber::render( 'single.twig', $context );
```

## Caching

`Timber::context()` can be called more than once in a page load, for example inside hooks that display only a small component of a page. That’s why it has a cache. But because the context can now be dynamic, I see two ways to go:

### Option 1 – Only cache global context

If we only cache the global context and don’t cache template contexts, we’d probably have to advise developers to always set the `post` and `posts` parameters to `false` when they use `Timber::context()` inside actions, because otherwise additional queries would run.

Or we could make it a standard to only use the global context via `context_global()`:

```php
add_shortcode( 'global_address', function() {
    return Timber::compile( 'global_address.twig', Timber::context_global() );
} );
```

### Option 2 – Cache everything separately

If we introduce separate caches for global variables and template contexts, there would be four caches:

- `$context_cache`: A cache for all global context variables (`site`, `request`, `theme`, `user`, `http_host`, `wp_title`, `body_class`) as well as context data set through the `timber_context` filter.
- `$context_chache_post`: A cache for post data in singular contexts.
- `$context_chache_posts`: A cache for post collection data in archive contexts.
- `$context_args`: A cache for the arguments passed to context.

The result for `Timber::context()` will be put together from these caches.

It should still be possible to run `Timber::context()` with different arguments after a cache is already set. To be able to ignore the post and posts cache by passing in new arguments, there’s the `$context_args` cache. This cache will save the arguments from a call to `Timber::context()`. Whenever arguments are passed to `Timber::context()`, it will compare the arguments with the arguments saved in this cache and will either **return the cache** or **the result for the new arguments, ignoring the cache**. If a new query runs based on different arguments, this query **won’t be saved** in the cache. The cache from the first run will persist, including the query saved in there.

Does this logic make sense? How should the context cache behave?

### Personal opinion

I’d settle for Option 1, because I think it might be easier to describe and understand. In my 3+ years developing themes with Timber, I only ever required the global context inside hooks.

## New filters

I first thought about using a lot of filters to change the context defaults, but then I realized it’s not really necessary. One new filter would suffice:

`timber/context/args`

With this filter, we can change the arguments that are passed to `Timber::context()`. When added globally in **functions.php**, it will affect all queries. But it could also be added in a template file like **single.php** or **archive.php** to affect only certain templates. Here’s an example:

**functions.php**

```php
// Globally disable `post` and `posts` in context
add_filter( 'timber/context/args', function( $args ) {
    $args['post'] = false;
    $args['posts'] = false;

    return $args;
} );
```

You could also use some logic here:

```php
// Globally disable `post` and `posts` in context
add_filter( 'timber/context/args', function( $args ) {
    if ( is_post_type_archive( 'book' ) ) {
        $args['posts'] = false;
    }

    return $args;
} );
```

## Discussion

The changes introduced here might be opinionated, but I thought it’s probably easiest if I propose a solution that we can then discuss.

- [x] Should we call it `cancel_default_query`, `run_default_query`, `overwrite_default_query` or `merge_default_query`?
- [x] Should `cancel_default_query` (or any other name we choose) also be used to tell Timber to not set `post` in the context?
- [x] Does the caching logic introduced for the context make sense? How should the context cache behave? Should we only cache the global context?

## Testing

I added tests, but testing is a little hard, because Unit Testing doesn’t work well with [Conditional Tags](https://codex.wordpress.org/Conditional_Tags), because it’s not really meant to be used for this.

## Todo

- [x] Complete the Context Guide when discussion is finished.
- [x] Update documentation where `Timber::get_context()` is used instead of `Timber::context()`.
- [x] Improve inline documentation for parameters, filters, etc.
- [x] Add changes to upgrade guide.