### PR TITLE
Update documentation

### DIFF
--- a/docs/guides/cheatsheet.md
+++ b/docs/guides/cheatsheet.md
@@ -9,7 +9,7 @@ Here are some helpful conversions for functions you’re probably well familiar 
 
 ```php
 $context = Timber::get_context();
-$context['post'] = new TimberPost();
+$context['post'] = new Timber\Post();
 Timber::render( 'single.twig', $context );
 ```
 

--- a/docs/guides/extending-timber.md
+++ b/docs/guides/extending-timber.md
@@ -11,7 +11,7 @@ The beauty of Timber is that the object-oriented nature lets you extend it to ma
 
 ## An example that extends TimberPost
 
-Timber's objects like `TimberPost`, `TimberTerm`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
+Timber's objects like `Timber\Post`, `TimberTerm`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
 
 
 ```twig
@@ -19,11 +19,11 @@ Timber's objects like `TimberPost`, `TimberTerm`, etc. are a great starting poin
 <h3>From the {{ post.issue.title }} issue</h3>
 ```
 
-Of course, `TimberPost` has no built-in concept of an issue (which I've built as a custom taxonomy called "issues"). So we're going to extend TimberPost to give it one:
+Of course, `Timber\Post` has no built-in concept of an issue (which I've built as a custom taxonomy called "issues"). So we're going to extend TimberPost to give it one:
 
 ```php
 <?php
-class MySitePost extends TimberPost {
+class MySitePost extends Timber\Post {
 
 	var $_issue;
 
@@ -41,7 +41,7 @@ issue data:
 
 ```php
 <?php
-class MySitePost extends TimberPost {
+class MySitePost extends Timber\Post {
 
 	var $_issue;
 
@@ -57,13 +57,13 @@ class MySitePost extends TimberPost {
 }
 ```
 
-Right now I'm in the midst of building a complex site for a hybrid foundation and publication. The posts on the site have some very specific requirements that requires a fair amount of logic. I can take the simple `TimberPost` object and extend it to make it work perfectly for this theme.
+Right now I'm in the midst of building a complex site for a hybrid foundation and publication. The posts on the site have some very specific requirements that requires a fair amount of logic. I can take the simple `Timber\Post` object and extend it to make it work perfectly for this theme.
 
 For example, I have a plugin that let's people insert manually related posts, but if they don't, WordPress will pull some automatically based on how the post is tagged.
 
 ```php
 	<?php
-	class MySitePost extends TimberPost {
+	class MySitePost extends Timber\Post {
 
 		function get_related_auto() {
 			$tags = $this->tags();

--- a/docs/guides/extending-timber.md
+++ b/docs/guides/extending-timber.md
@@ -11,7 +11,7 @@ The beauty of Timber is that the object-oriented nature lets you extend it to ma
 
 ## An example that extends TimberPost
 
-Timber's objects like `Timber\Post`, `TimberTerm`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
+Timber's objects like `Timber\Post`, `Timber\Term`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
 
 
 ```twig

--- a/docs/guides/sidebars.md
+++ b/docs/guides/sidebars.md
@@ -62,7 +62,7 @@ In this example, you would populate your sidebar from your main PHP file (home.p
 <?php
 /* single.php */
 $context = Timber::get_context();
-$post = new TimberPost();
+$post = new Timber\Post();
 $post_cat = $post->get_terms('category');
 $post_cat = $post_cat[0]->ID;
 $context['post'] = $post;

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -7,10 +7,10 @@ use Timber\Core;
 use Timber\CoreInterface;
 
 /**
- * The TimberComment class is used to view the output of comments. 99% of the time this will be in the context of the comments on a post. However you can also fetch a comment directly using its comment ID.
+ * The Timber\Comment class is used to view the output of comments. 99% of the time this will be in the context of the comments on a post. However you can also fetch a comment directly using its comment ID.
  * @example
  * ```php
- * $comment = new TimberComment($comment_id);
+ * $comment = new Timber\Comment($comment_id);
  * $context['comment_of_the_day'] = $comment;
  * Timber::render('index.twig', $context);
  * ```

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -50,7 +50,7 @@ abstract class Core {
 	 * @example
 	 * ```php
 	 * $data = array('airplane' => '757-200', 'flight' => '5316');
-	 * $post = new TimberPost()
+	 * $post = new Timber\Post()
 	 * $post->import(data);
 	 * echo $post->airplane; //757-200
 	 * ```

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -146,7 +146,7 @@ class Helper {
 	 * }
 	 *
 	 * $context = Timber::get_context();
-	 * $context['post'] = new TimberPost();
+	 * $context['post'] = new Timber\Post();
 	 * $context['my_form'] = TimberHelper::ob_function('the_form');
 	 * Timber::render('single-form.twig', $context);
 	 * ```

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -9,16 +9,16 @@ use Timber\URLHelper;
 
 
 /**
- * If TimberPost is the class you're going to spend the most time, TimberImage is the class you're going to have the most fun with.
+ * If TimberPost is the class you're going to spend the most time, Timber\Image is the class you're going to have the most fun with.
  * @example
  * ```php
  * $context = Timber::get_context();
- * $post = new TimberPost();
+ * $post = new Timber\Post();
  * $context['post'] = $post;
  *
  * // lets say you have an alternate large 'cover image' for your post stored in a custom field which returns an image ID
  * $cover_image_id = $post->cover_image;
- * $context['cover_image'] = new TimberImage($cover_image_id);
+ * $context['cover_image'] = new Timber\Image($cover_image_id);
  * Timber::render('single.twig', $context);
  * ```
  *
@@ -85,14 +85,14 @@ class Image extends Post implements CoreInterface {
 	protected $_wp_attached_file;
 
 	/**
-	 * Creates a new TimberImage object
+	 * Creates a new Timber\Image object
 	 * @example
 	 * ```php
 	 * // You can pass it an ID number
-	 * $myImage = new TimberImage(552);
+	 * $myImage = new Timber\Image(552);
 	 *
 	 * //Or send it a URL to an image
-	 * $myImage = new TimberImage('http://google.com/logo.jpg');
+	 * $myImage = new Timber\Image('http://google.com/logo.jpg');
 	 * ```
 	 * @param bool|int|string $iid
 	 */

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1049,13 +1049,13 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Gets the comments on a Timber\Post and returns them as an array of [TimberComments](#TimberComment) (or whatever comment class you set).
+	 * Gets the comments on a Timber\Post and returns them as an array of [Timber\Comment](#TimberComment) (or whatever comment class you set).
 	 * @api
 	 * @param int $count Set the number of comments you want to get. `0` is analogous to "all"
 	 * @param string $order use ordering set in WordPress admin, or a different scheme
 	 * @param string $type For when other plugins use the comments table for their own special purposes, might be set to 'liveblog' or other depending on what's stored in yr comments table
 	 * @param string $status Could be 'pending', etc.
-	 * @param string $CommentClass What class to use when returning Comment objects. As you become a Timber pro, you might find yourself extending TimberComment for your site or app (obviously, totally optional)
+	 * @param string $CommentClass What class to use when returning Comment objects. As you become a Timber pro, you might find yourself extending Timber\Comment for your site or app (obviously, totally optional)
 	 * @example
 	 * ```twig
 	 * {# single.twig #}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1614,7 +1614,7 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * @param string $field
-	 * @return TimberImage
+	 * @return Timber\Image
 	 */
 	public function get_image( $field ) {
 		return new $this->ImageClass($this->$field);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -993,7 +993,7 @@ class Post extends Core implements CoreInterface {
 	/**
 	 * Get the categoires on a particular post
 	 * @api
-	 * @return array of TimberTerms
+	 * @return array of Timber\Terms
 	 */
 	public function categories() {
 		return $this->terms('category');
@@ -1003,7 +1003,7 @@ class Post extends Core implements CoreInterface {
 	 * Returns a category attached to a post
 	 * @api
 	 * If mulitpuile categories are set, it will return just the first one
-	 * @return TimberTerm|null
+	 * @return Timber\Term|null
 	 */
 	public function category() {
 		return $this->get_category();
@@ -1592,7 +1592,7 @@ class Post extends Core implements CoreInterface {
 	 * @deprecated since 1.0
 	 * @codeCoverageIgnore
 	 * @see Timber\Post::categories
-	 * @return array of TimberTerms
+	 * @return array of Timber\Terms
 	 */
 	public function get_categories() {
 		return $this->terms('category');

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -9,12 +9,12 @@ use Timber\Theme;
 use Timber\Helper;
 
 /**
- * TimberSite gives you access to information you need about your site. In Multisite setups, you can get info on other sites in your network.
+ * Timber\Site gives you access to information you need about your site. In Multisite setups, you can get info on other sites in your network.
  * @example
  * ```php
  * $context = Timber::get_context();
  * $other_site_id = 2;
- * $context['other_site'] = new TimberSite($other_site_id);
+ * $context['other_site'] = new Timber\Site($other_site_id);
  * Timber::render('index.twig', $context);
  * ```
  * ```twig
@@ -95,14 +95,14 @@ class Site extends Core implements CoreInterface {
 	public $atom;
 
 	/**
-	 * Constructs a TimberSite object
+	 * Constructs a Timber\Site object
 	 * @example
 	 * ```php
 	 * //multisite setup
-	 * $site = new TimberSite(1);
-	 * $site_two = new TimberSite("My Cool Site");
+	 * $site = new Timber\Site(1);
+	 * $site_two = new Timber\Site("My Cool Site");
 	 * //non-multisite
-	 * $site = new TimberSite();
+	 * $site = new Timber\Site();
 	 * ```
 	 * @param string|int $site_name_or_id
 	 */
@@ -283,7 +283,7 @@ class Site extends Core implements CoreInterface {
 
 	/**
 	 * @deprecated 1.0.4
-	 * @see TimberSite::link
+	 * @see Timber\Site::link
 	 * @return string
 	 */
 	public function url() {

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -15,13 +15,13 @@ use Timber\URLHelper;
  * @example
  * ```php
  * //Get a term by its ID
- * $context['term'] = new TimberTerm(6);
+ * $context['term'] = new Timber\Term(6);
  * //Get a term when on a term archive page
- * $context['term_page'] = new TimberTerm();
+ * $context['term_page'] = new Timber\Term();
  * //Get a term with a slug
- * $context['team'] = new TimberTerm('patriots');
+ * $context['team'] = new Timber\Term('patriots');
  * //Get a team with a slug from a specific taxonomy
- * $context['st_louis'] = new TimberTerm('cardinals', 'baseball');
+ * $context['st_louis'] = new Timber\Term('cardinals', 'baseball');
  * Timber::render('index.twig', $context);
  * ```
  * ```twig
@@ -224,7 +224,7 @@ class Term extends Core implements CoreInterface {
 				$field_value = apply_filters('timber/term/meta/field', $field_value, $this->ID, $field_name, $this);
 			}
 			$this->$field_name = $field_value;
-			
+
 		}
 		return $this->$field_name;
 	}
@@ -377,7 +377,7 @@ class Term extends Core implements CoreInterface {
 
 	/**
 	 * Retrieves and outputs meta information stored with a term. This will use
-	 * both data stored under (old) ACF hacks and new (WP 4.6+) where term meta 
+	 * both data stored under (old) ACF hacks and new (WP 4.6+) where term meta
 	 * has its own table. If retrieving a special ACF field (repeater, etc.) you
 	 * can use the output immediately in Twig — no further processing is
 	 * required.


### PR DESCRIPTION
## Issue
Documentation is using some old classes: TimberPost, TimberUser, TimberTerm, ...

## Solution
Updated documentation to the new classes

## Impact
No, only the documentation has changed.

## Usage Changes
Change TimberPost to Timber\Post
Change TimberComment to Timber\Comment
Change TimberImage to Timber\Image
Change TimberTerm to Timber\Term
Change TimberSite to Timber\Site
