### PR TITLE
Feature/1826

### DIFF
--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -358,3 +358,11 @@ Read more about this in the [Escaping Guide](@todo).
 ## Namespaced Twig locations
 
 You can now use namespaced Twig locations. Read more about this in the [Template Locations Guide](@todo).
+
+## Deprecated Twig filters
+
+The following Twig filters have been deprecated and will be removed in future versions of Timber:
+
+* `get_class`
+* `get_type`
+* `print_r`

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -364,5 +364,6 @@ You can now use namespaced Twig locations. Read more about this in the [Template
 The following Twig filters have been deprecated and will be removed in future versions of Timber:
 
 * `get_class`
-* `get_type`
 * `print_r`
+
+In addition, the confusingly named `get_type` filter has been removed.

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -211,10 +211,6 @@ class Twig {
 			Helper::deprecated( '{{ get_class }}', null, '2.0.0' );
 			return get_class( $obj );
 		} ));
-		$twig->addFilter(new \Twig_SimpleFilter('get_type', function( $var ) {
-			Helper::deprecated( '{{ get_type }}', null, '2.0.0' );
-			return get_type($arr, true);
-		} ));
 		$twig->addFilter(new \Twig_SimpleFilter('print_r', function( $arr ) {
 			Helper::deprecated( '{{ print_r }}', null, '2.0.0' );
 			return print_r($arr, true);

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -207,11 +207,18 @@ class Twig {
 		$twig->addFilter(new \Twig_SimpleFilter('towebp', array('Timber\ImageHelper', 'img_to_webp')));
 
 		/* debugging filters */
-		$twig->addFilter(new \Twig_SimpleFilter('get_class', 'get_class'));
-		$twig->addFilter(new \Twig_SimpleFilter('get_type', 'get_type'));
+		$twig->addFilter(new \Twig_SimpleFilter('get_class', function( $obj ) {
+			Helper::deprecated( '{{ get_class }}', null, '2.0.0' );
+			return get_class( $obj );
+		} ));
+		$twig->addFilter(new \Twig_SimpleFilter('get_type', function( $var ) {
+			Helper::deprecated( '{{ get_type }}', null, '2.0.0' );
+			return get_type($arr, true);
+		} ));
 		$twig->addFilter(new \Twig_SimpleFilter('print_r', function( $arr ) {
-					return print_r($arr, true);
-				} ));
+			Helper::deprecated( '{{ print_r }}', null, '2.0.0' );
+			return print_r($arr, true);
+		} ));
 
 		/* other filters */
 		$twig->addFilter(new \Twig_SimpleFilter('stripshortcodes', 'strip_shortcodes'));

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -124,6 +124,9 @@
 			$this->assertEquals('FooxBarxQuack', trim(Timber::compile_string($twig, array('string' => $str, 'array' => $arr))));
 		}
 
+		/**
+		 * @expectedDeprecated {{ get_class }}
+		 */
 		function testFilterFunction() {
 			$pid = $this->factory->post->create(array('post_title' => 'Foo'));
 			$post = new Timber\Post( $pid );


### PR DESCRIPTION
**Ticket**: #1826 

#### Issue

Timber adds some debugging filters to Twig that are undocumented and don't offer much value beyond saving a few keystrokes. These are `{{ get_class }}`, `{{ print_r }}`, and the poorly name `{{ get_type }}`.

#### Solution

Simply deprecating the first two and removing `get_type` since it doesn't actually map to a native PHP function.

#### Impact

Somewhere, a unicorn will cry a single tear.

#### Usage Changes

New deprecation warnings. On the off-chance that someone implemented their own `get_type()` PHP function and used it as a filter, they will need to add it back as a fllter manually.

#### Considerations

A moment of silence for a sad unicorn, if you please.

#### Testing

Updated one test to expect a deprecation notice.