### PR TITLE
Jan 26/scrutinizer fixes

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -150,7 +150,7 @@ class Helper {
 	 * @param string $slug
 	 */
 	public static function _unlock_transient( $slug ) {
-		delete_transient($slug.'_lock', true);
+		delete_transient($slug.'_lock');
 	}
 
 	/**
@@ -434,7 +434,6 @@ class Helper {
 			return false;
 		}
 		throw new \InvalidArgumentException('$array is not an array, got:');
-		Helper::error_log($array);
 	}
 
 	/**
@@ -551,8 +550,8 @@ class Helper {
 	 *
 	 * If no match is found the function will return the inital argument.
 	 *
-	 * @param mix $obj WP Object
-	 * @return mix Instance of equivalent Timber object, or the argument if no match is found
+	 * @param mixed $obj WP Object
+	 * @return mixed Instance of equivalent Timber object, or the argument if no match is found
 	 */
 	public static function convert_wp_object( $obj ) {
 		if ( $obj instanceof \WP_Post ) {

--- a/lib/Integrations/CoAuthorsPlus.php
+++ b/lib/Integrations/CoAuthorsPlus.php
@@ -17,7 +17,7 @@ class CoAuthorsPlus {
 	 * Filters {{ post.authors }} to return authors stored from Co-Authors Plus
 	 * @since 1.1.4
 	 * @param array $author
-	 * @param Post $post
+	 * @param \Timber\Post $post
 	 * @return array of User objects
 	 */
 	public function authors( $author, $post ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1590,7 +1590,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 
 	/**
 	 * @api
-	 * @param bool $in_same_term
+	 * @param bool|string $in_same_term
 	 * @return mixed
 	 */
 	public function next( $in_same_term = false ) {
@@ -1599,7 +1599,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 			$this->_next = array();
 			$old_global = $post;
 			$post = $this;
-			if ( $in_same_term ) {
+			if ( is_string($in_same_term) && strlen($in_same_term) ) {
 				$adjacent = get_adjacent_post(true, '', false, $in_same_term);
 			} else {
 				$adjacent = get_adjacent_post(false, '', false);
@@ -1717,7 +1717,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * <h3>{{post.prev.title}}</h3>
 	 * <p>{{post.prev.preview(25)}}</p>
 	 * ```
-	 * @param bool $in_same_term
+	 * @param string|boolean $in_same_term
 	 * @return mixed
 	 */
 	public function prev( $in_same_term = false ) {
@@ -1756,7 +1756,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * ```twig
 	 * <img src="{{ post.thumbnail.src }}" />
 	 * ```
-	 * @return Timber\Image|null of your thumbnail
+	 * @return \Timber\Image|null of your thumbnail
 	 */
 	public function thumbnail() {
 		$tid = get_post_thumbnail_id($this->ID);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -96,7 +96,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	protected $_content;
 
 	/**
-	 * @var string The returned permalink from WP's get_permalink function
+	 * @var string|boolean The returned permalink from WP's get_permalink function
 	 */
 	protected $_permalink;
 
@@ -561,7 +561,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * and attach them to our Timber\Post object
 	 * @internal
 	 *
-	 * @param int $post_id
+	 * @param int|boolean $post_id
 	 *
 	 * @return array
 	 */
@@ -683,7 +683,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 *
 	 * @internal
 	 * @param  int|null $pid The ID to generate info from.
-	 * @return null|object|WP_Post
+	 * @return null|object|WP_Post|boolean
 	 */
 	protected function get_info( $pid = null ) {
 		$post = $this->prepare_post_info($pid);
@@ -711,7 +711,8 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * Gets the comment form for use on a single article page
 	 *
 	 * @api
-	 * @param array This $args array thing is a mess, [fix at some point](http://codex.wordpress.org/Function_Reference/comment_form)
+	 * @param array $args see [WordPress docs on comment_form](http://codex.wordpress.org/Function_Reference/comment_form)
+	 *                    for reference on acceptable parameters
 	 * @return string of HTML for the form
 	 */
 	public function comment_form( $args = array() ) {
@@ -1094,10 +1095,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 		if ( $this->is_previewing() ) {
 			$class_array = get_post_class($class, $this->post_parent);
 		}
-
-		if ( is_array($class_array) ) {
-			$class_array = implode(' ', $class_array);
-		}
+		$class_array = implode(' ', $class_array);
 
         $post = $old_global_post;
 		return $class_array;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -452,7 +452,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * @param integer $pid number to check against.
 	 * @return integer ID number of a post
 	 */
-	protected function check_post_id( $pid ) {
+	protected static function check_post_id( $pid ) {
 		if ( is_numeric($pid) && 0 === $pid ) {
 			$pid = get_the_ID();
 			return $pid;
@@ -682,7 +682,7 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	 * Used internally by init, etc. to build Timber\Post object.
 	 *
 	 * @internal
-	 * @param  int|null $pid The ID to generate info from.
+	 * @param  int|null|boolean $pid The ID to generate info from.
 	 * @return null|object|WP_Post|boolean
 	 */
 	protected function get_info( $pid = null ) {

--- a/lib/TermGetter.php
+++ b/lib/TermGetter.php
@@ -10,9 +10,9 @@ use Timber\Helper;
  */
 class TermGetter {
 	/**
-	 * @param int|WP_Term|object $term
+	 * @param int|\WP_Term|object $term
 	 * @param string $taxonomy
-	 * @return Timber\Term|WP_Error|null
+	 * @return \Timber\Term|\WP_Error|null
 	 */
 	public static function get_term( $term, $taxonomy, $TermClass = '\Timber\Term' ) {
 		$term = get_term($term, $taxonomy);

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -198,8 +198,8 @@ class Twig {
 	/**
 	 *
 	 *
-	 * @param Twig_Environment $twig
-	 * @return Twig_Environment
+	 * @param \Twig_Environment $twig
+	 * @return \Twig_Environment
 	 */
 	public function add_timber_filters( $twig ) {
 		/* image filters */
@@ -370,8 +370,8 @@ class Twig {
 	/**
 	 *
 	 *
-	 * @param string  $date
-	 * @param string  $format (optional)
+	 * @param string|\DateTime  $date
+	 * @param string            $format (optional)
 	 * @return string
 	 */
 	public function intl_date( $date, $format = null ) {

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -77,32 +77,35 @@ class Twig {
 		/**
 		 * Deprecated Timber object functions.
 		 */
-
 		$twig->addFunction( new Twig_Function(
 			'TimberPost',
-			function( $pid, $PostClass = 'Timber\Post' ) {
+			function( $post_id, $PostClass = 'Timber\Post' ) {
 				Helper::deprecated( '{{ TimberPost() }}', '{{ Post() }}', '2.0.0' );
+				return self::maybe_convert_array( $post_id, $PostClass );
 			}
 		) );
 
 		$twig->addFunction( new Twig_Function(
 			'TimberImage',
-			function( $pid = false, $ImageClass = 'Timber\Image' ) {
+			function( $post_id = false, $ImageClass = 'Timber\Image' ) {
 				Helper::deprecated( '{{ TimberImage() }}', '{{ Image() }}', '2.0.0' );
+				return self::maybe_convert_array( $post_id, $ImageClass );
 			}
 		) );
 
 		$twig->addFunction( new Twig_Function(
 			'TimberTerm',
-			function( $tid, $taxonomy = '', $TermClass = 'Timber\Term' ) {
+			function( $term_id, $taxonomy = '', $TermClass = 'Timber\Term' ) {
 				Helper::deprecated( '{{ TimberTerm() }}', '{{ Term() }}', '2.0.0' );
+				return self::handle_term_object($term_id, $taxonomy, $TermClass);
 			}
 		) );
 
 		$twig->addFunction( new Twig_Function(
 			'TimberUser',
-			function( $pid, $UserClass = 'Timber\User' ) {
+			function( $user_id, $UserClass = 'Timber\User' ) {
 				Helper::deprecated( '{{ TimberUser() }}', '{{ User() }}', '2.0.0' );
+				return self::maybe_convert_array($user_id, $UserClass);
 			}
 		) );
 
@@ -155,7 +158,7 @@ class Twig {
 	 * @param string        $TermClass the class to use for processing the term
 	 * @return Term|array
 	 */
-	function handle_term_object( $term_id, $taxonomy = '', $TermClass = 'Timber\Term' ) {
+	static function handle_term_object( $term_id, $taxonomy = '', $TermClass = 'Timber\Term' ) {
 		if ( $taxonomy != $TermClass ) {
 			// user has sent any additonal parameters, process
 			$processed_args = self::process_term_args($taxonomy, $TermClass);

--- a/lib/User.php
+++ b/lib/User.php
@@ -105,7 +105,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 	protected $roles;
 
 	/**
-	 * @param object|int|bool $uid
+	 * @param object|int|bool|string $uid
 	 */
 	public function __construct( $uid = false ) {
 		$this->init($uid);

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -51,6 +51,13 @@ class TestTimberSite extends Timber_UnitTestCase {
 		$this->assertContains('cardinals.jpg', $icon->src());
 	}
 
+
+	function testNullIcon() {
+		delete_option('site_icon');
+		$site = new Timber\Site();
+		$this->assertNull($site->icon());
+	}
+
 	function testSiteGet() {
 		update_option( 'foo', 'bar' );
 		$site = new Timber\Site();

--- a/tests/test-timber-twig-objects.php
+++ b/tests/test-timber-twig-objects.php
@@ -11,7 +11,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 		$iid = TestTimberImage::get_attachment();
 		$str = '{{ TimberImage('.$iid.').src }}';
 		$compiled = Timber::compile_string($str);
-		$this->assertEmpty($compiled);
+		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpg', $compiled);
 	}
 
 	function testImageInTwig() {
@@ -39,7 +39,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 		$images[] = TestTimberImage::get_attachment( 0, 'city-museum.jpg' );
 		$str = '{% for image in TimberImage(images) %}{{image.src}}{% endfor %}';
 		$compiled = Timber::compile_string($str, array('images' => $images));
-		$this->assertEmpty($compiled);
+		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/arch.jpghttp://example.org/wp-content/uploads/'.date('Y').'/'.date('m').'/city-museum.jpg', $compiled);
 	}
 
 	function testTimberImageInTwigToString() {
@@ -55,7 +55,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 	function testTimberPostInTwig(){
 		$pid = $this->factory->post->create(array('post_title' => 'Foo'));
 		$str = '{{ TimberPost('.$pid.').title }}';
-		$this->assertEmpty(Timber::compile_string($str));
+		$this->assertEquals('Foo', Timber::compile_string($str));
 	}
 
 	function testPostInTwig(){
@@ -71,7 +71,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 		$pids[] = $this->factory->post->create(array('post_title' => 'Foo'));
 		$pids[] = $this->factory->post->create(array('post_title' => 'Bar'));
 		$str = '{% for post in TimberPost(pids) %}{{post.title}}{% endfor %}';
-		$this->assertEmpty(Timber::compile_string($str, array('pids' => $pids)));
+		$this->assertEquals('FooBar', Timber::compile_string($str, array('pids' => $pids)));
 	}
 
 	function testPostsInTwig(){
@@ -102,8 +102,9 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 	 */
 	function testTimberUserInTwig(){
 		$uid = $this->factory->user->create(array('display_name' => 'Pete Karl'));
-		$str = '{{ TimberUser('.$uid.').name }}';
-		$this->assertEmpty(Timber::compile_string($str));
+		$template = '{{ TimberUser('.$uid.').name }}';
+		$str = Timber::compile_string($template);
+		$this->assertEquals('Pete Karl', $str);
 	}
 
 	function testUsersInTwig(){
@@ -126,7 +127,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 		$uids[] = $this->factory->user->create(array('display_name' => 'Estelle Getty'));
 		$uids[] = $this->factory->user->create(array('display_name' => 'Bea Arthur'));
 		$str = '{% for user in TimberUser(uids) %}{{user.name}} {% endfor %}';
-		$this->assertEmpty(trim(Timber::compile_string($str, array('uids' => $uids))));
+		$this->assertEquals('Estelle Getty Bea Arthur', trim(Timber::compile_string($str, array('uids' => $uids))));
 	}
 
 	/**
@@ -135,7 +136,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 	function testTimberTermInTwig(){
 		$tid = $this->factory->term->create(array('name' => 'Golden Girls'));
 		$str = '{{ TimberTerm(tid).title }}';
-		$this->assertEmpty(Timber::compile_string($str, array('tid' => $tid)));
+		$this->assertEquals('Golden Girls', Timber::compile_string($str, array('tid' => $tid)));
 	}
 
 	function testTermInTwig(){
@@ -151,7 +152,7 @@ class TestTimberTwigObjects extends Timber_UnitTestCase {
 		$tids[] = $this->factory->term->create(array('name' => 'Foods'));
 		$tids[] = $this->factory->term->create(array('name' => 'Cars'));
 		$str = '{% for term in TimberTerm(tids) %}{{term.title}} {% endfor %}';
-		$this->assertEmpty(Timber::compile_string($str, array('tids' => $tids)));
+		$this->assertEquals('Foods Cars ', Timber::compile_string($str, array('tids' => $tids)));
 	}
 
 	function testTermsInTwig(){


### PR DESCRIPTION
#### Issue
Scrutinizer flagged a number of documentation and commenting issues in the current 2.x branch. This resolves a number of them. 

Most significantly though, I discovered that in deprecating a bunch of Twig functions in `lib/Twig.php` functionality was removed. In 2.0 Twig code like:
```twig
{{ TimberPost(maybe_post).title }}
```

should now be written as:
```twig
{{ Post(maybe_post).title }}
```

However, these methods (`TimberPost`, `TimberTerm`, etc.) had not been properly deprecated until now. Thus, I think we should send the deprecation notice (which 2.x currently does) though still maintain present 1.x functionality (for now)

#### Solution
Restore functionality for these deprecated methods and update tests accordingly

#### Usage Changes
None

#### Considerations
We should totally kill these functions in 3.x now that they've been properly deprecated

#### Testing
Tests are updated
