### PR TITLE
2.x ACF integration cleanups

### DIFF
--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -21,7 +21,11 @@ class ACF {
 		add_filter('timber/term/pre_meta', array( $this, 'term_get_meta_field' ), 10, 5);
 		add_filter('timber/user/pre_meta', array( $this, 'user_get_meta_field' ), 10, 5);
 
-		// Deprecated
+		/**
+		 * Allowed a user to set a meta value
+		 *
+		 * @deprecated 2.0.0 with no replacement
+		 */
 		add_filter('timber/term/meta/set', array( $this, 'term_set_meta' ), 10, 4);
 	}
 

--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -15,7 +15,6 @@ use Timber\Helper;
 class ACF {
 
 	public function __construct() {
-		add_filter('timber/post/get_meta_values', array( $this, 'post_get_meta' ), 10, 2);
 		add_filter('timber/post/pre_meta', array( $this, 'post_get_meta_field' ), 10, 5);
 		add_filter('timber/post/meta_object_field', array( $this, 'post_meta_object' ), 10, 3);
 		add_filter('timber/term/get_meta_values', array( $this, 'term_get_meta' ), 10, 3);
@@ -24,10 +23,6 @@ class ACF {
 
 		// Deprecated
 		add_filter('timber/term/meta/set', array( $this, 'term_set_meta' ), 10, 4);
-	}
-
-	public function post_get_meta( $customs, $post_id ) {
-		return $customs;
 	}
 
 	/**
@@ -98,10 +93,6 @@ class ACF {
 			}
 			$fields = array_merge($fields, $fds);
 		}
-		return $fields;
-	}
-
-	public function user_get_meta( $fields, $user_id ) {
 		return $fields;
 	}
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -607,7 +607,6 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		/**
 		 * Filters post meta data.
 		 *
-		 * This filter is used by the ACF Integration.
 		 *
 		 * @todo Add description, example
 		 *


### PR DESCRIPTION
## Issue

In preparation for the pull request of the pull request for #1823, I found that there are two methods in the ACF integration that practically do nothing. The `post_get_meta()` method additionally has a filter. They were added in https://github.com/timber/timber/commit/9f04ff62bfb4716beffc00d5731ee3b24dc256c2 and in https://github.com/timber/timber/commit/933f8ded923d150be316d7bf62b4cfd92f3fb3f8.

## Solution

Remove the methods and the filter call.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

Ran tests. All good.