### PR TITLE
WIP: 2.x Deprecate get_field() in favor of meta()

### DIFF
--- a/docs/guides/escapers.md
+++ b/docs/guides/escapers.md
@@ -56,7 +56,7 @@ Uses WordPress' internal `esc_url` function on text. This should be used to sani
 
 **Twig**
 
-`<a href="{{ post.get_field('custom_link')|e('esc_url') }}"></a>`
+`<a href="{{ post.meta('custom_link')|e('esc_url') }}"></a>`
 
 **Output**
 
@@ -72,7 +72,7 @@ This is for plain old text. If your content has HTML markup you should not use `
 
 **Twig**
 
-`<div class="equation">{{ post.get_field('equation')|e('esc_html') }}</div>`
+`<div class="equation">{{ post.meta('equation')|e('esc_html') }}</div>`
 
 **Output**
 
@@ -86,7 +86,7 @@ Escapes text strings for echoing in JS. It is intended to be used for inline JS 
 
 **Twig**
 
-`<script>var bar = '{{ post.get_field('name') }}';</script>`
+`<script>var bar = '{{ post.meta('name') }}';</script>`
 
 **Output**
 

--- a/docs/guides/escaping.md
+++ b/docs/guides/escaping.md
@@ -17,7 +17,7 @@ If you want to enable Twig’s `autoescape` behavior, add these lines to `functi
 
 ```php
 if ( class_exists( 'Timber' ) ) {
-    Timber::$autoescape = true; 
+    Timber::$autoescape = true;
 }
 ```
 
@@ -88,7 +88,7 @@ This is for plain old text. If your content has HTML markup, you should not use 
 **Twig**
 
 ```twig
-<div class="equation">{{ post.get_field('equation')|e('esc_html') }}</div>
+<div class="equation">{{ post.meta('equation')|e('esc_html') }}</div>
 ```
 
 **Output**
@@ -104,7 +104,7 @@ Escapes text strings for echoing in JavaScript. It is intended to be used for in
 **Twig**
 
 ```twig
-<script>var bar = '{{ post.get_field('name')|e('esc_js') }}';</script>
+<script>var bar = '{{ post.meta('name')|e('esc_js') }}';</script>
 ```
 
 **Output**

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -485,14 +485,21 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param string          $value      Passing a non-null value will short-circuit
-		 *                                    `Comment::meta()`, returning the value instead.
-		 *                                    Default null.
+		 * @param string $value               The field value. Passing a non-null value will skip
+		 *                                    fetching the value from the database. Default null.
 		 * @param int             $comment_id The comment ID.
 		 * @param string          $field_name The name of the meta field to get the value for.
+		 * @param array           $args       An array of arguments.
 		 * @param \Timber\Comment $comment    The comment object.
 		 */
