### PR TITLE
ref #1731 -- apply suggested fix for comment order override

### DIFF
--- a/lib/CommentThread.php
+++ b/lib/CommentThread.php
@@ -75,9 +75,8 @@ class CommentThread extends \ArrayObject {
 	 * @internal
 	 */
 	protected function merge_args( $args ) {
-		$base = array('status' => 'approve');
-		$overrides = array('order' => $this->_order);
-		return array_merge($base, $args, $overrides);
+		$base = array('status' => 'approve', 'order' => $this->_order);
+		return array_merge($base, $args);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,7 @@ _Twig is the template language powering Timber; if you need a little background 
 = Develop (next release) =
 
 **Fixes and improvements**
+- Fixed issue with Timber not respecting comment order #1731 #2015
 
 **Changes for Theme Developers**
 


### PR DESCRIPTION
**Ticket**: #1731 

## Issue
Manual ordering args were overridden by class's value

## Solution
Make class's value the default, can now be overriden by user defined value

## Impact
This will only cause an issue in the case where someone's failed attempts to override were unsuccessful — now they'll succeed

## Testing
No new tests
