### PR TITLE
ACF Blocks documentation

### DIFF
--- a/docs/guides/acf-gutenberg-cookbook.md
+++ b/docs/guides/acf-gutenberg-cookbook.md
@@ -1,0 +1,88 @@
+---
+title: "Gutenberg with ACF Blocks Cookbook"
+menu:
+  main:
+    parent: "guides"
+---
+
+## What are the ACF Blocks
+ACF Blocks are the easiest way to create content blocks for [Gutenberg](https://wordpress.org/gutenberg/). You don't need any advanced JavaScript knowledge to create new blocks. If you want to learn more about them read the article on [advancedcustomfields.com](https://www.advancedcustomfields.com/blog/acf-5-8-introducing-acf-blocks-for-gutenberg/).
+
+## How to use ACF Blocks with Timber
+Before you can start using ACF Blocks, you must install the Advanced Custom Fields 5.8.0-beta or later.
+
+To create your content block, first you have to register it in `functions.php` or in a seperate plugin:
+```php
+add_action('acf/init', 'my_acf_init');
+function my_acf_init() {
+	
+	// check function exists
+	if( function_exists('acf_register_block') ) {
+		
+		// register a new block
+		acf_register_block(array(
+			'name'				=> 'example_block',
+			'title'				=> __('Example Block'),
+			'description'		=> __('A custom example block.'),
+			'render_callback'	=> 'my_acf_block_render_callback',
+			'category'			=> 'formatting',
+			'icon'				=> 'admin-comments',
+			'keywords'		    => array( 'example' ),
+		));
+	}
+}
+```
+
+next you you have to create a `render_callback`:
+```php
+function my_acf_block_render_callback( $block ) {
+    // store block values
+    $vars['block'] = $block;
+
+    // store field values
+    $vars['fields'] = get_fields(); 
+
+    // render the block
+    Timber::render( '/template-parts/block/example-block.twig', $vars );
+}
+
+```
+you create an extra array called `$vars` with two values:
+- **block** - with all data like block title, alignment etc
+- **fields** - all custom fields - also all the fields created in **ACF**
+
+finally you can create the template `template-parts/block/example-block.twig`:
+```twig
+{#
+/**
+ * Block Name: Example block
+ *
+ * This is the template that displays the example block.
+ */
+#}
+<div id="example-{{ block.id }}" class="wrapper">
+    <h1>{{ fields.title }}</h1>
+    <p>{{ fields.description }}</p>
+</div>
+<style type="text/css">
+	#testimonial-{{ block.id }} {
+		background: {{ fields.background_color }};
+		color: {{ fields.text_color }};
+	}
+</style>
+
+```
+
+## Using repeaters
+```
+{% for field in fields.repeater %}
+    Title: {{ field.title }} <br/>
+    Url: {{ field.url }}
+{% endfor %}
+```
+
+## Using groups
+```
+Title: {{ fields.group.title }} <br/>
+Url: {{ fields.group.url }}
+```


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1645

This the documentation for ACF Block in Timber.

I added the universal example and the examples for groups and repeaters - I don't think any other types are needed. Although if you think I should add some more I'll add them.

