### PR TITLE
Ref #1983 – Fix bug when WP_TESTS_DIR is not defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,15 @@ php:
     - 7.3
 
 env:
-    - WP_VERSION=4.7.12 WP_MULTISITE=0 PREFER_LOWEST="--prefer-lowest --prefer-stable"
-    - WP_VERSION=4.7.12 WP_MULTISITE=0 PREFER_LOWEST=""
-    - WP_VERSION=4.7.12 WP_MULTISITE=1 PREFER_LOWEST=""
-    - WP_VERSION=latest WP_MULTISITE=0 PREFER_LOWEST=""
-    - WP_VERSION=latest WP_MULTISITE=1 PREFER_LOWEST=""
-    - WP_VERSION=latest WP_MULTISITE=1 PREFER_LOWEST="--prefer-lowest --prefer-stable"
+    global:
+        - TMPDIR=/tmp
+    matrix:
+        - WP_VERSION=4.7.12 WP_MULTISITE=0 PREFER_LOWEST="--prefer-lowest --prefer-stable"
+        - WP_VERSION=4.7.12 WP_MULTISITE=0 PREFER_LOWEST=""
+        - WP_VERSION=4.7.12 WP_MULTISITE=1 PREFER_LOWEST=""
+        - WP_VERSION=latest WP_MULTISITE=0 PREFER_LOWEST=""
+        - WP_VERSION=latest WP_MULTISITE=1 PREFER_LOWEST=""
+        - WP_VERSION=latest WP_MULTISITE=1 PREFER_LOWEST="--prefer-lowest --prefer-stable"
 
 matrix:
     exclude:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -12,8 +12,14 @@ DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 SKIP_DB_CREATE=${6-false}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+TMPDIR=${TMPDIR-/tmp}
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+# think 'untrailingslashit(), but in bash"
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=$(echo $WP_TESTS_DIR | sed -e "s/\/$//")
+WP_CORE_DIR=$(echo $WP_CORE_DIR | sed -e "s/\/$//")
 
 download() {
     if [ `which curl` ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -92,8 +92,8 @@ install_wp() {
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -102,7 +102,7 @@ install_wp() {
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
 	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
+		local ioption='-i.bak'
 	else
 		local ioption='-i'
 	fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -29,8 +29,19 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
-	WP_TESTS_TAG="tags/$WP_VERSION"
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"
 else
@@ -44,7 +55,6 @@ else
 	fi
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
-
 set -ex
 
 install_wp() {
@@ -56,13 +66,29 @@ install_wp() {
 	mkdir -p $WP_CORE_DIR
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p /tmp/wordpress-nightly
-		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
-		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
-		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
 	else
-		if [ $WP_VERSION == 'latest' ]; then
+		if [[ $WP_VERSION == 'latest' ]]; then
 			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -23,7 +23,7 @@ WP_CORE_DIR=$(echo $WP_CORE_DIR | sed -e "s/\/$//")
 
 download() {
     if [ `which curl` ]; then
-        curl -s "$1" > "$2";
+        curl -sL "$1" > "$2";
     elif [ `which wget` ]; then
         wget -nv -O "$2" "$1"
     fi

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -150,8 +150,6 @@ install_db() {
 		fi
 	fi
 
-	#drop the db to start afresh
-	mysqladmin drop $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -150,6 +150,8 @@ install_db() {
 		fi
 	fi
 
+	#drop the db to start afresh
+	mysqladmin drop $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 	# create database
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,10 @@
 <?php
 
-$_tests_dir = getenv('WP_TESTS_DIR');
-if ( !$_tests_dir ) $_tests_dir = '/tmp/wordpress-tests-lib';
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
 
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( getenv( 'TMPDIR' ), '/' ) . '/wordpress-tests-lib';
+}
 
 require_once $_tests_dir . '/includes/functions.php';
 


### PR DESCRIPTION
**Ticket**: #1983

## Issue

As discussed with @aj-adl in https://github.com/timber/timber/pull/1983#issuecomment-490613098.

## Solution

This pull request adds a fallback for when the `WP_TESTS_DIR` is not defined, which considers the `TMPDIR` environment variable.

As soon as this pull request is merged, #1983 should be auto-merged as well.

## Impact

More failsafe testing setups.

## Usage Changes

None.

## Considerations

None.

## Testing

Manually tested in my local non-VVV testing setup.