### PR TITLE
Improve Image Guide

### DIFF
--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -105,7 +105,7 @@ When setting up your custom fields you’ll want to save the `image_id` to the f
 ### The quick way (for most situations)
 
 ```twig
-<img src="{{ TimberImage(post.hero_image).src }}" />
+<img src="{{ Timber\Image(post.hero_image).src }}" />
 ```
 
 ### The long way (for some special situations)
@@ -127,7 +127,7 @@ $data['post'] = $post;
 Timber::render( 'single.twig', $data );
 ```
 
-`TimberImage` should be initialized using a WordPress image ID. It can also take URLs and image objects, but that requires extra processing.
+`Timber\Image` should be initialized using a WordPress image ID. It can also take URLs and image objects, but that requires extra processing.
 
 You can now use all the above functions to transform your custom images in the same way. The format will be:
 
@@ -141,4 +141,4 @@ If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/a
 
 - **You can use** the `{{ image.src }}` or get the source of a WordPress image size, like `{{ image.src('large') }}`.
 
-- **You cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). The reason for this is that when you use one of these filters, then Timber creates a new file locally. But WordPress doesn’t know about that file, because it’s not associated with a WordPress image size registered through `add_image_size()`. Because of that, your CDN plugin will not be able to upload that image to the CDN server, because it doesn’t know the file exists, either.
+- **You cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). When you use one of these filters, Timber only creates a new file locally — but WordPress doesn’t know about that file (because it’s not associated with a WordPress image size registered through `add_image_size()`). Because of that, your CDN plugin will not be able to upload that image to the CDN server, because it doesn’t know the file exists, either.

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -139,8 +139,8 @@ You can now use all the above functions to transform your custom images in the s
 
 Timber’s image functions may be somewhat limited when using a CDN. If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, you should be aware of these limitations:
 
-- **You can use** the `{{ image.src }}` or get the source of a WordPress image size, like `{{ image.src('large') }}`.
+**You can use** the `{{ image.src }}` or get the source of a WordPress image size, like `{{ image.src('large') }}`.
 
-- **You cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). When you use one of these filters, Timber only creates a new file locally — but WordPress doesn’t know about that file (because it’s not associated with a WordPress image size registered through `add_image_size()`). Because of that, your CDN plugin will not be able to upload that image to the CDN server, because it doesn’t know the file exists, either.
+In some CDN setups, **you cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). When you use one of these filters, Timber only creates a new file locally — but WordPress doesn’t know about that file (because it’s not associated with a WordPress image size registered through `add_image_size()`). Because of that, some CDN plugins will not be able to upload that image to the CDN server, because they don’t know the file exists, either.
 
-However, there may be some CDN setups that work fine with the above filters (for example: one that’s merely watching the contents of the `wp-content/uploads` directory and copying it to the CDN). For example, these seem to work fine with the default setups for WPEngine and Pantheon.
+However, there may be some CDN setups that work fine with the above filters (for example: one that’s merely watching the contents of the `wp-content/uploads` directory and copying it to the CDN). For example, the filters seem to work fine with the default setups for WPEngine and Pantheon.

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -137,8 +137,10 @@ You can now use all the above functions to transform your custom images in the s
 
 ## Limitations when working with a CDN
 
-If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, then you need to know that Timber’s image functions are somewhat limited.
+Timber’s image functions may be somewhat limited when using a CDN. If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, you should be aware of these limitations:
 
 - **You can use** the `{{ image.src }}` or get the source of a WordPress image size, like `{{ image.src('large') }}`.
 
 - **You cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). When you use one of these filters, Timber only creates a new file locally — but WordPress doesn’t know about that file (because it’s not associated with a WordPress image size registered through `add_image_size()`). Because of that, your CDN plugin will not be able to upload that image to the CDN server, because it doesn’t know the file exists, either.
+
+However, there may be some CDN setups that work fine with the above filters (for example: one that’s merely watching the contents of the `wp-content/uploads` directory and copying it to the CDN). For example, these seem to work fine with the default setups for WPEngine and Pantheon.

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -105,7 +105,7 @@ When setting up your custom fields you’ll want to save the `image_id` to the f
 ### The quick way (for most situations)
 
 ```twig
