### PR TITLE
Alias Timber::get_context as Timber::context

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -226,6 +226,18 @@ class Timber {
 	================================ */
 
 	/**
+	 * Alias for Timber::get_context() which is deprecated in 2.0
+	 * 
+	 * This will allow us to update the starter theme to use the ::context method and better prepare * users for the upgrade (even if the details of what the method returns differs slightly)
+	 * @see \Timber\Timber::get_context()
+	 * @api
+	 * @return array
+	 */
+	public static function context() {
+		self::get_context();
+	}
+
+	/**
 	 * Get context.
 	 * @api
 	 * @return array

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -226,15 +226,18 @@ class Timber {
 	================================ */
 
 	/**
-	 * Alias for Timber::get_context() which is deprecated in 2.0
-	 * 
-	 * This will allow us to update the starter theme to use the ::context method and better prepare * users for the upgrade (even if the details of what the method returns differs slightly)
+	 * Alias for Timber::get_context() which is deprecated in 2.0.
+	 *
+	 * This will allow us to update the starter theme to use the ::context() method and better
+	 * prepare users for the upgrade (even if the details of what the method returns differs
+	 * slightly).
+	 *
 	 * @see \Timber\Timber::get_context()
 	 * @api
 	 * @return array
 	 */
 	public static function context() {
-		self::get_context();
+		return self::get_context();
 	}
 
 	/**

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -15,5 +15,10 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertEquals('http://example.org', $context['http_host']);
 	}
 
+	function testContext() {
+		$context = Timber::context();
+		$this->assertEquals('http://example.org', $context['http_host']);
+	}
+
 
 }


### PR DESCRIPTION
**Ticket**: #1784 

## Issue
Amongst the 2.0 API changes is `Timber::get_context` ==> `Timber::context();`. To help users prepare I wanted to update the starter theme to use `Timber::context();`. However, because this method doesn't exist yet, it triggers a fatal error

## Solution
Make an alias for `Timber::get_context()` at `Timber::context();`. This will allow me to update the starter theme. My goal is to minimize the number of deprecations a user has to deal with when/if they upgrade their theme to 2.0

## Impact
No impact on any existing code, just a bonus method out there

## Usage Changes / Considerations
We could consider actively encouraging users to start using `Timber::context();` by updating the docs and adding a deprecation notice to `get_context`. For now, I've left it at the lowest common denominator of "it's here, but no pressure man".

This aliased method is NOT what's coming in 2.0 which a more efficient and organized method. But this could help ease the transition.

## Testing
Tests pass. I didn't write a new test to cover `Timber::context()`
