### PR TITLE
Improve documentation for post previews

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -404,22 +404,26 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Get a preview of your post, if you have an excerpt it will use that,
-	 * otherwise it will pull from the post_content.
-	 * This uses Timber's PostPreview object.
-	 * If there's a <!-- more --> tag it will use that to mark where to pull through.
+	 * Gets a preview/excerpt of your post.
+	 *
+	 * If you have text defined in the excerpt textarea of your post, it will use that. Otherwise it
+	 * will pull from the post_content. If there's a <!-- more --> tag, it will use that to mark
+	 * where to pull through.
+	 *
+	 * This method returns `Timber\PostPreview` a object, which is a **chainable object**. This
+	 * means that you can change the output of the preview by **adding more methods**. Refer to the
+	 * documentation of the `Timber\PostPreview` to get an overview of all the available methods.
+	 *
 	 * @example
 	 * ```twig
-	 * <p>{{ post.preview.length(50).read_more("Continue Reading") }}</p>
+	 * {# Change the post preview text #}
+	 * <p>{{ post.preview.read_more('Continue Reading') }}</p>
+	 *
+	 * {# Additionally restrict the length to 50 words #}
+	 * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
 	 * ```
-	 * @method length(int) The number of words that WP should use to make the tease. 
-	 * @method chars(int) The number of characters that WP should use to make the tease.
-	 * @method force(bool) What happens if your custom post excerpt is longer then the length requested? By default (`$force = false`) it will use the full `post_excerpt`. However, you can set this to true to *force* your excerpt to be of the desired length
-	 * @method read_more(bool|string) The text you want to use on the 'readmore' link or no text (false)
-	 * @method strip(bool|string) true for default, false for none, string for list of custom attributes
-	 * @method end(string) The text to end the preview with (defaults to ...)
-	 * @see Timber\PostPreview
-	 * @return PostPreview
+	 * @see \Timber\PostPreview
+	 * @return \Timber\PostPreview
 	 */
 	public function preview() {
 		return new PostPreview($this);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -404,6 +404,19 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
+	 * get a preview of your post, if you have an excerpt it will use that,
+	 * otherwise it will pull from the post_content.
+	 * If there's a <!-- more --> tag it will use that to mark where to pull through.
+	 * @example
+	 * ```twig
+	 * <p>{{post.preview.length(50).read_more("Continue Reading")}}</p>
+	 * ```
+	 * @method length(int) The number of words that WP should use to make the tease. 
+	 * @method chars(int) The number of characters that WP should use to make the tease.
+	 * @method force(bool) What happens if your custom post excerpt is longer then the length requested? By default (`$force = false`) it will use the full `post_excerpt`. However, you can set this to true to *force* your excerpt to be of the desired length
+	 * @method read_more(bool|string) The text you want to use on the 'readmore' link or no text (false)
+	 * @method strip(bool|string) true for default, false for none, string for list of custom attributes
+	 * @method end(string) The text to end the preview with (defaults to ...)
 	 * @return PostPreview
 	 */
 	public function preview() {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -404,12 +404,13 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * get a preview of your post, if you have an excerpt it will use that,
+	 * Get a preview of your post, if you have an excerpt it will use that,
 	 * otherwise it will pull from the post_content.
+	 * This uses Timber's PostPreview object.
 	 * If there's a <!-- more --> tag it will use that to mark where to pull through.
 	 * @example
 	 * ```twig
-	 * <p>{{post.preview.length(50).read_more("Continue Reading")}}</p>
+	 * <p>{{ post.preview.length(50).read_more("Continue Reading") }}</p>
 	 * ```
 	 * @method length(int) The number of words that WP should use to make the tease. 
 	 * @method chars(int) The number of characters that WP should use to make the tease.
@@ -417,6 +418,7 @@ class Post extends Core implements CoreInterface {
 	 * @method read_more(bool|string) The text you want to use on the 'readmore' link or no text (false)
 	 * @method strip(bool|string) true for default, false for none, string for list of custom attributes
 	 * @method end(string) The text to end the preview with (defaults to ...)
+	 * @see Timber\PostPreview
 	 * @return PostPreview
 	 */
 	public function preview() {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -416,6 +416,9 @@ class Post extends Core implements CoreInterface {
 	 *
 	 * @example
 	 * ```twig
+     * {# Use default preview #}
+	 * <p>{{ post.preview }}</p>
+	 *
 	 * {# Change the post preview text #}
 	 * <p>{{ post.preview.read_more('Continue Reading') }}</p>
 	 *

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -11,6 +11,9 @@ namespace Timber;
  *
  * @example
  * ```twig
+ * {# Use default preview #}
+ * <p>{{ post.preview }}</p>
+ *
  * {# Change the post preview text #}
  * <p>{{ post.preview.read_more('Continue Reading') }}</p>
  *

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -3,10 +3,15 @@
 namespace Timber;
 
 /**
- * An object that lets a user easily modify the post preview to their
- * liking
+ * An object that lets a user easily modify the post preview to their liking.
+ * Designed to be used through the `Timber\Post::preview` method
+ * @example
+ * ```twig
+ * <p>{{ post.preview.length(50).read_more("Continue Reading") }}</p>
+ * ```
  * @since 1.0.4
-*/
+ * @see Timber\Post::preview()
+ */
 class PostPreview {
 
 	protected $post;

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -9,6 +9,13 @@ namespace Timber;
  * class all return the object itself, which means that this is a **chainable object**. You can
  * change the output of the preview by **adding more methods**.
  *
+ * By default, the preview will
+ *
+ * - have a length of 50 words, which will be forced, even if a longer excerpt is set on the post.
+ * - be stripped of all HTML tags.
+ * - have an ellipsis (…) as the end of the text.
+ * - have a "Read More" link appended.
+ *
  * @example
  * ```twig
  * {# Use default preview #}
@@ -163,10 +170,10 @@ class PostPreview {
 	 * ```
 	 * @param bool $force Whether the length of the preview should be forced to the requested
 	 *                    length, even if an editor wrote a manual excerpt that is longer than the
-	 *                    set length. Default `false`.
+	 *                    set length. Default `true`.
 	 * @return \Timber\PostPreview
 	 */
-	public function force( $force = false ) {
+	public function force( $force = true ) {
 		$this->force = $force;
 		return $this;
 	}

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -3,39 +3,110 @@
 namespace Timber;
 
 /**
- * An object that lets a user easily modify the post preview to their liking.
- * Designed to be used through the `Timber\Post::preview` method
+ * The PostPreview class lets a user modify a post preview/excerpt to their liking.
+ *
+ * It’s designed to be used through the `Timber\Post::preview()` method. The public methods of this
+ * class all return the object itself, which means that this is a **chainable object**. You can
+ * change the output of the preview by **adding more methods**.
+ *
  * @example
  * ```twig
- * <p>{{ post.preview.length(50).read_more("Continue Reading") }}</p>
+ * {# Change the post preview text #}
+ * <p>{{ post.preview.read_more('Continue Reading') }}</p>
+ *
+ * {# Additionally restrict the length to 50 words #}
+ * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
  * ```
  * @since 1.0.4
- * @see Timber\Post::preview()
+ * @see \Timber\Post::preview()
  */
 class PostPreview {
-
+	/**
+	 * Post.
+	 *
+	 * @var \Timber\Post
+	 */
 	protected $post;
+
+	/**
+	 * Preview end.
+	 *
+	 * @var string
+	 */
 	protected $end = '&hellip;';
+
+	/**
+	 * Force length.
+	 *
+	 * @var bool
+	 */
 	protected $force = false;
+
+	/**
+	 * Length in words.
+	 *
+	 * @var int
+	 */
 	protected $length = 50;
+
+	/**
+	 * Length in characters.
+	 *
+	 * @var bool
+	 */
 	protected $char_length = false;
+
+	/**
+	 * Read more text.
+	 *
+	 * @var string
+	 */
 	protected $readmore = 'Read More';
+
+	/**
+	 * HTML tag stripping behavior.
+	 *
+	 * @var bool
+	 */
 	protected $strip = true;
+
+	/**
+	 * Destroy tags.
+	 *
+	 * @var array List of tags that should always be destroyed.
+	 */
 	protected $destroy_tags = array('script', 'style');
 
 	/**
-	 * @param Post $post
+	 * PostPreview constructor.
+	 *
+	 * @api
+	 * @param \Timber\Post $post The post to pull the preview from.
 	 */
 	public function __construct( $post ) {
 		$this->post = $post;
 	}
 
+	/**
+	 * Returns the resulting preview.
+	 *
+	 * @api
+	 * @return string
+	 */
 	public function __toString() {
 		return $this->run();
 	}
 
 	/**
-	 * @param integer $length (in words) of the target preview
+	 * Restricts the length of the preview to a certain amount of words.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.length(50) }}</p>
+	 * ```
+	 * @param int $length The maximum amount of words (not letters) for the preview. Default `50`.
+	 * @return \Timber\PostPreview
 	 */
 	public function length( $length = 50 ) {
 		$this->length = $length;
@@ -43,7 +114,16 @@ class PostPreview {
 	}
 
 	/**
-	 * @param integer $char_length (in characters) of the target preview
+	 * Restricts the length of the preview to a certain amount of characters.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.chars(180) }}</p>
+	 * ```
+	 * @param int|bool $char_length The maximum amount of characters for the preview. Default
+	 *                              `false`.
+	 * @return \Timber\PostPreview
 	 */
 	public function chars( $char_length = false ) {
 		$this->char_length = $char_length;
@@ -51,7 +131,15 @@ class PostPreview {
 	}
 
 	/**
-	 * @param string $end how should the text in the preview end
+	 * Defines the text to end the preview with.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.end('… and much more!') }}</p>
+	 * ```
+	 * @param string $end The text for the end of the preview. Default `…`.
+	 * @return \Timber\PostPreview
 	 */
 	public function end( $end = '&hellip;' ) {
 		$this->end = $end;
@@ -59,15 +147,38 @@ class PostPreview {
 	}
 
 	/**
-	 * @param boolean $force If the editor wrote a manual excerpt longer than the set length, should it be "forced" to the size specified?
+	 * Forces preview lengths.
+	 *
+	 * What happens if your custom post excerpt is longer than the length requested? By default, it
+	 * will use the full `post_excerpt`. However, you can set this to `true` to *force* your excerpt
+	 * to be of the desired length.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <p>{{ post.preview.length(20).force }}</p>
+	 * ```
+	 * @param bool $force Whether the length of the preview should be forced to the requested
+	 *                    length, even if an editor wrote a manual excerpt that is longer than the
+	 *                    set length. Default `false`.
+	 * @return \Timber\PostPreview
 	 */
-	public function force( $force = true ) {
+	public function force( $force = false ) {
 		$this->force = $force;
 		return $this;
 	}
 
 	/**
-	 * @param string $readmore What the text displays as to the reader inside of the <a> tag
+	 * Defines the text to be used for the "Read More" link.
+	 *
+	 * Set this to `false` to not add a "Read More" link.
+	 *
+	 * @api
+	 * ```twig
+	 * <p>{{ post.preview.read_more('Learn more') }}</p>
+	 * ```
+	 * @param string $readmore Text for the link. Default 'Read More'.
+	 * @return \Timber\PostPreview
 	 */
 	public function read_more( $readmore = 'Read More' ) {
 		$this->readmore = $readmore;
@@ -75,7 +186,17 @@ class PostPreview {
 	}
 
 	/**
-	 * @param boolean|string $strip strip the tags or what? You can also provide a list of allowed tags (e.g. '<p><a>')
+	 * Defines how HTML tags should be stripped from the preview.
+	 *
+	 * @api
+	 * ```twig
+	 * {# Strips all HTML tags, except for bold or emphasized text #}
+	 * <p>{{ post.preview.length('50').strip('<strong><em>') }}</p>
+	 * ```
+	 * @param bool|string $strip Whether or how HTML tags in the preview should be stripped. Use
+	 *                           `true` to strip all tags, `false` for no stripping, or a string for
+	 *                           a list of allowed tags (e.g. '<p><a>'). Default `true`.
+	 * @return \Timber\PostPreview
 	 */
 	public function strip( $strip = true ) {
 		$this->strip = $strip;

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -215,7 +215,7 @@ class PostPreview {
 
 	/**
 	 * @param string $text
-	 * @param array|booelan $readmore_matches
+	 * @param array|bool $readmore_matches
 	 * @param boolean $trimmed was the text trimmed?
 	 */
 	protected function assemble( $text, $readmore_matches, $trimmed ) {


### PR DESCRIPTION
**Ticket**: #1870

## Issue

How should we document the chainable `{{ post.preview }}` method?

## Solution

Add documentation to all the methods of the `PostPreview` class.

## Impact

No custom DocBlock tags like `@method`. Lots of examples. Hopefully better documentation for post previews.

## Usage Changes

None.

## Testing

None.