### PR TITLE
Add possibility to disable cropping in resize function #1332

### DIFF
--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -106,7 +106,8 @@ class Resize extends ImageOperation {
 			return array(
 				'x' => 0, 'y' => 0,
 				'src_w' => $src_w, 'src_h' => $src_h,
-				'target_w' => $w, 'target_h' => $h
+				'target_w' => $w, 'target_h' => $h,
+				'crop' => false
 			);
 		}
 		// Get ratios
@@ -188,13 +189,17 @@ class Resize extends ImageOperation {
 			}
 
 			$crop = self::get_target_sizes($image);
-			$image->crop( 	$crop['x'],
-							$crop['y'],
-							$crop['src_w'],
-							$crop['src_h'],
-							$crop['target_w'],
-							$crop['target_h']
-			);
+			if (!isset($crop['crop']) || $crop['crop'] !== false) {
+				$image->crop( 	$crop['x'],
+								$crop['y'],
+								$crop['src_w'],
+								$crop['src_h'],
+								$crop['target_w'],
+								$crop['target_h']
+				);
+			else {
+				$image->resize($crop['target_w'], $crop['target_h']);
+			}
 			$quality = apply_filters( 'wp_editor_set_quality', 82, 'image/jpeg');
 			$image->set_quality($quality);
 			$result = $image->save($save_filename);


### PR DESCRIPTION
#### Issue
https://github.com/timber/timber/issues/280
https://github.com/timber/timber/issues/1332

#### Solution
Allow passing `false` as third argument of the resize function. With this the image will be resized to fit in the specified dimension while preserving the original aspect ratio and without cropping.

#### Impact
Adds less than 5 lines of code : )

#### Usage Changes
The 3rd parameter to the resize can be set `false` to disable cropping.

    <img src="{{ product.thumbnail|resize(1000,500,false) }}" />

#### Considerations
The current code had a condition `if (!$crop)` where I add the crop attributes (Line 110). Not sure if it was really used since it was not a documented option. But it was probably there for a reason I can't imagine.