### PR TITLE
Add support for non-cookied comment awaiting moderation message

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -427,10 +427,4 @@ class Comment extends Core implements CoreInterface {
 		return str_replace('&#038;', '&amp;', esc_url($out));
 	}
 
-	public static function get_unapproved_comment_author_email(){
-		if ( function_exists('wp_get_unapproved_comment_author_email') ) {
-			return wp_get_unapproved_comment_author_email();
-		}
-	}
-
 }

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -427,4 +427,11 @@ class Comment extends Core implements CoreInterface {
 		return str_replace('&#038;', '&amp;', esc_url($out));
 	}
 
+	public static function get_unapproved_comment_author_email(){
+		if ( function_exists('wp_get_unapproved_comment_author_email') ) {
+			return wp_get_unapproved_comment_author_email();
+		}
+		return 'afsdfad@dfsadfa.com';
+	}
+
 }

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -431,7 +431,6 @@ class Comment extends Core implements CoreInterface {
 		if ( function_exists('wp_get_unapproved_comment_author_email') ) {
 			return wp_get_unapproved_comment_author_email();
 		}
-		return 'afsdfad@dfsadfa.com';
 	}
 
 }

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1083,19 +1083,18 @@ class Post extends Core implements CoreInterface {
 		if ( strtolower($order) == 'wp' || strtolower($order) == 'wordpress' ) {
 			$args['order'] = get_option('comment_order');
 		}
-
 		if ( $user_ID ) {
 			$args['include_unapproved'] = array($user_ID);
 		} elseif ( !empty($comment_author_email) ) {
 			$args['include_unapproved'] = array($comment_author_email);
 		} elseif ( Comment::get_unapproved_comment_author_email() ) {
+
 			$unapproved_email = Comment::get_unapproved_comment_author_email();
 
 			if ( $unapproved_email ) {
 				$args['include_unapproved'] = array($unapproved_email);
 			}
 		}
-
 		$ct = new CommentThread($this->ID, false);
 		$ct->CommentClass = $CommentClass;
 		$ct->init($args);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1087,10 +1087,8 @@ class Post extends Core implements CoreInterface {
 			$args['include_unapproved'] = array($user_ID);
 		} elseif ( !empty($comment_author_email) ) {
 			$args['include_unapproved'] = array($comment_author_email);
-		} elseif ( Comment::get_unapproved_comment_author_email() ) {
-
-			$unapproved_email = Comment::get_unapproved_comment_author_email();
-
+		} elseif ( function_exists('wp_get_unapproved_comment_author_email') ) {
+			$unapproved_email = wp_get_unapproved_comment_author_email();
 			if ( $unapproved_email ) {
 				$args['include_unapproved'] = array($unapproved_email);
 			}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1088,7 +1088,14 @@ class Post extends Core implements CoreInterface {
 			$args['include_unapproved'] = array($user_ID);
 		} elseif ( !empty($comment_author_email) ) {
 			$args['include_unapproved'] = array($comment_author_email);
+		} elseif ( function_exists('wp_get_unapproved_comment_author_email') ) {
+			$unapproved_email = wp_get_unapproved_comment_author_email();
+
+			if ( $unapproved_email ) {
+				$args['include_unapproved'] = array($unapproved_email);
+			}
 		}
+
 		$ct = new CommentThread($this->ID, false);
 		$ct->CommentClass = $CommentClass;
 		$ct->init($args);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1088,8 +1088,8 @@ class Post extends Core implements CoreInterface {
 			$args['include_unapproved'] = array($user_ID);
 		} elseif ( !empty($comment_author_email) ) {
 			$args['include_unapproved'] = array($comment_author_email);
-		} elseif ( function_exists('wp_get_unapproved_comment_author_email') ) {
-			$unapproved_email = wp_get_unapproved_comment_author_email();
+		} elseif ( Comment::get_unapproved_comment_author_email() ) {
+			$unapproved_email = Comment::get_unapproved_comment_author_email();
 
 			if ( $unapproved_email ) {
 				$args['include_unapproved'] = array($unapproved_email);

--- a/tests/test-timber-comment-thread.php
+++ b/tests/test-timber-comment-thread.php
@@ -13,25 +13,19 @@
 		function testShowUnmoderatedCommentIfByAnon() {
 			global $wp_version;
 			$post_id = $this->factory->post->create();
-			add_filter('wp_get_current_commenter', function($author_data) {
-				$author_data['comment_author_email'] = 'jarednova@upstatement.com';
-				return $author_data;
-			});
 
-
-
-			$commenter = wp_get_current_commenter();
 			$quote = "And in that moment, I was a marine biologist";
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote,'comment_approved' => 0, 'comment_author_email' => 'jarednova@upstatement.com'));
 
 			$comment = get_comment($comment_id);
 
+			$post = new TimberPost($post_id);
+			$this->assertEquals(0, count($post->comments()) );
+
 			$_GET['unapproved'] = $comment->comment_ID;
 			$_GET['moderation-hash'] = wp_hash($comment->comment_date_gmt);
-
 			$post = new TimberPost($post_id);
 			$timber_comment = $post->comments()[0];
-
 			if ( !function_exists('wp_get_unapproved_comment_author_email') ) {
 				$this->markTestSkipped('WP 5.1 or greater required');
 			} else {

--- a/tests/test-timber-comment-thread.php
+++ b/tests/test-timber-comment-thread.php
@@ -25,10 +25,10 @@
 			$_GET['unapproved'] = $comment->comment_ID;
 			$_GET['moderation-hash'] = wp_hash($comment->comment_date_gmt);
 			$post = new TimberPost($post_id);
-			$timber_comment = $post->comments()[0];
 			if ( !function_exists('wp_get_unapproved_comment_author_email') ) {
-				$this->markTestSkipped('WP 5.1 or greater required');
+				$this->assertEquals(0, count( $post->comments() ));
 			} else {
+				$timber_comment = $post->comments()[0];
 				$this->assertEquals($quote, $timber_comment->comment_content);
 			}
 

--- a/tests/test-timber-comment-thread.php
+++ b/tests/test-timber-comment-thread.php
@@ -10,4 +10,34 @@
 			$this->assertEquals( 5, count($ct) );
 		}
 
+		function testShowUnmoderatedCommentIfByAnon() {
+			global $wp_version;
+			$post_id = $this->factory->post->create();
+			add_filter('wp_get_current_commenter', function($author_data) {
+				$author_data['comment_author_email'] = 'jarednova@upstatement.com';
+				return $author_data;
+			});
+
+
+
+			$commenter = wp_get_current_commenter();
+			$quote = "And in that moment, I was a marine biologist";
+			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote,'comment_approved' => 0, 'comment_author_email' => 'jarednova@upstatement.com'));
+
+			$comment = get_comment($comment_id);
+
+			$_GET['unapproved'] = $comment->comment_ID;
+			$_GET['moderation-hash'] = wp_hash($comment->comment_date_gmt);
+
+			$post = new TimberPost($post_id);
+			$timber_comment = $post->comments()[0];
+
+			if ( !function_exists('wp_get_unapproved_comment_author_email') ) {
+				$this->markTestSkipped('WP 5.1 or greater required');
+			} else {
+				$this->assertEquals($quote, $timber_comment->comment_content);
+			}
+
+		}
+
 	}

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -34,6 +34,8 @@
 			$post = new TimberPost($post_id);
 			$this->assertEquals(1, count($post->comments()));
 			wp_set_current_user( 0 );
