### PR TITLE
Menu optimizations

### DIFF
--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -296,7 +296,7 @@ class Menu extends Core {
 	 * @return mixed an instance of the user-configured $MenuItemClass
 	 */
 	protected function create_menu_item($item) {
-		return new $this->MenuItemClass($item);
+		return new $this->MenuItemClass( $item, $this );
 	}
 
 	/**

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -48,16 +48,24 @@ class Menu extends Core {
 
 	/**
 	 * @api
-	 * @var array The unfiltered options sent forward via the user in the __construct
-	 */
-	public $raw_options;
-
-	/**
-	 * @api
 	 * @var string The name of the menu (ex: `Main Navigation`).
 	 */
 	public $title;
 
+	/**
+	 * Menu options.
+	 *
+	 * @api
+	 * @since 1.9.6
+	 * @var array An array of menu options.
+	 */
+	public $options;
+
+	/**
+	 * @api
+	 * @var array The unfiltered options sent forward via the user in the __construct
+	 */
+	public $raw_options;
 
 	/**
 	 * Theme Location.
@@ -72,15 +80,25 @@ class Menu extends Core {
 	 * Initialize a menu.
 	 *
 	 * @param int|string $slug    A menu slug, the term ID of the menu, the full name from the admin
-	 *                            menu, the slug of theregistered location or nothing. Passing nothing
-	 *                            is good if you only have one menu. Timber will grab what it finds.
-	 * @param array      $options An array of options, right now only `depth` is supported
+	 *                            menu, the slug of the registered location or nothing. Passing
+	 *                            nothing is good if you only have one menu. Timber will grab what
+	 *                            it finds.
+	 * @param array      $options Optional. An array of options. Right now, only the `depth` is,
+	 *                            supported which says how many levels of hierarchy should be
+	 *                            included in the menu. Default `-1`, which is all levels.
 	 */
 	public function __construct( $slug = 0, $options = array() ) {
 		$menu_id = false;
 		$locations = get_nav_menu_locations();
 
-		$this->set_options((array)$options);
+		// For future enhancements?
+		$this->raw_options = $options;
+
+			'depth' => -1,
+		$this->options = wp_parse_args( array(
+		), (array) $options );
+
+		$this->depth = (int) $this->options['depth'];
 
 		if ( $slug != 0 && is_numeric($slug) ) {
 			$menu_id = $slug;
@@ -160,16 +178,6 @@ class Menu extends Core {
 			$this->id = $this->term_id;
 			$this->title = $this->name;
 		}
-	}
-
-	/**
-	 * @internal
-	 * @param mixed $options
-	 */
-	protected function set_options ($options) {
-		// Set any important options
-		$this->depth = (isset($options['depth']) ? (int)$options['depth'] : -1);
-		$this->raw_options = $options; // for future enhancements?
 	}
 
 	/**

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -59,6 +59,14 @@ class Menu extends Core {
 	public $title;
 
 
+	/**
+	 * Theme Location.
+	 *
+	 * @api
+	 * @since 1.9.6
+	 * @var string The theme location of the menu, if available.
+	 */
+	public $theme_location = null;
 
 	/**
 	 * Initialize a menu.
@@ -76,7 +84,7 @@ class Menu extends Core {
 
 		if ( $slug != 0 && is_numeric($slug) ) {
 			$menu_id = $slug;
-		} else if ( is_array($locations) && count($locations) ) {
+		} else if ( is_array($locations) && ! empty( $locations ) ) {
 			$menu_id = $this->get_menu_id_from_locations($slug, $locations);
 		} else if ( $slug === false ) {
 			$menu_id = false;
@@ -97,6 +105,13 @@ class Menu extends Core {
 	 */
 	protected function init( $menu_id ) {
 		$menu = wp_get_nav_menu_items($menu_id);
+		$locations = get_nav_menu_locations();
+
+		// Set theme location if available.
+		if ( ! empty( $locations ) && in_array( $menu_id, $locations, true ) ) {
+			$this->theme_location = array_search( $menu_id, $locations, true );
+		}
+
 		if ( $menu ) {
 			_wp_menu_item_classes_by_context($menu);
 			if ( is_array($menu) ) {

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -83,7 +83,7 @@ class Menu extends Core {
 	 *                            menu, the slug of the registered location or nothing. Passing
 	 *                            nothing is good if you only have one menu. Timber will grab what
 	 *                            it finds.
-	 * @param array      $options Optional. An array of options. Right now, only the `depth` is,
+	 * @param array      $options Optional. An array of options. Right now, only the `depth` is
 	 *                            supported which says how many levels of hierarchy should be
 	 *                            included in the menu. Default `0`, which is all levels.
 	 */

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -85,7 +85,7 @@ class Menu extends Core {
 	 *                            it finds.
 	 * @param array      $options Optional. An array of options. Right now, only the `depth` is,
 	 *                            supported which says how many levels of hierarchy should be
-	 *                            included in the menu. Default `-1`, which is all levels.
+	 *                            included in the menu. Default `0`, which is all levels.
 	 */
 	public function __construct( $slug = 0, $options = array() ) {
 		$menu_id = false;
@@ -94,8 +94,8 @@ class Menu extends Core {
 		// For future enhancements?
 		$this->raw_options = $options;
 
-			'depth' => -1,
 		$this->options = wp_parse_args( array(
+			'depth' => 0,
 		), (array) $options );
 
 		$this->depth = (int) $this->options['depth'];

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -94,9 +94,9 @@ class Menu extends Core {
 		// For future enhancements?
 		$this->raw_options = $options;
 
-		$this->options = wp_parse_args( array(
+		$this->options = wp_parse_args( (array) $options, array(
 			'depth' => 0,
-		), (array) $options );
+		) );
 
 		$this->depth = (int) $this->options['depth'];
 

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -60,6 +60,15 @@ class MenuItem extends Core implements CoreInterface {
 	 */
 	public $current_item_ancestor;
 
+	/**
+	 * Timber Menu.
+	 *
+	 * @api
+	 * @since 1.9.6
+	 * @var \Timber\Menu The `Timber\Menu` object the menu item is associated with.
+	 */
+	public $menu;
+
 	protected $_name;
 	protected $_menu_item_object_id;
 	protected $_menu_item_url;
@@ -68,9 +77,12 @@ class MenuItem extends Core implements CoreInterface {
 	/**
 	 * @internal
 	 * @param array|object $data
+	 * @param \Timber\Menu $menu The `Timber\Menu` object the menu item is associated with.
 	 */
-	public function __construct( $data ) {
+	public function __construct( $data, $menu ) {
+		$this->menu = $menu;
 		$data = (object) $data;
+
 		$this->import($data);
 		$this->import_classes($data);
 		if ( isset($this->name) ) {

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -81,7 +81,7 @@ class MenuItem extends Core implements CoreInterface {
 	 */
 	public function __construct( $data, $menu ) {
 		$this->menu = $menu;
-		$data = (object) $data;
+		$data       = (object) $data;
 
 		$this->import($data);
 		$this->import_classes($data);
@@ -250,7 +250,28 @@ class MenuItem extends Core implements CoreInterface {
 		}
 		$this->classes = array_merge($this->classes, $data->classes);
 		$this->classes = array_unique($this->classes);
-		$this->classes = apply_filters('nav_menu_css_class', $this->classes, $this, array(), 0);
+
+		/**
+		 * Filters the CSS classes applied to a menu item’s list item.
+		 *
+		 * @param string[]         $classes An array of the CSS classes that can be applied to the
+		 *                                  menu item’s `<li>` element.
+		 * @param \Timber\MenuItem $item    The current menu item.
+		 * @param \stdClass $args           An object of wp_nav_menu() arguments. In Timber, we
+		 *                                  don’t have these arguments because we don’t use a menu
+		 *                                  walker. Instead, you get the options that were used to
+		 *                                  create the `Timber\Menu` object.
+		 * @param int              $depth   Depth of menu item.
+		 */
+		$this->classes = apply_filters(
+			'nav_menu_css_class',
+			$this->classes,
+			$this,
+			// The options need to be an object.
+			(object) $this->menu->options,
+			0
+		);
+
 		$this->class = trim(implode(' ', $this->classes));
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -34,10 +34,11 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Changes for Theme Developers**
 - You can now skip the eager loading of meta vars through a filter #2014 (thanks @aj-adl @gchtr)
+- You can now more easily work with menu locations and filters #1959 #2018 (thanks @gchtr)
 
 = 1.9.6 =
 **Fixes and improvements**
-- Revert to Twig 1.34 to prevent compatability issues with WPML and other plug-ins
+- Revert to Twig 1.34 to prevent compatibility issues with WPML and other plug-ins
 
 = 1.9.5 =
 **Fixes and improvements**

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -200,6 +200,23 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		self::insertIntoMenu($menu_term['term_id'], $menu_items);
 		return $menu_term;
 	}
+
+	public function registerNavMenus( $locations ) {
+		$theme = new Timber\Theme();
+
+		update_option( 'theme_mods_' . $theme->slug, array(
+			'nav_menu_locations' => $locations,
+		) );
+
+		register_nav_menus(
+		    array(
+		    	'header-menu' => 'Header Menu',
+				'extra-menu' => 'Extra Menu',
+				'bonus' => 'The Bonus'
+		    )
+		);
+	}
+
 	public static function _createSimpleMenu( $name = 'My Menu' ) {
 		$menu_term = wp_insert_term( $name, 'nav_menu' );
 		$menu_items = array();
@@ -619,16 +636,12 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$built_menu_id = $built_menu['term_id'];
 
 		$this->buildMenu('Zappy', $items);
-		$theme = new TimberTheme();
-		$data = array('nav_menu_locations' => array('header-menu' => 0, 'extra-menu' => $built_menu_id, 'bonus' => 0));
-		update_option('theme_mods_'.$theme->slug, $data);
-		register_nav_menus(
-		    array(
-		    	'header-menu' => 'Header Menu',
-				'extra-menu' => 'Extra Menu',
-				'bonus' => 'The Bonus'
-		    )
-		);
+		$this->registerNavMenus( array(
+			'header-menu' => 0,
+			'extra-menu'  => $built_menu_id,
+			'bonus'       => 0,
+		) );
+
 		$menu = new TimberMenu('extra-menu');
 		$this->assertEquals('Ziggy', $menu->name);
 	}

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -5,6 +5,248 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	const MENU_NAME = 'Menu One';
 	const MENU_SLUG = 'nav_menu';
 
+	public static function _createTestMenu() {
+		$menu_term = wp_insert_term( self::MENU_NAME, self::MENU_SLUG );
+		$menu_id = $menu_term['term_id'];
+		$menu_items = array();
+		$parent_page = wp_insert_post(
+			array(
+				'post_title' => 'Home',
+				'post_status' => 'publish',
+				'post_name' => 'home',
+				'post_type' => 'page',
+				'menu_order' => 1
+			)
+		);
+		$parent_id = wp_insert_post( array(
+				'post_title' => '',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item'
+			) );
+		update_post_meta( $parent_id, '_menu_item_type', 'post_type' );
+		update_post_meta( $parent_id, '_menu_item_object', 'page' );
+		update_post_meta( $parent_id, '_menu_item_menu_item_parent', 0 );
+		update_post_meta( $parent_id, '_menu_item_object_id', $parent_page );
+		update_post_meta( $parent_id, '_menu_item_url', '' );
+		$menu_items[] = $parent_id;
+		$link_id = wp_insert_post(
+			array(
+				'post_title' => 'Upstatement',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 2
+			)
+		);
+
+		$menu_items[] = $link_id;
+		update_post_meta( $link_id, '_menu_item_type', 'custom' );
+		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
+		update_post_meta( $link_id, '_menu_item_url', 'http://upstatement.com' );
+		update_post_meta( $link_id, '_menu_item_xfn', '' );
+		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
+
+		/* make a child page */
+		$child_id = wp_insert_post( array(
+				'post_title' => 'Child Page',
+				'post_status' => 'publish',
+				'post_name' => 'child-page',
+				'post_type' => 'page',
+				'menu_order' => 3,
+			) );
+		$child_menu_item = wp_insert_post( array(
+				'post_title' => '',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+			) );
+		update_post_meta( $child_menu_item, '_menu_item_type', 'post_type' );
+		update_post_meta( $child_menu_item, '_menu_item_menu_item_parent', $parent_id );
+		update_post_meta( $child_menu_item, '_menu_item_object_id', $child_id );
+		update_post_meta( $child_menu_item, '_menu_item_object', 'page' );
+		update_post_meta( $child_menu_item, '_menu_item_url', '' );
+		$post = new TimberPost( $child_menu_item );
+		$menu_items[] = $child_menu_item;
+
+		/* make a grandchild page */
+		$grandchild_id = wp_insert_post( array(
+				'post_title' => 'Grandchild Page',
+				'post_status' => 'publish',
+				'post_name' => 'grandchild-page',
+				'post_type' => 'page',
+			) );
+		$grandchild_menu_item = wp_insert_post( array(
+				'post_title' => '',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 100,
+			) );
+		update_post_meta( $grandchild_menu_item, '_menu_item_type', 'post_type' );
+		update_post_meta( $grandchild_menu_item, '_menu_item_menu_item_parent', $child_menu_item );
+		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
+		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
+		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
+		$post = new TimberPost( $grandchild_menu_item );
+		$menu_items[] = $grandchild_menu_item;
+
+		/* make another grandchild page */
+		$grandchild_id = wp_insert_post( array(
+				'post_title' => 'Other Grandchild Page',
+				'post_status' => 'publish',
+				'post_name' => 'other grandchild-page',
+				'post_type' => 'page',
+			) );
+		$grandchild_menu_item = wp_insert_post( array(
+				'post_title' => '',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 101,
+			) );
+		update_post_meta( $grandchild_menu_item, '_menu_item_type', 'post_type' );
+		update_post_meta( $grandchild_menu_item, '_menu_item_menu_item_parent', $child_menu_item );
+		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
+		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
+		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
+		$post = new TimberPost( $grandchild_menu_item );
+		$menu_items[] = $grandchild_menu_item;
+
+		$root_url_link_id = wp_insert_post(
+			array(
+				'post_title' => 'Root Home',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 4
+			)
+		);
+
+		$menu_items[] = $root_url_link_id;
+		update_post_meta( $root_url_link_id, '_menu_item_type', 'custom' );
+		update_post_meta( $root_url_link_id, '_menu_item_object_id', $root_url_link_id );
+		update_post_meta( $root_url_link_id, '_menu_item_url', '/' );
+		update_post_meta( $root_url_link_id, '_menu_item_xfn', '' );
+		update_post_meta( $root_url_link_id, '_menu_item_menu_item_parent', 0 );
+
+		$link_id = wp_insert_post(
+			array(
+				'post_title' => 'People',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 6
+			)
+		);
+
+		$menu_items[] = $link_id;
+		update_post_meta( $link_id, '_menu_item_type', 'custom' );
+		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
+		update_post_meta( $link_id, '_menu_item_url', '#people' );
+		update_post_meta( $link_id, '_menu_item_xfn', '' );
+		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
+
+		$link_id = wp_insert_post(
+			array(
+				'post_title' => 'More People',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 7
+			)
+		);
+
+		$menu_items[] = $link_id;
+		update_post_meta( $link_id, '_menu_item_type', 'custom' );
+		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
+		update_post_meta( $link_id, '_menu_item_url', 'http://example.org/#people' );
+		update_post_meta( $link_id, '_menu_item_xfn', '' );
+		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
+
+		$link_id = wp_insert_post(
+			array(
+				'post_title' => 'Manual Home',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item',
+				'menu_order' => 8
+			)
+		);
+
+		$menu_items[] = $link_id;
+		update_post_meta( $link_id, '_menu_item_type', 'custom' );
+		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
+		update_post_meta( $link_id, '_menu_item_url', 'http://example.org' );
+		update_post_meta( $link_id, '_menu_item_xfn', '' );
+		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
+
+		self::insertIntoMenu($menu_id, $menu_items);
+		return $menu_term;
+	}
+
+	public static function buildMenu($name, $items) {
+		$menu_term = wp_insert_term( $name, 'nav_menu' );
+		$menu_items = array();
+		$i = 0;
+		foreach($items as $item) {
+			if ($item->type == 'link') {
+				$pid = wp_insert_post( array(
+					'post_title'  => '',
+					'post_status' => 'publish',
+					'post_type'   => 'nav_menu_item',
+					'menu_order'  => $i,
+				) );
+				update_post_meta( $pid, '_menu_item_type', 'custom' );
+				update_post_meta( $pid, '_menu_item_object_id', $pid );
+				update_post_meta( $pid, '_menu_item_url', $item->link );
+				update_post_meta( $pid, '_menu_item_xfn', '' );
+				update_post_meta( $pid, '_menu_item_menu_item_parent', 0 );
+				$menu_items[] = $pid;
+			}
+			$i++;
+		}
+		self::insertIntoMenu($menu_term['term_id'], $menu_items);
+		return $menu_term;
+	}
+	public static function _createSimpleMenu( $name = 'My Menu' ) {
+		$menu_term = wp_insert_term( $name, 'nav_menu' );
+		$menu_items = array();
+		$parent_page = wp_insert_post(
+			array(
+				'post_title' => 'Home',
+				'post_status' => 'publish',
+				'post_name' => 'home',
+				'post_type' => 'page',
+				'menu_order' => 1
+			)
+		);
+		$parent_id = wp_insert_post( array(
+				'post_title' => '',
+				'post_status' => 'publish',
+				'post_type' => 'nav_menu_item'
+			) );
+		update_post_meta( $parent_id, '_menu_item_type', 'post_type' );
+		update_post_meta( $parent_id, '_menu_item_object', 'page' );
+		update_post_meta( $parent_id, '_menu_item_menu_item_parent', 0 );
+		update_post_meta( $parent_id, '_menu_item_object_id', $parent_page );
+		update_post_meta( $parent_id, '_menu_item_url', '' );
+		update_post_meta( $parent_id, 'flood', 'molasses' );
+		$menu_items[] = $parent_id;
+		self::insertIntoMenu($menu_term['term_id'], $menu_items);
+		return $menu_term;
+	}
+
+	static function insertIntoMenu($menu_id, $menu_items) {
+		global $wpdb;
+		foreach ( $menu_items as $object_id ) {
+			$query = "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id, term_order) VALUES ($object_id, $menu_id, 0);";
+			$wpdb->query( $query );
+			update_post_meta( $object_id, 'tobias', 'funke' );
+		}
+		$menu_items_count = count( $menu_items );
+		$wpdb->query( "UPDATE $wpdb->term_taxonomy SET count = $menu_items_count WHERE taxonomy = 'nav_menu'; " );
+	}
+
+	static function setPermalinkStructure( $struc = '/%postname%/' ) {
+		global $wp_rewrite;
+		$wp_rewrite->set_permalink_structure( $struc );
+		$wp_rewrite->flush_rules();
+		update_option( 'permalink_structure', $struc );
+		flush_rewrite_rules( true );
+	}
+
 	function testBlankMenu() {
 		self::setPermalinkStructure();
 		self::_createTestMenu();
@@ -266,54 +508,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertContains( 'current-menu-item', $menu_items[3]->classes );
 	}
 
-	public static function buildMenu($name, $items) {
-		$menu_term = wp_insert_term( $name, 'nav_menu' );
-		$menu_items = array();
-		$i = 0;
-		foreach($items as $item) {
-			if ($item->type == 'link') {
-				$pid = wp_insert_post(array('post_title' => '', 'post_status' => 'publish', 'post_type' => 'nav_menu_item', 'menu_order' => $i));
-				update_post_meta( $pid, '_menu_item_type', 'custom' );
-				update_post_meta( $pid, '_menu_item_object_id', $pid );
-				update_post_meta( $pid, '_menu_item_url', $item->link );
-				update_post_meta( $pid, '_menu_item_xfn', '' );
-				update_post_meta( $pid, '_menu_item_menu_item_parent', 0 );
-				$menu_items[] = $pid;
-			}
-			$i++;
-		}
-		self::insertIntoMenu($menu_term['term_id'], $menu_items);
-		return $menu_term;
-	}
-
-	public static function _createSimpleMenu( $name = 'My Menu' ) {
-		$menu_term = wp_insert_term( $name, 'nav_menu' );
-		$menu_items = array();
-		$parent_page = wp_insert_post(
-			array(
-				'post_title' => 'Home',
-				'post_status' => 'publish',
-				'post_name' => 'home',
-				'post_type' => 'page',
-				'menu_order' => 1
-			)
-		);
-		$parent_id = wp_insert_post( array(
-				'post_title' => '',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item'
-			) );
-		update_post_meta( $parent_id, '_menu_item_type', 'post_type' );
-		update_post_meta( $parent_id, '_menu_item_object', 'page' );
-		update_post_meta( $parent_id, '_menu_item_menu_item_parent', 0 );
-		update_post_meta( $parent_id, '_menu_item_object_id', $parent_page );
-		update_post_meta( $parent_id, '_menu_item_url', '' );
-		update_post_meta( $parent_id, 'flood', 'molasses' );
-		$menu_items[] = $parent_id;
-		self::insertIntoMenu($menu_term['term_id'], $menu_items);
-		return $menu_term;
-	}
-
 	function testWPMLMenu() {
 		self::setPermalinkStructure();
 		self::_createTestMenu();
@@ -326,196 +520,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertFalse( $item->is_external() );
 		$this->assertEquals( 'http://example.org/home/', $item->link() );
 		$this->assertEquals( '/home/', $item->path() );
-	}
-
-	public static function _createTestMenu() {
-		$menu_term = wp_insert_term( self::MENU_NAME, self::MENU_SLUG );
-		$menu_id = $menu_term['term_id'];
-		$menu_items = array();
-		$parent_page = wp_insert_post(
-			array(
-				'post_title' => 'Home',
-				'post_status' => 'publish',
-				'post_name' => 'home',
-				'post_type' => 'page',
-				'menu_order' => 1
-			)
-		);
-		$parent_id = wp_insert_post( array(
-				'post_title' => '',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item'
-			) );
-		update_post_meta( $parent_id, '_menu_item_type', 'post_type' );
-		update_post_meta( $parent_id, '_menu_item_object', 'page' );
-		update_post_meta( $parent_id, '_menu_item_menu_item_parent', 0 );
-		update_post_meta( $parent_id, '_menu_item_object_id', $parent_page );
-		update_post_meta( $parent_id, '_menu_item_url', '' );
-		$menu_items[] = $parent_id;
-		$link_id = wp_insert_post(
-			array(
-				'post_title' => 'Upstatement',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 2
-			)
-		);
-
-		$menu_items[] = $link_id;
-		update_post_meta( $link_id, '_menu_item_type', 'custom' );
-		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
-		update_post_meta( $link_id, '_menu_item_url', 'http://upstatement.com' );
-		update_post_meta( $link_id, '_menu_item_xfn', '' );
-		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
-
-		/* make a child page */
-		$child_id = wp_insert_post( array(
-				'post_title' => 'Child Page',
-				'post_status' => 'publish',
-				'post_name' => 'child-page',
-				'post_type' => 'page',
-				'menu_order' => 3,
-			) );
-		$child_menu_item = wp_insert_post( array(
-				'post_title' => '',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-			) );
-		update_post_meta( $child_menu_item, '_menu_item_type', 'post_type' );
-		update_post_meta( $child_menu_item, '_menu_item_menu_item_parent', $parent_id );
-		update_post_meta( $child_menu_item, '_menu_item_object_id', $child_id );
-		update_post_meta( $child_menu_item, '_menu_item_object', 'page' );
-		update_post_meta( $child_menu_item, '_menu_item_url', '' );
-		$post = new TimberPost( $child_menu_item );
-		$menu_items[] = $child_menu_item;
-
-		/* make a grandchild page */
-		$grandchild_id = wp_insert_post( array(
-				'post_title' => 'Grandchild Page',
-				'post_status' => 'publish',
-				'post_name' => 'grandchild-page',
-				'post_type' => 'page',
-			) );
-		$grandchild_menu_item = wp_insert_post( array(
-				'post_title' => '',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 100,
-			) );
-		update_post_meta( $grandchild_menu_item, '_menu_item_type', 'post_type' );
-		update_post_meta( $grandchild_menu_item, '_menu_item_menu_item_parent', $child_menu_item );
-		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
-		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
-		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
-		$post = new TimberPost( $grandchild_menu_item );
-		$menu_items[] = $grandchild_menu_item;
-
-		/* make another grandchild page */
-		$grandchild_id = wp_insert_post( array(
-				'post_title' => 'Other Grandchild Page',
-				'post_status' => 'publish',
-				'post_name' => 'other grandchild-page',
-				'post_type' => 'page',
-			) );
-		$grandchild_menu_item = wp_insert_post( array(
-				'post_title' => '',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 101,
-			) );
-		update_post_meta( $grandchild_menu_item, '_menu_item_type', 'post_type' );
-		update_post_meta( $grandchild_menu_item, '_menu_item_menu_item_parent', $child_menu_item );
-		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
-		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
-		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
-		$post = new TimberPost( $grandchild_menu_item );
-		$menu_items[] = $grandchild_menu_item;
-
-		$root_url_link_id = wp_insert_post(
-			array(
-				'post_title' => 'Root Home',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 4
-			)
-		);
-
-		$menu_items[] = $root_url_link_id;
-		update_post_meta( $root_url_link_id, '_menu_item_type', 'custom' );
-		update_post_meta( $root_url_link_id, '_menu_item_object_id', $root_url_link_id );
-		update_post_meta( $root_url_link_id, '_menu_item_url', '/' );
-		update_post_meta( $root_url_link_id, '_menu_item_xfn', '' );
-		update_post_meta( $root_url_link_id, '_menu_item_menu_item_parent', 0 );
-
-		$link_id = wp_insert_post(
-			array(
-				'post_title' => 'People',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 6
-			)
-		);
-
-		$menu_items[] = $link_id;
-		update_post_meta( $link_id, '_menu_item_type', 'custom' );
-		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
-		update_post_meta( $link_id, '_menu_item_url', '#people' );
-		update_post_meta( $link_id, '_menu_item_xfn', '' );
-		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
-
-		$link_id = wp_insert_post(
-			array(
-				'post_title' => 'More People',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 7
-			)
-		);
-
-		$menu_items[] = $link_id;
-		update_post_meta( $link_id, '_menu_item_type', 'custom' );
-		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
-		update_post_meta( $link_id, '_menu_item_url', 'http://example.org/#people' );
-		update_post_meta( $link_id, '_menu_item_xfn', '' );
-		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
-
-		$link_id = wp_insert_post(
-			array(
-				'post_title' => 'Manual Home',
-				'post_status' => 'publish',
-				'post_type' => 'nav_menu_item',
-				'menu_order' => 8
-			)
-		);
-
-		$menu_items[] = $link_id;
-		update_post_meta( $link_id, '_menu_item_type', 'custom' );
-		update_post_meta( $link_id, '_menu_item_object_id', $link_id );
-		update_post_meta( $link_id, '_menu_item_url', 'http://example.org' );
-		update_post_meta( $link_id, '_menu_item_xfn', '' );
-		update_post_meta( $link_id, '_menu_item_menu_item_parent', 0 );
-
-		self::insertIntoMenu($menu_id, $menu_items);
-		return $menu_term;
-	}
-
-	static function insertIntoMenu($menu_id, $menu_items) {
-		global $wpdb;
-		foreach ( $menu_items as $object_id ) {
-			$query = "INSERT INTO $wpdb->term_relationships (object_id, term_taxonomy_id, term_order) VALUES ($object_id, $menu_id, 0);";
-			$wpdb->query( $query );
-			update_post_meta( $object_id, 'tobias', 'funke' );
-		}
-		$menu_items_count = count( $menu_items );
-		$wpdb->query( "UPDATE $wpdb->term_taxonomy SET count = $menu_items_count WHERE taxonomy = 'nav_menu'; " );
-	}
-
-	static function setPermalinkStructure( $struc = '/%postname%/' ) {
-		global $wp_rewrite;
-		$wp_rewrite->set_permalink_structure( $struc );
-		$wp_rewrite->flush_rules();
-		update_option( 'permalink_structure', $struc );
-		flush_rewrite_rules( true );
 	}
 
 	function testCustomArchivePage() {


### PR DESCRIPTION
**Ticket**: #1959

## Issue

See #1959.

## Solution

This pull request:

- Adds a `theme_location` property to the `Timber\Menu` class that is set when the menu is registered with a theme location.
- Adds a `menu` property to the `Timber\MenuItem` so it’s possible the parent menu object from a menu item. For this, the parent menu object is passed to the constructor of `Timber\MenuItem`.
- Adds an `options` property to the `Timber\Menu` class that holds an array of default options that can be adapted through `Timber\Menu`’s constructor. It also remove the `Timber\Menu::set_options()` method and moves its content back to the constructor. I thought there’s no need to have a separate function for this.
- Passes down the new `options` property as an object for the `$args` parameter in the nav_menu_css_class filter.
- Updates the default for `depth` from `-1` to `0` to match WordPress’s defaults in [`wp_nav_menu()`](https://developer.wordpress.org/reference/functions/wp_nav_menu/).

## Impact

Better parity with WordPress menu filters and defaults.

## Usage Changes

It’s possible to access the theme location in various places, like in the `nav_menu_css_class` filter:

```php
function my_secondary_menu_classes( $classes, $item, $args ) {
    if ( 'secondary' === $item->menu->theme_location ) {
        $classes[] = 'theme-location-secondary';
    }

    return $classes;
}

add_filter( 'nav_menu_css_class', 'my_secondary_menu_classes', 10, 3 ); 
```

And the `$args` parameter in that filter contains the options passed to `Timber\Menu`.

## Considerations

Should we add the options for the args parameter in the `nav_menu_css_class` filter or is it obsolete, because the same options could be accessed through `$item->menu->options`?

I didn’t add `theme_location` to `Timber\Menu::$options`, because when `theme_location` is used as an argument for `wp_nav_menu()`, it’s a query to select only the menu from that location. But in Timber, you could pass this in the first argument of `Timber\Menu::__construct()`. So you would never use it as an option.

In `Timber\Menu::init()`, I added `$locations = get_nav_menu_locations();` to get theme the locations in order to set the `theme_location` property. We already use `get_nav_menu_locations()` in the `Timber\Menu::__construct()`, but it didn’t feel right to pass it down as a parameter in `Timber\Menu::init()`. The locations should be cached by WordPress’s internal option handling, so I hope we’re fine here.

## Testing

Yes.