### PR TITLE
2.x Remove action context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ before_script:
     - composer require satooshi/php-coveralls:1.0.*
 
 script:
-    - if ( [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ) && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
+    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
 
 after_script:
-    - if ( [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ) && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
+    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
 
 after_success:
-    - if ( [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ) && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
+    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ before_script:
     - composer require satooshi/php-coveralls:1.0.*
 
 script:
-    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
+    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x" ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
 
 after_script:
-    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
+    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x" ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
 
 after_success:
-    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
+    - if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x" ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ before_script:
     - composer require satooshi/php-coveralls:1.0.*
 
 script:
-    - if [ [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
+    - if ( [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ) && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
 
 after_script:
-    - if [ [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
+    - if ( [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ) && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
 
 after_success:
-    - if [ [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
+    - if ( [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ) && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
     - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ before_script:
     - composer require satooshi/php-coveralls:1.0.*
 
 script:
-    - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
+    - if [ [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml; fi
 
 after_script:
-    - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
+    - if [ [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then php vendor/bin/coveralls -v; fi
 
 after_success:
-    - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
+    - if [ [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "2.x"] ] && [ "$TRAVIS_PHP_VERSION" == 7.1 ]; then coveralls; fi
     - bash <(curl -s https://codecov.io/bash)

--- a/docs/guides/wp-integration.md
+++ b/docs/guides/wp-integration.md
@@ -36,6 +36,24 @@ You can all actions in your Twig templates like this:
 
 If you ask yourself why there’s no underline between `do` and `action`: The expression [`do`](https://twig.symfony.com/doc/2.x/tags/do.html) is a feature of Twig which *calls a function without printing its return value*, like `{{ }}` does. Timber only register an `action` function, which then calls the `do_action()` function.
 
+If you want anything from the template's context, you'll need to pass that manually:
+
+```twig
+{% do action('my_action', 'foo', post) %}
+```
+
+```php  
+<?php   
+
+add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
+
+function my_function_with_args( $foo, $post ){    
+    echo 'I say ' . $foo . '!';
+    echo 'For the post with title ' . $post->title(); 
+}
+
+```
+
 ## Filters
 
 Timber already comes with a [set of useful filters](https://timber.github.io/docs/guides/filters/). If you have your own filters that you want to apply, you can use `apply_filters`.

--- a/docs/guides/wp-integration.md
+++ b/docs/guides/wp-integration.md
@@ -27,49 +27,14 @@ Full documentation to come.
 
 ## Actions
 
-Call them in your Twig template...
+You can all actions in your Twig templates like this:
 
 ```twig
 {% do action('my_action') %}
 {% do action('my_action_with_args', 'foo', 'bar') %}
 ```
 
-... in your `functions.php` file:
-
-```php
-<?php
-add_action( 'my_action', 'my_function' );
-
-function my_function( $context ) {
-    // $context stores the template context in case you need to reference it
-
-    // Outputs title of your post
-    echo $context['post']->post_title;
-}
-```
-
-```php
-<?php
-add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
-
-function my_function_with_args( $foo, $bar ){
-    echo 'I say ' . $foo . ' and ' . $bar;
-}
-```
-
-You can still get the context object when passing args, it’s always the _last_ argument...
-
-```php
-<?php
-add_action( 'my_action_with_args', 'my_function_with_args', 10, 3 );
-
-function my_function_with_args( $foo, $bar, $context ){
-    echo 'I say ' . $foo . ' and ' . $bar;
-    echo 'For the post with title ' . $context['post']->post_title;
-}
-```
-
-Please note the argument count that WordPress requires for `add_action`.
+If you ask yourself why there’s no underline between `do` and `action`: The expression [`do`](https://twig.symfony.com/doc/2.x/tags/do.html) is a feature of Twig which *calls a function without printing its return value*, like `{{ }}` does. Timber only register an `action` function, which then calls the `do_action()` function.
 
 ## Filters
 
@@ -156,7 +121,7 @@ public function widget( $args, $instance ) {
 
 Well, if it works for widgets, why shouldn't it work for shortcodes? Of course it does!
 
-Let’s implement a `[youtube]` shortcode which embeds a youtube video.  
+Let’s implement a `[youtube]` shortcode which embeds a youtube video.
 For the desired usage of `[youtube id=xxxx]`, we only need a few lines of code:
 
 ```php

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -42,12 +42,9 @@ class Twig {
 	 */
 	public function add_timber_functions( $twig ) {
 		/* actions and filters */
-		$twig->addFunction(new Twig_Function('action', function( $context ) {
-					$args = func_get_args();
-					array_shift($args);
-					$args[] = $context;
-					call_user_func_array('do_action', $args);
-				}, array('needs_context' => true)));
+		$twig->addFunction( new Twig_Function( 'action', function() {
+			call_user_func_array( 'do_action', func_get_args() );
+		} ) );
 
 		$twig->addFunction(new Twig_Function('function', array(&$this, 'exec_function')));
 		$twig->addFunction(new Twig_Function('fn', array(&$this, 'exec_function')));

--- a/tests/assets/test-action-context.twig
+++ b/tests/assets/test-action-context.twig
@@ -1,4 +1,0 @@
-Here: {{post.content|striptags}}
-{% do action('my_action_context_vars', 'foo', 'bar') %}
-{% do action('my_action_context_var', 'foo') %}
-{% do action('my_action_context') %}

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -89,47 +89,6 @@
 			$this->assertEquals('Stuff', $str);
 		}
 
-		function testDoActionContext(){
-			global $php_unit;
-			$php_unit = $this;
-			global $action_context_tally;
-			$action_context_tally = array();
-			add_action('my_action_context_vars', function($foo, $bar, $context) {
-				global $php_unit;
-				$php_unit->assertEquals('foo', $foo);
-				$php_unit->assertEquals('bar', $bar);
-				$php_unit->assertEquals('Jaredz Post', $context['post']->post_title);
-				global $action_context_tally;
-				$action_context_tally[] = 'my_action_context_vars';
-			}, 10, 3);
-
-			add_action('my_action_context_var', function($foo, $context) {
-				global $php_unit;
-				$php_unit->assertEquals('foo', $foo);
-				$php_unit->assertEquals('Jaredz Post', $context['post']->post_title);
-				global $action_context_tally;
-				$action_context_tally[] = 'my_action_context_vars';
-			}, 10, 2);
-
-			add_action('my_action_context', function($context){
-				global $php_unit;
-				$php_unit->assertEquals('Jaredz Post', $context['post']->post_title);
-				global $action_context_tally;
-				$action_context_tally[] = 'my_action_context';
-			});
-
-			add_action('timber/compile/done', function(){
-				global $php_unit;
-				global $action_context_tally;
-				$php_unit->assertContains('my_action_context_vars', $action_context_tally);
-				$php_unit->assertContains('my_action_context', $action_context_tally);
-			});
-			$post_id = $this->factory->post->create(array('post_title' => "Jaredz Post", 'post_content' => 'stuff to say'));
-			$context['post'] = new Timber\Post($post_id);
-			$str = Timber::compile('assets/test-action-context.twig', $context);
-			$this->assertEquals('Here: stuff to say', trim($str));
-		}
-
 		function testWordPressPasswordFilters(){
 			$post_id = $this->factory->post->create(array('post_title' => 'My Private Post', 'post_password' => 'abc123'));
 			$context = array();


### PR DESCRIPTION
**Ticket**: #1528

## Issue

Timber adds an `action` function for Twig like this:

```php
$twig->addFunction( new Twig_Function( 'action', function( $context ) {
    $args = func_get_args();
    array_shift( $args );
    $args[] = $context;
    call_user_func_array( 'do_action', $args) ;
}, array( 'needs_context' => true ) ) );
```

This function will always add the context as the last parameter in the hook, so that it can be used like this:

```php
<?php
add_action( 'my_action_with_args', 'my_function_with_args', 10, 3 );

function my_function_with_args( $foo, $bar, $context ){
    echo 'I say ' . $foo . ' and ' . $bar;
    echo 'For the post with title ' . $context['post']->post_title;
}
```

As I see it, this was added so that developers can add their own actions and receive the context, should they need it in the hook.

Like mentioned in the ticket, there can be problems: When you don’t pass in any parameters, Timber will automatically add the context as the first parameter. This can lead to unexpected behavior, because the action function receives a parameter although you might not have passed one when you used `{% do action() %}`.

Consider this example, where a plugin might add an action that receives a string:

```php
<?php
add_action( 'aye_aye', function( $string ) {
    echo 'I say ' . $string;
}, 10, 1 );
```

You could call the action like this, without an argument:

```twig
{% do action('aye_aye') %}
```

Timber would now pass a `$context` array to the action, which would lead to an array-to-string conversion error, because the action echoes out the string, which is an array in this case.

When calling `do_action`, Timber doesn’t know which functions will be called and how many arguments they will receive. Maybe we could read this out, but should we? And do we have to?

In my opinion, we should simply make it possible to call `do_action` and not try to do some magic here. The required arguments for `do_action` should just be passed in manually.

## Solution

- Delete functionality that adds the context automatically.
- Delete tests.
- Update documentation.

## Impact

This will break calls with `{% do action() %}` that relied on the context in an argument. That’s why it’s a good place to add it to version 2.0.

## Usage Changes

Hooks that expect the context to be passed as the last argument will have to be adapted so that the required arguments can be passed manually. So the example mentioned earlier would have to be rewritten like this:

```php
<?php
add_action( 'my_action_with_args', 'my_function_with_args', 10, 3 );

function my_function_with_args( $foo, $bar, $post ){
    echo 'I say ' . $foo . ' and ' . $bar;
    echo 'For the post with title ' . $post->post_title;
}
```

The post will be passed manually as a third argument.

```twig
{% do action( 'my_action_with_args', 'Yippie', 'Yeah', post ) %}
```

## Considerations

Did I forget to consider something?

## Testing

I removed the relevant tests.
