### PR TITLE
Update WooCommerce guide with missing step

### DIFF
--- a/docs/guides/woocommerce.md
+++ b/docs/guides/woocommerce.md
@@ -6,7 +6,17 @@ menu:
 ---
 
 ## Point of entry - main WooCommerce PHP file
-The first step to get your WooCommerce project integrated with Timber is creating a file named `woocommerce.php` in the root of your theme. That will establish the context and data to be passed to your Twig files:
+The first step to get your WooCommerce project integrated with Timber is declaring WooCommerce support in your theme's `functions.php` file like so:
+
+```
+function mytheme_add_woocommerce_support() {
+    add_theme_support( 'woocommerce' );
+}
+
+add_action( 'after_setup_theme', 'mytheme_add_woocommerce_support' );
+```
+
+Once that's done you can start integrating WooCommerce into your theme by creating a file named `woocommerce.php` in the root of your theme. That will establish the context and data to be passed to your Twig files:
 
 ```php
 <?php


### PR DESCRIPTION
#### Issue
This fixes the issue with the shop page not displaying any products.

#### Solution
Declare WooCommerce support in your functions.php file

#### Impact
None, just a documentation update.

#### Considerations
It may be worth considering adding some basic woocommerce support directly in the Timber Starter Theme