### PR TITLE
2.x Remove deprecated checks when fetching embedded media from post content

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1448,14 +1448,12 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		return apply_filters('get_the_time', $the_time, $tf);
 	}
 
-
 	/**
-	 * Returns the post_type object with labels and other info
+	 * Returns the PostType object for a post’s post type with labels and other info.
 	 *
 	 * @api
 	 * @since 1.0.4
 	 * @example
-	 *
 	 * ```twig
 	 * This post is from <span>{{ post.type.labels.name }}</span>
 	 * ```
@@ -1463,12 +1461,9 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * ```html
 	 * This post is from <span>Recipes</span>
 	 * ```
-	 * @return PostType
+	 * @return \Timber\PostType
 	 */
 	public function type() {
-		if ( isset($this->custom['type']) ) {
-			return $this->custom['type'];
-		}
 		if ( ! $this->__type instanceof PostType ) {
 			$this->__type = new PostType($this->post_type);
 		}
@@ -1747,19 +1742,17 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	}
 
 	/**
-	 * Returns the gallery
+	 * Returns galleries from the post’s content.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
 	 * {{ post.gallery }}
 	 * ```
-	 * @return html
+	 * @return array A list of arrays, each containing gallery data and srcs parsed from the
+	 * expanded shortcode.
 	 */
 	public function gallery( $html = true ) {
-		if ( isset($this->custom['gallery']) ) {
-			return $this->custom['gallery'];
-		}
 		$galleries = get_post_galleries($this->ID, $html);
 		$gallery = reset($galleries);
 
@@ -1767,22 +1760,19 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	}
 
 	/**
-	 * Returns the audio
+	 * Returns audio tags embedded in the post’s content.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
 	 * {{ post.audio }}
 	 * ```
-	 * @return html
+	 * @return bool|array A list of found HTML embeds.
 	 */
 	public function audio() {
-		if ( isset($this->custom['audio']) ) {
-			return $this->custom['audio'];
-		}
 		$audio = false;
 
-		// Only get audio from the content if a playlist isn't present.
+		// Only get audio from the content if a playlist isn’t present.
 		if ( false === strpos($this->content(), 'wp-playlist-script') ) {
 			$audio = get_media_embedded_in_content($this->content(), array('audio'));
 		}
@@ -1791,19 +1781,16 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	}
 
 	/**
-	 * Returns the video
+	 * Returns video tags embedded in the post’s content.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
 	 * {{ post.video }}
 	 * ```
-	 * @return html
+	 * @return bool|array A list of found HTML embeds.
 	 */
 	public function video() {
-		if ( isset($this->custom['video']) ) {
-			return $this->custom['video'];
-		}
 		$video = false;
 
 		// Only get video from the content if a playlist isn't present.

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -36,23 +36,4 @@
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Posts', $str);
 		}
-
-		function testLegacyTypeCustomField() {
-			$post_id = $this->factory->post->create();
-			update_post_meta($post_id, 'type', 'numberwang');
-			$post = new Timber\Post($post_id);
-			$template = '{{post.type}}';
-			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertEquals('numberwang', $str);
-		}
-
-		function testUnderscoreTypeCustomField() {
-			$post_id = $this->factory->post->create();
-			update_post_meta($post_id, '_type', 'numberwang');
-			$post = new Timber\Post($post_id);
-			$template = '{{post._type}}';
-			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertEquals('numberwang', $str);
-		}
-
 	}

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -964,13 +964,6 @@
 			$this->assertEquals(null, $post->gallery());
 		}
 
-		function testPostWithGalleryCustomField() {
-			$pid = $this->factory->post->create();
-			update_post_meta($pid, 'gallery', 'foo');
-			$post = new Timber\Post($pid);
-			$this->assertEquals('foo', $post->gallery());
-		}
-
 		function testPostWithoutAudio() {
 			$pid = $this->factory->post->create();
 			$post = new Timber\Post($pid);


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/1823#issuecomment-453276787

## Issue

With the new approach to fetch meta values outlined in #1823, there’s no need to check for existing custom meta values.

## Solution

Remove the checks.

## Impact

Probably (hopefully) none. The `$custom` property will be protected in the future (upcoming pull request), so proper error messages will be shown when updating to 2.x.

## Usage Changes

None.

## Considerations

None.

## Testing

Removed deprecated tests.