### PR TITLE
Remove some Timber/User overhead

### DIFF
--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -171,7 +171,7 @@ Up until now, there was only a representation for WordPress image attachments in
 
 - `meta()` – use `option()` instead.
 
-## Removed functions
+## Removed functions und properties
 
 The following functions were **removed from the codebase**, either because they were already deprecated or because they’re not used anymore.
 
@@ -242,6 +242,7 @@ The following functions were **removed from the codebase**, either because they 
 
 - `get_meta()` – use `{{ user.meta('my_field_name') }}` instead
 - `get_meta_field()` – use `{{ user.meta('my_field_name') }}` instead
+- `name` property – use `name()` method instead. You can still use `{{ user.name }}` in Twig.
 
 ### Timber\Comment
 

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -171,7 +171,7 @@ Up until now, there was only a representation for WordPress image attachments in
 
 - `meta()` – use `option()` instead.
 
-## Removed functions und properties
+## Removed functions and properties
 
 The following functions were **removed from the codebase**, either because they were already deprecated or because they’re not used anymore.
 

--- a/lib/User.php
+++ b/lib/User.php
@@ -124,27 +124,9 @@ class User extends Core implements CoreInterface, MetaInterface {
 	 * @return string a fallback for Timber\User::name()
 	 */
 	public function __toString() {
-		$name = $this->name();
-		if ( strlen($name) ) {
-			return $name;
-		}
-		if ( strlen($this->name) ) {
-			return $this->name;
-		}
-		return '';
+		return $this->name();
 	}
 
-	/**
-	 * @internal
-	 * @param string 	$field
-	 * @param mixed 	$value
-	 */
-	public function __set( $field, $value ) {
-		if ( 'name' === $field ) {
-			$this->display_name = $value;
-		}
-		$this->$field = $value;
-	}
 
 	/**
 	 * @internal
@@ -179,8 +161,6 @@ class User extends Core implements CoreInterface, MetaInterface {
 		}
 		unset($this->user_pass);
 		$this->id = $this->ID;
-		$this->name = $this->name();
-		$this->avatar = new Image(get_avatar_url($this->id));
 		$this->custom = $this->get_meta_values();
 		$this->import($this->custom, false, true);
 	}


### PR DESCRIPTION
#### Issue
In reviewing #1928 I noticed a bunch of excess code that was mucking-up the `Timber\User` class. Stuff that should be removed for 2.x, but left in place for 1.x users (in case there was any edge-edge-edge case stuff happening).

#### Solution
Remove it!

#### Impact
There could be some backwards compatibility issues for someone (for example) who was relying on `User::name` being a property vs. methods or some weird stuff I added long long ago (substituting "name" and "display name" for example.

#### Testing
No new tests, but all should still pass