### PR TITLE
ref #2020 -- revert Twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=5.3.0|7.*",
-    "twig/twig": "^1.34|^2.4",
+    "twig/twig": "1.34|^2.4",
     "upstatement/routes": "0.5",
     "composer/installers": "~1.0",
     "asm89/twig-cache-extension": "~1.0"


### PR DESCRIPTION
**Ticket**: #2020, #2016 

## Issue
Conflicts with versions of Twig are causing issues with WPML (and potentially other plugins)

## Solution
Revert the Twig 1.x version to 1.3.4 (same as Timber 1.9.4), release as a hotfix

## Impact
Minimal, only matters if someone has started to use Twig 1.35+ features in the last 24 hours that 1.9.5 has been out

## Usage Changes
None

## Considerations
- In the future we should ensure that dependency upgrades are reserved for minor version releases (so that should have come in 1.10)
- We should still plan to ship 1.10 with the newest Twig 1.x version
