### PR TITLE
Fix spacing issues in code examples

### DIFF
--- a/docs/guides/gutenberg.md
+++ b/docs/guides/gutenberg.md
@@ -22,21 +22,23 @@ To create a content block, you first have to register it in **functions.php** or
 
 ```php
 add_action( 'acf/init', 'my_acf_init' );
+
 function my_acf_init() {
-    // Check function exists.
-    if( function_exists('acf_register_block') ) {
-        
-        // Register a new block.
-        acf_register_block(array(
-            'name'				=> 'example_block',
-            'title'				=> __( 'Example Block', 'your-text-domain' ),
-            'description'		=> __( 'A custom example block.', 'your-text-domain' ),
-            'render_callback'	=> 'my_acf_block_render_callback',
-            'category'			=> 'formatting',
-            'icon'				=> 'admin-comments',
-            'keywords'		    => array( 'example' ),
-        ) );
+    // Bail out if function doesn’t exist.
+    if ( ! function_exists( 'acf_register_block' ) ) {
+        return;
     }
+
+    // Register a new block.
+    acf_register_block( array(
+        'name'            => 'example_block',
+        'title'           => __( 'Example Block', 'your-text-domain' ),
+        'description'     => __( 'A custom example block.', 'your-text-domain' ),
+        'render_callback' => 'my_acf_block_render_callback',
+        'category'        => 'formatting',
+        'icon'            => 'admin-comments',
+        'keywords'        => array( 'example' ),
+    ) );
 }
 ```
 
@@ -44,29 +46,29 @@ Next, you you have to create your `render_callback()` function:
 
 ```php
 /**
-*  This is the callback that displays the block.
-*
-* @param   array $block The block settings and attributes.
-* @param   string $content The block content (emtpy string).
-* @param   bool $is_preview True during AJAX preview.
-*/
+ *  This is the callback that displays the block.
+ *
+ * @param   array  $block      The block settings and attributes.
+ * @param   string $content    The block content (emtpy string).
+ * @param   bool   $is_preview True during AJAX preview.
+ */
 function my_acf_block_render_callback( $block, $content = '', $is_preview = false ) {
     $context = Timber::get_context();
-    
+
     // Store block values.
     $context['block'] = $block;
 
     // Store field values.
-    $context['fields'] = get_fields(); 
+    $context['fields'] = get_fields();
 
     // Store $is_preview value.
-    $context['is_preview'] = $is_preview; 
+    $context['is_preview'] = $is_preview;
 
     // Render the block.
     Timber::render( 'block/example-block.twig', $context );
 }
-
 ```
+
 You create an extra array called `$context` with three values:
 - **block** - with all data like block title, alignment etc
 - **fields** - all custom fields - also all the fields created in **ACF**
@@ -105,12 +107,11 @@ If you would like to use an external stylesheet both inside of the block editor 
 function my_acf_block_editor_style() {
     wp_enqueue_style(
         'example_block_css',
-        get_template_directory_uri() .'/assets/example-block.css'
+        get_template_directory_uri() . '/assets/example-block.css'
     );
 }
 
 add_action( 'enqueue_block_assets', 'my_acf_block_editor_style' );
-
 ```
 
 For more details about enqueueing assets read the [Gutenberg Handbook](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).


### PR DESCRIPTION
**Ticket**: #1884

## Issue

There are some spacing issues in the code examples when looking at the [live documentation](https://timber.github.io/docs/guides/gutenberg/).

![bildschirmfoto 2019-01-03 um 16 52 44](https://user-images.githubusercontent.com/2084481/50647301-8ac26a80-0f78-11e9-924a-b7cbdcdc6983.png)

## Solution

This pull request fixes these spacing issues so that the guide is easier to read.

I also applied a bailout pattern for the `function_exists( 'acf_register_block' )` check. In my opinion, nested if-statements are harder to read than a bailout pattern.

```php
// Bail out if function doesn’t exist.
if ( ! function_exists( 'acf_register_block' ) ) {
    return;
}
```