### PR TITLE
Cleanup of MenuItem

### DIFF
--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -151,7 +151,7 @@ a sidebar. You can use the `current_item()` helper to achieve this:
     {{ menu.current_item.title }}
   </a>
   <ul>
-    {% for child in menu.current_item.get_children %}
+    {% for child in menu.current_item.children %}
       <li>
         <a href="{{ child.link }}">{{ child.title }}</a>
       </li>
@@ -176,7 +176,7 @@ specify a depth of 2:
     {{ menu.current_item(2).title }}
   </a>
   <ul class="third-level-nav-items">
-    {% for child in menu.current_item(2).get_children %}
+    {% for child in menu.current_item(2).children %}
       <li>
         <a href="{{ child.link }}">{{ child.title }}</a>
       </li>

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -234,6 +234,7 @@ The following functions were **removed from the codebase**, either because they 
 
 ### Timber\MenuItem
 
+- `get_children()` – use `{{ item.children }}` instead
 - `get_link()` – use `{{ item.link }}` instead
 - `get_path()` – use `{{ item.path }}` instead
 - `permalink()` – use `{{ item.link }}` instead

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -348,7 +348,7 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 	 * Gets a comment meta value.
 	 *
 	 * @api
-	 * @deprecated 2.0.0, use `{{ comment.meta('field_name) }}` instead.
+	 * @deprecated 2.0.0, use `{{ comment.meta('field_name') }}` instead.
 	 *
 	 * @param string $field_name The field name for which you want to get the value.
 	 * @return mixed The meta field value.

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -356,7 +356,7 @@ class Menu extends Core {
 	 *     {{ menu.current_item.title }}
 	 *   </a>
 	 *   <ul>
-	 *     {% for child in menu.current_item.get_children %}
+	 *     {% for child in menu.current_item.children %}
 	 *       <li>
 	 *         <a href="{{ child.link }}">{{ child.title }}</a>
 	 *       </li>
@@ -437,9 +437,9 @@ class Menu extends Core {
 				}
 
 				// we're in the right subtree, so go deeper.
-				if ( $item->get_children() ) {
+				if ( $item->children() ) {
 					// reset the counter, since we're at a new level.
-					$items = $item->get_children();
+					$items = $item->children();
 					$i     = 0;
 					$currentDepth++;
 					continue;

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -362,7 +362,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 			return $this->$field_name;
 		}
 		if ( is_object($this->menu_object) && method_exists($this->menu_object, 'meta') ) {
-			return $this->menu_object->meta($field_name);
+			return $this->menu_object->meta($field_name, $args);
 		}
 		return null;
 	}

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -358,13 +358,12 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * @return mixed Whatever value is stored in the database. Null if no value could be found.
 	 */
 	public function meta( $field_name, $args = array() ) {
-		if ( is_object($this->menu_object) && method_exists($this->menu_object, 'meta') ) {
-			return $this->menu_object->meta($field_name);
-		}
 		if ( isset($this->$field_name) ) {
 			return $this->$field_name;
 		}
-
+		if ( is_object($this->menu_object) && method_exists($this->menu_object, 'meta') ) {
+			return $this->menu_object->meta($field_name);
+		}
 		return null;
 	}
 

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -226,6 +226,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * in Twig).
 	 *
 	 * @internal
