### PR TITLE
Create determine_id and a overriding function in Image 

### DIFF
--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -163,7 +163,7 @@ class Attachment extends Post implements CoreInterface {
 		 * thus there's nothing in the DB for us to do here 
 		 */
 		if ( null === $iid ) {
-			return null;
+			return;
 		}
 
 		$attachment_info = $this->get_attachment_info( $iid );
@@ -191,8 +191,6 @@ class Attachment extends Post implements CoreInterface {
 
 			$this->id = $this->ID;
 		}
-
-		return null;
 	}
 
 	/**
@@ -211,14 +209,16 @@ class Attachment extends Post implements CoreInterface {
 		}
 
 		/**
-		 * If passed a Timber\Attachment object, grab the ID and continue. Otherwise, try to check
-		 * for an ACF image array an take the ID from that array.
+		 * If passed a Timber\Attachment or WP_Post object, grab the ID and continue. Otherwise, try
+		 * to check for an ACF image array an take the ID from that array.
 		 */
-		if ( $iid instanceof Attachment ) {
-			$iid = (int) $iid->ID;
+		if ( $iid instanceof Attachment
+		    || ( $iid instanceof \WP_Post && 'attachment' === $iid->post_type )
+		) {
+		    $iid = (int) $iid->ID;
 		} elseif ( is_array( $iid ) && isset( $iid['ID'] ) ) {
-			// Assume ACF image array.
-			$iid = $iid['ID'];
+		    // Assume ACF image array.
+		    $iid = $iid['ID'];
 		}
 
 		if ( ! is_numeric( $iid ) && is_string( $iid ) ) {

--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -215,7 +215,7 @@ class Attachment extends Post implements CoreInterface {
 		if ( $iid instanceof Attachment
 		    || ( $iid instanceof \WP_Post && 'attachment' === $iid->post_type )
 		) {
-		    $iid = (int) $iid->ID;
+		    return (int) $iid->ID;
 		} elseif ( is_array( $iid ) && isset( $iid['ID'] ) ) {
 		    // Assume ACF image array.
 		    $iid = $iid['ID'];

--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -538,22 +538,4 @@ class Attachment extends Post implements CoreInterface {
 	public function get_pathinfo() {
 		return pathinfo( $this->file );
 	}
-
-	/**
-	 * Returns the `wp_upload_dir` and saves result to static var
-	 *
-	 * @internal
-	 * @link https://developer.wordpress.org/reference/functions/wp_upload_dir/
-	 *
-	 * @return array
-	 */
-	public static function wp_upload_dir() {
-		static $wp_upload_dir = false;
-
-		if ( ! $wp_upload_dir ) {
-			$wp_upload_dir = wp_upload_dir();
-		}
-
-		return $wp_upload_dir;
-	}
 }

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -280,4 +280,35 @@ class Image extends Attachment {
 
 		return in_array( $check['ext'], $image_exts, true );
 	}
+
+	/**
+	 * Tries to figure out the attachment id you want or otherwise handle when
+	 * a string or other data is sent (object, file path, etc.)
+	 * @internal
+	 * @deprecated since 2.0 functionality will no longer be supported in future releases
+	 * @param mixed a value to test against
+	 * @return int|null the numberic id we should be using for this post object 
+	 */
+	 protected function determine_id( $iid ) {
+	 	$iid = parent::determine_id( $iid );
+	 	if ( $iid instanceof \WP_Post ) {
+			$ref  = new \ReflectionClass( $this );
+			$post = $ref->getParentClass()->newInstance( $iid->ID );
+
+			// Check if it’s a post that has a featured image.
+			if ( $post->_thumbnail_id ) {
+				return $this->init( (int) $post->_thumbnail_id );
+			}
+
+			return $this->init( $iid->ID );
+		} elseif ( $iid instanceof Post ) {
+			/**
+			 * This will catch TimberPost and any post classes that extend TimberPost,
+			 * see http://php.net/manual/en/internals2.opcodes.instanceof.php#109108
+			 * and https://timber.github.io/docs/guides/extending-timber/
+			 */
+			$iid = (int) $iid->_thumbnail_id;
+		}
+		return $iid;
+	 }
 }

--- a/tests/test-timber-attachment.php
+++ b/tests/test-timber-attachment.php
@@ -79,6 +79,13 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase {
  		$this->assertContains($image->link(), $links);
  	}
 
+ 	function testAttachmentInitWithWP_Post() {
+ 		$aid = self::get_attachment();
+ 		$wp_post = get_post($aid);
+ 		$attach = new Timber\Attachment($wp_post);
+ 		$this->assertEquals($wp_post->ID, $attach->id);
+ 	}
+
 	function testAttachmentArray() {
 		$post_id = $this->factory->post->create();
 		$filename = self::copyTestAttachment('arch.jpg');

--- a/tests/test-timber-attachment.php
+++ b/tests/test-timber-attachment.php
@@ -7,7 +7,7 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase {
  ---------------- */
 
  	static function replace_attachment( $old_id, $new_id ) {
-		$uploadDir = wp_upload_dir();
+		$uploadDir = wp_get_upload_dir();
 		$newFile = $uploadDir['basedir'].'/'.get_post_meta($new_id, '_wp_attached_file', true);
 		$oldFile = $uploadDir['basedir'].'/'.get_post_meta($old_id, '_wp_attached_file', true);
 		if (!file_exists(dirname($oldFile)))
@@ -19,7 +19,7 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase {
  	}
 
 	static function copyTestAttachment( $img = 'arch.jpg', $dest_name = null ) {
-		$upload_dir = wp_upload_dir();
+		$upload_dir = wp_get_upload_dir();
 		if ( is_null($dest_name) ) {
 			$dest_name = $img;
 		}
@@ -29,7 +29,7 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase {
 	}
 
 	static function getTestAttachmentURL( $img = 'arch.jpg', $relative = false) {
-		$upload_dir = wp_upload_dir();
+		$upload_dir = wp_get_upload_dir();
 		$result = $upload_dir['url'].'/'.$img;
 		if ( $relative ) {
 			$result = str_replace(home_url(), '', $result);


### PR DESCRIPTION
**Ticket**: #1788 

#### Issue
This re-organizes the `Attachment::init` method and separates out a `determine_id` method (same as `Post`) to handle the logic of "wait, what attachment is the user _really_ trying to get?

This allows us to also isolate the remaining piece of `Image` code (which handles posts with `thumbnail_id`s) and move it into the `Image` class itself.

#### Considerations
The piece of isolated `Image` code for determining ID (which extrapolates that when a user sends a "regular" Post they probably intend to get the `thumbnail_id` associated with said post) is overly-opinionated and could cause unexpected behavior. I move that we deprecate this functionality.


#### Testing
`TestTimberImage::testTimberImageFromPost` currently passes, but once we remove the deprecated functionality, it fails.
```php
	function testTimberImageFromPost() {
		$post = $this->get_post_with_image();
		$image = $post->thumbnail();
		$post = get_post($post->ID);

		$str = '{{ Image(post).src }}';
		$result = Timber::compile_string( $str, array('post' => $post) );

		$this->assertEquals($image->src(), $result);
	}
```
this shows the functionality it preserves though. As you can see, I don't see it to be particularly helpful or useful
