### PR TITLE
Template trim fix

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -103,6 +103,9 @@ class Loader {
 
 		// Run through template array
 		foreach ( $templates as $template ) {
+
+			// Remove any whitespace around the template name
+			$template = trim( $template );
 			// Use the Twig loader to test for existance
 			if ( $loader->exists($template) ) {
 				// Return name of existing template

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -20,6 +20,11 @@
 			$str = Timber::compile( array('assets/barf.twig', 'assets/lonestar.twig') );
 			$this->assertFalse($str);
 		}
+		
+		function testWhitespaceTrimForTemplate(){
+			$str = Timber::compile('assets/single.twig ', array());
+			$this->assertEquals('I am single.twig in parent theme', trim($str));
+		}
 
 		function testTwigPathFilterAdded() {
 			$php_unit = $this;

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -20,10 +20,10 @@
 			$str = Timber::compile( array('assets/barf.twig', 'assets/lonestar.twig') );
 			$this->assertFalse($str);
 		}
-		
+
 		function testWhitespaceTrimForTemplate(){
 			$str = Timber::compile('assets/single.twig ', array());
-			$this->assertEquals('I am single.twig in parent theme', trim($str));
+			$this->assertEquals('I am single.twig', trim($str));
 		}
 
 		function testTwigPathFilterAdded() {


### PR DESCRIPTION
**Ticket**: Resolves #1705 

## Issue
A single whitespace before or after a template name (with the string) can cause the whole site to WSOD. While linters etc are great, if we can be a little more forgiving why not?


## Solution

Use trim within the template loader. 


## Impact
There should be no negative impacts, as filenames that begin or end in whitespace would generally be invalid, and everyone would be writing them without the whitespace, as it would cause a WSOD.


## Usage Changes
Timber's `render` and `compile` functions will now trim whitespace around template names before attempting to locate them.


## Considerations

Is it worth showing a warning when this happens? We could just silently allow it, but a warning could also be useful, perhaps via one of the helper functions.

If the dev is using a variable for the template name, they might like to know it's "wrong" as it could be causing other issues.

```php

$template = 'single.twig ';

if ( $template === 'single.twig') {
    // these things wont be done but the dev will wonder why as single.twig WILL render
}

// Will work if this PR gets merged
Timber::render( $template, $context );
````


## Testing

Test included in `tests/test-timber-loader.php`
