### PR TITLE
Fix DocBlock issues with new User::avatar() method

### DIFF
--- a/lib/User.php
+++ b/lib/User.php
@@ -339,7 +339,7 @@ class User extends Core implements CoreInterface {
 	 * Get a user avatar with a width and height of 150px:
 	 *
 	 * ```twig
-	 * <img src="{{ post.author.avatar({ size: 150 }) }}"/>
+	 * <img src="{{ post.author.avatar({ size: 150 }) }}">
 	 * ```
 	 *
 	 * @param null|array $args Parameters for

--- a/lib/User.php
+++ b/lib/User.php
@@ -331,26 +331,26 @@ class User extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Returns user's avatar url.
+	 * Gets a user’s avatar URL.
 	 *
 	 * @api
 	 * @since 1.9.1
-	 *
-	 * @param null|array $args parameters are same as those used in `get_avatar_url`
-	 *                         https://developer.wordpress.org/reference/functions/get_avatar_url/.
-	 *
 	 * @example
-	 * Getting 150px user avatar
+	 * Get a user avatar with a width and height of 150px:
 	 *
 	 * ```twig
-	 * <img src="{{ post.author.avatar({'size': 150}) }}"/>
+	 * <img src="{{ post.author.avatar({ size: 150 }) }}"/>
 	 * ```
-	 * @return string avatar url.
+	 *
+	 * @param null|array $args Parameters for
+	 *                         [`get_avatar_url()`](https://developer.wordpress.org/reference/functions/get_avatar_url/).
+	 * @return string|\Timber\Image The avatar URL.
 	 */
 	public function avatar( $args = null ) {
 		if ( $this->avatar_override ) {
 			return $this->avatar_override;
-		} 
-		return new Image(get_avatar_url($this->id, $args));
+		}
+
+		return new Image( get_avatar_url( $this->id, $args ) );
 	}
 }


### PR DESCRIPTION
**Ticket**: #1928

## Issue

Some smaller things that can be improved for the new `User::avatar()` function.

## Solution

Fix some issues in the DocBlock:

- Title cases.
- DocBlock tag order.
- Removed unnecessary quotes for hash notation in Twig (`{ size: 150 }`).
- Removed closing tag for `<img>`, because `<img>` is a void element and [must not have an end tag](https://www.w3.org/TR/2012/WD-html-markup-20120320/img.html#img-tags).
- Use Markdown for URL so it will actually be a link in the documentation.
- Fix return type. Because `Timber\Image::__toString()` returns the image source, directly outputting an image without `src()` (like in the example) works.

## Impact

None.

#### Usage Changes

None.

## Considerations

None.

## Testing

None.