### PR TITLE
Improve GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,18 @@
-Is this a support or usage question? Please post to [StackOverflow](http://stackoverflow.com/questions/tagged/timber) using the Timber tag
+<!--
+Is this a support or usage question? Please post to Stack Overflow (http://stackoverflow.com/questions/tagged/timber) using the Timber tag.
+-->
 
-### Expected behavior
+## Expected behavior
 <!-- Please describe what output you expect to see from Timber -->
 
-### Actual behavior
+## Actual behavior
 <!-- Please describe what you see instead. Please provide samples of HTML output or screenshots -->
 
-### Steps to reproduce behavior
+## Steps to reproduce behavior
 <!-- Please include complete code samples in-line or linked from [gists](https://gist.github.com/) -->
 
-### What version of WordPress, PHP and Timber are you using?
+## What version of WordPress, PHP and Timber are you using?
 <!-- Example: WordPress 4.4.1, PHP 5.4, Timber 0.22.5 -->
 
-### How did you install Timber? (for example, from GitHub, Composer/Packagist, WP.org?)
+## How did you install Timber? (for example, from GitHub, Composer/Packagist, WP.org?)
 <!-- Example: Upgraded to newest version via plugin updater in WordPress dashboard -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,19 +4,21 @@ about: Create a report to help us improve
 
 ---
 
-Is this a support or usage question? Please post to [StackOverflow](http://stackoverflow.com/questions/tagged/timber) using the Timber tag
+<!--
+Is this a support or usage question? Please post to Stack Overflow (http://stackoverflow.com/questions/tagged/timber) using the Timber tag.
+-->
 
-### Expected behavior
+## Expected behavior
 <!-- Please describe what output you expect to see from Timber -->
 
-### Actual behavior
+## Actual behavior
 <!-- Please describe what you see instead. Please provide samples of HTML output or screenshots -->
 
-### Steps to reproduce behavior
+## Steps to reproduce behavior
 <!-- Please include complete code samples in-line or linked from [gists](https://gist.github.com/) -->
 
-### What version of WordPress, PHP and Timber are you using?
+## What version of WordPress, PHP and Timber are you using?
 <!-- Example: WordPress 4.4.1, PHP 5.4, Timber 0.22.5 -->
 
-### How did you install Timber? (for example, from GitHub, Composer/Packagist, WP.org?)
+## How did you install Timber? (for example, from GitHub, Composer/Packagist, WP.org?)
 <!-- Example: Upgraded to newest version via plugin updater in WordPress dashboard -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,14 +4,14 @@ about: Suggest an idea for this project
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Is your feature request related to a problem? Please describe.
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Describe the solution you’d like
+<!-- A clear and concise description of what you want to happen. -->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Describe alternatives you’ve considered
+<!-- A clear and concise description of any alternative solutions or features you’ve considered. -->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,25 @@
-First off, hello! Thanks for submitting a PR. We love/welcome PRs (especially if it's your first). Have any questions? Read [this section in CONTRIBUTING.md](https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests) 
+<!--
+First off, hello!
+
+Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
+Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
+--> 
 
 **Ticket**: # <!-- Ignore this if not relevant -->
 
-#### Issue
+## Issue
 <!-- Description of the problem that this code change is solving -->
 
 
-#### Solution
+## Solution
 <!-- Description of the solution that this code changes are introducing to the application. -->
 
 
-#### Impact
+## Impact
 <!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
 
 
-#### Usage Changes
+## Usage Changes
 <!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
 
 Alternatively, you’re very welcome to directly edit the readme.txt file with:
@@ -24,9 +29,9 @@ Alternatively, you’re very welcome to directly edit the readme.txt file with:
 -->
 
 
-#### Considerations
+## Considerations
 <!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
 
 
-#### Testing
+## Testing
 <!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->


### PR DESCRIPTION
- I’ve found that I always have to change the heading levels in pull requests, if I add a little more text than usual. Let’s use `<h2>` for all the headings! They are not humongous, but add more structure and readability, in my opinion.
- Recently, I saw that some issues and pull requests were opened with text that should probably be commented out, so I added some HTML comments.
- Call me pedantic 😜.