+			$post = new TimberPost($post_id);
+			$this->assertEquals(0, count($post->comments()));
 		}
 
 		function testPostWithCustomCommentClass() {

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -58,6 +58,8 @@
 			$this->assertEquals(1, count($post->comments()));
 		}
 
+		
+
 		function testMultilevelThreadedComments() {
 			update_option('comment_order', 'ASC');
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

## Issue
In WordPress 4.9.6 with the GDPR updates, WordPress no longer displays the "comment awaiting moderation" message without the user agreeing to accept cookies when posting a comment. This could leave an anonymous visitor confused about whether or not their comment was properly submitted to the site. In WordPress 5.1 an update was made to display the visitor's comment along with the moderation message immediately after a comment was submitted - https://core.trac.wordpress.org/changeset/44659 however Timber does not yet support this update.

## Solution
This PR adds some handling to the `comments()` method in `Timber\Posts` to check if `wp_get_unapproved_comment_author_email()` exists and if so, check if the comment thread should display unapproved comments made by the visitor.

## Impact
This should allow anonymous commenters on WP sites running 5.1+ to see a comment awaiting moderation message after submitting a comment, whether or not they choose to accept cookies. This will only display on the next page load as it uses a hash in the redirection URL from the comment submission. This should not affect backward compatibility for older versions of WordPress as it is checked after the current checks for unapproved comments, and is wrapped in a `function_exists()` call to prevent a call to undefined function error.

## Usage Changes
None

## Considerations
Beyond the scope of this PR, but perhaps making a filter available for the `$args` array used in the `CommentThread->init()` call?

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Have not written any and not entirely sure how to approach for this honestly.
- Anonymous user submits comment form, without selecting to accept cookies
- Comment with ID matching the ID in the redirection query string should be returned in the comment list