### PR TITLE
Add clarification to Getting Started docs

### DIFF
--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -16,11 +16,21 @@ You can grab the all-things-included plugin at [WordPress.org](http://wordpress.
 
 The GitHub version of Timber requires [Composer](https://getcomposer.org/download/). If you'd prefer one-click installation, you should use the [WordPress.org](https://wordpress.org/plugins/timber-library/) version.
 
+Run the following Composer command from within your theme's root directory:
+
 ```shell
 composer require timber/timber
 ```
 
-If your theme is not setup to pull in Composer’s autoload file, you will need to add the following at the top of your `functions.php` file: 
+If you're using the [starter theme](https://github.com/timber/starter-theme), a `composer.json` file is already included, so you can run the following command instead:
+
+```shell
+composer install
+```
+
+Using the starter theme's existing `composer.json` file currently works slightly different and will install Timber to your site's `plugins` directory and will need to be activated via `wp-admin/plugins.php` rather than using Composer's autoload feature.
+
+If you're not using the starter theme or your theme is not setup to pull in Composer’s autoload file, you will need to add the following at the top of your `functions.php` file: 
 
 **functions.php**
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -28,23 +28,13 @@ If you're using the [starter theme](https://github.com/timber/starter-theme), a 
 composer install
 ```
 
-Using the starter theme's existing `composer.json` file currently works slightly different and will install Timber to your site's `plugins` directory and will need to be activated via `wp-admin/plugins.php` rather than using Composer's autoload feature.
-
-If you're not using the starter theme or your theme is not setup to pull in Composer’s autoload file, you will need to add the following at the top of your `functions.php` file: 
+If you're not using the starter theme or your theme is not setup to pull in Composer’s autoload file, you will need to add the following at the top of your `functions.php` file to load the Composer dependencies (including Timber), and initialize Timber.
 
 **functions.php**
 
 ```php
 <?php
 require_once( __DIR__ . '/vendor/autoload.php' );
-```
-
-Initialize Timber with:
-
-**functions.php**
-
-```php
-<?php
 $timber = new Timber\Timber();
 ```
 


### PR DESCRIPTION
Clarified which directory Composer should be used in.  Also added clarification for the scenario of using Composer with the starter theme instead of the WordPress.org install.

<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

**Ticket**:  #2039 

## Issue
<!-- Description of the problem that this code change is solving -->
Trying to use both the Composer install instructions _and_ the starter theme instructions resulted in some confusion when it came to activating the Timber plugin.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Added clarification for that specific use case.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
Possibly less headaches from new users, less support tickets.

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

It's odd that the starter theme has a composer.json file that is using an older Timber version and uses that package type that installs it as a plugin rather than the Composer autoload mechanism.  I'm not really sure the best solution.

