### PR TITLE
Filter for not forcing the WordPress way of get_posts.

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -53,14 +53,27 @@ class PostGetter {
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
 		/**
-		 * Checks if we should use **get_posts()** in a Timber or WordPress way.
+		 * Filters whether Timber::get_posts() should mirror WordPress’s get_posts() function.
 		 *
-		 * @since x.x.x
+		 * When passing `true` in this filter, Timber will set the following parameters for your query:
 		 *
-		 * @param boolean
+		 * - `ignore_sticky_posts = true`
+		 * - `suppress_filters = true`
+		 * - `no_found_rows = true`
+		 *
+		 * @since 1.9.5
+		 * @example
+		 * ```php
+		 * add_filter( 'timber/get_posts/mirror_wp_get_posts', '__return_true' );
+		 * ```
+		 *
+		 * @param bool $mirror Whether to mirror the `get_posts()` function of WordPress with all its
+		 *                     parameters. Default `false`.
 		 */
-		if ( apply_filters( 'timber/post_getter/wp_get_posts', false ) ) {
-			add_filter('pre_get_posts', array('Timber\PostGetter', 'set_query_defaults'));
+
+		$mirror_wp_get_posts = apply_filters( 'timber/get_posts/mirror_wp_get_posts', false );
+		if ( $mirror_wp_get_posts ) {
+			add_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );
 		}
 
 		$posts = self::query_posts($query, $PostClass);

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -59,7 +59,7 @@ class PostGetter {
 		 *
 		 * @param boolean
 		 */
-		if ( apply_filter( 'timber/post_getter/wp_get_posts', false ) ) {
+		if ( apply_filters( 'timber/post_getter/wp_get_posts', false ) ) {
 			add_filter('pre_get_posts', array('Timber\PostGetter', 'set_query_defaults'));
 		}
 

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -52,6 +52,7 @@ class PostGetter {
 	}
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
+
 		/**
 		 * Filters whether Timber::get_posts() should mirror WordPress’s get_posts() function.
 		 *
@@ -70,7 +71,6 @@ class PostGetter {
 		 * @param bool $mirror Whether to mirror the `get_posts()` function of WordPress with all its
 		 *                     parameters. Default `false`.
 		 */
-
 		$mirror_wp_get_posts = apply_filters( 'timber/get_posts/mirror_wp_get_posts', false );
 		if ( $mirror_wp_get_posts ) {
 			add_filter( 'pre_get_posts', array('Timber\PostGetter', 'set_query_defaults') );

--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -52,7 +52,17 @@ class PostGetter {
 	}
 
 	public static function get_posts( $query = false, $PostClass = '\Timber\Post', $return_collection = false ) {
-		add_filter('pre_get_posts', array('Timber\PostGetter', 'set_query_defaults'));
+		/**
+		 * Checks if we should use **get_posts()** in a Timber or WordPress way.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param boolean
+		 */
+		if ( apply_filter( 'timber/post_getter/wp_get_posts', false ) ) {
+			add_filter('pre_get_posts', array('Timber\PostGetter', 'set_query_defaults'));
+		}
+
 		$posts = self::query_posts($query, $PostClass);
 		return apply_filters('timber_post_getter_get_posts', $posts->get_posts($return_collection));
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 - Updated to most current version of Twig.
+- You can use WordPress's behavior of `get_posts` (versus `WP_Query`) in Timber's queries #1989 (thanks @palmiak) 
 
 **Changes for Theme Developers**
 - If you run into problems with unknown `Twig_SimpleFilter` or unknown `Twig_Filter` classes, you can use `Timber\Twig_Filter` instead.

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -115,7 +115,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$sticky_id = $this->factory->post->create();
 		$sticky = array($sticky_id, $pids[0]);
 		update_option('sticky_posts', $sticky);
-		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
+		add_filter( 'timber/get_posts/mirror_wp_get_posts', '__return_true' );
 		$posts = Timber::get_posts($pids);
 		$post_ids_gotten = array();
 		foreach($posts as $post) {
@@ -130,7 +130,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
 		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
 		update_option('sticky_posts', array($sticky_id));
-		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
+		add_filter( 'timber/get_posts/mirror_wp_get_posts', '__return_true' );
 		$posts = Timber::get_posts('post_type=post');
 		$this->assertEquals($last, $posts[0]->ID);
 		$posts = get_posts('post_type=post');
@@ -142,7 +142,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
 		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
 		update_option('sticky_posts', array($sticky_id));
-		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
+		add_filter( 'timber/get_posts/mirror_wp_get_posts', '__return_true' );
 		$posts = Timber::get_posts('post_type=post');
 		$this->assertEquals($last, $posts[0]->ID);
 		$posts = new Timber\PostQuery('post_type=post');
@@ -397,7 +397,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
             'orderby' => 'ID',
             'order' => 'ASC'
         );
-		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
+		add_filter( 'timber/get_posts/mirror_wp_get_posts', '__return_true' );
         $posts = Timber::get_posts($queryArgs);
         $this->assertEquals($numberPosts, count($posts));
 

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -397,7 +397,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
             'orderby' => 'ID',
             'order' => 'ASC'
         );
-
+		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
         $posts = Timber::get_posts($queryArgs);
         $this->assertEquals($numberPosts, count($posts));
 

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -115,6 +115,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$sticky_id = $this->factory->post->create();
 		$sticky = array($sticky_id, $pids[0]);
 		update_option('sticky_posts', $sticky);
+		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
 		$posts = Timber::get_posts($pids);
 		$post_ids_gotten = array();
 		foreach($posts as $post) {
@@ -129,6 +130,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
 		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
 		update_option('sticky_posts', array($sticky_id));
+		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
 		$posts = Timber::get_posts('post_type=post');
 		$this->assertEquals($last, $posts[0]->ID);
 		$posts = get_posts('post_type=post');
@@ -140,6 +142,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$sticky_id = $this->factory->post->create(array('post_date' => '2015-04-21 15:13:52'));
 		$last = $this->factory->post->create(array('post_date' => '2015-04-24 15:13:52'));
 		update_option('sticky_posts', array($sticky_id));
+		add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
 		$posts = Timber::get_posts('post_type=post');
 		$this->assertEquals($last, $posts[0]->ID);
 		$posts = new Timber\PostQuery('post_type=post');


### PR DESCRIPTION
**Ticket**: #1987

## Issue
Adds an additional filter that will give devs a chance to use get_posts in classic Timber way or in WP way.


## Solution
Adds an extra if + filter that can be set to true or false.


## Impact
It should solve issues like #1987 and on the hand will provide with quite easy way to solve #1812 


## Usage Changes
```
add_filter( 'timber/post_getter/wp_get_posts', '__return_true' );
add_filter( 'timber/post_getter/wp_get_posts', '__return_false' );
```


## Considerations
This is a temporary fix until we'll figure out what to do with `Timber::get_posts()`.

Also - I'm not sure about the filter name. Making those name is hard :(

## Testing
I added add_filter in tests so the test would run in WP way.
