### PR TITLE
Default to an empty array for get_pagination

### DIFF
--- a/lib/Pagination.php
+++ b/lib/Pagination.php
@@ -20,7 +20,7 @@ class Pagination {
 	 * @param array   $prefs
 	 * @return array mixed
 	 */
-	public static function get_pagination( $prefs ) {
+	public static function get_pagination( $prefs = array() ) {
 		$pagination = new self($prefs);
 		$pagination = get_object_vars($pagination);
 		return $pagination;


### PR DESCRIPTION
**Ticket**: #1758 

#### Issue
If a user is going to call `Timber\Pagination\get_pagination` they need to do so with an argument, even an empty one

```php
$context['pagination'] = Timber\Pagination::get_pagination( array() );
```

This is likely because the preferred method is:
```php
$context['pagination'] = new Timber\Pagination(); //works
```

#### Solution
This isn't a good solution (even calling `\Timber\Pagination` directly is generally not recommended). But it was in the starter theme for years this way (and tutorials, etc.) so I think we should make this less preferred method as easy-as-possible.


#### Impact
None.

#### Usage Changes
Nope. 

#### Considerations
Ideally consider making `Pagination` a protected class that can't be called directly. If someone wants pagination they almost certainly want the posts with them. Closing off this external access point in `3.x` or something might be the best way to ultimately resolve

#### Testing
None, but backwards compatibility behavior should be caught by prior tests