### PR TITLE
Ref #2012 – Update skipping get_post_meta() to match behavior in 2.0

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -547,7 +547,7 @@ class Post extends Core implements CoreInterface {
 		 *
 		 * // Add your own meta data.
 		 * add_filter( 'timber_post_get_meta_pre', function( $post_meta, $post_id, $post ) {
-    	 *     $post_meta = array(
+		 *     $post_meta = array(
 		 *         'custom_data_1' => 73,
 		 *         'custom_data_2' => 274,
 		 *     );

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -531,11 +531,16 @@ class Post extends Core implements CoreInterface {
 	 * @return array
 	 */
 	protected function get_post_custom( $pid ) {
-		apply_filters('timber_post_get_meta_pre', array(), $pid, $this);
-		$customs = get_post_custom($pid);
-		if ( !is_array($customs) || empty($customs) ) {
+		$customs = apply_filters('timber_post_get_meta_pre', array(), $pid, $this);
+
+		if ( is_array($customs) && empty($customs) ) {
+			$customs = get_post_custom($pid);
+		}
+
+		if ( !is_array($customs) ) {
 			return array();
 		}
+
 		foreach ( $customs as $key => $value ) {
 			if ( is_array($value) && count($value) == 1 && isset($value[0]) ) {
 				$value = $value[0];

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -531,24 +531,57 @@ class Post extends Core implements CoreInterface {
 	 * @return array
 	 */
 	protected function get_post_custom( $pid ) {
-		$customs = apply_filters('timber_post_get_meta_pre', array(), $pid, $this);
+		$post_meta = array();
 
-		if ( is_array($customs) && empty($customs) ) {
-			$customs = get_post_custom($pid);
+		/**
+		 * Filters post meta data before it is fetched from the database.
+		 *
+		 * Timber loads all meta values into the post object on initialization. With this filter,
+		 * you can disable fetching the meta values through the default method, which uses
+		 * `get_post_meta()`, by returning `false` or an non-empty array.
+		 *
+		 * @example
+		 * ```php
+		 * // Disable fetching meta values.
+		 * add_filter( 'timber_post_get_meta_pre', '__return_false' );
+		 *
+		 * // Add your own meta data.
+		 * add_filter( 'timber_post_get_meta_pre', function( $post_meta, $post_id, $post ) {
+    	 *     $post_meta = array(
+		 *         'custom_data_1' => 73,
+		 *         'custom_data_2' => 274,
+		 *     );
+		 *
+		 *     return $post_meta;
+		 * }, 10, 3 );
+		 * ```
+		 *
+		 * @param array $post_meta        An array of custom meta values. Passing false or a
+		 *                                non-empty array will skip fetching the values from the
+		 *                                database and will use the filtered values instead. Default
+		 *                                `array()`.
+		 * @param int          $post_id   The post ID.
+		 * @param \Timber\Post $post      The post object.
+		 */
+		$post_meta = apply_filters('timber_post_get_meta_pre', $post_meta, $pid, $this);
+
+		// Load all meta data when it wasn’t filtered before.
+		if ( false !== $post_meta && empty( $post_meta ) ) {
+			$post_meta = get_post_meta( $pid );
 		}
 
-		if ( !is_array($customs) ) {
+		if ( !is_array($post_meta) ) {
 			return array();
 		}
 
-		foreach ( $customs as $key => $value ) {
+		foreach ( $post_meta as $key => $value ) {
 			if ( is_array($value) && count($value) == 1 && isset($value[0]) ) {
 				$value = $value[0];
 			}
-			$customs[$key] = maybe_unserialize($value);
+			$post_meta[$key] = maybe_unserialize($value);
 		}
-		$customs = apply_filters('timber_post_get_meta', $customs, $pid, $this);
-		return $customs;
+		$post_meta = apply_filters('timber_post_get_meta', $post_meta, $pid, $this);
+		return $post_meta;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,7 @@ _Twig is the template language powering Timber; if you need a little background 
 **Fixes and improvements**
 
 **Changes for Theme Developers**
+- You can now skip the eager loading of meta vars through a filter #2014 (thanks @aj-adl @gchtr)
 
 
 = 1.9.5 =

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -319,6 +319,47 @@
 			$this->assertEquals($page2, trim(strip_tags( $post->get_paged_content() )));
 		}
 
+		function testMetaCustomPreFilterDisable(){
+
+			$callable = function(){ return false; };
+
+			add_filter( 'timber_post_get_meta_pre', $callable );
+
+			$post_id = $this->factory->post->create();
+
+			update_post_meta($post_id, 'hidden_value', 'Super secret value');
+
+			$post = new TimberPost($post_id);
+
+			$this->assertCount( 0, $post->custom);
+
+			remove_filter( 'timber_post_get_meta_pre', $callable );
+		}
+
+		function testMetaCustomPreFilterAlter(){
+
+			$callable = function( $customs, $pid, $post ) {
+				$key = 'critical_value';
+
+				return [
+					$key => get_post_meta( $pid, $key ),
+				];
+			};
+
+			add_filter( 'timber_post_get_meta_pre', $callable , 10, 3);
+
+			$post_id = $this->factory->post->create();
+
+			update_post_meta($post_id, 'hidden_value', 'super-big-secret');
+			update_post_meta($post_id, 'critical_value', 'I am needed, all the time');
+
+			$post = new TimberPost($post_id);
+			$this->assertCount( 1, $post->custom );
+			$this->assertEquals( $post->custom, array( 'critical_value' => 'I am needed, all the time' ) );
+
+			remove_filter( 'timber_post_get_meta_pre', $callable );
+		}
+
 		function testMetaCustomArrayFilter(){
 			add_filter('timber_post_get_meta', function($customs){
 				foreach($customs as $key=>$value){


### PR DESCRIPTION
**Ticket**: #2012

## Issue

In #2012 @aj-adl proposed a way to skip Timber from fetching meta values through `get_post_meta()` via the `timber_post_get_meta_pre` filter. Turns out that in 2.x, I added pretty much the same behavior, just with a new filter:

https://github.com/timber/timber/blob/35279e5fa8911c52854f2d268fc028bcf76c2313/lib/Post.php#L574-L624

I wasn’t sure whether this was over-optimization, but hey, here we have a use case already 😎.

## Solution

This pull request builds on #2012 to replicate the behavior that we’re going to add in 2.0 in the master branch so that this feature can be used now.

## Impact

None.

## Usage Changes

See #2012.

## Considerations

None.

## Testing

None.
