### PR TITLE
Bump upstatement/routes package to 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": ">=5.3.0|7.*",
     "twig/twig": "1.34.*|2.*",
-    "upstatement/routes": "0.4",
+    "upstatement/routes": "0.5",
     "composer/installers": "~1.0",
     "asm89/twig-cache-extension": "~1.0"
   },


### PR DESCRIPTION
## Issue

The current version of timber requires `upstatement/routes` r0.4. This version of `routes` requires an older version of `altorouter`, and that version of `altorouter` does a reset of `$_REQUEST` that causes some problems with other plugins (e.g. https://twitter.com/seanstickle/status/1103481154785693697).

## Solution

@jarednova over at Upstatement released 0.5 of `upstatement/routes` today that updates the version of `altorouter` that is used. This PR just bumps the version of `upstatement/routes` to 0.5.

## Impact

No expected impact. The changes to `upstatement/routes` since 0.4 have been minor -- just bumping the version of `altorouter` and adding a priority param (https://github.com/Upstatement/routes/commit/50401742278333746ccdf3e11dec222d31e9fe4c).