### PR TITLE
2.x Streamline get_meta_values() for classes that implement MetaInterface

### DIFF
--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -339,6 +339,12 @@ For the following filters, we updated the logic a little bit:
 
 In 1.x, you could return a non-empty array in these filters to skip fetching meta values from the database. In 2.x, you can also return `false` to achieve the same.
 
+```php
+add_filter('timber/post/pre_get_meta_values', function($custom_data, $post_id, $post){
+    return false;
+}, 10, 3);
+```
+
 ## New functions
 
 **Timber\Timber**

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -340,9 +340,7 @@ For the following filters, we updated the logic a little bit:
 In 1.x, you could return a non-empty array in these filters to skip fetching meta values from the database. In 2.x, you can also return `false` to achieve the same.
 
 ```php
-add_filter('timber/post/pre_get_meta_values', function($custom_data, $post_id, $post){
-    return false;
-}, 10, 3);
+add_filter( 'timber/post/pre_get_meta_values', '__return_false' );
 ```
 
 ## New functions

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -319,6 +319,25 @@ The following filters were deprecated without a replacement:
 
 If you’ve used `timber/term/meta` before, you might have to switch to `timer/term/get_meta_fields`. The `timber/term/meta` filter was introduced in 2.0 to be used instead of `timber/term/meta/field` and `timber_term_get_meta_field`. However, a filter `timber/term/meta` already existed in `Term::get_meta_values()` for version 1.0 and was renamed to `timber/term/get_meta_fields` to match the new naming conventions.
 
+### New hooks
+
+We added new hooks:
+
+**Timber\Term**
+
+- `timber/term/pre_get_meta_values`
+
+### Updated hook logic
+
+For the following filters, we updated the logic a little bit:
+
+- `timber/post/pre_get_meta_values`
+- `timber/term/pre_get_meta_values`
+- `timber/user/pre_get_meta_values`
+- `timber/comment/pre_get_meta_values`
+
+In 1.x, you could return a non-empty array in these filters to skip fetching meta values from the database. In 2.x, you can also return `false` to achieve the same.
+
 ## New functions
 
 **Timber\Timber**

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -383,7 +383,7 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 			$comment_id = $this->ID;
 		}
 
-		$comment_metas = array();
+		$comment_meta = array();
 
 		/**
 		 * Filters comment meta data before it is fetched from the database.
@@ -392,19 +392,24 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 * you can disable fetching the meta values through the default method, which uses
 		 * `get_comment_meta()`, by returning `false` or a non-empty array.
 		 *
-		 * @todo Add example
+		 * @example
+		 * ```php
+		 * add_filter( 'timber/comment/pre_get_meta_values', function($comment_meta, $comment_id, $comment) {
+		 *     return false;
+		 * }, 10, 3);
+		 * ```
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array           $comment_metas An array of comment meta data. Passing `false` or a
-		 *                                       non-empty array will skip fetching values from the
-		 *                                       database and will use the filtered values instead.
-		 *                                       Default `array()`.
-		 * @param int             $comment_id    The comment ID.
-		 * @param \Timber\Comment $comment       The comment object.
+		 * @param array           $comment_meta An array of comment meta data. Passing `false` or a
+		 *                                      non-empty array will skip fetching values from the
+		 *                                      database and will use the filtered values instead.
+		 *                                      Default `array()`.
+		 * @param int             $comment_id   The comment ID.
+		 * @param \Timber\Comment $comment      The comment object.
 		 */
