### PR TITLE
1921/deprecate update methods

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -86,14 +86,16 @@ abstract class Core {
 		}
 	}
 
-
 	/**
-	 * @deprecated 2.0.0 use `\update_metadata` instead.
-	 * @param string  $key
-	 * @param mixed   $value
+	 * Updates metadata for the object.
+	 *
+	 * @deprecated 2.0.0 Use `update_metadata()` instead.
+	 *
+	 * @param string $key   The key of the meta field to update.
+	 * @param mixed  $value The new value.
 	 */
 	public function update( $key, $value ) {
-		Helper::deprecated('Timber\Core::update', "update_metadata", '2.0.0');
+		Helper::deprecated( 'Timber\Core::update()', 'update_metadata()', '2.0.0' );
 		update_metadata($this->object_type, $this->ID, $key, $value);
 	}
 

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -88,11 +88,12 @@ abstract class Core {
 
 
 	/**
-	 * @deprecated since 2.0.0
+	 * @deprecated 2.0.0 with no replacement
 	 * @param string  $key
 	 * @param mixed   $value
 	 */
 	public function update( $key, $value ) {
+		Helper::deprecated('Timber\Core::update', "update_metadata", '2.0.0');
 		update_metadata($this->object_type, $this->ID, $key, $value);
 	}
 

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -88,7 +88,7 @@ abstract class Core {
 
 
 	/**
-	 * @deprecated 2.0.0 with no replacement
+	 * @deprecated 2.0.0 use `\update_metadata` instead.
 	 * @param string  $key
 	 * @param mixed   $value
 	 */

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -274,12 +274,12 @@ class Helper {
 	}
 
 	/**
-	 * Trigger a deprecation warning.
+	 * Triggers a deprecation warning.
 	 *
 	 * @api
-	 * @param string $function the name of the current function/method.
-	 * @param string $replacement function to use instead.
-	 * @param string $version when we deprecated this.
+	 * @param string $function    The name of the deprecated function/method.
+	 * @param string $replacement Function to use instead.
+	 * @param string $version     When we deprecated this.
 	 * @return void
 	 */
 	public static function deprecated( $function, $replacement, $version ) {

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -277,9 +277,9 @@ class Helper {
 	 * Trigger a deprecation warning.
 	 *
 	 * @api
-	 * @param string 	$function the name of the current function/method
-	 * @param string 	$replacement function to use instead
-	 * @param string 	$version when we deprecated this
+	 * @param string $function the name of the current function/method.
+	 * @param string $replacement function to use instead.
+	 * @param string $version when we deprecated this.
 	 * @return void
 	 */
 	public static function deprecated( $function, $replacement, $version ) {

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -277,7 +277,9 @@ class Helper {
 	 * Trigger a deprecation warning.
 	 *
 	 * @api
-	 *
+	 * @param string 	$function the name of the current function/method
+	 * @param string 	$replacement function to use instead
+	 * @param string 	$version when we deprecated this
 	 * @return void
 	 */
 	public static function deprecated( $function, $replacement, $version ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -413,13 +413,16 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	}
 
 	/**
-	 * updates the post_meta of the current object with the given value
-	 * @deprecated 2.0.0 use `\update_post_meta` instead.
-	 * @param string $field
-	 * @param mixed  $value
+	 * Updates post_meta of the current object with the given value.
+	 *
+	 * @deprecated 2.0.0 Use `update_post_meta()` instead.
+	 *
+	 * @param string $field The key of the meta field to update.
+	 * @param mixed  $value The new value.
 	 */
 	public function update( $field, $value ) {
-		Helper::deprecated('Timber\Post::update', 'update_post_meta', '2.0.0');
+		Helper::deprecated( 'Timber\Post::update()', 'update_post_meta()', '2.0.0' );
+
 		if ( isset($this->ID) ) {
 			update_post_meta($this->ID, $field, $value);
 			$this->$field = $value;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -414,10 +414,12 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 
 	/**
 	 * updates the post_meta of the current object with the given value
+	 * @deprecated 2.0.0 with no replacement
 	 * @param string $field
 	 * @param mixed $value
 	 */
 	public function update( $field, $value ) {
+		Helper::deprecated('Timber\Post::update', 'update_post_meta', '2.0.0');
 		if ( isset($this->ID) ) {
 			update_post_meta($this->ID, $field, $value);
 			$this->$field = $value;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -414,9 +414,9 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 
 	/**
 	 * updates the post_meta of the current object with the given value
-	 * @deprecated 2.0.0 with no replacement
+	 * @deprecated 2.0.0 use `\update_post_meta` instead.
 	 * @param string $field
-	 * @param mixed $value
+	 * @param mixed  $value
 	 */
 	public function update( $field, $value ) {
 		Helper::deprecated('Timber\Post::update', 'update_post_meta', '2.0.0');

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -330,12 +330,16 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @deprecated 2.0.0 use `\update_option` or `\update_blog_option` instead.
-	 * @param string  $key
-	 * @param mixed   $value
+	 * Updates a site option.
+	 *
+	 * @deprecated 2.0.0 Use `update_option()` or `update_blog_option()` instead.
+	 *
+	 * @param string $key   The key of the site option to update.
+	 * @param mixed  $value The new value.
 	 */
 	public function update( $key, $value ) {
-		Helper::deprecated('Timber\Site::update', 'update_option', '2.0.0');
+		Helper::deprecated( 'Timber\Site::update()', 'update_option()', '2.0.0' );
+
 		/**
 		 * Filters a value before it is updated in the site options.
 		 *

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -330,7 +330,7 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 * @deprecated 2.0.0 with no replacement
+	 * @deprecated 2.0.0 use `\update_option` or `\update_blog_option` instead.
 	 * @param string  $key
 	 * @param mixed   $value
 	 */

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -330,12 +330,12 @@ class Site extends Core implements CoreInterface {
 	}
 
 	/**
-	 *
-	 * @internal
+	 * @deprecated 2.0.0 with no replacement
 	 * @param string  $key
 	 * @param mixed   $value
 	 */
 	public function update( $key, $value ) {
+		Helper::deprecated('Timber\Site::update', 'update_option', '2.0.0');
 		/**
 		 * Filters a value before it is updated in the site options.
 		 *

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -672,13 +672,16 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	}
 
 	/**
-	 * @deprecated 2.0.0 use `\update_term_meta` instead.
+	 * Updates term_meta of the current object with the given value.
 	 *
-	 * @param string  $key
-	 * @param mixed   $value
+	 * @deprecated 2.0.0 Use `update_term_meta()` instead.
+	 *
+	 * @param string $key   The key of the meta field to update.
+	 * @param mixed  $value The new value.
 	 */
 	public function update( $key, $value ) {
-		Helper::deprecated('Timber\Term::update', 'update_term_meta', '2.0.0');
+		Helper::deprecated( 'Timber\Term::update()', 'update_term_meta()', '2.0.0' );
+
 		/**
 		 * Filters term meta value that is going to be updated.
 		 *

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -29,11 +29,11 @@ use Timber\URLHelper;
  * Timber::render('index.twig', $context);
  * ```
  * ```twig
- * <h2>{{term_page.name}} Archives</h2>
+ * <h2>{{ term_page.name }} Archives</h2>
  * <h3>Teams</h3>
  * <ul>
- *     <li>{{st_louis.name}} - {{st_louis.description}}</li>
- *     <li>{{team.name}} - {{team.description}}</li>
+ *     <li>{{ st_louis.name}} - {{ st_louis.description }}</li>
+ *     <li>{{ team.name}} - {{ team.description }}</li>
  * </ul>
  * ```
  * ```html
@@ -41,7 +41,7 @@ use Timber\URLHelper;
  * <h3>Teams</h3>
  * <ul>
  *     <li>St. Louis Cardinals - Winner of 11 World Series</li>
- *     <li>New England Patriots - Winner of 4 Super Bowls</li>
+ *     <li>New England Patriots - Winner of 6 Super Bowls</li>
  * </ul>
  * ```
  */
@@ -672,7 +672,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	}
 
 	/**
-	 * @deprecated 2.0.0 with no replacement
+	 * @deprecated 2.0.0 use `\update_term_meta` instead.
 	 *
 	 * @param string  $key
 	 * @param mixed   $value

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -672,13 +672,13 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	}
 
 	/**
-	 * @api
 	 * @deprecated 2.0.0 with no replacement
 	 *
 	 * @param string  $key
 	 * @param mixed   $value
 	 */
 	public function update( $key, $value ) {
+		Helper::deprecated('Timber\Term::update', 'update_term_meta', '2.0.0');
 		/**
 		 * Filters term meta value that is going to be updated.
 		 *

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -22,7 +22,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 		$comment = new Timber\Comment( $comment_id );
-		$comment->update( 'ghost', 'busters' );
+		update_metadata('comment', $comment_id, 'ghost', 'busters');
 		add_filter( 'timber/comment/meta', array( $this, 'filter_timber_comment_get_meta_field' ), 10, 4 );
 		$this->assertEquals( $comment->meta( 'ghost' ), 'busters' );
 		remove_filter( 'timber/comment/meta', array( $this, 'filter_timber_comment_get_meta_field' ) );
@@ -38,7 +38,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 	function testUserMetaFilter() {
 		$uid = $this->factory->user->create();
 		$user = new Timber\User( $uid );
-		$user->update( 'jared', 'novack' );
+		update_metadata('user', $uid, 'jared', 'novack');
 		add_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ), 10, 5 );
 		$this->assertEquals( $user->meta( 'jared' ), 'novack' );
 		remove_filter( 'timber/user/meta', array( $this, 'filter_timber_user_get_meta_field' ) );

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -242,15 +242,6 @@
 			$this->assertEquals($post2->id, $post_id);
 		}
 
-		function testUpdate(){
-			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
-			$rand = rand_str();
-			$post->update('test_meta', $rand);
-			$post = new Timber\Post($post_id);
-			$this->assertEquals($rand, $post->test_meta);
-		}
-
 		function testCanEdit(){
 			wp_set_current_user(1);
 			$post_id = $this->factory->post->create(array('post_author' => 1));
@@ -258,8 +249,6 @@
 			$this->assertTrue($post->can_edit());
 			wp_set_current_user(0);
 		}
-
-
 
 		function testTitle(){
 			$title = 'Fifteen Million Merits';

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -46,9 +46,9 @@ class TestTimberProperty extends Timber_UnitTestCase {
 	}
 
 	/**
-	 * @expectedDeprecated Timber\Site::update
-	 * @expectedDeprecated Timber\Post::update
-	 * @expectedDeprecated Timber\Core::update
+	 * @expectedDeprecated Timber\Site::update()
+	 * @expectedDeprecated Timber\Post::update()
+	 * @expectedDeprecated Timber\Core::update()
 	 */
 	function testMeta() {
 		$vars = $this->_initObjects();

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -36,21 +36,28 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$site = new Timber\Site();
 		return array( 'post' => $post, 'user' => $user, 'term' => $term, 'comment' => $comment, 'site' => $site );
 	}
-	
-	/**
-	 * @expectedDeprecated timber/term/meta/set
-	 */
+
 	function testMetaForTerm() {
 		$vars = $this->_initObjects();
 		extract( $vars );
-		$term->update( 'abraham', 'lincoln' );
+		update_term_meta($term->ID, 'abraham', 'lincoln');
 		$this->assertEquals( 'lincoln', $term->abraham );
 		$this->assertEquals( 'lincoln', Timber::compile_string( '{{term.abraham}}', array( 'term' => $term ) ) );
 	}
 
+	/**
+	 * @expectedDeprecated Timber\Site::update
+	 * @expectedDeprecated Timber\Post::update
+	 * @expectedDeprecated Timber\Core::update
+	 */
 	function testMeta() {
 		$vars = $this->_initObjects();
 		extract( $vars );
+		if ( is_multisite() ) {
+			update_blog_option($this->ID, $key, $value);
+		} else {
+			update_option('bill', 'clinton');
+		}
 		$site->update( 'bill', 'clinton' );
 		$post->update( 'thomas', 'jefferson' );
 		//

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -53,11 +53,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 	function testMeta() {
 		$vars = $this->_initObjects();
 		extract( $vars );
-		if ( is_multisite() ) {
-			update_blog_option($this->ID, $key, $value);
-		} else {
-			update_option('bill', 'clinton');
-		}
+
 		$site->update( 'bill', 'clinton' );
 		$post->update( 'thomas', 'jefferson' );
 		//


### PR DESCRIPTION
**Ticket**: #1921 

#### Issue
There were some random `update()` methods on the main objects that let you update meta data — but that was about it.

#### Solution
Deprecate 'em!

#### Impact
People will get deprecation notices

#### Considerations
Perhaps one day, a project will come about to unify all of WP's various read/update/delete methodology, but it will not be this one

#### Testing
Updated the relevant tests to just use WP native functions. Updated one test to watch for the deprecation notices
