### PR TITLE
Ref #1972 – Twig deprecated features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=5.3.0|7.*",
-    "twig/twig": "^1.34|^2.0",
+    "twig/twig": "^1.34|^2.4",
     "upstatement/routes": "0.5",
     "composer/installers": "~1.0",
     "asm89/twig-cache-extension": "~1.0"

--- a/lib/FunctionWrapper.php
+++ b/lib/FunctionWrapper.php
@@ -61,12 +61,12 @@ class FunctionWrapper {
 	 *
 	 * When a function is added more than once, addFunction() will throw a LogicException that states that the function
 	 * is already registered. By catching this exception, we can prevent a fatal error.
-	 * @see Twig_Extension_Staging::addFunction()
+	 * @see \Twig\Extension\StagingExtension::addFunction()
 	 *
 	 * @deprecated since 1.3.0
 	 * @todo remove in 1.4.0
-	 * @param \Twig_Environment $twig
-	 * @return \Twig_Environment
+	 * @param \Twig\Environment $twig
+	 * @return \Twig\Environment
 	 */
 	public function add_to_twig( $twig ) {
 		$wrapper = $this;

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -458,7 +458,7 @@ class Image extends Post implements CoreInterface {
 	 * @example
 	 * ```twig
 	 * <h1>{{ post.title }}</h1>
-	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" />
+	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumbnail.srcset }}" />
 	 * ```
 	 * ```html
 	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w" />
@@ -477,7 +477,7 @@ class Image extends Post implements CoreInterface {
 	 * @example
 	 * ```twig
 	 * <h1>{{ post.title }}</h1>
-	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumnbail.srcset }}" sizes="{{ post.thumbnail.img_sizes }}" />
+	 * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumbnail.srcset }}" sizes="{{ post.thumbnail.img_sizes }}" />
 	 * ```
 	 * ```html
 	 * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w sizes="(max-width: 1024px) 100vw, 102" />

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -245,18 +245,18 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension('Twig_Extension_Core')->setEscaper('esc_url', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
 			return esc_url($string);
 		});
-		$twig->getExtension('Twig_Extension_Core')->setEscaper('wp_kses_post', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
 			return wp_kses_post($string);
 		});
 
-		$twig->getExtension('Twig_Extension_Core')->setEscaper('esc_html', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
 			return esc_html($string);
 		});
 
-		$twig->getExtension('Twig_Extension_Core')->setEscaper('esc_js', function( \Twig_Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
 			return esc_js($string);
 		});
 


### PR DESCRIPTION
**Ticket**: #1972

## Issue

We missed some deprecated Twig class names in #1963.

## Solution

Use the new namespaced Twig class names. We should be save to do this when we require Twig versions that already support the new class names Timber’s composer.json. For this, I upgraded the required Twig version from `^2.0` to `^2.4` (Namespaces were introduced in 2.4: https://github.com/twigphp/Twig/blob/328d2aeba0b92002570b769706f500089ef6e1db/CHANGELOG#L161).

## Impact

There should be no impact.

## Usage Changes

None.

## Considerations

None.

## Testing

Ran tests locally.