-		$comment_metas = apply_filters( 'timber/comment/pre_get_meta_values',
-			$comment_metas,
+		$comment_meta = apply_filters( 'timber/comment/pre_get_meta_values',
+			$comment_meta,
 			$comment_id,
 			$this
 		);
@@ -418,17 +423,17 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 */
 		do_action_deprecated(
 			'timber_comment_get_meta_pre',
-			array( $comment_metas, $comment_id ),
+			array( $comment_meta, $comment_id ),
 			'2.0.0',
 			'timber/comment/pre_get_meta_values'
 		);
 
 		// Load all meta data when it wasn’t filtered before.
-		if ( false !== $comment_metas && empty( $comment_metas ) ) {
-			$comment_metas = get_comment_meta($comment_id);
+		if ( false !== $comment_meta && empty( $comment_meta ) ) {
+			$comment_meta = get_comment_meta($comment_id);
 		}
 
-		foreach ( $comment_metas as &$cm ) {
+		foreach ( $comment_meta as &$cm ) {
 			if ( is_array($cm) && count($cm) == 1 ) {
 				$cm = $cm[0];
 			}
@@ -440,17 +445,26 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 * Timber loads all meta values into the comment object on initialization. With this filter,
 		 * you can change meta values after they were fetched from the database.
 		 *
-		 * @todo Add example
+		 * @example
+		 * ```php
+		 * add_filter('timber/comment/get_meta_values', function($comment_meta, $comment_id, $comment) {
+		 *     if ( $comment_id == 12345 ) {
+		 *         // do something special
+		 *         $comment_meta['foo'] = $comment_meta['foo'].' bar';
+		 *     }
+		 *     return $comment_meta;
+		 * });
+		 * ```
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array           $comment_metas Comment meta data.
-		 * @param int             $comment_id    The comment ID.
-		 * @param \Timber\Comment $comment       The comment object.
+		 * @param array           $comment_meta Comment meta data.
+		 * @param int             $comment_id   The comment ID.
+		 * @param \Timber\Comment $comment      The comment object.
 		 */
-		$comment_metas = apply_filters(
+		$comment_meta = apply_filters(
 			'timber/comment/get_meta_values',
-			$comment_metas,
+			$comment_meta,
 			$comment_id,
 			$this
 		);
@@ -461,14 +475,14 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 * @deprecated 2.0.0, use `timber/comment/get_meta_values`
 		 * @since 0.15.4
 		 */
-		$comment_metas = apply_filters_deprecated(
+		$comment_meta = apply_filters_deprecated(
 			'timber_comment_get_meta',
-			array( $comment_metas, $comment_id ),
+			array( $comment_meta, $comment_id ),
 			'2.0.0',
 			'timber/comment/get_meta_values'
 		);
 
-		return $comment_metas;
+		return $comment_meta;
 	}
 
 	/**

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -389,13 +389,19 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		$comment_metas = array();
 
 		/**
-		 * Filters comment meta data before is fetched from the database.
+		 * Filters comment meta data before it is fetched from the database.
+		 *
+		 * Timber loads all meta values into the comment object on initialization. With this filter,
+		 * you can disable fetching the meta values through the default method, which uses
+		 * `get_comment_meta()`, by returning `false` or a non-empty array.
+		 *
+		 * @todo Add example
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array           $comment_metas An array of comment meta data. Passing a non-empty
-		 *                                       array will skip fetching values from the database
-		 *                                       and will use the filtered values instead.
+		 * @param array           $comment_metas An array of comment meta data. Passing `false` or a
+		 *                                       non-empty array will skip fetching values from the
+		 *                                       database and will use the filtered values instead.
 		 *                                       Default `array()`.
 		 * @param int             $comment_id    The comment ID.
 		 * @param \Timber\Comment $comment       The comment object.
@@ -420,7 +426,8 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 			'timber/comment/pre_get_meta_values'
 		);
 
-		if ( ! is_array( $comment_metas ) || empty( $comment_metas ) ) {
+		// Load all meta data when it wasn’t filtered before.
+		if ( false !== $comment_metas && empty( $comment_metas ) ) {
 			$comment_metas = get_comment_meta($comment_id);
 		}
 
@@ -431,9 +438,12 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		}
 
 		/**
-		 * Filters comment meta data.
+		 * Filters comment meta data fetched from the database.
 		 *
-		 * @todo Add description, example
+		 * Timber loads all meta values into the comment object on initialization. With this filter,
+		 * you can change meta values after they were fetched from the database.
+		 *
+		 * @todo Add example
 		 *
 		 * @since 2.0.0
 		 *
@@ -449,7 +459,7 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		);
 
 		/**
-		 * Filters comment meta data.
+		 * Filters comment meta data fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/comment/get_meta_values`
 		 * @since 0.15.4

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -394,9 +394,9 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter( 'timber/comment/pre_get_meta_values', function($comment_meta, $comment_id, $comment) {
+		 * add_filter( 'timber/comment/pre_get_meta_values', function( $comment_meta, $comment_id, $comment ) {
 		 *     return false;
-		 * }, 10, 3);
+		 * }, 10, 3 );
 		 * ```
 		 *
 		 * @since 2.0.0
@@ -447,13 +447,14 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter('timber/comment/get_meta_values', function($comment_meta, $comment_id, $comment) {
-		 *     if ( $comment_id == 12345 ) {
-		 *         // do something special
-		 *         $comment_meta['foo'] = $comment_meta['foo'].' bar';
+		 * add_filter( 'timber/comment/get_meta_values', function( $comment_meta, $comment_id, $comment ) {
+		 *     if ( 12345 === (int) $comment_id ) {
+		 *         // Do something special.
+		 *         $comment_meta['foo'] = $comment_meta['foo'] . ' bar';
 		 *     }
+		 *
 		 *     return $comment_meta;
-		 * });
+		 * }, 10, 3 );
 		 * ```
 		 *
 		 * @since 2.0.0

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -561,11 +561,11 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * and attach them to our Timber\Post object
 	 * @internal
 	 *
-	 * @param int $pid
+	 * @param int $post_id
 	 *
 	 * @return array
 	 */
-	protected function get_meta_values( $pid ) {
+	protected function get_meta_values( $post_id ) {
 		$post_meta = array();
 
 		/**
@@ -577,19 +577,28 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter('timber/post/pre_get_meta_values', function($custom_data, $post_id, $post){
-    	 *     return false;
-		 * }, 10, 3);
+		 * // Disable fetching meta values.
+		 * add_filter( 'timber/post/pre_get_meta_values', '__return_false' );
+		 *
+		 * // Add your own meta data.
+		 * add_filter( 'timber/post/pre_get_meta_values', function( $post_meta, $post_id, $post ) {
+    	 *     $post_meta = array(
+		 *         'custom_data_1' => 73,
+		 *         'custom_data_2' => 274,
+		 *     );
+		 *
+		 *     return $post_meta;
+		 * }, 10, 3 );
 		 * ```
 		 * @since 2.0.0
 		 *
 		 * @param array        $post_meta An array of custom meta values. Passing false or a non-empty
 		 *                                array will skip fetching the values from the database and
 		 *                                will use the filtered values instead. Default `array()`.
-		 * @param int          $pid       The post ID.
+		 * @param int          $post_id   The post ID.
 		 * @param \Timber\Post $post      The post object.
 		 */
-		$post_meta = apply_filters( 'timber/post/pre_get_meta_values', $post_meta, $pid, $this );
+		$post_meta = apply_filters( 'timber/post/pre_get_meta_values', $post_meta, $post_id, $this );
 
 		/**
 		 * Filters post meta data before it is fetched from the database.
@@ -598,14 +607,14 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 */
 		do_action_deprecated(
 			'timber_post_get_meta_pre',
-			array( $post_meta, $pid, $this ),
+			array( $post_meta, $post_id, $this ),
 			'2.0.0',
 			'timber/post/pre_get_meta_values'
 		);
 
 		// Load all meta data when it wasn’t filtered before.
 		if ( false !== $post_meta && empty( $post_meta ) ) {
-			$post_meta = get_post_meta( $pid );
+			$post_meta = get_post_meta( $post_id );
 		}
 
 		foreach ( $post_meta as $key => $value ) {
@@ -623,22 +632,23 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter('timber/post/get_meta_values', function($post_meta, $post_id, $post) {
-		 *     if ( $post_id == 12345 ) {
-		 *         // do something special
-		 *         $post_meta['foo'] = $post_meta['foo'].' bar';
+		 * add_filter( 'timber/post/get_meta_values', function( $post_meta, $post_id, $post ) {
+		 *     if ( 'event' === $post->post_type ) {
+		 *         // Do something special.
+		 *         $post_meta['foo'] = $post_meta['foo'] . ' bar';
 		 *     }
+		 *
 		 *     return $post_meta;
-		 * });
+		 * }, 10, 3 );
 		 * ```
 		 *
 		 * @since 2.0.0
 		 *
 		 * @param array        $post_meta Post meta data.
-		 * @param int          $pid       The post ID.
+		 * @param int          $post_id   The post ID.
 		 * @param \Timber\Post $post      The post object.
 		 */
-		$post_meta = apply_filters( 'timber/post/get_meta_values', $post_meta, $pid, $this );
+		$post_meta = apply_filters( 'timber/post/get_meta_values', $post_meta, $post_id, $this );
 
 		/**
 		 * Filters post meta data fetched from the database.
@@ -647,7 +657,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 */
 		$post_meta = apply_filters_deprecated(
 			'timber_post_get_meta',
-			array( $post_meta, $pid, $this ),
+			array( $post_meta, $post_id, $this ),
 			'2.0.0',
 			'timber/post/get_meta_values'
 		);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -566,7 +566,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * @return array
 	 */
 	protected function get_meta_values( $pid ) {
-		$customs = array();
+		$post_meta = array();
 
 		/**
 		 * Filters post meta data before it is fetched from the database.
@@ -575,17 +575,21 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 * you can disable fetching the meta values through the default method, which uses
 		 * `get_post_meta()`, by returning `false` or an non-empty array.
 		 *
-		 * @todo  Add example.
-		 *
+		 * @example
+		 * ```php
+		 * add_filter('timber/post/pre_get_meta_values', function($custom_data, $post_id, $post){
+    	 *     return false;
+		 * }, 10, 3);
+		 * ```
 		 * @since 2.0.0
 		 *
-		 * @param array        $customs An array of custom meta values. Passing false or a non-empty
-		 *                              array will skip fetching the values from the database and
-		 *                              will use the filtered values instead. Default `array()`.
-		 * @param int          $pid     The post ID.
-		 * @param \Timber\Post $post    The post object.
+		 * @param array        $post_meta An array of custom meta values. Passing false or a non-empty
+		 *                                array will skip fetching the values from the database and
+		 *                                will use the filtered values instead. Default `array()`.
+		 * @param int          $pid       The post ID.
+		 * @param \Timber\Post $post      The post object.
 		 */
-		$customs = apply_filters( 'timber/post/pre_get_meta_values', $customs, $pid, $this );
+		$post_meta = apply_filters( 'timber/post/pre_get_meta_values', $post_meta, $pid, $this );
 
 		/**
 		 * Filters post meta data before it is fetched from the database.
@@ -594,21 +598,21 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 */
 		do_action_deprecated(
 			'timber_post_get_meta_pre',
-			array( $customs, $pid, $this ),
+			array( $post_meta, $pid, $this ),
 			'2.0.0',
 			'timber/post/pre_get_meta_values'
 		);
 
 		// Load all meta data when it wasn’t filtered before.
-		if ( false !== $customs && empty( $customs ) ) {
-			$customs = get_post_meta( $pid );
+		if ( false !== $post_meta && empty( $post_meta ) ) {
+			$post_meta = get_post_meta( $pid );
 		}
 
-		foreach ( $customs as $key => $value ) {
+		foreach ( $post_meta as $key => $value ) {
 			if ( is_array($value) && count($value) == 1 && isset($value[0]) ) {
 				$value = $value[0];
 			}
-			$customs[$key] = maybe_unserialize($value);
+			$post_meta[$key] = maybe_unserialize($value);
 		}
 
 		/**
@@ -617,29 +621,38 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		 * Timber loads all meta values into the post object on initialization. With this filter,
 		 * you can change meta values after they were fetched from the database.
 		 *
-		 * @todo Add example.
+		 * @example
+		 * ```php
+		 * add_filter('timber/post/get_meta_values', function($post_meta, $post_id, $post) {
+		 *     if ( $post_id == 12345 ) {
+		 *         // do something special
+		 *         $post_meta['foo'] = $post_meta['foo'].' bar';
+		 *     }
+		 *     return $post_meta;
+		 * });
+		 * ```
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array        $customs Post meta data.
-		 * @param int          $pid     The post ID.
-		 * @param \Timber\Post $post    The post object.
+		 * @param array        $post_meta Post meta data.
+		 * @param int          $pid       The post ID.
+		 * @param \Timber\Post $post      The post object.
 		 */
-		$customs = apply_filters( 'timber/post/get_meta_values', $customs, $pid, $this );
+		$post_meta = apply_filters( 'timber/post/get_meta_values', $post_meta, $pid, $this );
 
 		/**
 		 * Filters post meta data fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/post/get_meta_values`
 		 */
-		$customs = apply_filters_deprecated(
+		$post_meta = apply_filters_deprecated(
 			'timber_post_get_meta',
-			array( $customs, $pid, $this ),
+			array( $post_meta, $pid, $this ),
 			'2.0.0',
 			'timber/post/get_meta_values'
 		);
 
-		return $customs;
+		return $post_meta;
 	}
 
 	/**

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -569,20 +569,26 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		$customs = array();
 
 		/**
-		 * Fires before post meta data is imported into the object.
+		 * Filters post meta data before it is fetched from the database.
+		 *
+		 * Timber loads all meta values into the post object on initialization. With this filter,
+		 * you can disable fetching the meta values through the default method, which uses
+		 * `get_post_meta()`, by returning `false` or an non-empty array.
+		 *
+		 * @todo  Add example.
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array        $customs An array of custom meta values. Passing an non-empty array
-		 *                              will skip fetching the values from the database and will use
-		 *                              the filtered values instead.
+		 * @param array        $customs An array of custom meta values. Passing false or a non-empty
+		 *                              array will skip fetching the values from the database and
+		 *                              will use the filtered values instead. Default `array()`.
 		 * @param int          $pid     The post ID.
 		 * @param \Timber\Post $post    The post object.
 		 */
 		$customs = apply_filters( 'timber/post/pre_get_meta_values', $customs, $pid, $this );
 
 		/**
-		 * Fires before post meta data is imported into the object.
+		 * Filters post meta data before it is fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/post/pre_get_meta_values`
 		 */
@@ -593,8 +599,9 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 			'timber/post/pre_get_meta_values'
 		);
 
-		if ( !is_array($customs) || empty($customs) ) {
-			$customs = get_post_custom($pid);
+		// Load all meta data when it wasn’t filtered before.
+		if ( false !== $customs && empty( $customs ) ) {
+			$customs = get_post_meta( $pid );
 		}
 
 		foreach ( $customs as $key => $value ) {
@@ -605,11 +612,12 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		}
 
 		/**
-		 * Filters post meta data.
+		 * Filters post meta data fetched from the database.
 		 *
-		 * This filter is used by the ACF Integration.
+		 * Timber loads all meta values into the post object on initialization. With this filter,
+		 * you can change meta values after they were fetched from the database.
 		 *
-		 * @todo Add description, example
+		 * @todo Add example.
 		 *
 		 * @since 2.0.0
 		 *
@@ -620,7 +628,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		$customs = apply_filters( 'timber/post/get_meta_values', $customs, $pid, $this );
 
 		/**
-		 * Filters post meta data.
+		 * Filters post meta data fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/post/get_meta_values`
 		 */
@@ -947,7 +955,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		);
 
 		if ( null === $value ) {
-			$value = get_post_meta($this->ID, $field_name);
+			$value = get_post_meta( $this->ID, $field_name );
 			if ( is_array($value) && count($value) == 1 ) {
 				$value = $value[0];
 			}

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -148,8 +148,8 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	 * @param int $tid
 	 * @return array
 	 */
-	protected function get_meta_values( $tid ) {
-		$customs = array();
+	protected function get_meta_values( $term_id ) {
+		$term_meta = array();
 
 		/**
 		 * Filters term meta data before it is fetched from the database.
@@ -158,30 +158,35 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		 * you can disable fetching the meta values through the default method, which uses
 		 * `get_term_meta()`, by returning `false` or a non-empty array.
 		 *
-		 * @todo  Add example.
+		 * @example
+		 * ```php
+		 * add_filter( 'timber/term/pre_get_meta_values', function($term_meta, $term_id, $term) {
+		 *     return false;
+		 * }, 10, 3);
+		 * ```
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array        $customs An array of custom meta values. Passing `false` or a
+		 * @param array        $term_meta An array of custom meta values. Passing `false` or a
 		 *                              non-empty array will skip fetching the values from the
 		 *                              database and will use the filtered values instead. Default
 		 *                              `array()`.
 		 * @param int          $term_id The term ID.
 		 * @param \Timber\Term $term    The term object.
 		 */
-		$customs = apply_filters( 'timber/term/pre_get_meta_values', $customs, $tid, $this );
+		$term_meta = apply_filters( 'timber/term/pre_get_meta_values', $term_meta, $term_id, $this );
 
 		// Load all meta data when it wasn’t filtered before.
-		if ( false !== $customs && empty( $customs ) ) {
-			$customs = get_term_meta( $tid );
+		if ( false !== $term_meta && empty( $term_meta ) ) {
+			$term_meta = get_term_meta( $term_id );
 		}
 
-		foreach ( $customs as $key => $value ) {
+		foreach ( $term_meta as $key => $value ) {
 			if ( is_array( $value ) && 1 === count( $value ) && isset( $value[0] ) ) {
 				$value = $value[0];
 			}
 
-			$customs[ $key ] = maybe_unserialize( $value );
+			$term_meta[ $key ] = maybe_unserialize( $value );
 		}
 
 		/**
@@ -192,29 +197,38 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * This filter is used by the ACF Integration.
 		 *
-		 * @todo Add example
+		 * @example
+		 * ```php
+		 * add_filter('timber/term/get_meta_values', function($term_meta, $term_id, $term) {
+		 *     if ( $term_id == 123 ) {
+		 *         // do something special
+		 *         $term_meta['foo'] = $term_meta['foo'].' bar';
+		 *     }
+		 *     return $term_meta;
+		 * });
+		 * ```
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array        $customs Custom term meta data.
-		 * @param int          $term_id Term ID.
-		 * @param \Timber\Term $term    Term object.
+		 * @param array        $term_meta Custom term meta data.
+		 * @param int          $term_id   Term ID.
+		 * @param \Timber\Term $term      Term object.
 		 */
-		$customs = apply_filters('timber/term/get_meta_values', $customs, $tid, $this);
+		$term_meta = apply_filters('timber/term/get_meta_values', $term_meta, $term_id, $this);
 
 		/**
 		 * Filters term meta data fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/term/meta`
 		 */
-		$customs = apply_filters_deprecated(
+		$term_meta = apply_filters_deprecated(
 			'timber_term_get_meta',
-			array( $customs, $tid, $this ),
+			array( $term_meta, $term_id, $this ),
 			'2.0.0',
 			'timber/term/get_meta_values'
 		);
 
-		return $customs;
+		return $term_meta;
 	}
 
 	/**

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -152,7 +152,43 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		$customs = array();
 
 		/**
-		 * Filters term meta data.
+		 * Filters term meta data before it is fetched from the database.
+		 *
+		 * Timber loads all meta values into the term object on initialization. With this filter,
+		 * you can disable fetching the meta values through the default method, which uses
+		 * `get_term_meta()`, by returning `false` or a non-empty array.
+		 *
+		 * @todo  Add example.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array        $customs An array of custom meta values. Passing `false` or a
+		 *                              non-empty array will skip fetching the values from the
+		 *                              database and will use the filtered values instead. Default
+		 *                              `array()`.
+		 * @param int          $term_id The term ID.
+		 * @param \Timber\Term $term    The term object.
+		 */
+		$customs = apply_filters( 'timber/term/pre_get_meta_values', $customs, $tid, $this );
+
+		// Load all meta data when it wasn’t filtered before.
+		if ( false !== $customs && empty( $customs ) ) {
+			$customs = get_term_meta( $tid );
+		}
+
+		foreach ( $customs as $key => $value ) {
+			if ( is_array( $value ) && 1 === count( $value ) && isset( $value[0] ) ) {
+				$value = $value[0];
+			}
+
+			$customs[ $key ] = maybe_unserialize( $value );
+		}
+
+		/**
+		 * Filters term meta data fetched from the database.
+		 *
+		 * Timber loads all meta values into the term object on initialization. With this filter,
+		 * you can change meta values after they were fetched from the database.
 		 *
 		 * This filter is used by the ACF Integration.
 		 *
@@ -167,7 +203,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		$customs = apply_filters('timber/term/get_meta_values', $customs, $tid, $this);
 
 		/**
-		 * Filters term meta data.
+		 * Filters term meta data fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/term/meta`
 		 */

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -160,8 +160,17 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter( 'timber/term/pre_get_meta_values', function($term_meta, $term_id, $term) {
-		 *     return false;
+		 * // Disable fetching meta values.
+		 * add_filter( 'timber/term/pre_get_meta_values', '__return_false' );
+		 *
+		 * // Add your own meta data.
+		 * add_filter( 'timber/term/pre_get_meta_values', function( $term_meta, $term_id, $term ) {
+    	 *     $term_meta = array(
+		 *         'custom_data_1' => 73,
+		 *         'custom_data_2' => 274,
+		 *     );
+		 *
+		 *     return $term_meta;
 		 * }, 10, 3);
 		 * ```
 		 *
@@ -199,13 +208,14 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter('timber/term/get_meta_values', function($term_meta, $term_id, $term) {
-		 *     if ( $term_id == 123 ) {
-		 *         // do something special
-		 *         $term_meta['foo'] = $term_meta['foo'].' bar';
+		 * add_filter( 'timber/term/get_meta_values', function( $term_meta, $term_id, $term ) {
+		 *     if ( 123 === $term_id ) {
+		 *         // Do something special.
+		 *         $term_meta['foo'] = $term_meta['foo'] . ' bar';
 		 *     }
+		 *
 		 *     return $term_meta;
-		 * });
+		 * }, 10, 3 );
 		 * ```
 		 *
 		 * @since 2.0.0
@@ -214,7 +224,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		 * @param int          $term_id   Term ID.
 		 * @param \Timber\Term $term      Term object.
 		 */
-		$term_meta = apply_filters('timber/term/get_meta_values', $term_meta, $term_id, $this);
+		$term_meta = apply_filters( 'timber/term/get_meta_values', $term_meta, $term_id, $this );
 
 		/**
 		 * Filters term meta data fetched from the database.

--- a/lib/User.php
+++ b/lib/User.php
@@ -180,71 +180,86 @@ class User extends Core implements CoreInterface, MetaInterface {
 	 * @return array|null
 	 */
 	protected function get_meta_values() {
-		if ( $this->ID ) {
-			$um = array();
-
-			/**
-			 * Filters user meta data before it is fetched from the database.
-			 *
-			 * @since 2.0.0
-			 *
-			 * @param array        $user_meta User meta data. Passing a non-empty array will skip
-			 *                                fetching meta values from the database, returning the
-			 *                                filtered value instead. Default `array()`.
-			 * @param int          $user_id   The user ID.
-			 * @param \Timber\User $user      The user object.
-			 */
-			$um = apply_filters( 'timber/user/pre_get_meta_values', $um, $this->ID, $this );
-
-			/**
-			 * Filters user meta data before it is fetched from the database.
-			 *
-			 * @deprecated 2.0.0, use `timber/user/pre_get_meta_values`
-			 */
-			$um = apply_filters_deprecated(
-				'timber_user_get_meta_pre',
-				array( $um, $this->ID, $this ),
-				'2.0.0',
-				'timber/user/pre_get_meta_values'
-			);
-
-			if ( empty($um) ) {
-				$um = get_user_meta($this->ID);
-			}
-			$custom = array();
-			foreach ( $um as $key => $value ) {
-				if ( is_array($value) && count($value) === 1 ) {
-					$value = $value[0];
-				}
-				$custom[ $key ] = maybe_unserialize($value);
-			}
-
-			/**
-			 * Filters user meta data fetched from the database.
-			 *
-			 * @since 2.0.0
-			 *
-			 * @param array        $user_meta User meta data fetched from the database.
-			 * @param int          $user_id   The user ID.
-			 * @param \Timber\User $user      The user object.
-			 */
-			$custom = apply_filters( 'timber/user/get_meta_values', $custom, $this->ID, $this );
-
-			/**
-			 * Filters user meta data fetched from the database.
-			 *
-			 * @deprecated 2.0.0, use `timber/user/get_meta_values`
-			 */
-			$custom = apply_filters_deprecated(
-				'timber_user_get_meta',
-				array( $custom, $this->ID, $this ),
-				'2.0.0',
-				'timber/user/get_meta_values'
-			);
-
-			return $custom;
+		if ( ! $this->ID ) {
+			return null;
 		}
-		return null;
+
+		$um = array();
+
+		/**
+		 * Filters user meta data before it is fetched from the database.
+		 *
+		 * Timber loads all meta values into the user object on initialization. With this filter,
+		 * you can disable fetching the meta values through the default method, which uses
+		 * `get_user_meta()`, by returning `false` or a non-empty array.
+		 *
+		 * @todo Add example
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array        $user_meta An array of custom meta values. Passing `false` or a
+		 *                                non-empty array will skip fetching meta values from the
+		 *                                database, returning the filtered value instead. Default
+		 *                                `array()`.
+		 * @param int          $user_id   The user ID.
+		 * @param \Timber\User $user      The user object.
+		 */
+		$um = apply_filters( 'timber/user/pre_get_meta_values', $um, $this->ID, $this );
+
+		/**
+		 * Filters user meta data before it is fetched from the database.
+		 *
+		 * @deprecated 2.0.0, use `timber/user/pre_get_meta_values`
+		 */
+		$um = apply_filters_deprecated(
+			'timber_user_get_meta_pre',
+			array( $um, $this->ID, $this ),
+			'2.0.0',
+			'timber/user/pre_get_meta_values'
+		);
+
+		// Load all meta data when it wasn’t filtered before.
+		if ( false !== $um && empty( $um ) ) {
+			$um = get_user_meta($this->ID);
+		}
+
+		$custom = array();
+		foreach ( $um as $key => $value ) {
+			if ( is_array($value) && count($value) === 1 ) {
+				$value = $value[0];
+			}
+			$custom[ $key ] = maybe_unserialize($value);
+		}
+
+		/**
+		 * Filters user meta data fetched from the database.
+		 *
+		 * Timber loads all meta values into the user object on initialization. With this filter,
+		 * you can change meta values after they were fetched from the database.
+		 *
+		 * @todo Add example
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param array        $user_meta User meta data fetched from the database.
+		 * @param int          $user_id   The user ID.
+		 * @param \Timber\User $user      The user object.
+		 */
+		$custom = apply_filters( 'timber/user/get_meta_values', $custom, $this->ID, $this );
+
+		/**
+		 * Filters user meta data fetched from the database.
+		 *
+		 * @deprecated 2.0.0, use `timber/user/get_meta_values`
+		 */
+		$custom = apply_filters_deprecated(
+			'timber_user_get_meta',
+			array( $custom, $this->ID, $this ),
+			'2.0.0',
+			'timber/user/get_meta_values'
+		);
+
+		return $custom;
 	}
 
 	/**

--- a/lib/User.php
+++ b/lib/User.php
@@ -195,10 +195,20 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter('timber/user/pre_get_meta_values', function($user_meta, $user_id, $user){
-    	 *     return false;
-		 * }, 10, 3);
+		 * // Disable fetching meta values.
+		 * add_filter( 'timber/user/pre_get_meta_values', '__return_false' );
+		 *
+		 * // Add your own meta values.
+		 * add_filter( 'timber/user/pre_get_meta_values', function( $user_meta, $user_id, $user ) {
+		 *     $user_meta = array(
+		 *         'custom_data_1' => 73,
+		 *         'custom_data_2' => 274,
+		 *     );
+		 *
+		 *     return $user_meta;
+		 * }, 10, 3 );
 		 * ```
+		 *
 		 * @since 2.0.0
 		 *
 		 * @param array        $user_meta An array of custom meta values. Passing `false` or a
@@ -243,13 +253,14 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 *
 		 * @example
 		 * ```php
-		 * add_filter('timber/user/get_meta_values', function($user_meta, $user_id, $user) {
-		 *     if ( $user_id == 123 ) {
-		 *         // do something special
-		 *         $user_meta['foo'] = $user_meta['foo'].' bar';
+		 * add_filter( 'timber/user/get_meta_values', function( $user_meta, $user_id, $user ) {
+		 *     if ( 123 === $user_id ) {
+		 *         // Do something special.
+		 *         $user_meta['foo'] = $user_meta['foo'] . ' bar';
 		 *     }
+		 *
 		 *     return $user_meta;
-		 * });
+		 * }, 10, 3 );
 		 * ```
 		 *
 		 * @since 2.0.0

--- a/lib/User.php
+++ b/lib/User.php
@@ -193,8 +193,12 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * you can disable fetching the meta values through the default method, which uses
 		 * `get_user_meta()`, by returning `false` or a non-empty array.
 		 *
-		 * @todo Add example
-		 *
+		 * @example
+		 * ```php
+		 * add_filter('timber/user/pre_get_meta_values', function($user_meta, $user_id, $user){
+    	 *     return false;
+		 * }, 10, 3);
+		 * ```
 		 * @since 2.0.0
 		 *
 		 * @param array        $user_meta An array of custom meta values. Passing `false` or a
@@ -223,12 +227,12 @@ class User extends Core implements CoreInterface, MetaInterface {
 			$um = get_user_meta($this->ID);
 		}
 
-		$custom = array();
+		$user_meta = array();
 		foreach ( $um as $key => $value ) {
 			if ( is_array($value) && count($value) === 1 ) {
 				$value = $value[0];
 			}
-			$custom[ $key ] = maybe_unserialize($value);
+			$user_meta[ $key ] = maybe_unserialize($value);
 		}
 
 		/**
@@ -237,7 +241,16 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * Timber loads all meta values into the user object on initialization. With this filter,
 		 * you can change meta values after they were fetched from the database.
 		 *
-		 * @todo Add example
+		 * @example
+		 * ```php
+		 * add_filter('timber/user/get_meta_values', function($user_meta, $user_id, $user) {
+		 *     if ( $user_id == 123 ) {
+		 *         // do something special
+		 *         $user_meta['foo'] = $user_meta['foo'].' bar';
+		 *     }
+		 *     return $user_meta;
+		 * });
+		 * ```
 		 *
 		 * @since 2.0.0
 		 *
@@ -245,21 +258,21 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * @param int          $user_id   The user ID.
 		 * @param \Timber\User $user      The user object.
 		 */
-		$custom = apply_filters( 'timber/user/get_meta_values', $custom, $this->ID, $this );
+		$user_meta = apply_filters( 'timber/user/get_meta_values', $user_meta, $this->ID, $this );
 
 		/**
 		 * Filters user meta data fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/user/get_meta_values`
 		 */
-		$custom = apply_filters_deprecated(
+		$user_meta = apply_filters_deprecated(
 			'timber_user_get_meta',
-			array( $custom, $this->ID, $this ),
+			array( $user_meta, $this->ID, $this ),
 			'2.0.0',
 			'timber/user/get_meta_values'
 		);
 
-		return $custom;
+		return $user_meta;
 	}
 
 	/**


### PR DESCRIPTION
## Issue

- The `Term` class is still missing a `timber/term/pre_get_meta_values` filter.
- Preventing the automatic fetching of all meta values only works by passing a non-empty array. If a developer wanted to disable fetching meta values, they’d have to invent an array item, like `array( 'something' )`. That’s not very intuitive.
- Some issues in DocBlocks.

## Solution

### Documentation

I improved the DocBlocks for the filters and added some more descriptions.

### get_post_meta() instead of get_post_custom()

I changed the method for fetching all meta data for posts from `get_post_custom()` to `get_post_meta()`. The difference is that `get_post_custom()` will fetch the post ID of the current post if not provided, while `get_post_meta()` requires a post ID to be present. In the context of a `Timber\Post` object, we always require a post ID, so it’s safe to use `get_post_meta()`. This is in line with the methods that the other classes use: `get_term_meta()`, `get_user_meta()` and `get_comment_meta()`.

### Update to pre-filtering logic

I streamlined the logic for pre-filtering so that when the `timber/{object_type}/pre_get_meta_values` is used, it will **skip fetching the meta values from the database** when the filter:

- returns `false`
- or returns a non-empty array

Prior to this pull request, it was only possible to skip pre-fetching via a non-empty array. So you’d have to invent an array item like `array( 'something' )` to disable pre-fetching.

Now, if developers want to completely disable fetching meta values on object initialization, they can return `false` in this filter:

```php
add_filter( 'timber/post/pre_get_meta_values', '__return_false' );
```

Or they can still return an array that already provides meta values.

## Impact

For the pre-filtering logic, until now, passing in a non-array value would trigger fetching the meta values. Now, passing an empty value that is not `false` will trigger fetching the meta values.

## Usage Changes

- See **Impact**.
- New filter `timber/term/pre_get_meta_values` becomes available.

Also see updates to Update Guide for 2.0.

## Considerations

Currently, there are four different filters:

- `timber/post/pre_get_meta_values`
- `timber/term/pre_get_meta_values`
- `timber/user/pre_get_meta_values`
- `timber/comment/pre_get_meta_values`

We could also write this with the same filter for each class, passing in the object type as an argument instead of passing it in the filter name:

```php
$meta_values = apply_filters( 'timber/pre_get_meta_values', $meta_values, 'post', $post_id, $this );
$meta_values = apply_filters( 'timber/pre_get_meta_values', $meta_values, 'term', $term_id, $this );
$meta_values = apply_filters( 'timber/pre_get_meta_values', $meta_values, 'user', $user_id, $this );
$meta_values = apply_filters( 'timber/pre_get_meta_values', $meta_values, 'comment', $comment_id, $this );
```

This way, one could disable prefetching meta values for all classes:

```php
add_filter( 'timber/pre_get_meta_values', '__return_false' );
```

But then again, this would be a slightly different approach to all the other meta filters, which wouldn’t be consistent either.

## Testing

I ran tests with coverage. All seems good, coverage shouldn’t change. But as far as I see it, not all meta filters are covered with tests. Some tests exist for the deprecated filters after fetching values from the database. I guess this should be handled in a separate issue/pull request.