### PR TITLE
Streamline get_meta_values functions across objects

### DIFF
--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -385,13 +385,11 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 
 	/**
 	 * @internal
+	 *
 	 * @param int $comment_id
 	 * @return array
 	 */
-	protected function get_meta_values( $comment_id = null ) {
-		if ( $comment_id === null ) {
-			$comment_id = $this->ID;
-		}
+	protected function get_meta_values( $comment_id ) {
 
 		$comment_meta = array();
 

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -94,6 +94,14 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 
 	public $_depth = 0;
 
+	/**
+	 * Meta data.
+	 *
+	 * @api
+	 * @var array All custom field data for the object.
+	 */
+	public $custom = array();
+
 	protected $children = array();
 
 	/**
@@ -128,8 +136,9 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 		$this->import($comment_data);
 		$this->ID = $this->comment_ID;
 		$this->id = $this->comment_ID;
-		$comment_meta_data = $this->get_meta_values($this->ID);
-		$this->import($comment_meta_data);
+		$this->custom = $this->get_meta_values($this->ID);
+
+		$this->import( $this->custom );
 	}
 
 	/**
@@ -433,9 +442,11 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 			$comment_meta = get_comment_meta($comment_id);
 		}
 
-		foreach ( $comment_meta as &$cm ) {
-			if ( is_array($cm) && count($cm) == 1 ) {
-				$cm = $cm[0];
+		if ( ! empty ( $comment_meta ) ) {
+			foreach ( $comment_meta as &$cm ) {
+				if ( is_array($cm) && count($cm) == 1 ) {
+					$cm = $cm[0];
+				}
 			}
 		}
 
@@ -482,6 +493,11 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 			'2.0.0',
 			'timber/comment/get_meta_values'
 		);
+
+		// Ensure proper return value.
+		if ( empty( $comment_meta ) ) {
+			$comment_meta = array();
+		}
 
 		return $comment_meta;
 	}

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -386,7 +386,7 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 	/**
 	 * @internal
 	 * @param int $comment_id
-	 * @return mixed
+	 * @return array
 	 */
 	protected function get_meta_values( $comment_id = null ) {
 		if ( $comment_id === null ) {

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -98,6 +98,7 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 	 * Meta data.
 	 *
 	 * @api
+	 * @since 2.0.0
 	 * @var array All custom field data for the object.
 	 */
 	public $custom = array();

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -79,8 +79,10 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 	public $object_type = 'post';
 
 	/**
+	 * Meta data.
+	 *
 	 * @api
-	 * @var array Stores custom meta data
+	 * @var array All custom field data for the object.
 	 */
 	public $custom = array();
 
@@ -623,11 +625,13 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 			$post_meta = get_post_meta( $post_id );
 		}
 
-		foreach ( $post_meta as $key => $value ) {
-			if ( is_array($value) && count($value) == 1 && isset($value[0]) ) {
-				$value = $value[0];
+		if ( ! empty( $post_meta ) ) {
+			foreach ( $post_meta as $key => $value ) {
+				if ( is_array($value) && count($value) == 1 && isset($value[0]) ) {
+					$value = $value[0];
+				}
+				$post_meta[$key] = maybe_unserialize($value);
 			}
-			$post_meta[$key] = maybe_unserialize($value);
 		}
 
 		/**
@@ -667,6 +671,11 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 			'2.0.0',
 			'timber/post/get_meta_values'
 		);
+
+		// Ensure proper return value.
+		if ( empty( $post_meta ) ) {
+			$post_meta = array();
+		}
 
 		return $post_meta;
 	}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -566,11 +566,9 @@ class Post extends Core implements CoreInterface, MetaInterface, Setupable {
 
 	/**
 	 * Used internally to fetch the metadata fields (wp_postmeta table)
-	 * and attach them to our Timber\Post object
 	 * @internal
 	 *
-	 * @param int|boolean $post_id
-	 *
+	 * @param int $post_id
 	 * @return array
 	 */
 	protected function get_meta_values( $post_id ) {

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -68,6 +68,14 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	public $taxonomy;
 
 	/**
+	 * Meta data.
+	 *
+	 * @api
+	 * @var array All custom field data for the object.
+	 */
+	public $custom = array();
+
+	/**
 	 * @api
 	 * @param int $tid
 	 * @param string $tax
@@ -190,12 +198,14 @@ class Term extends Core implements CoreInterface, MetaInterface {
 			$term_meta = get_term_meta( $term_id );
 		}
 
-		foreach ( $term_meta as $key => $value ) {
-			if ( is_array( $value ) && 1 === count( $value ) && isset( $value[0] ) ) {
-				$value = $value[0];
-			}
+		if ( ! empty( $term_meta ) ) {
+			foreach ( $term_meta as $key => $value ) {
+				if ( is_array( $value ) && 1 === count( $value ) && isset( $value[0] ) ) {
+					$value = $value[0];
+				}
 
-			$term_meta[ $key ] = maybe_unserialize( $value );
+				$term_meta[ $key ] = maybe_unserialize( $value );
+			}
 		}
 
 		/**
@@ -237,6 +247,11 @@ class Term extends Core implements CoreInterface, MetaInterface {
 			'2.0.0',
 			'timber/term/get_meta_values'
 		);
+
+		// Ensure proper return value.
+		if ( empty( $term_meta ) ) {
+			$term_meta = array();
+		}
 
 		return $term_meta;
 	}

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -154,7 +154,8 @@ class Term extends Core implements CoreInterface, MetaInterface {
 
 	/**
 	 * @internal
-	 * @param int $tid
+	 *
+	 * @param int $term_id
 	 * @return array
 	 */
 	protected function get_meta_values( $term_id ) {

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -71,6 +71,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	 * Meta data.
 	 *
 	 * @api
+	 * @since 2.0.0
 	 * @var array All custom field data for the object.
 	 */
 	public $custom = array();

--- a/lib/User.php
+++ b/lib/User.php
@@ -170,7 +170,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 		}
 		unset($this->user_pass);
 		$this->id = $this->ID;
-		$this->custom = $this->get_meta_values();
+		$this->custom = $this->get_meta_values( $this->ID );
 		$this->import($this->custom, false, true);
 	}
 
@@ -179,13 +179,11 @@ class User extends Core implements CoreInterface, MetaInterface {
 	 * Retrieves the custom (meta) data on a user and returns it.
 	 *
 	 * @internal
+	 *
+	 * @param int $user_id
 	 * @return array
 	 */
-	protected function get_meta_values() {
-		if ( ! $this->ID ) {
-			return null;
-		}
-
+	protected function get_meta_values( $user_id ) {
 		$user_meta = array();
 
 		/**
@@ -220,7 +218,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * @param int          $user_id   The user ID.
 		 * @param \Timber\User $user      The user object.
 		 */
-		$user_meta = apply_filters( 'timber/user/pre_get_meta_values', $user_meta, $this->ID, $this );
+		$user_meta = apply_filters( 'timber/user/pre_get_meta_values', $user_meta, $user_id, $this );
 
 		/**
 		 * Filters user meta data before it is fetched from the database.
@@ -229,14 +227,14 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 */
 		$user_meta = apply_filters_deprecated(
 			'timber_user_get_meta_pre',
-			array( $user_meta, $this->ID, $this ),
+			array( $user_meta, $user_id, $this ),
 			'2.0.0',
 			'timber/user/pre_get_meta_values'
 		);
 
 		// Load all meta data when it wasn’t filtered before.
 		if ( false !== $user_meta && empty( $user_meta ) ) {
-			$user_meta = get_user_meta($this->ID);
+			$user_meta = get_user_meta($user_id);
 		}
 
 		if ( ! empty( $user_meta ) ) {
@@ -272,7 +270,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * @param int          $user_id   The user ID.
 		 * @param \Timber\User $user      The user object.
 		 */
-		$user_meta = apply_filters( 'timber/user/get_meta_values', $user_meta, $this->ID, $this );
+		$user_meta = apply_filters( 'timber/user/get_meta_values', $user_meta, $user_id, $this );
 
 		/**
 		 * Filters user meta data fetched from the database.
@@ -281,7 +279,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 */
 		$user_meta = apply_filters_deprecated(
 			'timber_user_get_meta',
-			array( $user_meta, $this->ID, $this ),
+			array( $user_meta, $user_id, $this ),
 			'2.0.0',
 			'timber/user/get_meta_values'
 		);

--- a/lib/User.php
+++ b/lib/User.php
@@ -98,6 +98,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 	 * Meta data.
 	 *
 	 * @api
+	 * @since 2.0.0
 	 * @var array All custom field data for the object.
 	 */
 	public $custom = array();

--- a/lib/User.php
+++ b/lib/User.php
@@ -95,6 +95,14 @@ class User extends Core implements CoreInterface, MetaInterface {
 	public $user_nicename;
 
 	/**
+	 * Meta data.
+	 *
+	 * @api
+	 * @var array All custom field data for the object.
+	 */
+	public $custom = array();
+
+	/**
 	 * The roles the user is part of.
 	 *
 	 * @api
@@ -177,7 +185,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 			return null;
 		}
 
-		$um = array();
+		$user_meta = array();
 
 		/**
 		 * Filters user meta data before it is fetched from the database.
@@ -211,31 +219,32 @@ class User extends Core implements CoreInterface, MetaInterface {
 		 * @param int          $user_id   The user ID.
 		 * @param \Timber\User $user      The user object.
 		 */
-		$um = apply_filters( 'timber/user/pre_get_meta_values', $um, $this->ID, $this );
+		$user_meta = apply_filters( 'timber/user/pre_get_meta_values', $user_meta, $this->ID, $this );
 
 		/**
 		 * Filters user meta data before it is fetched from the database.
 		 *
 		 * @deprecated 2.0.0, use `timber/user/pre_get_meta_values`
 		 */
-		$um = apply_filters_deprecated(
+		$user_meta = apply_filters_deprecated(
 			'timber_user_get_meta_pre',
-			array( $um, $this->ID, $this ),
+			array( $user_meta, $this->ID, $this ),
 			'2.0.0',
 			'timber/user/pre_get_meta_values'
 		);
 
 		// Load all meta data when it wasn’t filtered before.
-		if ( false !== $um && empty( $um ) ) {
-			$um = get_user_meta($this->ID);
+		if ( false !== $user_meta && empty( $user_meta ) ) {
+			$user_meta = get_user_meta($this->ID);
 		}
 
-		$user_meta = array();
-		foreach ( $um as $key => $value ) {
-			if ( is_array($value) && count($value) === 1 ) {
-				$value = $value[0];
+		if ( ! empty( $user_meta ) ) {
+			foreach ( $user_meta as $key => $value ) {
+				if ( is_array($value) && count($value) === 1 ) {
+					$value = $value[0];
+				}
+				$user_meta[ $key ] = maybe_unserialize($value);
 			}
-			$user_meta[ $key ] = maybe_unserialize($value);
 		}
 
 		/**
@@ -275,6 +284,11 @@ class User extends Core implements CoreInterface, MetaInterface {
 			'2.0.0',
 			'timber/user/get_meta_values'
 		);
+
+		// Ensure proper return value.
+		if ( empty( $user_meta ) ) {
+			$user_meta = array();
+		}
 
 		return $user_meta;
 	}
@@ -475,7 +489,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 		);
 		return $this->meta( $field_name );
   }
-  
+
   /**
 	 * Creates an associative array with user role slugs and their translated names.
 	 *

--- a/lib/User.php
+++ b/lib/User.php
@@ -179,7 +179,7 @@ class User extends Core implements CoreInterface, MetaInterface {
 	 * Retrieves the custom (meta) data on a user and returns it.
 	 *
 	 * @internal
-	 * @return array|null
+	 * @return array
 	 */
 	protected function get_meta_values() {
 		if ( ! $this->ID ) {

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -167,9 +167,41 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$this->assertEquals('Kramer, Elaine Benes, J. Peterman, ', $compiled);
 	}
 
+	function testPreGetMetaValuesDisableFetch(){
+		add_filter( 'timber/comment/pre_get_meta_values', '__return_false' );
 
+		$comment = $this->factory->comment->create();
 
+		update_user_meta( $comment, 'hidden_value', 'Super secret value' );
 
+		$comment = new Timber\Comment( $comment );
 
+		$this->assertCount( 0, $comment->custom );
 
+		remove_filter( 'timber/comment/pre_get_meta_values', '__return_false' );
+	}
+
+	function testPreGetMetaValuesCustomFetch(){
+		$callable = function( $comment_meta, $pid, $post ) {
+			$key = 'critical_value';
+
+			return [
+				$key => get_comment_meta( $pid, $key ),
+			];
+		};
+
+		add_filter( 'timber/comment/pre_get_meta_values', $callable , 10, 3);
+
+		$comment_id = $this->factory->comment->create();
+
+		update_comment_meta( $comment_id, 'hidden_value', 'super-big-secret' );
+		update_comment_meta( $comment_id, 'critical_value', 'I am needed, all the time' );
+
+		$comment = new Timber\Comment( $comment_id );
+
+		$this->assertCount( 1, $comment->custom );
+		$this->assertEquals( $comment->custom, array( 'critical_value' => 'I am needed, all the time' ) );
+
+		remove_filter( 'timber/comment/pre_get_meta_values', $callable );
+	}
 }

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -379,25 +379,21 @@
 			$this->assertEquals($page2, trim(strip_tags( $post->paged_content() )));
 		}
 
-		function testMetaCustomPreFilterDisable(){
-
-			$callable = function(){ return false; };
-
-			add_filter( 'timber_post_get_meta_pre', $callable );
+		function testPreGetMetaValuesDisableFetch(){
+			add_filter( 'timber/post/pre_get_meta_values', '__return_false' );
 
 			$post_id = $this->factory->post->create();
 
-			update_post_meta($post_id, 'hidden_value', 'Super secret value');
+			update_post_meta( $post_id, 'hidden_value', 'Super secret value' );
 
 			$post = new Timber\Post($post_id);
 
 			$this->assertCount( 0, $post->custom );
 
-			remove_filter( 'timber_post_get_meta_pre', $callable );
+			remove_filter( 'timber/post/pre_get_meta_values', '__return_false' );
 		}
 
-		function testMetaCustomPreFilterAlter(){
-
+		function testPreGetMetaValuesCustomFetch(){
 			$callable = function( $customs, $pid, $post ) {
 				$key = 'critical_value';
 
@@ -406,18 +402,18 @@
 				];
 			};
 
-			add_filter( 'timber_post_get_meta_pre', $callable , 10, 3);
+			add_filter( 'timber/post/pre_get_meta_values', $callable , 10, 3);
 
 			$post_id = $this->factory->post->create();
 
-			update_post_meta($post_id, 'hidden_value', 'super-big-secret');
-			update_post_meta($post_id, 'critical_value', 'I am needed, all the time');
+			update_post_meta( $post_id, 'hidden_value', 'super-big-secret' );
+			update_post_meta( $post_id, 'critical_value', 'I am needed, all the time' );
 
 			$post = new Timber\Post($post_id);
 			$this->assertCount( 1, $post->custom );
 			$this->assertEquals( $post->custom, array( 'critical_value' => 'I am needed, all the time' ) );
 
-			remove_filter( 'timber_post_get_meta_pre', $callable );
+			remove_filter( 'timber/post/pre_get_meta_values', $callable );
 		}
 
 		/**

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -359,6 +359,43 @@
 			$this->assertContains($term->edit_link(), $links);
 		}
 
+		function testPreGetMetaValuesDisableFetch(){
+			add_filter( 'timber/term/pre_get_meta_values', '__return_false' );
+
+			$term_id = $this->factory->term->create();
+
+			update_term_meta( $term_id, 'hidden_value', 'Super secret value' );
+
+			$term = new Timber\Term( $term_id );
+
+			$this->assertCount( 0, $term->custom );
+
+			remove_filter( 'timber/term/pre_get_meta_values', '__return_false' );
+		}
+
+		function testPreGetMetaValuesCustomFetch(){
+			$callable = function( $term_meta, $pid, $post ) {
+				$key = 'critical_value';
+
+				return [
+					$key => get_term_meta( $pid, $key ),
+				];
+			};
+
+			add_filter( 'timber/term/pre_get_meta_values', $callable , 10, 3);
+
+			$term_id = $this->factory->term->create();
+
+			update_term_meta( $term_id, 'hidden_value', 'super-big-secret' );
+			update_term_meta( $term_id, 'critical_value', 'I am needed, all the time' );
+
+			$term = new Timber\Term( $term_id );
+
+			$this->assertCount( 1, $term->custom );
+			$this->assertEquals( $term->custom, array( 'critical_value' => 'I am needed, all the time' ) );
+
+			remove_filter( 'timber/term/pre_get_meta_values', $callable );
+		}
 	}
 
 	class Arts extends Timber\Term {

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -69,4 +69,42 @@
 			$user = new Timber\User($uid);
 			$this->assertEquals('http://2.gravatar.com/avatar/b2965625410b81a2b25ef02b54493ce0?s=96&d=mm&r=g', $user->avatar());
 		}
+
+		function testPreGetMetaValuesDisableFetch(){
+			add_filter( 'timber/user/pre_get_meta_values', '__return_false' );
+
+			$user_id = $this->factory->user->create();
+
+			update_user_meta( $user_id, 'hidden_value', 'Super secret value' );
+
+			$user = new Timber\User( $user_id );
+
+			$this->assertCount( 0, $user->custom );
+
+			remove_filter( 'timber/user/pre_get_meta_values', '__return_false' );
+		}
+
+		function testPreGetMetaValuesCustomFetch(){
+			$callable = function( $user_meta, $pid, $post ) {
+				$key = 'critical_value';
+
+				return [
+					$key => get_user_meta( $pid, $key ),
+				];
+			};
+
+			add_filter( 'timber/user/pre_get_meta_values', $callable , 10, 3);
+
+			$user_id = $this->factory->user->create();
+
+			update_user_meta( $user_id, 'hidden_value', 'super-big-secret' );
+			update_user_meta( $user_id, 'critical_value', 'I am needed, all the time' );
+
+			$user = new Timber\User( $user_id );
+
+			$this->assertCount( 1, $user->custom );
+			$this->assertEquals( $user->custom, array( 'critical_value' => 'I am needed, all the time' ) );
+
+			remove_filter( 'timber/user/pre_get_meta_values', $callable );
+		}
 	}


### PR DESCRIPTION
**Ticket**: #1617 

## Issue

There were failing tests after merging in #2014. And it made me realize that for the meta functionality, I added way too few tests.

## Solution

This pull request first streamlines the functionality of what the `get_meta_values()` does across Post, Term, User and Comment objects. I figured it’s actually good this is coming together step by step, because when I started out with working on meta for 2.x, I was hard to get an overview.

Now, all objects import all meta values into a `custom` property. And all `get_meta_values()` functions do pretty much the same, including the same variable pattern etc.

I also added tests for the different objects. The tests that were introduced in #2012 are really good to test the `timber/{object}/pre_get_meta_values` filter (Thanks, @aj-adl!). 

## Impact

Fewer fails.

## Usage Changes

None.

## Considerations

I need to add more tests to improve coverage of changes for meta. There will be more pull requests.

## Testing

Yes.