### PR TITLE
2.x: Update escaping docs

### DIFF
--- a/docs/guides/escaping.md
+++ b/docs/guides/escaping.md
@@ -18,7 +18,7 @@ If you want to enable Twig’s `autoescape` behavior, add these lines to `functi
 
 ```php
 if ( class_exists( 'Timber' ) ) {
-    Timber::$autoescape = true; 
+    Timber::$autoescape = 'html; 
 }
 ```
 

--- a/docs/guides/escaping.md
+++ b/docs/guides/escaping.md
@@ -18,7 +18,7 @@ If you want to enable Twig’s `autoescape` behavior, add these lines to `functi
 
 ```php
 if ( class_exists( 'Timber' ) ) {
-    Timber::$autoescape = 'html; 
+    Timber::$autoescape = 'html'; 
 }
 ```
 

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -166,6 +166,7 @@ Up until now, there was only a representation for WordPress image attachments in
 ### Timber\Timber
 
 - `get_context()` - use `context()` instead.
+- `$autoescape = true` - use `$autoescape = 'html'` instead.
 
 ### Timber\Site
 


### PR DESCRIPTION
Almost identical to https://github.com/timber/timber/pull/1841, so please look there for details.

Differences:
- This PR doesn't add a fallback if `autoescape` is set to `true`.
- This PR adds a note about the change in the Upgrade Guide.