### PR TITLE
ref #2024 -- patch for custom MenuItems

### DIFF
--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -79,7 +79,7 @@ class MenuItem extends Core implements CoreInterface {
 	 * @param array|object $data
 	 * @param \Timber\Menu $menu The `Timber\Menu` object the menu item is associated with.
 	 */
-	public function __construct( $data, $menu ) {
+	public function __construct( $data, $menu = null ) {
 		$this->menu = $menu;
 		$data       = (object) $data;
 
@@ -251,6 +251,12 @@ class MenuItem extends Core implements CoreInterface {
 		$this->classes = array_merge($this->classes, $data->classes);
 		$this->classes = array_unique($this->classes);
 
+		$options = new \stdClass();
+		if ( isset( $this->menu->options ) ) {
+			// The options need to be an object.
+			$options = (object) $this->menu->options;
+		}
+
 		/**
 		 * Filters the CSS classes applied to a menu item’s list item.
 		 *
@@ -267,8 +273,7 @@ class MenuItem extends Core implements CoreInterface {
 			'nav_menu_css_class',
 			$this->classes,
 			$this,
-			// The options need to be an object.
-			(object) $this->menu->options,
+			$options,
 			0
 		);
 

--- a/tests/php/custom-menu-item-class.php
+++ b/tests/php/custom-menu-item-class.php
@@ -1,0 +1,5 @@
+<?php
+
+class CustomMenuItemClass extends Timber\MenuItem {
+
+}

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -741,4 +741,17 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 		remove_filter( 'nav_menu_css_class', $filter );
 	}
+
+	function testCustomMenuItemClass() {
+		require_once('php/custom-menu-item-class.php');
+		$term    = self::_createTestMenu();
+		$menu_id = $term['term_id'];
+		$menu_items = wp_get_nav_menu_items($menu_id);
+		$tmis = [];
+		foreach( $menu_items as $mi ) {
+			$tmi = new CustomMenuItemClass($mi);
+			array_push($tmis, $tmi);
+		}
+		$this->assertEquals($tmis[4]->post_title, 'People');
+	}
 }


### PR DESCRIPTION
**Ticket**: #2024 #1988 

## Issue
Inadvertent breaking change introduced by new `Timber\MenuItem` constructor definition in `1.10`


## Solution
Set a default `null` value for the menu


## Impact
Filtering CSS classes (and other things that a user might do with menu info) won't work

## Usage Changes
None

## Considerations
Probably something that we don't need to bring into 2.x


## Testing
No new tests