+	 * @deprecated 2.0.0, use `item.children` instead.
 	 * @example
 	 * ```twig
 	 * {% for child in item.get_children %}
@@ -237,10 +238,12 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * @return array|bool Array of children of a menu item. Empty if there are no child menu items.
 	 */
 	public function get_children() {
-		if ( isset($this->children) ) {
-			return $this->children;
-		}
-		return false;
+		Helper::deprecated(
+			"{{ item.get_children }}",
+			"{{ item.children }}",
+			'2.0.0'
+		);
+		return $this->children();
 	}
 
 	/**
@@ -381,11 +384,8 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 			"{{ item.meta('field_name') }}",
 			'2.0.0'
 		);
-
 		return $this->meta( $field_name );
 	}
-
-	/* Aliases */
 
 	/**
 	 * Get the child menu items of a `Timber\MenuItem`.
@@ -402,7 +402,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * @return array|bool Array of children of a menu item. Empty if there are no child menu items.
 	 */
 	public function children() {
-		return $this->get_children();
+		return $this->children;
 	}
 
 	/**
@@ -416,7 +416,6 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 */
 	public function external() {
 		Helper::warn( '{{ item.external }} is deprecated. Use {{ item.is_external }} instead.' );
-
 		return $this->is_external();
 	}
 
@@ -477,23 +476,4 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 		}
 	}
 
-	/**
-	 * Get the featured image of the post associated with the menu item.
-	 *
-	 * @api
-	 * @deprecated 1.5.2, to be removed in v2.0
-	 * @example
-	 * ```twig
-	 * {% for item in menu.items %}
-	 *     <li><a href="{{ item.link }}"><img src="{{ item.thumbnail }}"/></a></li>
-	 * {% endfor %}
-	 * ```
-	 * @return \Timber\Image|null The featured image object.
-	 */
-	public function thumbnail() {
-		$mo = $this->master_object();
-		if ( $mo && method_exists($mo, 'thumbnail') ) {
-			return $mo->thumbnail();
-		}
-	}
 }

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -277,7 +277,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 		if ( $this->type() !== 'custom' ) {
 			return false;
 		}
-		return URLHelper::is_external($this->url);
+		return URLHelper::is_external( $this->link() );
 	}
 
 	/**
@@ -337,7 +337,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * @return string The type of the menu item.
 	 */
 	public function type() {
-		return $this->_menu_item_type;
+		return $this->meta('_menu_item_type');
 	}
 
 	/**
@@ -364,7 +364,6 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 		if ( is_object($this->menu_object) && method_exists($this->menu_object, 'meta') ) {
 			return $this->menu_object->meta($field_name, $args);
 		}
-		return null;
 	}
 
 	/**
@@ -432,9 +431,9 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 */
 	public function link() {
 		if ( ! isset($this->url) || !$this->url ) {
-			if ( isset($this->_menu_item_type) && $this->_menu_item_type === 'custom' ) {
-				$this->url = $this->_menu_item_url;
-			} elseif ( isset($this->menu_object) && method_exists($this->menu_object, 'get_link') ) {
+			if ( 'custom' === $this->type() ) {
+				$this->url = $this->meta('_menu_item_url');
+			} elseif ( isset($this->menu_object) && method_exists($this->menu_object, 'link') ) {
 					$this->url = $this->menu_object->link();
 			}
 		}

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -430,13 +430,6 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * @return string A full URL, like `http://mysite.com/thing/`.
 	 */
 	public function link() {
-		if ( ! isset($this->url) || !$this->url ) {
-			if ( 'custom' === $this->type() ) {
-				$this->url = $this->meta('_menu_item_url');
-			} elseif ( isset($this->menu_object) && method_exists($this->menu_object, 'link') ) {
-					$this->url = $this->menu_object->link();
-			}
-		}
 		return $this->url;
 	}
 

--- a/tests/assets/child-menu.twig
+++ b/tests/assets/child-menu.twig
@@ -1,10 +1,10 @@
 <ul class="nav navbar-nav">
      {% for item in menu.items %}
      <li>
-          {% if item.get_children %}
+          {% if item.children %}
                <a href="{{item.link}}" class="has-children">{{item.title}}</a>
                <ul class="dropdown-menu" role="menu">
-               {% for child in item.get_children %}
+               {% for child in item.children %}
                     <li><a href="{{child.link}}">{{child.title}}</a></li>
                {% endfor %}
                </ul>

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -201,6 +201,20 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertGreaterThan( 0, $item->id );
 	}
 
