### PR TITLE
Deprecate Timber::get_pagination

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -730,6 +730,8 @@ class Timber {
 	 * Get pagination.
 	 *
 	 * @api
+	 * @deprecated 2.0.0
+	 * @link https://timber.github.io/docs/guides/pagination/
 	 * @param array $prefs an array of preference data.
 	 * @return array|mixed
 	 */


### PR DESCRIPTION
Add deprecated and link tags

#1825

