### PR TITLE
Using PostGetter::get_post_class on Post->convert. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Timber is great for any WordPress developer who cares about writing good, mainta
 * [**Pine**](https://github.com/azeemhassni/pine) A CLI _installer_ for Timber
 * [**Timber CLI**](https://github.com/nclud/wp-timber-cli) A CLI for Timber
 * [**Timber Commented Include**](https://github.com/djboris88/timber-commented-include) Debug output via HTML comments before and after each include statement in Twig
+* [**Timber Debugger**](https://github.com/djboris88/timber-debugger) Package that provides extra debugging options for Timber
 * [**Timber Dump Extension**](https://github.com/nlemoine/timber-dump-extension) Debug output with nice formatting
 * [**Timber Photon**](https://github.com/slimndap/TimberPhoton) Plug-in to use JetPack's free Photon image manipulation and CDN with Timber
 * [**Timber Sugar**](https://github.com/timber/sugar) A catch-all for goodies to use w Timber

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ By
 [Lukas Gächter](https://github.com/gchtr) ([@lgaechter](https://twitter.com/lgaechter)), 
 [Pascal Knecht](https://github.com/pascalknecht) ([@pascalknecht](https://twitter.com/revenwo)), 
 [Maciej Palmowski](https://github.com/palmiak) ([@palmiak_fp](https://twitter.com/palmiak_fp)),
+[Coby Tamayo](https://github.com/acobster) ([@cobytamayo](https://keybase.io/acobster)),
 [Upstatement](https://twitter.com/upstatement) and [hundreds of other GitHub contributors](https://github.com/timber/timber/graphs/contributors)
 
 [![Build Status](https://img.shields.io/travis/timber/timber/master.svg?style=flat-square)](https://travis-ci.org/timber/timber)

--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -99,6 +99,10 @@ Finally, you can set a breakpoint anywhere in your Twig file:
 </nav>
 ```
 
+## Timber Debugger
+
+The [**Timber Debugger**](https://github.com/djboris88/timber-debugger) package includes all three extensions mentioned above:  the [Timber Dump](https://github.com/nlemoine/timber-dump-extension) extension, the [Timber Commented Include](https://github.com/djboris88/timber-commented-include) extension and the [Twig Breakpoints](https://github.com/ajgarlag/AjglBreakpointTwigExtension) extension.
+
 ## Using Timber Debug Bar plugin
 
 There’s a [Timber add-on](http://wordpress.org/plugins/debug-bar-timber/) for the [WordPress debug bar](https://wordpress.org/plugins/debug-bar/).  

--- a/docs/guides/gutenberg.md
+++ b/docs/guides/gutenberg.md
@@ -43,7 +43,14 @@ function my_acf_init() {
 Next, you you have to create your `render_callback()` function:
 
 ```php
-function my_acf_block_render_callback( $block ) {
+/**
+*  This is the callback that displays the block.
+*
+* @param   array $block The block settings and attributes.
+* @param   string $content The block content (emtpy string).
+* @param   bool $is_preview True during AJAX preview.
+*/
+function my_acf_block_render_callback( $block, $content = '', $is_preview = false ) {
     $context = Timber::get_context();
     
     // Store block values.
@@ -52,14 +59,18 @@ function my_acf_block_render_callback( $block ) {
     // Store field values.
     $context['fields'] = get_fields(); 
 
+    // Store $is_preview value.
+    $context['is_preview'] = $is_preview; 
+
     // Render the block.
     Timber::render( 'block/example-block.twig', $context );
 }
 
 ```
-You create an extra array called `$context` with two values:
+You create an extra array called `$context` with three values:
 - **block** - with all data like block title, alignment etc
 - **fields** - all custom fields - also all the fields created in **ACF**
+- **is_preview** - returns true during AJAX preview
 
 Finally, you can create the template **block/example-block.twig**:
 
@@ -71,6 +82,11 @@ Finally, you can create the template **block/example-block.twig**:
  * This is the template that displays the example block.
  */
 #}
+
+{% if is_preview %}
+    <p>I will only appear in the editor.</p>
+{% endif %}
+
 <div id="example-{{ block.id }}" class="wrapper">
     <h1>{{ fields.title }}</h1>
     <p>{{ fields.description }}</p>
@@ -88,7 +104,7 @@ If you would like to use an external stylesheet both inside of the block editor 
 ```php
 function my_acf_block_editor_style() {
     wp_enqueue_style(
-        'logo_grid_css',
+        'example_block_css',
         get_template_directory_uri() .'/assets/example-block.css'
     );
 }

--- a/docs/guides/gutenberg.md
+++ b/docs/guides/gutenberg.md
@@ -22,21 +22,23 @@ To create a content block, you first have to register it in **functions.php** or
 
 ```php
 add_action( 'acf/init', 'my_acf_init' );
+
 function my_acf_init() {
-    // Check function exists.
-    if( function_exists('acf_register_block') ) {
-        
-        // Register a new block.
-        acf_register_block(array(
-            'name'				=> 'example_block',
-            'title'				=> __( 'Example Block', 'your-text-domain' ),
-            'description'		=> __( 'A custom example block.', 'your-text-domain' ),
-            'render_callback'	=> 'my_acf_block_render_callback',
-            'category'			=> 'formatting',
-            'icon'				=> 'admin-comments',
-            'keywords'		    => array( 'example' ),
-        ) );
+    // Bail out if function doesn’t exist.
+    if ( ! function_exists( 'acf_register_block' ) ) {
+        return;
     }
+
+    // Register a new block.
+    acf_register_block( array(
+        'name'            => 'example_block',
+        'title'           => __( 'Example Block', 'your-text-domain' ),
+        'description'     => __( 'A custom example block.', 'your-text-domain' ),
+        'render_callback' => 'my_acf_block_render_callback',
+        'category'        => 'formatting',
+        'icon'            => 'admin-comments',
+        'keywords'        => array( 'example' ),
+    ) );
 }
 ```
 
@@ -44,29 +46,29 @@ Next, you you have to create your `render_callback()` function:
 
 ```php
 /**
-*  This is the callback that displays the block.
-*
-* @param   array $block The block settings and attributes.
-* @param   string $content The block content (emtpy string).
-* @param   bool $is_preview True during AJAX preview.
-*/
+ *  This is the callback that displays the block.
+ *
+ * @param   array  $block      The block settings and attributes.
+ * @param   string $content    The block content (emtpy string).
+ * @param   bool   $is_preview True during AJAX preview.
+ */
 function my_acf_block_render_callback( $block, $content = '', $is_preview = false ) {
     $context = Timber::get_context();
-    
+
     // Store block values.
     $context['block'] = $block;
 
     // Store field values.
-    $context['fields'] = get_fields(); 
+    $context['fields'] = get_fields();
 
     // Store $is_preview value.
-    $context['is_preview'] = $is_preview; 
+    $context['is_preview'] = $is_preview;
 
     // Render the block.
     Timber::render( 'block/example-block.twig', $context );
 }
-
 ```
+
 You create an extra array called `$context` with three values:
 - **block** - with all data like block title, alignment etc
 - **fields** - all custom fields - also all the fields created in **ACF**
@@ -105,12 +107,11 @@ If you would like to use an external stylesheet both inside of the block editor 
 function my_acf_block_editor_style() {
     wp_enqueue_style(
         'example_block_css',
-        get_template_directory_uri() .'/assets/example-block.css'
+        get_template_directory_uri() . '/assets/example-block.css'
     );
 }
 
 add_action( 'enqueue_block_assets', 'my_acf_block_editor_style' );
-
 ```
 
 For more details about enqueueing assets read the [Gutenberg Handbook](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -480,4 +480,26 @@ class Helper {
 		Helper::warn('TimberHelper::get_current_url() is deprecated and will be removed in future versions, use Timber\URLHelper::get_current_url()');
 		return URLHelper::get_current_url();
 	}
+
+	/**
+	 * Converts a WP object (WP_Post, WP_Term) into his
+	 * equivalent Timber class (Timber\Post, Timber\Term).
+	 *
+	 * If no match is found the function will return the inital argument.
+	 *
+	 * @param mix $obj WP Object
+	 * @return mix Instance of equivalent Timber object, or the argument if no match is found
+	 */
+	public static function convert_wp_object( $obj ) {
+
+		if ( $obj instanceof \WP_Post ) {
+			return new \Timber\Post($obj->ID);
+		} elseif ( $obj instanceof \WP_Term ) {
+			return new \Timber\Term($obj->term_id);
+		} elseif ( $obj instanceof \WP_User ) {
+			return new \Timber\User($obj->ID);
+		}
+
+		return $obj;
+	}
 }

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -491,9 +491,9 @@ class Helper {
 	 * @return mix Instance of equivalent Timber object, or the argument if no match is found
 	 */
 	public static function convert_wp_object( $obj ) {
-
 		if ( $obj instanceof \WP_Post ) {
-			return new \Timber\Post($obj->ID);
+			$class = \Timber\PostGetter::get_post_class($obj->post_type);
+			return new $class($obj->ID);
 		} elseif ( $obj instanceof \WP_Term ) {
 			return new \Timber\Term($obj->term_id);
 		} elseif ( $obj instanceof \WP_User ) {

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -307,7 +307,11 @@ class ImageHelper {
 	 */
 	protected static function process_delete_generated_files( $filename, $ext, $dir, $search_pattern, $match_pattern = null ) {
 		$searcher = '/'.$filename.$search_pattern;
-		foreach ( glob($dir.$searcher) as $found_file ) {
+		$files = glob($dir.$searcher);
+		if ( $files === false || empty($files) ) {
+			return;
+		}
+		foreach ( $files as $found_file ) {
 			$pattern = '/'.preg_quote($dir, '/').'\/'.preg_quote($filename, '/').$match_pattern.preg_quote($ext, '/').'/';
 			$match = preg_match($pattern, $found_file);
 			if ( !$match_pattern || $match ) {

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -105,7 +105,7 @@ class Menu extends Core {
 				 *
 				 * @see wp_nav_menu()
 				 */
-				$default_args = array(
+				$default_args_array = array(
 					'menu'            => '',
 					'container'       => 'div',
 					'container_class' => '',
@@ -130,7 +130,10 @@ class Menu extends Core {
 				 *
 				 * @see wp_nav_menu()
 				 */
-				$menu = apply_filters( 'wp_nav_menu_objects', $menu, $default_args );
+				$default_args_array = apply_filters( 'wp_nav_menu_args', $default_args_array );
+				$default_args_obj = (object) $default_args_array;
+
+				$menu = apply_filters( 'wp_nav_menu_objects', $menu, $default_args_obj );
 
 				$menu = self::order_children($menu);
 				$menu = self::strip_to_depth_limit($menu);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -404,7 +404,29 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @return PostPreview
+	 * Gets a preview/excerpt of your post.
+	 *
+	 * If you have text defined in the excerpt textarea of your post, it will use that. Otherwise it
+	 * will pull from the post_content. If there's a <!-- more --> tag, it will use that to mark
+	 * where to pull through.
+	 *
+	 * This method returns `Timber\PostPreview` a object, which is a **chainable object**. This
+	 * means that you can change the output of the preview by **adding more methods**. Refer to the
+	 * documentation of the `Timber\PostPreview` to get an overview of all the available methods.
+	 *
+	 * @example
+	 * ```twig
+     * {# Use default preview #}
+	 * <p>{{ post.preview }}</p>
+	 *
+	 * {# Change the post preview text #}
+	 * <p>{{ post.preview.read_more('Continue Reading') }}</p>
+	 *
+	 * {# Additionally restrict the length to 50 words #}
+	 * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
+	 * ```
+	 * @see \Timber\PostPreview
+	 * @return \Timber\PostPreview
 	 */
 	public function preview() {
 		return new PostPreview($this);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -811,7 +811,7 @@ class Post extends Core implements CoreInterface {
 	 */
 	public function field_object( $field_name ) {
 		$value = apply_filters('timber/post/meta_object_field', null, $this->ID, $field_name, $this);
-		$value = $this->convert($value, __CLASS__);
+		$value = $this->convert($value);
 		return $value;
 	}
 
@@ -834,7 +834,7 @@ class Post extends Core implements CoreInterface {
 			}
 		}
 		$value = apply_filters('timber_post_get_meta_field', $value, $this->ID, $field_name, $this);
-		$value = $this->convert($value, __CLASS__);
+		$value = $this->convert($value);
 		return $value;
 	}
 
@@ -1367,18 +1367,16 @@ class Post extends Core implements CoreInterface {
 	 * @param array|WP_Post $data
 	 * @param string $class
 	 */
-	public function convert( $data, $class = '\Timber\Post' ) {
-		if ( $data instanceof WP_Post ) {
-			$data = new $class($data);
+	public function convert( $data ) {
+		if ( is_object($data) ) {
+			$data = Helper::convert_wp_object($data);
 		} else if ( is_array($data) ) {
 			$func = __FUNCTION__;
 			foreach ( $data as &$ele ) {
-				if ( gettype($ele) === 'array' ) {
-					$ele = $this->$func($ele, $class);
-				} else {
-					if ( $ele instanceof WP_Post ) {
-						$ele = new $class($ele);
-					}
+				if ( is_array($ele) ) {
+					$ele = $this->$func($ele);
+				} else if ( is_object($ele) ) {
+					$ele = Helper::convert_wp_object($ele);
 				}
 			}
 		}

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -3,34 +3,120 @@
 namespace Timber;
 
 /**
- * An object that lets a user easily modify the post preview to their
- * liking
+ * The PostPreview class lets a user modify a post preview/excerpt to their liking.
+ *
+ * It’s designed to be used through the `Timber\Post::preview()` method. The public methods of this
+ * class all return the object itself, which means that this is a **chainable object**. You can
+ * change the output of the preview by **adding more methods**.
+ *
+ * By default, the preview will
+ *
+ * - have a length of 50 words, which will be forced, even if a longer excerpt is set on the post.
+ * - be stripped of all HTML tags.
+ * - have an ellipsis (…) as the end of the text.
+ * - have a "Read More" link appended.
+ *
+ * @example
+ * ```twig
+ * {# Use default preview #}
+ * <p>{{ post.preview }}</p>
+ *
+ * {# Change the post preview text #}
+ * <p>{{ post.preview.read_more('Continue Reading') }}</p>
+ *
+ * {# Additionally restrict the length to 50 words #}
+ * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
+ * ```
  * @since 1.0.4
-*/
+ * @see \Timber\Post::preview()
+ */
 class PostPreview {
-
+	/**
+	 * Post.
+	 *
+	 * @var \Timber\Post
+	 */
 	protected $post;
+
+	/**
+	 * Preview end.
+	 *
+	 * @var string
+	 */
 	protected $end = '&hellip;';
+
+	/**
+	 * Force length.
+	 *
+	 * @var bool
+	 */
 	protected $force = false;
+
+	/**
+	 * Length in words.
+	 *
+	 * @var int
+	 */
 	protected $length = 50;
+
+	/**
+	 * Length in characters.
+	 *
+	 * @var bool
+	 */
 	protected $char_length = false;
+
+	/**
+	 * Read more text.
+	 *
+	 * @var string
+	 */
 	protected $readmore = 'Read More';
+
+	/**
+	 * HTML tag stripping behavior.
+	 *
+	 * @var bool
+	 */
 	protected $strip = true;
+
+	/**
+	 * Destroy tags.
+	 *
+	 * @var array List of tags that should always be destroyed.
+	 */
 	protected $destroy_tags = array('script', 'style');
 
 	/**
-	 * @param Post $post
+	 * PostPreview constructor.
+	 *
+	 * @api
+	 * @param \Timber\Post $post The post to pull the preview from.
 	 */
 	public function __construct( $post ) {
 		$this->post = $post;
 	}
 
+	/**
+	 * Returns the resulting preview.
+	 *
+	 * @api
+	 * @return string
+	 */
 	public function __toString() {
 		return $this->run();
 	}
 
 	/**
-	 * @param integer $length (in words) of the target preview
+	 * Restricts the length of the preview to a certain amount of words.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.length(50) }}</p>
+	 * ```
+	 * @param int $length The maximum amount of words (not letters) for the preview. Default `50`.
+	 * @return \Timber\PostPreview
 	 */
 	public function length( $length = 50 ) {
 		$this->length = $length;
@@ -38,7 +124,16 @@ class PostPreview {
 	}
 
 	/**
-	 * @param integer $char_length (in characters) of the target preview
+	 * Restricts the length of the preview to a certain amount of characters.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.chars(180) }}</p>
+	 * ```
+	 * @param int|bool $char_length The maximum amount of characters for the preview. Default
+	 *                              `false`.
+	 * @return \Timber\PostPreview
 	 */
 	public function chars( $char_length = false ) {
 		$this->char_length = $char_length;
@@ -46,7 +141,15 @@ class PostPreview {
 	}
 
 	/**
-	 * @param string $end how should the text in the preview end
+	 * Defines the text to end the preview with.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.end('… and much more!') }}</p>
+	 * ```
+	 * @param string $end The text for the end of the preview. Default `…`.
+	 * @return \Timber\PostPreview
 	 */
 	public function end( $end = '&hellip;' ) {
 		$this->end = $end;
@@ -54,7 +157,21 @@ class PostPreview {
 	}
 
 	/**
-	 * @param boolean $force If the editor wrote a manual excerpt longer than the set length, should it be "forced" to the size specified?
+	 * Forces preview lengths.
+	 *
+	 * What happens if your custom post excerpt is longer than the length requested? By default, it
+	 * will use the full `post_excerpt`. However, you can set this to `true` to *force* your excerpt
+	 * to be of the desired length.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.length(20).force }}</p>
+	 * ```
+	 * @param bool $force Whether the length of the preview should be forced to the requested
+	 *                    length, even if an editor wrote a manual excerpt that is longer than the
+	 *                    set length. Default `true`.
+	 * @return \Timber\PostPreview
 	 */
 	public function force( $force = true ) {
 		$this->force = $force;
@@ -62,7 +179,16 @@ class PostPreview {
 	}
 
 	/**
-	 * @param string $readmore What the text displays as to the reader inside of the <a> tag
+	 * Defines the text to be used for the "Read More" link.
+	 *
+	 * Set this to `false` to not add a "Read More" link.
+	 *
+	 * @api
+	 * ```twig
+	 * <p>{{ post.preview.read_more('Learn more') }}</p>
+	 * ```
+	 * @param string $readmore Text for the link. Default 'Read More'.
+	 * @return \Timber\PostPreview
 	 */
 	public function read_more( $readmore = 'Read More' ) {
 		$this->readmore = $readmore;
@@ -70,7 +196,17 @@ class PostPreview {
 	}
 
 	/**
-	 * @param boolean|string $strip strip the tags or what? You can also provide a list of allowed tags (e.g. '<p><a>')
+	 * Defines how HTML tags should be stripped from the preview.
+	 *
+	 * @api
+	 * ```twig
+	 * {# Strips all HTML tags, except for bold or emphasized text #}
+	 * <p>{{ post.preview.length('50').strip('<strong><em>') }}</p>
+	 * ```
+	 * @param bool|string $strip Whether or how HTML tags in the preview should be stripped. Use
+	 *                           `true` to strip all tags, `false` for no stripping, or a string for
+	 *                           a list of allowed tags (e.g. '<p><a>'). Default `true`.
+	 * @return \Timber\PostPreview
 	 */
 	public function strip( $strip = true ) {
 		$this->strip = $strip;
@@ -79,7 +215,7 @@ class PostPreview {
 
 	/**
 	 * @param string $text
-	 * @param array|booelan $readmore_matches
+	 * @param array|bool $readmore_matches
 	 * @param boolean $trimmed was the text trimmed?
 	 */
 	protected function assemble( $text, $readmore_matches, $trimmed ) {

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -115,25 +115,34 @@ class PostPreview {
 		$len = $this->length;
 		$chars = $this->char_length;
 		$strip = $this->strip;
+		$allowable_tags = ( $strip && is_string($strip)) ? $strip : false;
 		$readmore_matches = array();
 		$text = '';
 		$trimmed = false;
 		if ( isset($this->post->post_excerpt) && strlen($this->post->post_excerpt) ) {
+			$text = $this->post->post_excerpt;
 			if ( $this->force ) {
-				$text = TextHelper::trim_words($this->post->post_excerpt, $len, false);
+				
+				if ( $allowable_tags ) {
+					$text = TextHelper::trim_words($text, $len, false, strtr($allowable_tags, '<>', '  '));
+				} else {
+					$text = TextHelper::trim_words($text, $len, false);
+				}
 				if ( $chars !== false ) {
-					$text = TextHelper::trim_characters($this->post->post_excerpt, $chars, false);
+					$text = TextHelper::trim_characters($text, $chars, false);
 				}
 				$trimmed = true;
-			} else {
-				$text = $this->post->post_excerpt;
-			}
+			} 
 		}
 		if ( !strlen($text) && preg_match('/<!--\s?more(.*?)?-->/', $this->post->post_content, $readmore_matches) ) {
 			$pieces = explode($readmore_matches[0], $this->post->post_content);
 			$text = $pieces[0];
 			if ( $force ) {
-				$text = TextHelper::trim_words($text, $len, false);
+				if ( $allowable_tags ) {
+					$text = TextHelper::trim_words($text, $len, false, strtr($allowable_tags, '<>', '  '));
+				} else {
+					$text = TextHelper::trim_words($text, $len, false);
+				}
 				if ( $chars !== false ) {
 					$text = TextHelper::trim_characters($text, $chars, false);
 				}
@@ -144,7 +153,11 @@ class PostPreview {
 		if ( !strlen($text) ) {
 			$text = $this->post->content();
 			$text = TextHelper::remove_tags($text, $this->destroy_tags);
-			$text = TextHelper::trim_words($text, $len, false);
+			if ( $allowable_tags ) {
+				$text = TextHelper::trim_words($text, $len, false, strtr($allowable_tags, '<>', '  '));
+			} else {
+				$text = TextHelper::trim_words($text, $len, false);
+			}
 			if ( $chars !== false ) {
 				$text = TextHelper::trim_characters($text, $chars, false);
 			}
@@ -154,7 +167,6 @@ class PostPreview {
 			return trim($text);
 		}
 		if ( $strip ) {
-			$allowable_tags = (is_string($strip)) ? $strip : null;
 			$text = trim(strip_tags($text, $allowable_tags));
 		}
 		if ( strlen($text) ) {

--- a/lib/TextHelper.php
+++ b/lib/TextHelper.php
@@ -18,13 +18,10 @@ class TextHelper {
      * @author  @CROSP
      * @param   string $text      Text to trim.
      * @param   int    $num_chars Number of characters. Default is 60.
-     * @param   string|null $more      Optional. What to append if $text needs to be trimmed. Default '&hellip;'.
+     * @param   string $more      What to append if $text needs to be trimmed. Defaults to '&hellip;'.
      * @return  string trimmed text.
      */
-    public static function trim_characters( $text, $num_chars = 60, $more = null ) {
-        if ( $more === null ) {
-            $more = __('&hellip;');
-        }
+    public static function trim_characters( $text, $num_chars = 60, $more = '&hellip;' ) {
         $text = wp_strip_all_tags($text);
         $text = mb_strimwidth($text, 0, $num_chars, $more);
         return $text;
@@ -44,10 +41,10 @@ class TextHelper {
             $more = __('&hellip;');
         }
         $original_text = $text;
-        $allowed_tag_string = '';
-        foreach ( explode(' ', apply_filters('timber/trim_words/allowed_tags', $allowed_tags)) as $tag ) {
-            $allowed_tag_string .= '<'.$tag.'>';
-        }
+       
+        $allowed_tags_array = explode(' ', apply_filters('timber/trim_words/allowed_tags', $allowed_tags));
+        $allowed_tags_array = array_filter($allowed_tags_array, function($value) { return $value !== ''; });
+        $allowed_tag_string = '<'.implode('><', $allowed_tags_array).'>';
         $text = strip_tags($text, $allowed_tag_string);
         /* translators: If your word count is based on single characters (East Asian characters), enter 'characters'. Otherwise, enter 'words'. Do not translate into your own language. */
         if ( 'characters' == _x('words', 'word count: words or characters?') && preg_match('/^utf\-?8$/i', get_option('blog_charset')) ) {

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -225,7 +225,7 @@ class Twig {
 					return apply_filters_ref_array($tag, $args);
 				} ));
 
-		
+
 		$twig = apply_filters('timber/twig', $twig);
 		/**
 		 * get_twig is deprecated, use timber/twig
@@ -358,14 +358,14 @@ class Twig {
 	 * @param string $second_delimiter
 	 * @return string
 	 */
-	public function add_list_separators( $arr, $first_delimiter = ',', $second_delimiter = 'and' ) {
+	public function add_list_separators( $arr, $first_delimiter = ',', $second_delimiter = ' and' ) {
 		$length = count($arr);
 		$list = '';
 		foreach ( $arr as $index => $item ) {
 			if ( $index < $length - 2 ) {
 				$delimiter = $first_delimiter.' ';
 			} elseif ( $index == $length - 2 ) {
-				$delimiter = ' '.$second_delimiter.' ';
+				$delimiter = $second_delimiter.' ';
 			} else {
 				$delimiter = '';
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,8 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 - Please add bullet points here with your PR. The heading for this section will get the correct version number once released.
-- Fix an error with handling args for nav menus #1865 (thanks @palmiak)
+* Fix an error with handling args for nav menus #1865 (thanks @palmiak)
+* Allowed tags won't be stripped when automatically generating an excerpt #1886 (thanks @davefx)
 
 **Changes for Theme Developers**
 - Please add bullet points here with your PR. The heading for this section will get the correct version number once released.

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 - Please add bullet points here with your PR. The heading for this section will get the correct version number once released.
+- Fix an error with handling args for nav menus #1865 (thanks @palmiak)
 
 **Changes for Theme Developers**
 - Please add bullet points here with your PR. The heading for this section will get the correct version number once released.

--- a/tests/assets/Sport.php
+++ b/tests/assets/Sport.php
@@ -1,0 +1,9 @@
+<?php
+
+class Sport extends \Timber\Post {
+	
+	function channel() {
+		return 'ESPN';
+	}
+
+}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -252,4 +252,34 @@
 			$this->assertEquals('', $str);
 		}
 
+		function testConvertWPObject() {
+
+			// Test WP_Post -> \Timber\Post
+			$post_id = $this->factory->post->create();
+			$wp_post = get_post( $post_id );
+			$timber_post = \Timber\Helper::convert_wp_object($wp_post);
+			$this->assertTrue($timber_post instanceof \Timber\Post);
+
+			// Test WP_Term -> \Timber\Term
+			$term_id = $this->factory->term->create();
+			$wp_term = get_term( $term_id );
+			$timber_term = \Timber\Helper::convert_wp_object($wp_term);
+			$this->assertTrue($timber_term instanceof \Timber\Term);
+
+			// Test WP_User -> \Timber\User
+			$user_id = $this->factory->user->create();
+			$wp_user = get_user_by('id', $user_id);
+			$timber_user = \Timber\Helper::convert_wp_object($wp_user);
+			$this->assertTrue($timber_user instanceof \Timber\User);
+
+			// Test strange input
+			$random_int = 2018;
+			$convert_int = \Timber\Helper::convert_wp_object($random_int);
+			$this->assertTrue($convert_int === $random_int);
+
+			$array = array();
+			$convert_array = \Timber\Helper::convert_wp_object($array);
+			$this->assertTrue(is_array($convert_array));
+		}
+
 	}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -282,4 +282,22 @@
 			$this->assertTrue(is_array($convert_array));
 		}
 
+		function testCovertPostWithClassMap() {
+			register_post_type('book');
+			require_once('assets/Sport.php');
+			add_filter('Timber\PostClassMap', function( $post_classes ) {
+				$post_classes = array('sport' => 'Sport', 'post' => 'Timber');
+				$post_classes['sport'] = 'Sport';
+				return $post_classes;
+			});
+
+			$sport_id = $this->factory->post->create(array('post_type' => 'sport', 'post_title' => 'Basketball Player'));
+			$wp_post = get_post($sport_id);
+			$sport_post = \Timber\Helper::convert_wp_object($wp_post);
+			$this->assertEquals('Sport', get_class($sport_post));
+			$this->assertEquals('ESPN', $sport_post->channel());
+
+
+		}
+
 	}

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -72,6 +72,12 @@
 			$exists = file_exists( $resized_path );
 			$this->assertTrue( $exists );
 		}
+		/**
+		 * @doesNotPerformAssertions
+		 */
+		function testDeleteFalseFile() {
+			TimberImageHelper::delete_generated_files('/etc/www/image.jpg');
+		}
 
 		function testLetterbox() {
 			$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -26,8 +26,8 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
 		$post = new TimberPost();
-		$timber_post = $post->convert( $wp_post, 'TimberPost' );
-		$this->assertTrue( $timber_post instanceof TimberPost );
+		$timber_post = $post->convert( $wp_post );
+		$this->assertTrue( $timber_post instanceof \Timber\Post );
 	}
 
 	function testACFHasFieldPostFalse() {
@@ -71,10 +71,10 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}
 
-	
+
 	function testACFFieldObject() {
 		$key = 'field_5ba2c660ed26d';
-		$fp_id = $this->factory->post->create(array('post_content' => 'a:10:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";}', 'post_title' => 'Thinger', 'post_name' => $key, 'post_type' => 'acf-field'));	
+		$fp_id = $this->factory->post->create(array('post_content' => 'a:10:{s:4:"type";s:4:"text";s:12:"instructions";s:0:"";s:8:"required";i:0;s:17:"conditional_logic";i:0;s:7:"wrapper";a:3:{s:5:"width";s:0:"";s:5:"class";s:0:"";s:2:"id";s:0:"";}s:13:"default_value";s:0:"";s:11:"placeholder";s:0:"";s:7:"prepend";s:0:"";s:6:"append";s:0:"";s:9:"maxlength";s:0:"";}', 'post_title' => 'Thinger', 'post_name' => $key, 'post_type' => 'acf-field'));
 		$pid      = $this->factory->post->create();
 		update_field( 'thinger', 'foo', $pid );
 		update_field( '_thinger', $key, $pid );

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -4,6 +4,24 @@
 
 		protected $gettysburg = 'Four score and seven years ago our fathers brought forth on this continent a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal.';
 
+		function test1886Error() {
+			$expected = '<p>Govenment:</p> <ul> <li>of the <strong>people</strong></li> <li>by the people</li> <li>for the people</li> </ul>';
+			$post_id = $this->factory->post->create(array('post_content' => $expected.'<blockquote>Lincoln</blockquote>', 'post_excerpt' => false));
+			$post = new Timber\Post($post_id);
+			$template = "{{ post.preview.strip('<p><strong><ul><ol><li><br>') }}";
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals($expected.' <p>Lincoln</p>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
+		}
+
+		function test1886ErrorWithForce() {
+			$expected = '<p>Govenment:</p> <ul> <li>of the <strong>people</strong></li> <li>by the people</li> <li>for the people</li> </ul>';
+			$post_id = $this->factory->post->create(array('post_excerpt' => $expected, 'post_content' => $this->gettysburg));
+			$post = new Timber\Post($post_id);
+			$template = "{{ post.preview.strip('<ul><li>').length(10).force }}";
+			$str = Timber::compile_string($template, array('post' => $post));
+			$this->assertEquals('Govenment: <ul> <li>of the people</li> <li>by the people</li> <li>for the</li></ul>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
+		}
+
 		function testPreviewWithStyleTags() {
 			global $wpdb;
 			$style = '<style>body { background-color: red; }</style><b>Yo.</b> ';

--- a/tests/test-timber-text-helper.php
+++ b/tests/test-timber-text-helper.php
@@ -15,4 +15,18 @@
 			$this->assertFalse($maybe_starts_with);
 		}
 
+		function testTruncateEastAsian() {
+			$chars = "寒くなってきましたね。14日には北海道でも記録的に遅い初雪が降ったそ";
+			$str = '{{ "'.$chars.'"|truncate( 5, true ) }}';
+			$result = Timber::compile_string($str);
+			$this->assertEquals(wp_trim_words($chars, 5), $result);
+		}
+
+		function testTruncaseEnglish() {
+			$chars = $this->gettysburg;
+			$str = '{{ "'.$chars.'"|truncate( 5, true ) }}';
+			$result = Timber::compile_string($str);
+			$this->assertEquals(wp_trim_words($this->gettysburg, 5), $result);
+		}
+
 	}

--- a/tests/test-timber-twig-filters.php
+++ b/tests/test-timber-twig-filters.php
@@ -65,7 +65,9 @@
 				$data['day'] = '1983-09-28 20:14:48';
 				$str = Timber::compile_string("{{day|date('F jS, Y g:ia')}}", $data);
 				$this->assertEquals('septiembre 28th, 1983 8:14pm', $str);
+				return;
 			}
+			$this->markTestSkipped('WPLANG needs to be set to `es_ES` to test');
 		}
 
 		function testTwigFilterDateI18nWordPressOption(){
@@ -74,7 +76,9 @@
 				$data['day'] = '1983-09-28';
 				$str = Timber::compile_string("{{day|date}}", $data);
 				$this->assertEquals('28 septiembre, 1983', $str);
+				return;
 			}
+			$this->markTestSkipped('WPLANG needs to be set to `es_ES` to test');
 		}
 
 		function testTwigFilterDateWordPressOption(){
@@ -88,6 +92,12 @@
 			$data['authors'] = array('Tom','Rick','Harry','Mike');
 			$str = Timber::compile_string("{{authors|list}}", $data);
 			$this->assertEquals('Tom, Rick, Harry and Mike', $str);
+		}
+
+		function testTwigFilterListOxford() {
+			$data['authors'] = array('Tom','Rick','Harry','Mike');
+			$str = Timber::compile_string("{{authors|list(',', ', and')}}", $data);
+			$this->assertEquals('Tom, Rick, Harry, and Mike', $str);
 		}
 
 


### PR DESCRIPTION
…lection like acf relation fields use Timber Post Class Maps

First off, hello! Thanks for submitting a PR. We love/welcome PRs (especially if it's your first). Have any questions? Read [this section in CONTRIBUTING.md](https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests) 

**Ticket**: # <!-- Ignore this if not relevant -->

#### Issue
When using acf relation fields, the post classmap was not being used to cast the post to the right types.


#### Solution
This code uses PostGetter::get_post_class on Post->convert to cast posts to the right classes, according the class map.


#### Impact
I think that it's just a small impact.


#### Usage Changes
No usage changes


#### Considerations
No considerations


#### Testing
No unit tests, should I?
