### PR TITLE
Sync trim_words with wp_trim_words

### DIFF
--- a/functions/timber-helper.php
+++ b/functions/timber-helper.php
@@ -175,7 +175,7 @@ class TimberHelper {
         $text = strip_tags( $text, $allowed_tag_string );
         /* translators: If your word count is based on single characters (East Asian characters),
         enter 'characters'. Otherwise, enter 'words'. Do not translate into your own language. */
-        if ( 'characters' == _x( 'words', 'word count: words or characters?' ) && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+        if ( strpos( _x( 'words', 'Word count type. Do not translate!' ), 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
             $text = trim( preg_replace( "/[\n\r\t ]+/", ' ', $text ), ' ' );
             preg_match_all( '/./u', $text, $words_array );
             $words_array = array_slice( $words_array[0], 0, $num_words + 1 );


### PR DESCRIPTION
Sync functionality/translation context with [wp_trim_words](https://developer.wordpress.org/reference/functions/wp_trim_words/)

**Ticket**: #1874

#### Issue
Fix trim_words function / sync with wordpress core functionality


#### Solution
trim_words function will work correctly for character based languages

#### Usage Changes
None