-<img src="{{ Timber\Image(post.hero_image).src }}" />
+<img src="{{ Image(post.hero_image).src }}" />
 ```
 
 ### The long way (for some special situations)

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -43,6 +43,8 @@ The first parameter is `width`, the second is `height` (optional). So if you don
 
 All of these filters are written specifically to interact with WordPress’s image API. So don’t worry, no weird TimThumb stuff going on—this is all using WordPress’s internal image sizing stuff.
 
+Be aware of the limitations of this function [when working with a CDN](https://timber.github.io/docs/guides/cookbook-images/#limitations-when-working-with-a-cdn).
+
 ## Letterboxing images
 
 Let’s say you have an image that you want to contain to a certain size without any cropping. If the proportions don’t fit you’ll letterbox the extra space. I find this is really useful when getting logos to all appear next to each other. You can do this with:
@@ -55,7 +57,7 @@ Here `width` and `height` are required. The third argument is the background col
 
 ## Converting images
 
-Let’s say your client or editor can be a bit lazy (no!), resorting to PNGs where only JPGs are required. I’ve seen this a lot. People will just upload screenshots that are saved by default as PNGs. No problemo!
+Let’s say your client or editor is a bit lazy and they resort to PNGs where only JPGs are required. We have all seen this a lot. People will just upload screenshots that are saved by default as PNGs. No problemo!
 
 ```twig
 <img src="{{ post.thumbnail.src|tojpg }}" />
@@ -69,6 +71,18 @@ You can use this in conjunction with other filters.
 
 Filters are executed from left to right. You’ll probably want to convert to JPG before running the resizing, etc.
 
+### Using WebP images
+
+Similar to the `|tojpg` filter, there’s a `|towebp` filter.
+
+```twig
+<picture>
+   <source srcset="{{ post.thumbnail.src|towebp }}" type="image/webp">
+   <source srcset="{{ post.thumbnail.src|tojpg }}" type="image/jpeg">
+   <img src="{{ post.thumbnail.src|tojpg }}" alt="{{ post.title }}">
+</picture>
+```
+
 ## Generating retina sizes
 
 You can use Timber to generate @2x image sizes for retina devices. For example, using `srcset`:
@@ -80,24 +94,7 @@ You can use Timber to generate @2x image sizes for retina devices. For example, 
     {{ post.thumbnail.src|retina(4) }} 4x">
 ```
 
-This can be used in conjunction with other filters, so for example:
-
-```twig
-<img src="{{ post.thumbnail.src|resize(400, 300) }}" srcset="{{ post.thumbnail.src|resize(400, 300)|retina(1) }} 1x,
-    {{ post.thumbnail.src|resize(400, 300)|retina(2) }}  2x,
-    {{ post.thumbnail.src|resize(400, 300)|retina(3) }}  3x,
-    {{ post.thumbnail.src|resize(400, 300)|retina(4) }}  4x">
-```
-
-## Using WebP images
-
-```twig
-<picture>
-   <source srcset="{{ post.thumbnail.src|towebp }}" type="image/webp">
-   <source srcset="{{ post.thumbnail.src|tojpg }}" type="image/jpeg">
-   <img src="{{ post.thumbnail.src|tojpg }}" alt="{{ post.title }}">
-</picture>
-```
+Unfortunately, it’s not possible to use the `|retina()` filter in combination with `|resize()`, because it would create an upscaled image. We are working on making this work eventually.
 
 ## Using images in custom fields
 
@@ -137,3 +134,11 @@ You can now use all the above functions to transform your custom images in the s
 ```twig
 <img src="{{ post.hero_image.src|resize(500, 300) }}" />
 ```
+
+## Limitations when working with a CDN
+
+If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, then you need to know that Timber’s image functions are somewhat limited.
+
+- **You can use** the `{{ image.src }}` or get the source of a WordPress image size, like `{{ image.src('large') }}`.
+
+- **You cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). The reason for this is that when you use one of these filters, then Timber creates a new file locally. But WordPress doesn’t know about that file, because it’s not associated with a WordPress image size registered through `add_image_size()`. Because of that, your CDN plugin will not be able to upload that image to the CDN server, because it doesn’t know the file exists, either.


### PR DESCRIPTION
**Ticket**: #429, #404 and #1672

## Issue

There have been requests to better document the limitations with Timber’s image functions.

## Solution

Let’s try to list the limitations in the image guide.

- Adds new section about the limitations when using a CDN. In #429, several people mentioned it doesn’t work with `resize()`. But then, it wouldn’t work with `letterbox()`, `tojpg()` and `towebp()` either, right? Here’s where I’m not entirely sure.
- Adds changes proposed in #404 and #1672, that are only in the 2.x branch for now. I wanted them to be in the master branch, too.
- Moves the «Using WebP images» section into the «Converting images» section.

## Impact

None.

## Usage Changes

None.

## Considerations

Improving Timber’s overall image experience will eventually make these updates useless. Hopefully.

## Testing

None.