### PR TITLE
Set ignore_sticky_posts=true as default wp_query argument

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -68,8 +68,8 @@ class PostGetter {
 	 * Sets some default values for those parameters for the query when not set. WordPress's get_posts sets a few of
 	 * these parameters true by default (compared to WP_Query), we should do the same.
 	 * @internal
-	 * @param WP_Query $query
-	 * @return WP_Query
+	 * @param \WP_Query $query
+	 * @return \WP_Query
 	 */
 	public static function set_query_defaults( $query ) {
 		if ( isset($query->query) && !isset( $query->query['ignore_sticky_posts']) ) {

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -52,7 +52,7 @@ class PostGetter {
 	}
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
-		add_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );
+		add_filter('pre_get_posts', array('Timber\PostGetter', 'set_query_defaults'));
 		$posts = self::query_posts($query, $PostClass);
 		return apply_filters('timber_post_getter_get_posts', $posts->get_posts($return_collection));
 	}
@@ -72,16 +72,16 @@ class PostGetter {
 	 * @return \WP_Query
 	 */
 	public static function set_query_defaults( $query ) {
-		if ( isset($query->query) && !isset( $query->query['ignore_sticky_posts']) ) {
+		if ( isset($query->query) && !isset($query->query['ignore_sticky_posts']) ) {
 			$query->set('ignore_sticky_posts', true);
 		}
-		if ( isset($query->query) && !isset( $query->query['supress_filters']) ) {
+		if ( isset($query->query) && !isset($query->query['supress_filters']) ) {
 			$query->set('supress_filters', true);
 		}
-		if ( isset($query->query) && !isset( $query->query['no_found_rows']) ) {
+		if ( isset($query->query) && !isset($query->query['no_found_rows']) ) {
 			$query->set('no_found_rows', true);
 		}
-		remove_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );
+		remove_filter('pre_get_posts', array('Timber\PostGetter', 'set_query_defaults'));
 		return $query;
 	}
 
@@ -160,7 +160,7 @@ class PostGetter {
 			Helper::error_log('Unexpeted value for PostClass: '.print_r($post_class, true));
 		}
 
-		if ( $post_class_use === '\Timber\Post' || $post_class_use === 'Timber\Post') {
+		if ( $post_class_use === '\Timber\Post' || $post_class_use === 'Timber\Post' ) {
 			return $post_class_use;
 		}
 

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -53,7 +53,6 @@ class PostGetter {
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
 		add_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );
-		$query = self::apply_get_posts_query_modifiers($query);
 		$posts = self::query_posts($query, $PostClass);
 		return apply_filters('timber_post_getter_get_posts', $posts->get_posts($return_collection));
 	}

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -52,6 +52,8 @@ class PostGetter {
 	}
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
+		add_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );
+		$query = self::apply_get_posts_query_modifiers($query);
 		$posts = self::query_posts($query, $PostClass);
 		return apply_filters('timber_post_getter_get_posts', $posts->get_posts($return_collection));
 	}
@@ -61,6 +63,20 @@ class PostGetter {
 		if ( method_exists($posts, 'current') && $post = $posts->current() ) {
 			return $post;
 		}
+	}
+
+	/**
+	 * Sets some default values for the query when not set
+	 * @internal
+	 * @param WP_Query $query
+	 * @return WP_Query
+	 */
+	public static function set_query_defaults( $query ) {
+		// WordPress's get_posts sets ignore_sticky_posts true by default. We should do the same
+		if ( isset($query->query) && !isset( $query->query['ignore_sticky_posts']) ) {
+			$query->set('ignore_sticky_posts', true);
+		}
+		return $query;
 	}
 
 	/**

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -66,15 +66,22 @@ class PostGetter {
 	}
 
 	/**
-	 * Sets some default values for the query when not set
+	 * Sets some default values for those parameters for the query when not set. WordPress's get_posts sets a few of
+	 * these parameters true by default (compared to WP_Query), we should do the same.
 	 * @internal
 	 * @param WP_Query $query
 	 * @return WP_Query
 	 */
 	public static function set_query_defaults( $query ) {
-		// WordPress's get_posts sets ignore_sticky_posts true by default. We should do the same
+		// 
 		if ( isset($query->query) && !isset( $query->query['ignore_sticky_posts']) ) {
 			$query->set('ignore_sticky_posts', true);
+		}
+		if ( isset($query->query) && !isset( $query->query['supress_filters']) ) {
+			$query->set('supress_filters', true);
+		}
+		if ( isset($query->query) && !isset( $query->query['no_found_rows']) ) {
+			$query->set('no_found_rows', true);
 		}
 		return $query;
 	}

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -72,7 +72,6 @@ class PostGetter {
 	 * @return WP_Query
 	 */
 	public static function set_query_defaults( $query ) {
-		// 
 		if ( isset($query->query) && !isset( $query->query['ignore_sticky_posts']) ) {
 			$query->set('ignore_sticky_posts', true);
 		}
@@ -82,6 +81,7 @@ class PostGetter {
 		if ( isset($query->query) && !isset( $query->query['no_found_rows']) ) {
 			$query->set('no_found_rows', true);
 		}
+		remove_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );
 		return $query;
 	}
 

--- a/lib/QueryIterator.php
+++ b/lib/QueryIterator.php
@@ -23,7 +23,7 @@ class QueryIterator implements \Iterator, \Countable {
 	public function __construct( $query = false, $posts_class = 'Timber\Post' ) {
 		add_action('pre_get_posts', array($this, 'fix_number_posts_wp_quirk'));
 		add_action('pre_get_posts', array($this, 'fix_cat_wp_quirk'));
-		add_action('pre_get_posts', array($this, 'set_query_defaults'));
+		
 		if ( $posts_class ) {
 			$this->_posts_class = $posts_class;
 		}
@@ -160,19 +160,6 @@ class QueryIterator implements \Iterator, \Countable {
 				&& !isset($query->query['cat']) ) {
 			$query->set('cat', $query->query['category']);
 			unset($query->query['category']);
-		}
-		return $query;
-	}
-
-    /**
-     * Sets some default values for the query when not set
-     * @param WP_Query $query
-     * @return WP_Query
-     */
-	public static function set_query_defaults( $query ) {
-	    //WordPress' get_posts sets ignore_sticky_posts true by default. We should do the same
-		if ( isset($query->query) && !isset($query->query['ignore_sticky_posts']) ) {
-			$query->set('ignore_sticky_posts', true);
 		}
 		return $query;
 	}

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -121,14 +121,14 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 
 	function testStickyAgainstGetPosts() {
 		delete_option('sticky_posts');
-		$pids = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
+		$first = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
-		$pids = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
+		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
 		update_option('sticky_posts', array($sticky_id));
 		$posts = Timber::get_posts('post_type=post');
-		$this->assertEquals($sticky_id, $posts[0]->ID);
+		$this->assertEquals($last, $posts[0]->ID);
 		$posts = get_posts('post_type=post');
-		$this->assertEquals($sticky_id, $posts[0]->ID);
+		$this->assertEquals($last, $posts[0]->ID);
 	}
 
 	function testStickyAgainstQuery() {

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -2,6 +2,11 @@
 
 class TestTimberPostGetter extends Timber_UnitTestCase {
 
+
+	function setUp() {
+		delete_option('sticky_posts');
+		parent::setUp();
+	}
 	/**
 	 * @group wp_query_hacks
 	 */
@@ -120,7 +125,6 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 	}
 
 	function testStickyAgainstGetPosts() {
-		delete_option('sticky_posts');
 		$first = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
 		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
@@ -131,8 +135,18 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$this->assertEquals($last, $posts[0]->ID);
 	}
 
+	function testStickyAgainstTwoSuccessiveLookups() {
+		$first = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
+		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
+		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
+		update_option('sticky_posts', array($sticky_id));
+		$posts = Timber::get_posts('post_type=post');
+		$this->assertEquals($last, $posts[0]->ID);
+		$posts = new Timber\PostQuery('post_type=post');
+		$this->assertEquals($sticky_id, $posts[0]->ID);
+	}
+
 	function testStickyAgainstQuery() {
-		delete_option('sticky_posts');
 		$pids = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
 		$pids = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
@@ -140,7 +154,6 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$posts = new Timber\PostQuery('post_type=post');
 		$this->assertEquals($sticky_id, $posts[0]->ID);
 		$posts = new WP_Query('post_type=post');
-		//error_log(print_r($posts, true));
 		$this->assertEquals($sticky_id, $posts->posts[0]->ID);
 	}
 

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -119,6 +119,31 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$this->assertContains($pids[0], $post_ids_gotten);
 	}
 
+	function testStickyAgainstGetPosts() {
+		delete_option('sticky_posts');
+		$pids = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
+		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
+		$pids = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
+		update_option('sticky_posts', array($sticky_id));
+		$posts = Timber::get_posts('post_type=post');
+		$this->assertEquals($sticky_id, $posts[0]->ID);
+		$posts = get_posts('post_type=post');
+		$this->assertEquals($sticky_id, $posts[0]->ID);
+	}
+
+	function testStickyAgainstQuery() {
+		delete_option('sticky_posts');
+		$pids = $this->factory->post->create(array('post_date' => '2015-04-23 15:13:52'));
+		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
+		$pids = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
+		update_option('sticky_posts', array($sticky_id));
+		$posts = new Timber\PostQuery('post_type=post');
+		$this->assertEquals($sticky_id, $posts[0]->ID);
+		$posts = new WP_Query('post_type=post');
+		//error_log(print_r($posts, true));
+		$this->assertEquals($sticky_id, $posts->posts[0]->ID);
+	}
+
 	function testGetPostsWithClassMap() {
 		register_post_type('portfolio', array('public' => true));
 		register_post_type('alert', array('public' => true));


### PR DESCRIPTION
... to prevent fetching too many posts when using stickies.

This fixes #1812 and makes sure that `Timber::get_posts()` produces the same output as WP `get_posts()` when using sticky posts.

**Ticket**: #1812

#### Issue
See my bug report: when using sticky posts; the incorrect amount of posts in returned.

#### Solution
I've added a method `set_query_defaults` to `QueryIterator` which is hooked at  `pre_get_posts`. The method sets `ignore_sticky_posts` to `true` if not set otherwise.
This is the same behaviour as WP `get_posts`, see `wp-includes/post.php:1759`.

#### Impact
Other than fixing this bug, no impact, presumably.


#### Testing
I've added  `testGettingPostsWithStickiesReturnsCorrectAmountOfPosts`  in `test-timber-post-getter.php`
If you comment out the new `add_action set_query_defaults` at `QueryIterator.php:26` the test will fail. With my fix, it will pass.
