### PR TITLE
Add homemade mime_content_type method to ImageHelper

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -157,11 +157,22 @@ class ImageHelper {
     	return $ret;
 	}
 
-	static function _mime_content_type($filename) {
+	/**
+	 * 
+	 * Reads a file's mime type. This is a hack b/c some installs of PHP don't enable this function
+	 * by default. See #1798 for more info
+	 * @since 1.8.1
+	 * @param string $filename to test.
+	 * @return string|boolean mime type if found (eg. `image/svg` or `text/plain`) false if not
+	 */
+	static function _mime_content_type( $filename ) {
+		if ( function_exists( 'mime_content_type' ) ) {
+			return mime_content_type( $filename );
+		}
 	    $result = new \finfo();
 
-	    if ( file_exists($filename) === true ) {
-	        return $result->file($filename, FILEINFO_MIME_TYPE);
+	    if ( file_exists( $filename ) === true ) {
+	        return $result->file( $filename, FILEINFO_MIME_TYPE );
 	    }
 
 	    return false;

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -151,10 +151,20 @@ class ImageHelper {
 	public static function is_svg( $file_path ) {
 		$ret = false;
 		if ( isset($file_path) && '' !== $file_path && file_exists($file_path) ) {
-			$mime = mime_content_type($file_path);
+			$mime = self::_mime_content_type($file_path);
     		$ret  = in_array($mime, ['image/svg+xml', 'text/html', 'text/plain', 'image/svg']);
     	}
     	return $ret;
+	}
+
+	static function _mime_content_type($filename) {
+	    $result = new \finfo();
+
+	    if ( file_exists($filename) === true ) {
+	        return $result->file($filename, FILEINFO_MIME_TYPE);
+	    }
+
+	    return false;
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: #1797 

#### Issue
Version 1.8.0's `is_svg` method includes checking for whether or not a file is an SVG and includes a call to PHP's `mime_content_type`. Unfortunatley, this PHP method is not available in all installs and might require a PECL installation or enabling via PHP.ini:

https://stackoverflow.com/questions/14809054/mime-content-type-function-not-working

#### Solution
I rolled my own `mime_content_type` method using the `finfo` class.

#### Impact
I fear the performance on this might not be as good as the native method, but I haven't tested to validate

#### Usage Changes
None

#### Considerations
- Maybe `ImageHelper::\_mime_content_type` could call the native if it's available and only use the "homemade" component if it's not
- Maybe this is all stupid, and we should just check for the presence of `.svg` or `.SVG` in the file name and call it a day

#### Testing
All tests pass
