### PR TITLE
User avatar resize

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -214,7 +214,7 @@ class Image extends Post implements CoreInterface {
 
 	/**
 	 * @internal
-	 * @param int $iid
+	 * @param int|bool|string $iid
 	 */
 	public function init( $iid = false ) {
 		//Make sure we actually have something to work with

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -94,7 +94,7 @@ class Image extends Post implements CoreInterface {
 	 * //Or send it a URL to an image
 	 * $myImage = new TimberImage('http://google.com/logo.jpg');
 	 * ```
-	 * @param int|string $iid
+	 * @param bool|int|string $iid
 	 */
 	public function __construct( $iid ) {
 		$this->init($iid);

--- a/lib/Integrations/CoAuthorsPlusUser.php
+++ b/lib/Integrations/CoAuthorsPlusUser.php
@@ -34,6 +34,9 @@ class CoAuthorsPlusUser extends \Timber\User {
 			$avatar_url = get_avatar_url($coauthor->user_email);
 		}
 		if ( $avatar_url ) {
+			/**
+		 	 * @property string url to use for avatar image
+		 	 */
 			$this->avatar = new \Timber\Image($avatar_url);
 		}
 	}

--- a/lib/Integrations/CoAuthorsPlusUser.php
+++ b/lib/Integrations/CoAuthorsPlusUser.php
@@ -34,7 +34,7 @@ class CoAuthorsPlusUser extends \Timber\User {
 			$avatar_url = get_avatar_url($coauthor->user_email);
 		}
 		if ( $avatar_url ) {
-			$this->_avatar_override = new \Timber\Image($avatar_url);
+			$this->avatar = new \Timber\Image($avatar_url);
 		}
 	}
 }

--- a/lib/Integrations/CoAuthorsPlusUser.php
+++ b/lib/Integrations/CoAuthorsPlusUser.php
@@ -34,7 +34,7 @@ class CoAuthorsPlusUser extends \Timber\User {
 			$avatar_url = get_avatar_url($coauthor->user_email);
 		}
 		if ( $avatar_url ) {
-			$this->avatar = new \Timber\Image($avatar_url);
+			$this->_avatar_override = new \Timber\Image($avatar_url);
 		}
 	}
 }

--- a/lib/User.php
+++ b/lib/User.php
@@ -94,14 +94,7 @@ class User extends Core implements CoreInterface {
 	 * @return string a fallback for TimberUser::name()
 	 */
 	public function __toString() {
-		$name = $this->name();
-		if ( strlen($name) ) {
-			return $name;
-		}
-		if ( strlen($this->name) ) {
-			return $this->name;
-		}
-		return '';
+		return $this->name();
 	}
 
 	/**

--- a/lib/User.php
+++ b/lib/User.php
@@ -35,6 +35,12 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * @api
+	 * @var string A URL to an avatar that overrides anything from Gravatar, etc.
+	 */
+	public $avatar_override;
+
+	/**
+	 * @api
 	 * @var string The description from WordPress
 	 */
 	public $description;
@@ -93,7 +99,7 @@ class User extends Core implements CoreInterface {
 			return $name;
 		}
 		if ( strlen($this->name) ) {
-			return $this->name;
+			return $this->cname;
 		}
 		return '';
 	}
@@ -337,8 +343,8 @@ class User extends Core implements CoreInterface {
 	 * @api
 	 * @since 1.9.1
 	 *
-	 * @param array $args parameters are same as those used in `get_avatar_url`
-	 *              https://developer.wordpress.org/reference/functions/get_avatar_url/ .
+	 * @param null|array $args parameters are same as those used in `get_avatar_url`
+	 *                         https://developer.wordpress.org/reference/functions/get_avatar_url/.
 	 *
 	 * @example
 	 * Getting 150px user avatar
@@ -348,7 +354,10 @@ class User extends Core implements CoreInterface {
 	 * ```
 	 * @return string avatar url.
 	 */
-	public function avatar( $args = '' ) {
+	public function avatar( $args = null ) {
+		if ( $this->_avatar ) {
+			return $this->_avatar;
+		} 
 		return new Image(get_avatar_url($this->id, $args));
 	}
 }

--- a/lib/User.php
+++ b/lib/User.php
@@ -355,8 +355,8 @@ class User extends Core implements CoreInterface {
 	 * @return string avatar url.
 	 */
 	public function avatar( $args = null ) {
-		if ( $this->_avatar ) {
-			return $this->_avatar;
+		if ( $this->_avatar_override ) {
+			return $this->_avatar_override;
 		} 
 		return new Image(get_avatar_url($this->id, $args));
 	}

--- a/lib/User.php
+++ b/lib/User.php
@@ -42,12 +42,6 @@ class User extends Core implements CoreInterface {
 
 	/**
 	 * @api
-	 * @var string|Image The URL of the author's avatar
-	 */
-	public $avatar;
-
-	/**
-	 * @api
 	 * @var  string The first name of the user
 	 */
 	public $first_name;
@@ -159,7 +153,6 @@ class User extends Core implements CoreInterface {
 		unset($this->user_pass);
 		$this->id = $this->ID;
 		$this->name = $this->name();
-		$this->avatar = $this->avatar($args);
 		$custom = $this->get_custom();
 		$this->import($custom);
 	}

--- a/lib/User.php
+++ b/lib/User.php
@@ -159,7 +159,7 @@ class User extends Core implements CoreInterface {
 		unset($this->user_pass);
 		$this->id = $this->ID;
 		$this->name = $this->name();
-		$this->avatar = new Image(get_avatar_url($this->id));
+		$this->avatar = $this->avatar($args);
 		$custom = $this->get_custom();
 		$this->import($custom);
 	}
@@ -336,5 +336,26 @@ class User extends Core implements CoreInterface {
 	 */
 	public function can( $capability ) {
 		return user_can($this->ID, $capability);
+	}
+
+	/**
+	 * Returns user's avatar url.
+	 *
+	 * @api
+	 * @since 1.9.1
+	 *
+	 * @param array $args parameters are same as those used in `get_avatar_url`
+	 *              https://developer.wordpress.org/reference/functions/get_avatar_url/ .
+	 *
+	 * @example
+	 * Getting 150px user avatar
+	 *
+	 * ```twig
+	 * <img src="{{ post.author.avatar({'size': 150}) }}"/>
+	 * ```
+	 * @return string avatar url.
+	 */
+	public function avatar( $args = '' ) {
+		return new Image(get_avatar_url($this->id, $args));
 	}
 }

--- a/lib/User.php
+++ b/lib/User.php
@@ -99,7 +99,7 @@ class User extends Core implements CoreInterface {
 			return $name;
 		}
 		if ( strlen($this->name) ) {
-			return $this->cname;
+			return $this->name;
 		}
 		return '';
 	}
@@ -355,8 +355,8 @@ class User extends Core implements CoreInterface {
 	 * @return string avatar url.
 	 */
 	public function avatar( $args = null ) {
-		if ( $this->_avatar_override ) {
-			return $this->_avatar_override;
+		if ( $this->avatar_override ) {
+			return $this->avatar_override;
 		} 
 		return new Image(get_avatar_url($this->id, $args));
 	}

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -62,6 +62,11 @@
 			$this->assertEquals('/blog/author/lincoln/', trailingslashit($user->path()) );
 			$user->president = '16th';
 			$this->assertEquals('16th', $user->president);
+		}
 
+		function testAvatar() {
+			$uid = $this->factory->user->create(array('display_name' => 'Maciej Palmowski', 'user_login' => 'palmiak', 'user_email' => 'm.palmowski@spiders.agency'));
+			$user = new Timber\User($uid);
+			$this->assertEquals('http://2.gravatar.com/avatar/b2965625410b81a2b25ef02b54493ce0?s=96&d=mm&r=g', $user->avatar());
 		}
 	}


### PR DESCRIPTION
**Ticket**: #1730

#### Issue
Author avatar only used default size. As described in the issue "Now, I know I can do `post.author.avatar.src | resize('128x128')` but it won't stretch the image if base size is 96px."


#### Solution
I just added a possibility to pass arguments to `get_avatar_url`


#### Impact
It's fully backward compatible.


#### Usage Changes
The only change is that user can pass an array as argument - it's documented, so everything should be clear.

#### Testing
There wasn't any tests for avatar before - I'm not sure is there anything to test.
