### PR TITLE
docs: Fix wrong capitalization with the term "PhpStorm"

### DIFF
--- a/docs/getting-started/twig-tools.md
+++ b/docs/getting-started/twig-tools.md
@@ -12,7 +12,7 @@ The purpose of this page is to identify helpful tools for working with Twig.
 * Text Mate & Sublime text bundle – [Anomareh's PHP-Twig](https://github.com/Anomareh/PHP-Twig.tmbundle)
 * Emacs – [Web Mode](http://web-mode.org/)
 * Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
-* PHPStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PHPStorm](http://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
+* PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](http://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
 * Atom – Syntax highlighting with the [Atom Component](https://atom.io/packages/php-twig).
 
 ## WordPress tools


### PR DESCRIPTION
Just fixed wrong capitalization with PhpStorm in the docs :)