### PR TITLE
Update autoescape option

### DIFF
--- a/docs/guides/escapers.md
+++ b/docs/guides/escapers.md
@@ -11,7 +11,7 @@ By default, Timber does *not* escape the output of standard tags (i.e. `{{ post.
 
 ```php
 if ( class_exists('Timber') ) {
-	Timber::$autoescape = true;
+	Timber::$autoescape = 'html';
 }
 ```
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -151,7 +151,7 @@ class Loader {
 		$loader = $this->get_loader();
 		$params = array('debug' => WP_DEBUG, 'autoescape' => false);
 		if ( isset(Timber::$autoescape) ) {
-			$params['autoescape'] = Timber::$autoescape;
+			$params['autoescape'] = Timber::$autoescape === true ? 'html' : Timber::$autoescape;
 		}
 		if ( Timber::$cache === true ) {
 			Timber::$twig_cache = true;


### PR DESCRIPTION
#### Issue
As discussed [here](https://github.com/timber/timber/pull/1786#issuecomment-433835735), `autoescape = true` has been deprecated since Twig 1.21 in favor of `autoescape = 'html'`.

#### Solution
This PR updates the docs to reflect this change, and adds a fallback to automatically change `Timber::$autoescape = true` to `Timber::$autoescape = 'html'` if applicable.

#### Impact
No impact.

#### Usage Changes
It is recommended to update `Timber::$autoescape = true` to `Timber::$autoescape = 'html'` to ensure compatibility with Timber 2.x.

#### Considerations
N/A

#### Testing
N/A