### PR TITLE
2.x Fix failing test

### DIFF
--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -1002,11 +1002,12 @@
 
 			$pid = $this->factory->post->create(array('post_content' => $quote));
 			$post = new Timber\Post($pid);
-			$expected = array(
-				'<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>'
-			);
 
-			$this->assertEquals($expected, $post->video());
+			$video    = $post->video();
+			$value    = array_shift( $video );
+			$expected = '/<iframe [^>]+ src="https:\/\/www\.youtube\.com\/embed\/Jf37RalsnEs\?feature=oembed" [^>]+>/i';
+
+			$this->assertRegExp( $expected, $value );
 		}
 
 		function testPathAndLinkWithPort() {


### PR DESCRIPTION
**Ticket**: #1617 

## Issue

There’s at least one failing test that appears when testing against newer versions of WordPress.

For example, the test `TestTimberPost::testPostWithVideo()` will fail, because with newer versions of WordPress, the embed will look different. Instead of 

```html
<iframe width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
```

the result will include a title attribute

```html
<iframe title="Building sane, reusable WordPress templates with Twig and Timber - WPCampus 2017" width="500" height="281" src="https://www.youtube.com/embed/Jf37RalsnEs?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
```

We can’t just include that title attribute in the expected string, because the expected string is different for different WordPress versions.

## Solution

Resolve these tests.

For the `TestTimberPost::testPostWithVideo()` test, a regular expression check will be used.

## Impact

Fixes failing Travis tests.

## Usage Changes

None.

## Considerations

Nope.

## Testing

Yep.