### PR TITLE
Added big example to top of CommentThread class — with nesting

### DIFF
--- a/docs/guides/comments.md
+++ b/docs/guides/comments.md
@@ -1,0 +1,65 @@
+---
+title: "Comments"
+menu:
+  main:
+    parent: "guides"
+---
+
+## Simple Comment Implementation
+Looking to do non-threaded comments? This pattern can be expanded upon. If you're looking to customize the HTML of the comment form, you can get the necessary HTML from the starter theme's [comment-form.twig](https://github.com/timber/starter-theme/blob/master/templates/comment-form.twig) file.
+
+**single.twig**
+```twig
+<section class="post-{{ post.id }}">
+  <h1>{{ post.title }}</h1>
+  <div class="content">
+    {{ post.content }}
+  </div>
+  <div class="comments">
+    {% for comment in post.comments %}
+      <article class="comment" id="comment-{{ comment.id }}">
+      	<h5 class="comment-author">{{ comment.author.name }} says</h5>
+        {{ comment.content }}
+      </article>
+    {% endfor %}
+    {{ function('comment_form') }}
+  </div>
+</section>
+```
+
+## Threaded Comments
+
+Timber contains the `CommentThread` class to help manage comment threads. However, because replying to threaded comments involves WordPress's HTML and JavaScript we recommend employing threaded comments like so:
+
+**single.twig**
+```twig
+{# single.twig #}
+<div id="post-comments">
+  <h4>Comments on {{ post.title }}</h4>
+  <ul>
+    {% for comment in post.comments %}
+      {% include 'comment.twig' %}
+    {% endfor %}
+  </ul>
+  <div class="comment-form">
+    {{ function('comment_form') }}
+  </div>
+</div>
+```
+
+```twig
+{# comment.twig #}
+<li>
+  <div>{{ comment.content }}</div>
+  <p class="comment-author">{{ comment.author.name }}</p>
+  {{ function('comment_form') }}
+  <!-- nested comments here -->
+  {% if comment.children %}
+    <div class="replies"> 
+      {% for child_comment in comment.children %}
+        {% include 'comment.twig' with { comment:child_comment } %}
+      {% endfor %}
+    </div> 
+  {% endif %}    
+</li>
+```

--- a/docs/guides/comments.md
+++ b/docs/guides/comments.md
@@ -27,9 +27,34 @@ Looking to do non-threaded comments? This pattern can be expanded upon. If you'r
 </section>
 ```
 
-## Threaded Comments
+## Threaded Comments (Method 1)
 
-Timber contains the `CommentThread` class to help manage comment threads. However, because replying to threaded comments involves WordPress's HTML and JavaScript we recommend employing threaded comments like so:
+You can implement threaded comments this way (if you don't mind using WordPres's comment markup).
+
+**single.twig**
+```twig
+<section class="post-{{ post.id }}">
+  <h1>{{ post.title }}</h1>
+  <div class="content">
+    {{ post.content }}
+  </div>
+  <div class="comments">
+    {{ function('comments_template') }}
+  </div>
+</section>
+```
+
+**functions.php**
+```php
+//Include the comment reply Javascript
+add_action('wp_print_scripts', function(){
+  if ( (!is_admin()) && is_singular() && comments_open() && get_option('thread_comments') ) wp_enqueue_script( 'comment-reply' );
+});
+```
+
+## Threaded Comments (Method 2)
+
+Timber contains the `CommentThread` class to help manage comment threads. If you need to build something custom, you can implement it like so:
 
 **single.twig**
 ```twig

--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -4,6 +4,35 @@ namespace Timber;
 
 use Timber\Comment;
 
+/**
+ * This object is a special type of array that hold WordPress comments as Timber\Comment objects. 
+ * You propbably won't use this directly. This object is returned when calling `{{ post.comments }}` 
+ * in Twig.
+ *
+ * @example
+ * ```twig
+ * <div id="post-comments">
+ *   <h4>Comments on {{ post.title }}</h4>
+ *   <ul>
+ *     {% for comment in post.comments %}
+ *       {% include 'comment.twig' %}
+ *     {% endfor %}
+ *	 </ul>
+ * 
+ * #comment.twig
+ * <li>
+ *   <div>{{ comment.content }}</div>
+ *   <p class="comment-author">{{ comment.author.name }}</p>
+ *   <!-- nested comments here -->
+ *   {% if comment.children %}
+ *     <div class="replies"> 
+ *	     {% for child_comment in comment.children %}
+ *         {% include 'comment.twig' with { comment:child_comment } %}
+ *       {% endfor %}
+ *     </div> 
+ *   {% endif %}    
+ * </li>
+ */
 class CommentThread extends \ArrayObject {
 
 	var $CommentClass = 'Timber\Comment';
@@ -78,8 +107,6 @@ class CommentThread extends \ArrayObject {
 				$parents[$comment->ID] = $comment;
 			}
 		}
-
-		
 
 		foreach ( $children as &$comment ) {
 			$parent_id = $comment->comment_parent;

--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -18,7 +18,11 @@ use Timber\Comment;
  *     {% for comment in post.comments %}
  *       {% include 'comment.twig' %}
  *     {% endfor %}
- *	 </ul>
+ *   </ul>
+ *   <div class="comment-form">
+ *     {{ function('comment_form') }}
+ *   </div>
+ * </div>
  * ```
  *
  * ```twig
@@ -26,6 +30,7 @@ use Timber\Comment;
  * <li>
  *   <div>{{ comment.content }}</div>
  *   <p class="comment-author">{{ comment.author.name }}</p>
+ *   {{ function('comment_form') }}
  *   <!-- nested comments here -->
  *   {% if comment.children %}
  *     <div class="replies"> 

--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -57,6 +57,9 @@ class CommentThread extends \ArrayObject {
 		}
 	}
 
+	/**
+	 * @internal
+	 */
 	protected function fetch_comments( $args = array() ) {
 		$args['post_id'] = $this->post_id;
 		$comments = get_comments($args);
@@ -64,14 +67,8 @@ class CommentThread extends \ArrayObject {
 	}
 
 	/**
-	 * @experimental
+	 * @internal
 	 */
-	public function orderby( $orderby = 'wp' ) {
-		$this->_orderby = $orderby;
-		$this->init();
-		return $this;
-	}
-
 	protected function merge_args( $args ) {
 		$base = array('status' => 'approve');
 		$overrides = array('order' => $this->_order);
@@ -79,6 +76,7 @@ class CommentThread extends \ArrayObject {
 	}
 
 	/**
+	 * @internal
 	 * @experimental
 	 */
 	public function order( $order = 'ASC' ) {
@@ -87,6 +85,19 @@ class CommentThread extends \ArrayObject {
 		return $this;
 	}
 
+	/**
+	 * @internal
+	 * @experimental
+	 */
+	public function orderby( $orderby = 'wp' ) {
+		$this->_orderby = $orderby;
+		$this->init();
+		return $this;
+	}
+
+	/**
+	 * @internal
+	 */
 	public function init( $args = array() ) {
 		global $overridden_cpage;
 		$args = self::merge_args($args);
@@ -129,10 +140,16 @@ class CommentThread extends \ArrayObject {
 		$this->import_comments($parents);
 	}
 
+	/**
+	 * @internal
+	 */
 	protected function clear() {
 		$this->exchangeArray(array());
 	}
 
+	/**
+	 * @internal
+	 */
 	protected function import_comments( $arr ) {
 		$this->clear();
 		$i = 0;

--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -11,6 +11,7 @@ use Timber\Comment;
  *
  * @example
  * ```twig
+ * {# single.twig #}
  * <div id="post-comments">
  *   <h4>Comments on {{ post.title }}</h4>
  *   <ul>
@@ -18,8 +19,10 @@ use Timber\Comment;
  *       {% include 'comment.twig' %}
  *     {% endfor %}
  *	 </ul>
- * 
- * #comment.twig
+ * ```
+ *
+ * ```twig
+ * {# comment.twig #}
  * <li>
  *   <div>{{ comment.content }}</div>
  *   <p class="comment-author">{{ comment.author.name }}</p>
@@ -32,6 +35,7 @@ use Timber\Comment;
  *     </div> 
  *   {% endif %}    
  * </li>
+ * ```
  */
 class CommentThread extends \ArrayObject {
 

--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -5,19 +5,14 @@ namespace Timber;
 use Timber\Comment;
 
 /**
- * Class CommentThread
- *
- * This object is a special type of array that hold WordPress comments as `Timber\Comment` objects.
- * You probably won’t use this directly. This object is returned when calling `{{ post.comments }}`
+ * This object is a special type of array that hold WordPress comments as `Timber\Comment` objects. 
+ * You probably won't use this directly. This object is returned when calling `{{ post.comments }}` 
  * in Twig.
  *
- * @example
- *
- * **single.twig**
- *
+ * @example 
  * ```twig
+ * {# single.twig #}
  * <div id="post-comments">
-<<<<<<< HEAD
  *   <h4>Comments on {{ post.title }}</h4>
  *   <ul>
  *     {% for comment in post.comments %}
@@ -27,22 +22,12 @@ use Timber\Comment;
  *   <div class="comment-form">
  *     {{ function('comment_form') }}
  *   </div>
-=======
- *     <h4>Comments on {{ post.title }}</h4>
- *     <ul>
- *         {% for comment in post.comments %}
- *             {% include 'comment.twig' %}
- *         {% endfor %}
- *	   </ul>
->>>>>>> 9d51e73aab5e8f345bf3a72d925a22b827dc6b91
  * </div>
  * ```
  *
- * **comment.twig**
- *
  * ```twig
+ * {# comment.twig #}
  * <li>
-<<<<<<< HEAD
  *   <div>{{ comment.content }}</div>
  *   <p class="comment-author">{{ comment.author.name }}</p>
  *   {{ function('comment_form') }}
@@ -54,18 +39,6 @@ use Timber\Comment;
  *       {% endfor %}
  *     </div> 
  *   {% endif %}    
-=======
- *     <div>{{ comment.content }}</div>
- *     <p class="comment-author">{{ comment.author.name }}</p>
- *     <!-- nested comments here -->
- *     {% if comment.children %}
- *         <div class="replies">
- *             {% for child_comment in comment.children %}
- *                 {% include 'comment.twig' with { comment: child_comment } %}
- *             {% endfor %}
- *         </div>
- *     {% endif %}
->>>>>>> 9d51e73aab5e8f345bf3a72d925a22b827dc6b91
  * </li>
  * ```
  */

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1065,7 +1065,11 @@ class Post extends Core implements CoreInterface {
 	 *     {% for comment in post.comments() %}
 	 *       {% include 'comment.twig' %}
 	 *     {% endfor %}
-	 *	 </ul>
+	 *   </ul>
+	 *   <div class="comment-form">
+	 *     {{ function('comment_form') }}
+	 *   </div>
+	 * </div>
 	 * ```
 	 *
 	 * ```twig
@@ -1073,16 +1077,9 @@ class Post extends Core implements CoreInterface {
 	 * <li>
 	 *   <div>{{ comment.content }}</div>
 	 *   <p class="comment-author">{{ comment.author.name }}</p>
-	 *   <!-- nested comments here -->
-	 *   {% if comment.children %}
-	 *     <div class="replies"> 
-	 *	     {% for child_comment in comment.children %}
-	 *         {% include 'comment.twig' with { comment:child_comment } %}
-	 *       {% endfor %}
-	 *     </div> 
-	 *   {% endif %}    
 	 * </li>
 	 * ```
+	 * @see \Timber\CommentThread for an example with nested comments
 	 * @return bool|array
 	 */
 	public function comments( $count = null, $order = 'wp', $type = 'comment', $status = 'approve', $CommentClass = 'Timber\Comment' ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1049,7 +1049,7 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Gets the comments on a Timber\Post and returns them as an array of [Timber\Comment](#TimberComment) (or whatever comment class you set).
+	 * Gets the comments on a Timber\Post and returns them as a Timber\CommentThread: a PHP ArrayObject of [Timber\Comment](#TimberComment) (or whatever comment class you set).
 	 * @api
 	 * @param int $count Set the number of comments you want to get. `0` is analogous to "all"
 	 * @param string $order use ordering set in WordPress admin, or a different scheme
@@ -1059,13 +1059,29 @@ class Post extends Core implements CoreInterface {
 	 * @example
 	 * ```twig
 	 * {# single.twig #}
-	 * <h4>Comments:</h4>
-	 * {% for comment in post.comments %}
-	 * 	<div class="comment-{{comment.ID}} comment-order-{{loop.index}}">
-	 * 		<p>{{comment.author.name}} said:</p>
-	 * 		<p>{{comment.content}}</p>
-	 * 	</div>
-	 * {% endfor %}
+	 * <div id="post-comments">
+	 *   <h4>Comments on {{ post.title }}</h4>
+	 *   <ul>
+	 *     {% for comment in post.comments() %}
+	 *       {% include 'comment.twig' %}
+	 *     {% endfor %}
+	 *	 </ul>
+	 * ```
+	 *
+	 * ```twig
+	 * {# comment.twig #}
+	 * <li>
+	 *   <div>{{ comment.content }}</div>
+	 *   <p class="comment-author">{{ comment.author.name }}</p>
+	 *   <!-- nested comments here -->
+	 *   {% if comment.children %}
+	 *     <div class="replies"> 
+	 *	     {% for child_comment in comment.children %}
+	 *         {% include 'comment.twig' with { comment:child_comment } %}
+	 *       {% endfor %}
+	 *     </div> 
+	 *   {% endif %}    
+	 * </li>
 	 * ```
 	 * @return bool|array
 	 */


### PR DESCRIPTION
**Ticket**: #1971

## Issue
As noted, the only example of how to do nested comments is buried in the tests

## Solution
Put an example in!

## Impact
Expands the example in `Timber\Post::comments` showing a nested example. The same example appears in the a new docblock for `Timber\CommentThread`.

## Considerations
Is this the right place? Originally I had it just in CommentThread — but since that's not really intended to be a public class, it felt wrong. This solution provides where I think people are most likely to discover it: with `{{ post.comments }}` which they interface with, and `CommentThread.php` in case someone is looking through the files