### PR TITLE
Adds roles() and can() method

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -86,9 +86,9 @@ class Comment extends Core implements CoreInterface {
 	 * ```html
 	 * <h3>Comments by...</h3>
 	 * <ol>
-	 * 	<li>Jared Novack, who is a contributor</li>
-	 * 	<li>Katie Ricci, who is a subscriber</li>
-	 * 	<li>Rebecca Pearl, who is a author</li>
+	 *  <li>Jared Novack, who is a contributor</li>
+	 *  <li>Katie Ricci, who is a subscriber</li>
+	 *  <li>Rebecca Pearl, who is a author</li>
 	 * </ol>
 	 * ```
 	 * @return User
@@ -130,13 +130,13 @@ class Comment extends Core implements CoreInterface {
 		}
 
 		$email = $this->avatar_email();
-		
+
 		$args = array('size' => $size, 'default' => $default);
 		$args = apply_filters('pre_get_avatar_data', $args, $email);
 		if ( isset($args['url']) ) {
 			return $args['url'];
 		}
-		
+
 		$email_hash = '';
 		if ( !empty($email) ) {
 			$email_hash = md5(strtolower(trim($email)));
@@ -206,7 +206,7 @@ class Comment extends Core implements CoreInterface {
 	 * @return boolean
 	 */
 	public function approved() {
-		return Helper::is_true($this->comment_approved);		
+		return Helper::is_true($this->comment_approved);
 	}
 
 	/**

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -79,7 +79,7 @@ class Comment extends Core implements CoreInterface {
 	 * <h3>Comments by...</h3>
 	 * <ol>
 	 * {% for comment in post.comments %}
-	 * 	<li>{{comment.author.name}}, who is a {{comment.author.role}}</li>
+	 * 	<li>{{comment.author.name}}, who is a {{comment.author.roles|join(', ')}}</li>
 	 * {% endfor %}
 	 * </ol>
 	 * ```

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -79,7 +79,7 @@ class Comment extends Core implements CoreInterface {
 	 * <h3>Comments by...</h3>
 	 * <ol>
 	 * {% for comment in post.comments %}
-	 * 	<li>{{comment.author.name}}, who is a {{comment.author.roles|join(', ')}}</li>
+	 *     <li>{{comment.author.name}}, who has the following roles: {{comment.author.roles|join(', ')}}</li>
 	 * {% endfor %}
 	 * </ol>
 	 * ```

--- a/lib/User.php
+++ b/lib/User.php
@@ -247,13 +247,13 @@ class User extends Core implements CoreInterface {
 	/**
 	 * Creates an associative array with user role slugs and their translated names.
 	 *
-	 * @api
+	 * @internal
 	 * @since 1.8.5
-	 * @param array $roles user roles
+	 * @param array $roles user roles.
 	 * @return array|null
 	 */
 	protected function get_roles( $roles ) {
-		if ( empty( $roles ) ) {
+		if ( empty($roles) ) {
 			return null;
 		}
 
@@ -264,13 +264,13 @@ class User extends Core implements CoreInterface {
 
 		foreach ( $roles as $role ) {
 			$name = $role;
-			if ( isset( $names[ $role ] ) ) {
-				$name = translate_user_role( $names[ $role ] );
+			if ( isset($names[ $role ]) ) {
+				$name = translate_user_role($names[ $role ]);
 			}
 
-			$values[$role] = $name;
+			$values[ $role ] = $name;
 		}
-		
+
 		return $values;
 	}
 
@@ -289,7 +289,7 @@ class User extends Core implements CoreInterface {
 	 * ```twig
 	 * <h2>Role name</h2>
 	 * {% for role in post.author.roles %}
-	 *     {{ role }} 
+	 *     {{ role }}
 	 * {% endfor %}
 	 * ```
 	 * ```twig
@@ -298,13 +298,13 @@ class User extends Core implements CoreInterface {
 	 * ```
 	 * ```twig
 	 * {% for slug, name in post.author.roles %}
-	 *     {{ slug }} 
+	 *     {{ slug }}
 	 * {% endfor %}
 	 * ```
 	 *
 	 * @return array|null
 	 */
-	public function roles() {		
+	public function roles() {
 		return $this->roles;
 	}
 
@@ -322,18 +322,18 @@ class User extends Core implements CoreInterface {
 	 *
 	 * @param string $capability The capability to check.
 	 *
-         * @example
-         * Give moderation users another CSS class to style them differently.
-         *
-         * ```twig
-         * <span class="comment-author {{ comment.author.can('moderate_comments') ? 'comment-author--is-moderator }}">
-         *     {{ comment.author.name }}
-         * </span>
-         * ```
+	 * @example
+	 * Give moderation users another CSS class to style them differently.
+	 *
+	 * ```twig
+	 * <span class="comment-author {{ comment.author.can('moderate_comments') ? 'comment-author--is-moderator }}">
+	 *     {{ comment.author.name }}
+	 * </span>
+	 * ```
 	 *
 	 * @return bool Whether the user has the capability.
 	 */
 	public function can( $capability ) {
-		return user_can( $this->ID, $capability );
+		return user_can($this->ID, $capability);
 	}
 }

--- a/lib/User.php
+++ b/lib/User.php
@@ -245,7 +245,7 @@ class User extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Create the array with user roles names and slugs.
+	 * Creates an associative array with user role slugs and their translated names.
 	 *
 	 * @api
 	 * @since 1.8.5
@@ -262,7 +262,7 @@ class User extends Core implements CoreInterface {
 
 		$values = array();
 
-		foreach( $roles as $role ) {
+		foreach ( $roles as $role ) {
 			$name = $role;
 			if ( isset( $names[ $role ] ) ) {
 				$name = translate_user_role( $names[ $role ] );
@@ -276,6 +276,12 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * Gets the user roles.
+	 * Roles shouldn’t be used to check whether a user has a capability. Use roles only for
+	 * displaying purposes. For example, if you want to display the name of the subscription a user
+	 * has on the site behind a paywall.
+	 *
+	 * If you want to check for capabilities, use `{{ user.can('capability') }}`. If you only want
+	 * to check whether a user is logged in, you can use `{% if user %}`.
 	 *
 	 * @api
 	 * @since 1.8.5
@@ -283,7 +289,7 @@ class User extends Core implements CoreInterface {
 	 * ```twig
 	 * <h2>Role name</h2>
 	 * {% for role in post.author.roles %}
-	 *   {{ role }} 
+	 *     {{ role }} 
 	 * {% endfor %}
 	 * ```
 	 * ```twig
@@ -291,8 +297,8 @@ class User extends Core implements CoreInterface {
 	 * {{ post.author.roles|join(', ') }}
 	 * ```
 	 * ```twig
-	 * {% for slug in post.author.roles|keys %}
-	 *   {{ slug }} 
+	 * {% for slug, name in post.author.roles %}
+	 *     {{ slug }} 
 	 * {% endfor %}
 	 * ```
 	 *
@@ -304,6 +310,12 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * Checks whether a user has a capability.
+	 *
+	 * Don’t use role slugs for capability checks. While checking against a role in place of a
+	 * capability is supported in part, this practice is discouraged as it may produce unreliable
+	 * results. This includes cases where you want to check whether a user is registered. If you
+	 * want to check whether a user is a Subscriber, use `{{ user.can('read') }}`. If you only want
+	 * to check whether a user is logged in, you can use `{% if user %}`.
 	 *
 	 * @api
 	 * @since 1.8.5

--- a/lib/User.php
+++ b/lib/User.php
@@ -249,10 +249,10 @@ class User extends Core implements CoreInterface {
 	 *
 	 * @api
 	 * @since 1.8.5
-	 *
+	 * @param array $roles user roles
 	 * @return array|null
 	 */
-	public function get_roles( $roles ) {
+	protected function get_roles( $roles ) {
 		if ( empty( $roles ) ) {
 			return null;
 		}
@@ -317,22 +317,20 @@ class User extends Core implements CoreInterface {
 	 * want to check whether a user is a Subscriber, use `{{ user.can('read') }}`. If you only want
 	 * to check whether a user is logged in, you can use `{% if user %}`.
 	 *
-	 * Don’t use role slugs for capability checks. While checking against a role in place of a
-	 * capability is supported in part, this practice is discouraged as it may produce unreliable
-	 * results. This includes cases where you want to check whether a user is registered. If you
-	 * want to check whether a user is a Subscriber, use `{{ user.can('read') }}`. If you only want
-	 * to check whether a user is logged in, you can use `{% if user %}`.
-	 *
 	 * @api
 	 * @since 1.8.5
 	 *
 	 * @param string $capability The capability to check.
-	 * @example
-	 * ```twig
-	 * {% if post.author.can('editor') %}
-	 * 	User has the capability "editor"
-	 * {% endif %}
-	 * ```
+	 *
+         * @example
+         * Give moderation users another CSS class to style them differently.
+         *
+         * ```twig
+         * <span class="comment-author {{ comment.author.can('moderate_comments') ? 'comment-author--is-moderator }}">
+         *     {{ comment.author.name }}
+         * </span>
+         * ```
+	 *
 	 * @return bool Whether the user has the capability.
 	 */
 	public function can( $capability ) {

--- a/lib/User.php
+++ b/lib/User.php
@@ -254,7 +254,9 @@ class User extends Core implements CoreInterface {
 	 */
 	protected function get_roles( $roles ) {
 		if ( empty($roles) ) {
+			// @codeCoverageIgnoreStart
 			return null;
+			// @codeCoverageIgnoreEnd
 		}
 
 		$wp_roles = wp_roles();
@@ -267,7 +269,6 @@ class User extends Core implements CoreInterface {
 			if ( isset($names[ $role ]) ) {
 				$name = translate_user_role($names[ $role ]);
 			}
-
 			$values[ $role ] = $name;
 		}
 

--- a/lib/User.php
+++ b/lib/User.php
@@ -317,6 +317,12 @@ class User extends Core implements CoreInterface {
 	 * want to check whether a user is a Subscriber, use `{{ user.can('read') }}`. If you only want
 	 * to check whether a user is logged in, you can use `{% if user %}`.
 	 *
+	 * Don’t use role slugs for capability checks. While checking against a role in place of a
+	 * capability is supported in part, this practice is discouraged as it may produce unreliable
+	 * results. This includes cases where you want to check whether a user is registered. If you
+	 * want to check whether a user is a Subscriber, use `{{ user.can('read') }}`. If you only want
+	 * to check whether a user is logged in, you can use `{% if user %}`.
+	 *
 	 * @api
 	 * @since 1.8.5
 	 *

--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,8 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Changes for Theme Developers**
 - Please add bullet points here with your PR. The heading for this section will get the correct version number once released.
+- Adds support for roles on the user object. Example: `{{ post.author.roles }}` which returns an array of roles #1898 (thanks @palmiak)
+- Adds support for capabilities on the user object. Example: `{{post.author.can("moderate_comments")}}` which returns true or false #1898 (thanks @palmiak)
 
 = 1.8.4 =
 **Fixes and improvements**

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -16,6 +16,19 @@
 			$this->assertEquals($uid, $user->id);
 		}
 
+		function testUserCapability() {
+			$uid = $this->factory->user->create(array('display_name' => 'Tito Bottitta', 'user_login' => 'mbottitta', 'role' => 'editor'));
+			$user = new Timber\User('mbottitta');
+			$this->assertTrue($user->can('edit_posts'));
+			$this->assertFalse($user->can('activate_plugins'));
+		}
+
+		function testUserRole() {
+			$uid = $this->factory->user->create(array('display_name' => 'Tito Bottitta', 'user_login' => 'mbottitta', 'role' => 'editor'));
+			$user = new Timber\User('mbottitta');
+			$this->assertArrayHasKey('editor', $user->roles());
+		}
+
 		function testDescription() {
 			$uid = $this->factory->user->create(array('display_name' => 'Baberaham Lincoln', 'user_login' => 'blincoln'));
 			update_user_meta($uid, 'description', 'Sixteenth President');


### PR DESCRIPTION
**Ticket**: #1866

#### Issue
Adds to new methods to `User`:
- `roles()` - an array with role slugs and names
- `can()` - checks if user is having a capability

#### Solution
Just added the code after discussion with @gchtr in #1866  


#### Impact
Shouldn't have any. It's something new.


#### Usage Changes
Everything is described in the examples provided in inline documentation.

#### Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


#### Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
