### PR TITLE
Conditional eager-loading of post meta values

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -531,11 +531,16 @@ class Post extends Core implements CoreInterface {
 	 * @return array
 	 */
 	protected function get_post_custom( $pid ) {
-		apply_filters('timber_post_get_meta_pre', array(), $pid, $this);
-		$customs = get_post_custom($pid);
-		if ( !is_array($customs) || empty($customs) ) {
+		$customs = apply_filters('timber_post_get_meta_pre', array(), $pid, $this);
+
+		if ( is_array($customs) && empty($customs) ) {
+			$customs = get_post_custom($pid);
+		}
+
+		if ( !is_array($customs) ) {
 			return array();
 		}
+
 		foreach ( $customs as $key => $value ) {
 			if ( is_array($value) && count($value) == 1 && isset($value[0]) ) {
 				$value = $value[0];

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -319,6 +319,47 @@
 			$this->assertEquals($page2, trim(strip_tags( $post->get_paged_content() )));
 		}
 
+		function testMetaCustomPreFilterDisable(){
+
+			$callable = function(){ return false; };
+
+			add_filter( 'timber_post_get_meta_pre', $callable );
+
+			$post_id = $this->factory->post->create();
+
+			update_post_meta($post_id, 'hidden_value', 'Super secret value');
+
+			$post = new TimberPost($post_id);
+
+			$this->assertCount( 0, $post->custom);
+
+			remove_filter( 'timber_post_get_meta_pre', $callable );
+		}
+
+		function testMetaCustomPreFilterAlter(){
+
+			$callable = function( $customs, $pid, $post ) {
+				$key = 'critical_value';
+
+				return [
+					$key => get_post_meta( $pid, $key ),
+				];
+			};
+
+			add_filter( 'timber_post_get_meta_pre', $callable , 10, 3);
+
+			$post_id = $this->factory->post->create();
+
+			update_post_meta($post_id, 'hidden_value', 'super-big-secret');
+			update_post_meta($post_id, 'critical_value', 'I am needed, all the time');
+
+			$post = new TimberPost($post_id);
+			$this->assertCount( 1, $post->custom );
+			$this->assertEquals( $post->custom, array( 'critical_value' => 'I am needed, all the time' ) );
+
+			remove_filter( 'timber_post_get_meta_pre', $callable );
+		}
+
 		function testMetaCustomArrayFilter(){
 			add_filter('timber_post_get_meta', function($customs){
 				foreach($customs as $key=>$value){


### PR DESCRIPTION

**Ticket**: Fixes #2011 

## Issue
Allows the user to control what post meta values get eager-loaded into `\Timber\Post->custom`


## Solution
Supports both disabling, and conditional loading

## Impact
This filter currently cannot affect how the parent function of `get_post_custom` runs. There is a potential issue if people have been hooking into here to perform some action, and returned null / void etc as previously the return value had no effect. I doubt many people are getting that into the guts of Timber, but it is something to be considered

## Usage Changes

Allows the user to return `false` or `null` to stop the eager-loading, or return an array of `$key => $value` which will then be processed and imported into the `Timber\Post` or derivative object. 

## Considerations
naming? not suer how this looks in 2.0, seems like some changes there


## Testing
Unit tests included and passing in `tests-timber-post.php`
