### PR TITLE
Responsive image attributes

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -467,8 +467,8 @@ class Image extends Post implements CoreInterface {
 	 */
 	public function srcset( $size = "full" ) {
 		$srcset = wp_get_attachment_image_srcset($this->ID, $size);
-		$srcset = apply_filters('timber/image/srcset', $srcsset, $this->ID);
-		$srcset = apply_filters('timber_image_srcset', $srcsset, $this->ID);
+		$srcset = apply_filters('timber/image/srcset', $srcset, $this->ID);
+		$srcset = apply_filters('timber_image_srcset', $srcset, $this->ID);
 		return $srcset;
 	}
 	

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -466,7 +466,10 @@ class Image extends Post implements CoreInterface {
 	 *	@return bool|string
 	 */
 	public function srcset( $size = "full" ) {
-		return wp_get_attachment_image_srcset($this->ID, $size);
+		$srcset = wp_get_attachment_image_srcset($this->ID, $size);
+		$srcset = apply_filters('timber/image/srcset', $srcsset, $this->ID);
+		$srcset = apply_filters('timber_image_srcset', $srcsset, $this->ID);
+		return $srcset;
 	}
 	
 	/**
@@ -483,7 +486,10 @@ class Image extends Post implements CoreInterface {
 	 *	@return bool|string
 	 */
 	public function img_sizes( $size = "full" ) {
-		return wp_get_attachment_image_sizes($this->ID, $size);
+		$img_sizes = wp_get_attachment_image_sizes($this->ID, $size);
+		$img_sizes = apply_filters('timber/image/img_sizes', $img_sizes, $this->ID);
+		$img_sizes = apply_filters('timber_image_img_sizes', $img_sizes, $this->ID);
+		return $img_sizes;
 	}
 	
 	/**

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -453,6 +453,40 @@ class Image extends Post implements CoreInterface {
 	}
 
 	/**
+	 * @param string $size a size known to WordPress (like "medium")
+	 * @api
+	 * @example
+	 * ```twig
+	 * <h1>{{ post.title }}</h1>
+	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" />
+	 * ```
+	 * ```html
+	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w "
+	 * ```
+	 *	@return bool|string
+	 */
+	public function srcset( $size = "full" ) {
+		return wp_get_attachment_image_srcset($this->ID, $size);
+	}
+	
+	/**
+	 * @param string $size a size known to WordPress (like "medium")
+	 * @api
+	 * @example
+	 * ```twig
+	 * <h1>{{ post.title }}</h1>
+	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" sizes="{{ post.thumbnail.sizes }}" />
+	 * ```
+	 * ```html
+	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w sizes="(max-width: 1024px) 100vw, 102"
+	 * ```
+	 *	@return bool|string
+	 */
+	public function img_sizes( $size = "full" ) {
+		return wp_get_attachment_image_sizes($this->ID, $size);
+	}
+	
+	/**
 	 * @internal
 	 * @return bool true if media is an image
 	 */

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -461,7 +461,7 @@ class Image extends Post implements CoreInterface {
 	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" />
 	 * ```
 	 * ```html
-	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w "
+	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w" />
 	 * ```
 	 *	@return bool|string
 	 */
@@ -481,7 +481,7 @@ class Image extends Post implements CoreInterface {
 	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" sizes="{{ post.thumbnail.sizes }}" />
 	 * ```
 	 * ```html
-	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w sizes="(max-width: 1024px) 100vw, 102"
+	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w sizes="(max-width: 1024px) 100vw, 102" />
 	 * ```
 	 *	@return bool|string
 	 */


### PR DESCRIPTION
#### Issue
I didn't see an easy way to get the srcset and sizes attributes for a Timber\Image object that was as simple as `post.thumbnail.src`.

#### Solution
It seemed like a good idea to add `srcset` and `sizes` as public methods, allowing `post.thumbnail.srcset` and `post.thumbnail.sizes`. Unfortunately, `.sizes` didn't work but `img_sizes` did.

#### Impact
As far as I can tell, none.

#### Usage Changes
Should be no impact.

#### Considerations
For whatever reason, creating a size() method in the Image object wasn't working. It didn't throw an error, just that `post.thumbnail.sizes` didn't ever call the method. It'd be a more intuitive call than `img_sizes`, which would be nice.

#### Testing
There's really nothing to fail, it's just a method to get the data that's more in keeping with the rest of the project.
