### PR TITLE
[WIP] 2.x Improve magic methods in Core

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -42,10 +42,11 @@ abstract class Core {
 	 * @see https://secure.php.net/manual/en/language.oop5.overloading.php#object.call
 	 * @see: https://github.com/fabpot/Twig/issues/2
 	 * @param string the name of the method being called
+	 * @param array args not used.
 	 * @return mixed the value of the meta field named `$field`, if truthy;
 	 * false otherwise
 	 */
-	public function __call( string $field, $_ ) {
+	public function __call( $field, $_ ) {
 		if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
 			return $meta_value;
 		}
@@ -75,7 +76,7 @@ abstract class Core {
 	 * `$field()` as a method with no arguments, or false if neither returns a
 	 * truthy value
 	 */
-	public function __get( string $field ) {
+	public function __get( $field ) {
 		if ( method_exists($this, 'meta') && $meta_value = $this->meta($field) ) {
 			return $this->$field = $meta_value;
 		}


### PR DESCRIPTION
**Ticket**: #478, #1904

## Issue

See #478. 

@acobster I realized I can create a pull request from the branch in your repository. I went ahead and did this, so we won’t forget about this and so that I can resolve the failing tests and maybe improve the documentation about this. Thanks for your work on this!

## Solution

### Prevents infinite loops

Prevents infinite loops when:

- a `meta()` method wouldn’t exist.
- an inaccessible method is called.

By never calling `__get()` from `__call()`, but replicating the logic we need, we can circumvent an infinite loop.

### Removes possibility to access inaccessible properties.

The following check is removed from `__get()`:

```php
if ( property_exists( $this, $field ) ) {
    return $this->field;
}
```

With the check removed, we are not allowed anymore access properties that are normally inaccessible (protected or private properties). Inaccessible properties are inaccessible for a reason, that’s why we shouldn’t allow them to be accessible through magic methods. This will allow us to finish work in #1904.

## Impact

Possibly, there will be quite a few errors for developers who try to access inaccessible properties.

## Usage Changes

- **`{{ post.meta('my_field`) }}** is the _preferred_ way to get custom data
- **`{{ post.my_field }}`** is the _preferred_ way to get custom data that is modified by a custom method. However, if that method doesn't exist, Timber will fall back to the equivalent `{{ post.meta('my_field'} }}` call.

## Considerations

Should we add deprecation notices for anything here? I don’t even know if that would be possible.

## Testing

Still WIP.