### PR TITLE
Removed Lisa Templates from twig-tools.md

### DIFF
--- a/docs/getting-started/twig-tools.md
+++ b/docs/getting-started/twig-tools.md
@@ -15,10 +15,6 @@ The purpose of this page is to identify helpful tools for working with Twig.
 * PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](http://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
 * Atom – Syntax highlighting with the [Atom Component](https://atom.io/packages/php-twig).
 
-## WordPress tools
-
-* [Lisa Templates](https://wordpress.org/plugins/lisa-templates/) – allows you to write Twig-templates in the WordPress admin that renders through a shortcode or widget.
-
 ## Other	
  * [Watson-Ruby](http://nhmood.github.io/watson-ruby/) – An inline issue manager. Put tags like `[todo]` in a Twig comment and find it easily later. Watson supports Twig as of version 1.6.3.
 


### PR DESCRIPTION
Removed Lisa Templates as: 
"This plugin was closed on November 7, 2018 and is no longer available for download. Reason: Author Request."

First off, hello! Thanks for submitting a PR. We love/welcome PRs (especially if it's your first). Have any questions? Read [this section in CONTRIBUTING.md](https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests) 


#### Issue
Lisa Templates link in docs goes to dead link on wordpress: 
"This plugin was closed on November 7, 2018 and is no longer available for download. Reason: Author Request."

#### Solution
removed link and section header (as would be redundant).

#### Impact
minimal.

#### Usage Changes
mild docs change.

#### Testing
n/a
