### PR TITLE
Prevent autoloading of tests/php folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
   "autoload-dev": {
     "classmap": [
       "tests/"
+    ],
+    "exclude-from-classmap": [
+      "tests/php"
     ]
   },
   "repositories": [


### PR DESCRIPTION
## Issue

In the unit tests, we sometimes require other PHP files, e.g. in **test-timber-term.php**:
 
https://github.com/timber/timber/blob/7385f93457e27f1139a1b0e9d4efb8c202e75320/tests/test-timber-term.php#L172

When using `classmap`, Composer autoloads these classes whenever `class_exists()` is called, not only when we require them:

https://github.com/timber/timber/blob/7385f93457e27f1139a1b0e9d4efb8c202e75320/composer.json#L51-L54

In #1931, I wrote a test where I needed a particular class to exist only for a particular test. For the other tests, the class **shouldn’t** exist.

That test failed in Travis, because I didn’t use `composer dump-autoload` locally before running the tests and so in Travis, the class was found and triggered the error, while locally I didn’t see that error.

## Solution

I looked for an option to ignore certain classes from autoloading and found that we can use [`exclude-from-classmap`](https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps) to prevent certain files to be autoloaded.

This pull requests sets the `tests/php` folder to be excluded from the Composer classmaps, so that all classes in that folder always have to required manually by unit tests.

## Impact

By not autoloading the `tests/php` folder, we should have better expectations of what should happen in tests.

## Usage Changes

None?

## Considerations

Can you imagine how much I learn every day about various coding stuff when working on Timber 😎?

## Testing

Tested. There should be no changes for the current tests.