### PR TITLE
Improve notes about CDN limitations

### DIFF
--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -137,12 +137,21 @@ You can now use all the above functions to transform your custom images in the s
 
 ## Limitations when working with a CDN
 
-Timber’s image functions may be somewhat limited when using a CDN. If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, you should be aware of these limitations.
+Timber’s image functions may be somewhat limited when using a CDN.
+There are [differences between Pull CDN and Push CDN](https://cdn.net/push-vs-pull-cdn/).
 
-Be aware that there are [differences between Pull CDN and Push CDN](https://cdn.net/push-vs-pull-cdn/). You should be **fine when you use a Pull CDN**, because there, you pass in which directories of your website you want to map to your CDN. The links to assets in those directories will be automatically replaced with the links to the CDN in the resulting HTML. The Pull CDN will «pull» these files to the server, if they don’t exist yet.
+### Using a Pull CDN
 
-However, when you use a Push CDN, you need to be aware of the following limitation:
+You should be **fine when you use a Pull CDN**, because there, you pass in which directories of your website you want to map to your CDN. The links to assets in those directories will be automatically replaced with the links to the CDN in the resulting HTML. The Pull CDN will «pull» these files to the server, if they don’t exist yet.
+
+### Using a Push CDN
+
+When you use a Push CDN, you need to be aware of the following limitation:
 
 **When you use a filter that creates a new image**, like `|resize()`, `|letterbox()` or **a filter that converts your image to another format**, like `|tojpg` or `|towebp`, it probably won’t work. With these filters, Timber creates a new file locally. But WordPress doesn’t know about that file, because it’s not associated with a WordPress image size registered through `add_image_size()`. Because of that, some CDN plugins will not be able to upload/push that image to the CDN server, because they don’t know the file exists, either.
 
 **You are safe if you use** `{{ image.src }}` or if you get the source of a WordPress image size, like `{{ image.src('large') }}`.
+
+Examples for plugins that work with Push CDN:
+
+- [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/)

--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -137,10 +137,12 @@ You can now use all the above functions to transform your custom images in the s
 
 ## Limitations when working with a CDN
 
-Timber’s image functions may be somewhat limited when using a CDN. If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, you should be aware of these limitations:
+Timber’s image functions may be somewhat limited when using a CDN. If you use a plugin like [WP Offload Media Lite](https://wordpress.org/plugins/amazon-s3-and-cloudfront/) to store your images on a CDN, you should be aware of these limitations.
 
-**You can use** the `{{ image.src }}` or get the source of a WordPress image size, like `{{ image.src('large') }}`.
+Be aware that there are [differences between Pull CDN and Push CDN](https://cdn.net/push-vs-pull-cdn/). You should be **fine when you use a Pull CDN**, because there, you pass in which directories of your website you want to map to your CDN. The links to assets in those directories will be automatically replaced with the links to the CDN in the resulting HTML. The Pull CDN will «pull» these files to the server, if they don’t exist yet.
 
-In some CDN setups, **you cannot use** a filter that creates a new image, like `|resize()`, `|letterbox()` or a filter that converts your image to another format (like `|tojpg` or `|towebp`). When you use one of these filters, Timber only creates a new file locally — but WordPress doesn’t know about that file (because it’s not associated with a WordPress image size registered through `add_image_size()`). Because of that, some CDN plugins will not be able to upload that image to the CDN server, because they don’t know the file exists, either.
+However, when you use a Push CDN, you need to be aware of the following limitation:
 
-However, there may be some CDN setups that work fine with the above filters (for example: one that’s merely watching the contents of the `wp-content/uploads` directory and copying it to the CDN). For example, the filters seem to work fine with the default setups for WPEngine and Pantheon.
+**When you use a filter that creates a new image**, like `|resize()`, `|letterbox()` or **a filter that converts your image to another format**, like `|tojpg` or `|towebp`, it probably won’t work. With these filters, Timber creates a new file locally. But WordPress doesn’t know about that file, because it’s not associated with a WordPress image size registered through `add_image_size()`. Because of that, some CDN plugins will not be able to upload/push that image to the CDN server, because they don’t know the file exists, either.
+
+**You are safe if you use** `{{ image.src }}` or if you get the source of a WordPress image size, like `{{ image.src('large') }}`.


### PR DESCRIPTION
**Ticket**: #1925

Let’s rewrite the CDN limitation section again based on the new information provided by @palmiak. It looks like when Maciej talked about «Push CDN», he was talking about the same as the following section by Jared:

> However, there may be some CDN setups that work fine with the above filters (for example: one that’s merely watching the contents of the `wp-content/uploads` directory and copying it to the CDN). For example, the filters seem to work fine with the default setups for WPEngine and Pantheon.

I changed the text to first hint about the differences between Push and Pull CDN and then describe how this relates to Timber.