### PR TITLE
Bail if glob error in file delete sweeper

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -308,7 +308,7 @@ class ImageHelper {
 	protected static function process_delete_generated_files( $filename, $ext, $dir, $search_pattern, $match_pattern = null ) {
 		$searcher = '/'.$filename.$search_pattern;
 		$files = glob($dir.$searcher);
-		if ( $files === false ) {
+		if ( $files === false || empty($files) ) {
 			return;
 		}
 		foreach ( $files as $found_file ) {

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -307,7 +307,11 @@ class ImageHelper {
 	 */
 	protected static function process_delete_generated_files( $filename, $ext, $dir, $search_pattern, $match_pattern = null ) {
 		$searcher = '/'.$filename.$search_pattern;
-		foreach ( glob($dir.$searcher) as $found_file ) {
+		$files = glob($dir.$searcher);
+		if ( $files === false ) {
+			return;
+		}
+		foreach ( $files as $found_file ) {
 			$pattern = '/'.preg_quote($dir, '/').'\/'.preg_quote($filename, '/').$match_pattern.preg_quote($ext, '/').'/';
 			$match = preg_match($pattern, $found_file);
 			if ( !$match_pattern || $match ) {

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -72,6 +72,12 @@
 			$exists = file_exists( $resized_path );
 			$this->assertTrue( $exists );
 		}
+		/**
+		 * @doesNotPerformAssertions
+		 */
+		function testDeleteFalseFile() {
+			TimberImageHelper::delete_generated_files('/etc/www/image.jpg');
+		}
 
 		function testLetterbox() {
 			$file_loc = TestTimberImage::copyTestImage( 'eastern.jpg' );


### PR DESCRIPTION
**Ticket**: #1855

#### Issue
If for some reason PHP is unable to access files in the relevant directory for deletion (say, permissions not allowed), that error is unhandled and creates an error in Timber

#### Solution
Wait to see what files are returned from `glob` and process accordingly

#### Impact
No backwards issues. This will likely solve a "silent error" that's not disrupting site behavior — but addling lots of log entries

#### Usage Changes
No usage changes

#### Considerations
Could investigate further as to _when_ this would be invoked and handle different situations differently (most likely, with better error messaging).

#### Testing
No new tests which will likely create a decrease in coverage %