### PR TITLE
Update documentation.

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -470,14 +470,14 @@ class Image extends Post implements CoreInterface {
 			return wp_get_attachment_image_srcset($this->ID, $size);
 		}
 	}
-	
+
 	/**
 	 * @param string $size a size known to WordPress (like "medium")
 	 * @api
 	 * @example
 	 * ```twig
 	 * <h1>{{ post.title }}</h1>
-	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" sizes="{{ post.thumbnail.sizes }}" />
+	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" sizes="{{ post.thumbnail.img_sizes }}" />
 	 * ```
 	 * ```html
 	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w sizes="(max-width: 1024px) 100vw, 102" />
@@ -489,7 +489,7 @@ class Image extends Post implements CoreInterface {
 			return wp_get_attachment_image_sizes($this->ID, $size);
 		}
 	}
-	
+
 	/**
 	 * @internal
 	 * @return bool true if media is an image


### PR DESCRIPTION
https://github.com/timber/timber/pull/1819#issuecomment-460633755

Documentation was incorrectly using post.thumbnail.sizes instead of post.thumbnail.img_sizes.