### PR TITLE
Ref #1854 - Fix failing tests for webp

### DIFF
--- a/lib/Image/Operation/ToWebp.php
+++ b/lib/Image/Operation/ToWebp.php
@@ -4,6 +4,7 @@ namespace Timber\Image\Operation;
 
 use Timber\Helper as Helper;
 use Timber\Image\Operation as ImageOperation;
+use Timber\ImageHelper;
 
 /**
  * This class is used to process webp images. Not all server configurations support webp. 


### PR DESCRIPTION
**Ticket**: #1854

## Issue

One my shortest pull requests 😅.

In #1854, a check was introduced that calls `ImageHelper` without adding an `use` statement, which caused some tests to fail (`TestTimberImageToWEBP`), because PHP tried to use the class under the namespace `Timber\Image\Operations`, which doesn’t exist then.

https://github.com/timber/timber/blob/3f6619f1fe7bf1a988d908ca8cf2d0f72212c220/lib/Image/Operation/ToWebp.php#L49-L51

## Solution

Add the `use` statement.

## Impact

No errors.

## Usage Changes

None.

## Considerations

Why did the tests fail on my local machine and not in Travis? 🤔

## Testing

Successully ran tests in `TestTimberImageToWEBP`.
