### PR TITLE
1974 wpml menu fix

### DIFF
--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -259,9 +259,10 @@ class Menu extends Core {
 					$item = new $this->PostClass($item);
 				}
 				$menu_item = $this->create_menu_item($item);
-				if ( isset($old_menu_item) ) {
+				if ( $old_menu_item ) {
 					$menu_item->import_classes($old_menu_item);
 				}
+				$old_menu_item = null;
 				$index[$item->ID] = $menu_item;
 			}
 		}

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -247,6 +247,7 @@ class Menu extends Core {
 	protected function order_children( $items ) {
 		$index = array();
 		$menu = array();
+		$wp_post_menu_item = null;
 		foreach ( $items as $item ) {
 			if ( isset($item->title) ) {
 				// Items from WordPress can come with a $title property which conflicts with methods

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -255,14 +255,14 @@ class Menu extends Core {
 			}
 			if ( isset($item->ID) ) {
 				if ( is_object($item) && get_class($item) == 'WP_Post' ) {
-					$old_menu_item = $item;
+					$wp_post_menu_item = $item;
 					$item = new $this->PostClass($item);
 				}
 				$menu_item = $this->create_menu_item($item);
-				if ( $old_menu_item ) {
-					$menu_item->import_classes($old_menu_item);
+				if ( $wp_post_menu_item ) {
+					$menu_item->import_classes($wp_post_menu_item);
 				}
-				$old_menu_item = null;
+				$wp_post_menu_item = null;
 				$index[$item->ID] = $menu_item;
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 - Updated to most current version of Twig.
+- Fix to menu items getting incorrect classes in WPML and others #1974
 
 **Changes for Theme Developers**
 - If you run into problems with unknown `Twig_SimpleFilter` or unknown `Twig_Filter` classes, you can use `Timber\Twig_Filter` instead.


### PR DESCRIPTION
**Ticket**: #1974 

## Issue
The last WPML language switcher menu item was picking up the prior item's classes

## Solution
While we want to use the `WP_Post` object (as opposed to the Timber-based object) to pull classes from, we need to clear its value to prevent the issue from occurring

## Impact
This fixes #1974 (including @mgarabedian related issue). Unlike #2009, this isn't WPML-specific

## Usage Changes
None

## Testing
I tested locally against a real WPML instance and verified the fix. I don't think new tests are necessary since this removes a bug vs. creating a feature