+	function testMenuMetaSet() {
+		$mid = self::_createSimpleMenu('Tester');
+		$menu = new Timber\Menu($mid);
+		$items = $menu->get_items();
+		$item = $items[0];
+		$item->foo = 'bar';
+		update_post_meta( $item->ID, 'ziggy', 'stardust' );
+		$this->assertNotEquals( $item->ID, $item->master_object->ID );
+		$this->assertEquals( 'bar', $item->foo );
+		$this->assertEquals( 'bar', $item->meta('foo') );
+		$this->assertEquals( 'stardust', $item->meta('ziggy') );
+		$this->assertNull( $item->meta('asdfafds') );
+	}
+
 	function testMenuItemWithHash() {
 		self::_createTestMenu();
 		$menu = new Timber\Menu();

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -150,10 +150,13 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[1];
-		$this->assertTrue( $item->is_external() );
+		unset($item->url);
+		
 		$struc = get_option( 'permalink_structure' );
-		$this->assertEquals( 'http://upstatement.com', $item->url );
 		$this->assertEquals( 'http://upstatement.com', $item->link() );
+		$this->assertEquals( 'http://upstatement.com', $item->url );
+		$this->assertTrue( $item->is_external() );
+
 	}
 
 	function testMenuItemIsTargetBlank() {

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -142,6 +142,16 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertNotContains( 'foobar', $str );
 	}
 
+	function testImportClasses() {
+		$menu = self::_createSimpleMenu('Main Tester');
+		$menu = new Timber\Menu('Main Tester');
+		$items = $menu->get_items();
+		$item = $items[0];
+		$array = array('classes' => array('menu-test-class'));
+		$item->import_classes($array);
+		$this->assertContains('menu-test-class', $item->classes);
+	}
+
 	function testMenuItemLink() {
 		self::setPermalinkStructure();
 		self::_createTestMenu();

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -150,8 +150,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 3, count( $menu->get_items() ) );
 		$items = $menu->get_items();
 		$item = $items[1];
-		unset($item->url);
-		
 		$struc = get_option( 'permalink_structure' );
 		$this->assertEquals( 'http://upstatement.com', $item->link() );
 		$this->assertEquals( 'http://upstatement.com', $item->url );

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -57,7 +57,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 		$nav_menu = new Timber\Menu( $menu_term['term_id'] );
 
-		$str    = '{{ menu.items[0].ID }} - {{ menu.items[0].thumbnail.src }}';
+		$str    = '{{ menu.items[0].ID }} - {{ menu.items[0].master_object.thumbnail.src }}';
 		$result = Timber::compile_string( $str, array( 'menu' => $nav_menu ) );
 		$this->assertEquals( $menu_items[0]->ID . ' - http://example.org/wp-content/uploads/' . date( 'Y/m' ) . '/arch.jpg', $result );
 	}
@@ -74,7 +74,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		add_post_meta( $pid, '_thumbnail_id', $iid, true );
 		$post = new \Timber\Post($pid);
 		$page_menu = new Timber\Menu();
-		$str = '{% for item in menu.items %}{{item.thumbnail.src}}{% endfor %}';
+		$str = '{% for item in menu.items %}{{item.master_object.thumbnail.src}}{% endfor %}';
 		$result = Timber::compile_string($str, array('menu' => $page_menu));
 		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $result);
 	}


### PR DESCRIPTION
## Issue
`Timber\MenuItem` hadn't received some of the same ❤️ as other classes. There were deprecated methods that weren't removed and methods with old names that needed to be deprecated

## Solution
- Removed `MenuItem::thumbnail` (deprecated since 1.5.2)
- Deprecated `MenuItem::get_children` (follows the same pattern as `Timber\Post` and others), update docs accordingly
- Fix how `Timber\MenuItem::meta` method worked. Wasn't fully covered and had an inaccessible code block. This is necessary to ensure ACF data and others that attach metadata directly to the `nav_menu_item` can get data out

## Impact
Should fix potential issues and bring this class's coverage up and in line with other classes

## Usage Changes
Noted new deprecations in `upgrade-guides/2.0.md`

## Considerations
There are grander issues with the menu #1820. This is potentially helpful in that direction, but by no means a solve.

## Testing
Updated tests to use current non-deprecated methods; added test to cover a variety of meta situations
