### PR TITLE
Make phpcs a dev requirement in composer.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,30 +49,29 @@ We try to follow the [WordPress Coding Standards](https://make.wordpress.org/cor
 
 ### Use PHP_CodeSniffer to detect coding standard violations
 
-To check where the code deviates from the standards, you can use [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer). Timber comes with a `phpcs.xml` in the root folder of the repository, so that the coding standards will automatically be applied for the Timber code base.
-
-- Install PHP_CodeSniffer globally by following this guide: <https://github.com/squizlabs/PHP_CodeSniffer#installation>.
-- Install WPCS by following this guide: <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#installation>.
+To check where the code deviates from the standards, you can use [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer). Timber comes with a `phpcs.xml` in the root folder of the repository, so that the the Timber code base will be automatically checked for coding standards violations.
 
 #### Command Line Usage
 
-To run PHP_CodeSniffer with the default settings on all relevant Timber files, use the following command from the root folder of the Timber library: 
+When you run `composer install` in Timber’s repository root, you will get all required dependencies to check the coding standards.
+
+To run PHP_CodeSniffer with the default settings on all relevant Timber files, use the following command from the root folder of the Timber repository: 
 
 ```bash
-phpcs
+./vendor/bin/phpcs
 ```
 
-You could check a single file like this:
+You can check a single file like this:
 
 ```bash
-phpcs ./lib/Menu.php
+./vendor/bin/phpcs ./lib/Menu.php
 ```
 
-Use `phpcs --help` for a list of available settings.
+Use `./vendor/bin/phpcs --help` for a list of available settings or refer to the [PHP_CodeSniffer documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki).
 
 #### Use it in your IDE
 
-Please refer to <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#how-to-use> for different ways to use PHP_CodeSniffer directly in your IDE. In some IDEs like PHPStorm, you may have to select the `phpcs.xml` explicitly to apply the proper standards.
+Please refer to <https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#using-phpcs-and-wpcs-from-within-your-ide> for different ways to use PHP_CodeSniffer directly in your IDE. In some IDEs like PHPStorm, you may have to select the `phpcs.xml` explicitly to apply the proper standards.
 
 #### Whitelisting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ When you run `composer install` in Timber’s repository root, you will get all 
 To run PHP_CodeSniffer with the default settings on all relevant Timber files, use the following command from the root folder of the Timber repository: 
 
 ```bash
-./vendor/bin/phpcs
+composer lint
 ```
 
 You can check a single file like this:

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,6 @@
     }
   ],
   "scripts": {
-    "lint": "./vendor/bin/phpcs --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1"
+    "lint": "phpcs --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,8 @@
       "type": "composer",
       "url": "https://wpackagist.org"
     }
-  ]
+  ],
+  "scripts": {
+    "lint": "./vendor/bin/phpcs --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,13 @@
     "asm89/twig-cache-extension": "~1.0"
   },
   "require-dev": {
-    "wpackagist-plugin/advanced-custom-fields": "5.*",
+    "johnpbloch/wordpress": "4.*",
     "phpunit/phpunit": "5.7.16|6.*",
+    "squizlabs/php_codesniffer": "3.*",
+    "wp-coding-standards/wpcs": "^2.0",
+    "wpackagist-plugin/advanced-custom-fields": "5.*",
     "wpackagist-plugin/co-authors-plus": "3.2.*",
-    "johnpbloch/wordpress": "4.*"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
   },
   "suggest": {
     "satooshi/php-coveralls": "1.0.* for code coverage"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -64,7 +64,6 @@
         </properties>
     </rule>
 
-
     <!--
         Hook Names
 
@@ -79,12 +78,4 @@
             <property name="additionalWordDelimiters" value="/"/>
         </properties>
     </rule>
-
-    <rule ref="PEAR.Functions.FunctionCallSignature">
-        <properties>
-            <property name="requiredSpacesAfterOpen" value="0" />
-            <property name="requiredSpacesBeforeClose" value="0"/>
-        </properties>
-    </rule>
-
 </ruleset>


### PR DESCRIPTION
**Tickets**: #1795, #1677, https://github.com/timber/timber/pull/1930#issuecomment-466715389

## Issue

All dependencies required for checking the coding standards with `phpcs` should be added as dev dependencies.

## Solution

- Fixed sniff that was only added to 2.x in #1677.
- Added `composer lint` script.
- Updated composer.json with new dependencies. Sort lines alphabetically in `require-dev`.
- Updated CONTRIBUTING.md

## Impact

It will be easier for developers who want to check the coding standards.

## Usage Changes

`./vendor/bin/phpcs` should be used instead of `phpcs`. To make it even easier, `composer lint` can be used.

## Considerations

- **Travis** – As soon as we fixed all the coding standard errors with the release of 2.x, we can add checking against coding standards to Travis. Otherwise, we would be flooded with error messages 😱. There’s some guidance on how to do that: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards#travis-ci.

## Testing

I uninstalled the globally installed PHP_CodeSniffer and WordPress Coding Standards to make sure that the newly added dependencies are used. It worked!