-		$value = apply_filters( 'timber/comment/pre_meta', null, $this->ID, $field_name, $this );
+		$value = apply_filters(
+			'timber/comment/pre_meta',
+			null,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
 
 		/**
 		 * Filters the value for a comment meta field before it is fetched from the database.
@@ -506,12 +513,9 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 			'timber/comment/pre_meta'
 		);
 
-		// Short-circuit
-		if ( $value ) {
-			return $value;
+		if ( null === $value ) {
+			$value = get_comment_meta($this->ID, $field_name, true);
 		}
-
-		$value = get_comment_meta($this->ID, $field_name, true);
 
 		/**
 		 * Filters the value for a comment meta field.
@@ -523,9 +527,17 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 * @param string          $value      The field value.
 		 * @param int             $comment_id The comment ID.
 		 * @param string          $field_name The name of the meta field to get the value for.
+		 * @param array           $args       An array of arguments.
 		 * @param \Timber\Comment $comment    The comment object.
 		 */
-		$value = apply_filters( 'timber/comment/get_meta', $value, $this->ID, $field_name, $this );
+		$value = apply_filters(
+			'timber/comment/get_meta',
+			$value,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
 
 		/**
 		 * Filters the value for a comment meta field.

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -31,7 +31,7 @@ use Timber\CoreInterface;
  * <p class="comment-attribution">- Sullivan Ballou</p>
  * ```
  */
-class Comment extends Core implements CoreInterface {
+class Comment extends Core implements CoreInterface, MetaInterface {
 
 	public $PostClass = 'Post';
 	public $object_type = 'comment';
@@ -472,9 +472,12 @@ class Comment extends Core implements CoreInterface {
 	 * @api
 	 *
 	 * @param string $field_name The field name for which you want to get the value.
+     * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
 	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name ) {
+	public function meta( $field_name, $args = array() ) {
 		/**
 		 * Filters the value for a comment meta field before it is fetched from the database.
 		 *
@@ -537,6 +540,26 @@ class Comment extends Core implements CoreInterface {
 		);
 
 		return $value;
+	}
+
+	/**
+	 * Gets a comment meta value.
+	 *
+	 * @api
+	 * @deprecated 2.0.0, use `{{ comment.meta('field_name') }}` instead.
+	 * @see \Timber\Comment::meta()
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
+	 */
+	public function get_field( $field_name = null ) {
+		Helper::deprecated(
+			"{{ comment.get_field('field_name') }}",
+			"{{ comment.meta('field_name') }}",
+			'2.0.0'
+		);
+
+		return $this->meta( $field_name );
 	}
 
 	/**

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -131,6 +131,8 @@ abstract class Core {
 	}
 
 	/**
+	 * @deprecated since 2.0.0
+	 *
 	 * @param string $field_name
 	 * @return mixed
 	 */

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -129,14 +129,4 @@ abstract class Core {
 		$ret['can_edit'] = $this->can_edit();
 		return $ret;
 	}
-
-	/**
-	 * @deprecated since 2.0.0
-	 *
-	 * @param string $field_name
-	 * @return mixed
-	 */
-	public function get_field( $field_name ) {
-		return $this->get_meta_field($field_name);
-	}
 }

--- a/lib/CoreInterface.php
+++ b/lib/CoreInterface.php
@@ -15,7 +15,4 @@ interface CoreInterface {
 	 * @return boolean
 	 */
 	public function __isset( $field );
-
-	public function meta( $key );
-
 }

--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -16,11 +16,11 @@ class ACF {
 
 	public function __construct() {
 		add_filter('timber/post/get_meta_values', array( $this, 'post_get_meta' ), 10, 2);
-		add_filter('timber/post/get_meta', array( $this, 'post_get_meta_field' ), 10, 3);
+		add_filter('timber/post/pre_meta', array( $this, 'post_get_meta_field' ), 10, 4);
 		add_filter('timber/post/meta_object_field', array( $this, 'post_meta_object' ), 10, 3);
 		add_filter('timber/term/get_meta_values', array( $this, 'term_get_meta' ), 10, 3);
-		add_filter('timber/term/meta', array( $this, 'term_get_meta_field' ), 10, 4);
-		add_filter('timber/user/pre_meta', array( $this, 'user_get_meta_field' ), 10, 3);
+		add_filter('timber/term/pre_meta', array( $this, 'term_get_meta_field' ), 10, 5);
+		add_filter('timber/user/pre_meta', array( $this, 'user_get_meta_field' ), 10, 4);
 
 		// Deprecated
 		add_filter('timber/term/meta/set', array( $this, 'term_set_meta' ), 10, 4);
@@ -30,17 +30,46 @@ class ACF {
 		return $customs;
 	}
 
-	public function post_get_meta_field( $value, $post_id, $field_name ) {
-		return get_field($field_name, $post_id);
+	/**
+	 * Gets meta value for a post through ACF’s API.
+	 *
+	 * @param string $value      The field value. Default null.
+	 * @param int    $post_id    The post ID.
+	 * @param string $field_name The name of the meta field to get the value for.
+	 * @param array  $args       An array of arguments.
+	 * @return mixed|false
+	 */
+	public function post_get_meta_field( $value, $post_id, $field_name, $args ) {
+		$args = wp_parse_args( $args, array(
+			'format_value' => true,
+		) );
+
+		return get_field( $field_name, $post_id, $args['format_value'] );
 	}
 
 	public function post_meta_object( $value, $post_id, $field_name ) {
 		return get_field_object($field_name, $post_id);
 	}
 
-	public function term_get_meta_field( $value, $term_id, $field_name, $term ) {
-		$searcher = $term->taxonomy . '_' . $term->ID;
-		return get_field($field_name, $searcher);
+	/**
+	 * Gets meta value for a term through ACF’s API.
+	 *
+	 * @param string $value      The field value. Default null.
+	 * @param int    $term_id    The post ID.
+	 * @param string $field_name The name of the meta field to get the value for.
+	 * @param array  $args       An array of arguments.
+	 * @return mixed|false
+	 */
+	public function term_get_meta_field( $value, $term_id, $field_name, $args, $term ) {
+		$args = wp_parse_args( $args, array(
+			'format_value' => true,
+		) );
+
+		return get_field(
+			$field_name,
+			$term->taxonomy . '_' . $term->ID,
+			$args['format_value']
+		);
 	}
 
 	/**
@@ -74,7 +103,20 @@ class ACF {
 		return $fields;
 	}
 
-	public function user_get_meta_field( $value, $uid, $field ) {
-		return get_field($field, 'user_' . $uid);
+	/**
+	 * Gets meta value for a user through ACF’s API.
+	 *
+	 * @param string $value      The field value. Default null.
+	 * @param int    $user_id    The post ID.
+	 * @param string $field_name The name of the meta field to get the value for.
+	 * @param array  $args       An array of arguments.
+	 * @return mixed|false
+	 */
+	public function user_get_meta_field( $value, $user_id, $field_name, $args ) {
+		$args = wp_parse_args( $args, array(
+			'format_value' => true,
+		) );
+
+		return get_field( $field_name, 'user_' . $user_id, $args );
 	}
 }

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -12,7 +12,7 @@ use Timber\URLHelper;
  *
  * @api
  */
-class MenuItem extends Core implements CoreInterface {
+class MenuItem extends Core implements CoreInterface, MetaInterface {
 	/**
 	 * @api
 	 * @var array Array of children of a menu item. Empty if there are no child menu items.
@@ -348,18 +348,41 @@ class MenuItem extends Core implements CoreInterface {
 	 * ```twig
 	 * <a class="icon-{{ item.meta('icon') }}" href="{{ item.link }}">{{ item.title }}</a>
 	 * ```
-	 * @param string $key The meta key to get the value for.
+	 * @param string $field_name The meta key to get the value for.
+	 * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
 	 * @return mixed Whatever value is stored in the database. Null if no value could be found.
 	 */
-	public function meta( $key ) {
+	public function meta( $field_name, $args = array() ) {
 		if ( is_object($this->menu_object) && method_exists($this->menu_object, 'meta') ) {
-			return $this->menu_object->meta($key);
+			return $this->menu_object->meta($field_name);
 		}
-		if ( isset($this->$key) ) {
-			return $this->$key;
+		if ( isset($this->$field_name) ) {
+			return $this->$field_name;
 		}
 
 		return null;
+	}
+
+	/**
+	 * Gets a menu item meta value.
+	 *
+	 * @api
+	 * @deprecated 2.0.0, use `{{ item.meta('field_name') }}` instead.
+	 * @see \Timber\MenuItem::meta()
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
+	 */
+	public function get_field( $field_name = null ) {
+		Helper::deprecated(
+			"{{ item.get_field('field_name') }}",
+			"{{ item.meta('field_name') }}",
+			'2.0.0'
+		);
+
+		return $this->meta( $field_name );
 	}
 
 	/* Aliases */

--- a/lib/MetaInterface.php
+++ b/lib/MetaInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Timber;
+
+/**
+ * Interface MetaInterface
+ *
+ * An interface for classes that implement getting meta values from the database.
+ *
+ * @since 2.0.0
+ */
+interface MetaInterface {
+	/**
+	 * Gets a meta value.
+	 *
+	 * Returns a meta value for an object that’s saved in the database.
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
+	 * @return mixed The meta field value.
+	 */
+	public function meta( $field_name, $args = array() );
+
+	/**
+	 * Gets a meta value.
+	 *
+	 * @api
+	 * @deprecated 2.0.0
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
+	 */
+	public function get_field( $field_name );
+}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -849,10 +849,10 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * @return mixed The meta field value.
 	 */
 	public function meta( $field_name = null, $args = array() ) {
-
-    if ( $rd = $this->get_revised_data_from_method('meta', $field_name) ) {
+        if ( $rd = $this->get_revised_data_from_method('meta', $field_name) ) {
 			return $rd;
 		}
+
 		/**
 		 * Filters the value for a post meta field before it is fetched from the database.
 		 *
@@ -861,20 +861,21 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 * @see   \Timber\Post::meta()
 		 * @since 2.0.0
 		 *
-		 * @param string       $value      The field value. Default null.
+		 * @param string       $value      The field value. Default null. Passing a non-null value
+		 *                                 will skip fetching the value from the database.
 		 * @param int          $post_id    The post ID.
 		 * @param string       $field_name The name of the meta field to get the value for.
+		 * @param array        $args       An array of arguments.
 		 * @param \Timber\Post $post       The post object.
 		 */
-		$value = apply_filters( 'timber/post/pre_meta', null, $this->ID, $field_name, $this );
-
-		if ( null === $field_name ) {
-			Helper::warn('You have not set what meta field you want to retrive this can cause strange behavior and is not recommended');
-		}
-
-		if ( "meta" === $field_name ) {
-			Helper::warn('You are trying to retrive a meta field named "meta" this can cause strange behavior and is not recommended');
-		}
+		$value = apply_filters(
+			'timber/post/pre_meta',
+			null,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
 
 		/**
 		 * Filters the value for a post meta field before it is fetched from the database.
@@ -888,7 +889,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 			'timber/post/pre_meta'
 		);
 
-		if ( $value === null ) {
+		if ( null === $value ) {
 			$value = get_post_meta($this->ID, $field_name);
 			if ( is_array($value) && count($value) == 1 ) {
 				$value = $value[0];
@@ -911,9 +912,17 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 * @param string       $value      The field value.
 		 * @param int          $post_id    The post ID.
 		 * @param string       $field_name The name of the meta field to get the value for.
+		 * @param array        $args       An array of arguments.
 		 * @param \Timber\Post $post       The post object.
 		 */
-		$value = apply_filters( 'timber/post/meta', $value, $this->ID, $field_name, $this );
+		$value = apply_filters(
+			'timber/post/meta',
+			$value,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
 
 		/**
 		 * Filters the value for a post meta field.

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -846,7 +846,7 @@ class Post extends Core implements CoreInterface, Setupable {
 	 * @return mixed The meta field value.
 	 */
 	public function meta( $field_name = null ) {
-  
+
     if ( $rd = $this->get_revised_data_from_method('meta', $field_name) ) {
 			return $rd;
 		}
@@ -963,12 +963,12 @@ class Post extends Core implements CoreInterface, Setupable {
 		global $post;
 		$old_global_post = $post;
     $post = $this;
-    
+
 		$class_array = get_post_class($class, $this->ID);
 		if ( $this->is_previewing() ) {
 			$class_array = get_post_class($class, $this->post_parent);
 		}
-    
+
 		if ( is_array($class_array) ) {
 			$class_array = implode(' ', $class_array);
 		}
@@ -1253,7 +1253,7 @@ class Post extends Core implements CoreInterface, Setupable {
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	protected function get_revised_data_from_method( $method, ...$args ) {
 		$rev = $this->get_post_preview_object();
@@ -1440,6 +1440,7 @@ class Post extends Core implements CoreInterface, Setupable {
 	 *
 	 * @api
 	 * @deprecated 2.0.0, use `{{ post.meta('field_name') }}` instead.
+	 * @see \Timber\Post::meta()
 	 *
 	 * @param string $field_name The field name for which you want to get the value.
 	 * @return mixed The meta field value.

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -56,7 +56,7 @@ use WP_Post;
  * </article>
  * ```
  */
-class Post extends Core implements CoreInterface, Setupable {
+class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 
 	/**
 	 * @var string The name of the class to handle images by default
@@ -843,9 +843,12 @@ class Post extends Core implements CoreInterface, Setupable {
 	 * @api
 	 *
 	 * @param string $field_name The field name for which you want to get the value.
+	 * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
 	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name = null ) {
+	public function meta( $field_name = null, $args = array() ) {
 
     if ( $rd = $this->get_revised_data_from_method('meta', $field_name) ) {
 			return $rd;
@@ -926,6 +929,31 @@ class Post extends Core implements CoreInterface, Setupable {
 
 		$value = $this->convert($value, __CLASS__);
 		return $value;
+	}
+
+	/**
+	 * Gets a post meta value.
+	 *
+	 * @api
+	 * @deprecated 2.0.0, use `{{ post.meta('field_name') }}` instead.
+	 * @see \Timber\Post::meta()
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
+	 */
+	public function get_field( $field_name = null ) {
+		Helper::deprecated(
+			"{{ post.get_field('field_name') }}",
+			"{{ post.meta('field_name') }}",
+			'2.0.0'
+		);
+
+		if ( $field_name === null ) {
+			// On the off-chance the field is actually named meta.
+			$field_name = 'meta';
+		}
+
+		return $this->meta( $field_name );
 	}
 
 	/**
@@ -1433,31 +1461,6 @@ class Post extends Core implements CoreInterface, Setupable {
 		}
 		$this->_permalink = get_permalink($this->ID);
 		return $this->_permalink;
-	}
-
-	/**
-	 * Gets a post meta value.
-	 *
-	 * @api
-	 * @deprecated 2.0.0, use `{{ post.meta('field_name') }}` instead.
-	 * @see \Timber\Post::meta()
-	 *
-	 * @param string $field_name The field name for which you want to get the value.
-	 * @return mixed The meta field value.
-	 */
-	public function get_field( $field_name = null ) {
-		Helper::deprecated(
-			"{{ post.get_field('field_name') }}",
-			"{{ post.meta('field_name' }}",
-			'2.0.0'
-		);
-
-		if ( $field_name === null ) {
-			//on the off-chance the field is actually named meta
-			$field_name = 'meta';
-		}
-
-		return $this->meta( $field_name );
 	}
 
 	/**

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -363,61 +363,95 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	 * ```
 	 *
 	 * @param string $field_name The field name for which you want to get the value.
+	 * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
 	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name ) {
-		if ( !isset($this->$field_name) ) {
-			$field_value = get_term_meta($this->ID, $field_name, true);
-			if ( !$field_value ) {
-				/**
-				 * Filters the value for a term meta field.
-				 *
-				 * This filter is used by the ACF Integration.
-				 *
-				 * @todo Add example
-				 *
-				 * @see   \Timber\Term::meta()
-				 * @since 0.21.9
-				 *
-				 * @param mixed        $field_value The field value.
-				 * @param int          $term_id     The term ID.
-				 * @param string       $field_name  The name of the meta field to get the value for.
-				 * @param \Timber\Term $term        The term object.
-				 */
-				$field_value = apply_filters(
-					'timber/term/meta',
-					$field_value,
-					$this->ID,
-					$field_name,
-					$this
-				);
-
-				/**
-				 * Filters the value for a term meta field.
-				 *
-				 * @deprecated 2.0.0, use `timber/term/meta`
-				 */
-				$field_value = apply_filters_deprecated(
-					'timber/term/meta/field',
-					array( $field_value, $this->ID, $field_name, $this ),
-					'2.0.0',
-					'timber/term/meta'
-				);
-
-				/**
-				 * Filters the value for a term meta field.
-				 *
-				 * @deprecated 2.0.0, use `timber/term/meta`
-				 */
-				$field_value = apply_filters_deprecated(
-					'timber_term_get_meta_field',
-					array( $field_value, $this->ID, $field_name, $this ),
-					'2.0.0',
-					'timber/term/meta'
-				);
-			}
-			$this->$field_name = $field_value;
+	public function meta( $field_name, $args = array() ) {
+		if ( isset($this->$field_name) ) {
+			return $this->$field_name;
 		}
+
+		/**
+		 * Filters the value for a term meta field before it is fetched from the database.
+		 *
+		 * @todo  Add description, example
+		 *
+		 * @see   \Timber\Term::meta()
+		 * @since 2.0.0
+		 *
+		 * @param string       $value      The field value. Passing a non-null value will skip
+		 *                                 fetching the value from the database. Default null.
+		 * @param int          $post_id    The post ID.
+		 * @param string       $field_name The name of the meta field to get the value for.
+		 * @param array        $args       An array of arguments.
+		 * @param \Timber\Term $term       The term object.
+		 */
+		$value = apply_filters(
+			'timber/term/pre_meta',
+			null,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
+
+		if ( null === $value ) {
+			$value = get_term_meta($this->ID, $field_name, true);
+		}
+
+		/**
+		 * Filters the value for a term meta field.
+		 *
+		 * This filter is used by the ACF Integration.
+		 *
+		 * @todo Add example
+		 *
+		 * @see   \Timber\Term::meta()
+		 * @since 0.21.9
+		 *
+		 * @param mixed        $value The field value.
+		 * @param int          $term_id     The term ID.
+		 * @param string       $field_name  The name of the meta field to get the value for.
+		 * @param array        $args        An array of arguments.
+		 * @param \Timber\Term $term        The term object.
+		 */
+		$value = apply_filters(
+			'timber/term/meta',
+			$value,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
+
+		/**
+		 * Filters the value for a term meta field.
+		 *
+		 * @deprecated 2.0.0, use `timber/term/meta`
+		 */
+		$value = apply_filters_deprecated(
+			'timber/term/meta/field',
+			array( $value, $this->ID, $field_name, $this ),
+			'2.0.0',
+			'timber/term/meta'
+		);
+
+		/**
+		 * Filters the value for a term meta field.
+		 *
+		 * @deprecated 2.0.0, use `timber/term/meta`
+		 */
+		$value = apply_filters_deprecated(
+			'timber_term_get_meta_field',
+			array( $value, $this->ID, $field_name, $this ),
+			'2.0.0',
+			'timber/term/meta'
+		);
+
+		$this->$field_name = $value;
+
 		return $this->$field_name;
 	}
 

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -45,7 +45,7 @@ use Timber\URLHelper;
  * </ul>
  * ```
  */
-class Term extends Core implements CoreInterface {
+class Term extends Core implements CoreInterface, MetaInterface {
 
 	public $PostClass = 'Timber\Post';
 	public $TermClass = 'Term';
@@ -419,6 +419,26 @@ class Term extends Core implements CoreInterface {
 			$this->$field_name = $field_value;
 		}
 		return $this->$field_name;
+	}
+
+	/**
+	 * Gets a term meta value.
+	 *
+	 * @api
+	 * @deprecated 2.0.0, use `{{ term.meta('field_name') }}` instead.
+	 * @see \Timber\Term::meta()
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
+	 */
+	public function get_field( $field_name = null ) {
+		Helper::deprecated(
+			"{{ term.get_field('field_name') }}",
+			"{{ term.meta('field_name') }}",
+			'2.0.0'
+		);
+
+		return $this->meta( $field_name );
 	}
 
 	/**

--- a/lib/User.php
+++ b/lib/User.php
@@ -274,22 +274,30 @@ class User extends Core implements CoreInterface, MetaInterface {
 	 * @return mixed The meta field value.
 	 */
 	public function meta( $field_name, $args = array() ) {
-		$value = null;
-
 		/**
 		 * Filters a user meta field before it is fetched from the database.
+		 *
+		 * @todo Add description, example
 		 *
 		 * @see \Timber\User::meta()
 		 * @since 2.0.0
 		 *
 		 * @param mixed        $value      The field value. Passing a non-null value will skip
 		 *                                 fetching the value from the database, returning the
-		 *                                 filtered value instead. Default `null`.
-		 * @param int          $user_id    The user ID
+		 *                                 filtered value instead. Default null.
+		 * @param int          $user_id    The user ID.
 		 * @param string       $field_name The name of the meta field to get the value for.
+		 * @param array        $args       An array of arguments.
 		 * @param \Timber\User $user       The user object.
 		 */
-		$value = apply_filters( 'timber/user/pre_meta', $value, $this->ID, $field_name, $this );
+		$value = apply_filters(
+			'timber/user/pre_meta',
+			null,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
 
 		/**
 		 * Filters a user meta field before it is fetched from the database.
@@ -316,9 +324,17 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * @param mixed        $value      The field value.
 		 * @param int          $user_id    The user ID.
 		 * @param string       $field_name The name of the meta field to get the value for.
+		 * @param array        $args       An array of arguments.
 		 * @param \Timber\User $user       The user object.
 		 */
-		$value = apply_filters( 'timber/user/meta', $value, $this->ID, $field_name, $this );
+		$value = apply_filters(
+			'timber/user/meta',
+			$value,
+			$this->ID,
+			$field_name,
+			$args,
+			$this
+		);
 
 		/**
 		 * Filters the value for a user meta field.

--- a/lib/User.php
+++ b/lib/User.php
@@ -45,7 +45,7 @@ use Timber\Image;
  *     and it’s by David Foster Wallace</p>
  * ```
  */
-class User extends Core implements CoreInterface {
+class User extends Core implements CoreInterface, MetaInterface {
 
 	public $object_type = 'user';
 	public static $representation = 'user';
@@ -268,9 +268,12 @@ class User extends Core implements CoreInterface {
 	 * @api
 	 *
 	 * @param string $field_name The field name for which you want to get the value.
+	 * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
 	 * @return mixed The meta field value.
 	 */
-	public function meta( $field_name ) {
+	public function meta( $field_name, $args = array() ) {
 		$value = null;
 
 		/**
@@ -330,6 +333,26 @@ class User extends Core implements CoreInterface {
 		);
 
 		return $value;
+	}
+
+	/**
+	 * Gets a user meta value.
+	 *
+	 * @api
+	 * @deprecated 2.0.0, use `{{ user.meta('field_name') }}` instead.
+	 * @see \Timber\User::meta()
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @return mixed The meta field value.
+	 */
+	public function get_field( $field_name = null ) {
+		Helper::deprecated(
+			"{{ user.get_field('field_name') }}",
+			"{{ user.meta('field_name') }}",
+			'2.0.0'
+		);
+
+		return $this->meta( $field_name );
 	}
 
 	/**

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -6,12 +6,12 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		update_post_meta( $post_id, 'Frank', 'Drebin' );
 		$tp = new Timber\Post( $post_id );
-		add_filter( 'timber/post/meta', array( $this, 'filter_timber_post_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/post/meta', array( $this, 'filter_timber_post_get_meta_field' ), 10, 5 );
 		$this->assertEquals( 'Drebin', $tp->meta( 'Frank' ) );
 		remove_filter( 'timber/post/meta', array( $this, 'filter_timber_post_get_meta_field' ) );
 	}
 
-	function filter_timber_post_get_meta_field( $value, $pid, $field_name, $timber_post ) {
+	function filter_timber_post_get_meta_field( $value, $pid, $field_name, $args, $timber_post ) {
 		$this->assertEquals( 'Frank', $field_name );
 		$this->assertEquals( 'Drebin', $value );
 		$this->assertSame( $timber_post->ID, $pid );
@@ -39,12 +39,12 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		$uid = $this->factory->user->create();
 		$user = new Timber\User( $uid );
 		$user->update( 'jared', 'novack' );
-		add_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ), 10, 5 );
 		$this->assertEquals( $user->meta( 'jared' ), 'novack' );
 		remove_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ) );
 	}
 
-	function filter_timber_user_get_meta_field( $value, $uid, $field_name, $timber_user ) {
+	function filter_timber_user_get_meta_field( $value, $uid, $field_name, $args, $timber_user ) {
 		$this->assertEquals( 'jared', $field_name );
 		$this->assertEquals( 'novack', $value );
 		$this->assertEquals( $timber_user->ID, $uid );
@@ -54,13 +54,13 @@ class TestTimberFilters extends Timber_UnitTestCase {
 	function testTermMetaFilter() {
 		$tid = $this->factory->term->create();
 		$term = new Timber\Term( $tid );
-		add_filter( 'timber/term/meta', array( $this, 'filter_timber_term_get_meta_field' ), 10, 4 );
+		add_filter( 'timber/term/meta', array( $this, 'filter_timber_term_get_meta_field' ), 10, 5 );
 
 		$term->meta( 'panic', 'oh yeah' );
 		remove_filter( 'timber/term/meta', array( $this, 'filter_timber_term_get_meta_field' ) );
 	}
 
-	function filter_timber_term_get_meta_field( $value, $tid, $field_name, $timber_term ) {
+	function filter_timber_term_get_meta_field( $value, $tid, $field_name, $args, $timber_term ) {
 		$this->assertEquals( $tid, $timber_term->ID );
 		$this->assertEquals( $field_name, 'panic' );
 		return $value;

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -431,8 +431,6 @@
 		/**
 		 * This tests was created to catch what happens when you do weird things to {{ post.meta }},
 		 * like calling it when nothing's assigned and trying to output a default property as a string.
-		 *
-		 * @expectedException Twig_Error_Runtime
 		 */
 		function testPostMetaMetaArrayProperty(){
 			$post_id = $this->factory->post->create();


### PR DESCRIPTION
**Ticket**: #1827

## Solution

### MetaInterface

Added an interface `MetaInterface` as proposed by @pascalknecht. The goal is to have less inheritance and more «contracts». All classes that want to implement fetching meta values from the database should implement `MetaInterface`.

I made `Post`, `Term`, `User`, `Comment` and `MenuItem` implement this class. This means that any methods for handling meta values were removed from `Core` and `CoreInterface`.

Because every class now implements their own methods for `meta()` and the deprecated `get_field()` method, this has the additional benefit that in the generated reference documentation, all these methods will be properly documented 🎉.

### Integrations

Added a parameter `$args` to `timber/{object}/pre_meta` and `timber/{object}/meta` (where object can be `post`, `term`, `user`, `comment`).

I added the `$args` parameter before the `$object` parameter, because I think it might be used more often than the object parameter.

```php
/**
 * Filters the value for a post meta field.
 *
 * This filter is used by the ACF Integration.
 *
 * @see   \Timber\Post::meta()
 * @since 2.0.0
 *
 * @param string       $value      The field value.
 * @param int          $post_id    The post ID.
 * @param string       $field_name The name of the meta field to get the value for.
 * @param array        $args       An array of arguments.
 * @param \Timber\Post $post       The post object.
 */
$value = apply_filters(
    'timber/post/meta',
    $value,
    $this->ID,
    $field_name,
    $args,
    $this
);
```

### ACF Integration

I updated the ACF integration:

- Changed ACF integration to use `timber/post/pre_meta` instead of `timber/post/meta`. This will prevent running `get_post_meta()`.
- Changed ACF integration to use `timber/term/pre_meta` instead of `timber/term/meta`. This will prevent running `get_term_meta()`.

This makes it possible to use the third argument for [`get_field()`](https://www.advancedcustomfields.com/resources/get_field/) in the following way:

```twig
{{ post.meta('field_name', { format_value: true }) }}
```

### Post

Removed unnecessary warning when no value was provided for `meta()`:

```php
if ( null === $field_name ) {
    Helper::warn('You have not set what meta field you want to retrive this can cause strange behavior and is not recommended');
}
```

Removed unnecessary warning when `meta` field name was used

```php
if ( 'meta' === $field_name ) {
    Helper::warn('You’re trying to retrieve a meta field named "meta". This can cause strange behavior and is not recommended.');
}
```

We can’t use the defensive method for `__get()`, because Twig accesses an object method directly, when it’s public and it exists. That’s why we can’t add a warning here.

### Term

- Added new `timber/term/pre_meta` filter to make it behave like `$post->meta()`.

### Comment

- Renamed `timber/comment/get_meta` to `timber/comment/meta` to make it follow the same pattern as in the other classes.
- Removed shirt-circuit and applied behavior of `$post->meta()`

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.

Alternatively, you’re very welcome to directly edit the readme.txt file with:
- A quick summary, including your Github handle.
- A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
- New usage instructions, possibly with a short code example.
-->

## Considerations

### Meta caching

In `Term`, there’s still a check at the beginning of `meta()`:

```php
if ( isset($this->$field_name) ) {
    return $this->$field_name;
}
```

This is a small caching mechanism. Do we need this? Depending on what we do in https://github.com/timber/timber/issues/1823, we don’t. Otherwise, we should probably add it to the other classes as well.

## Testing

<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
