### PR TITLE
Meta data for Menu object

### DIFF
--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -5,7 +5,7 @@ namespace Timber;
 use Timber\Core;
 use Timber\Post;
 
-class Menu extends Core {
+class Menu extends Term {
 
 	public $MenuItemClass = 'Timber\MenuItem';
 	public $PostClass = 'Timber\Post';

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -415,13 +415,29 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals( 'http://upstatement.com', $item->link() );
 	}
 
-	function testMenuMeta() {
+	function testMenuItemMetaAlt() {
+		$menu_info = $this->_createSimpleMenu();
+		$menu = new TimberMenu($menu_info['term_id']);
+		$item = $menu->items[0];
+		$this->assertEquals('molasses', $item->meta('flood'));
+	}
+
+	function testMenuItemMeta() {
 		self::_createTestMenu();
 		$menu = new TimberMenu();
 		$items = $menu->get_items();
 		$item = $items[0];
 		$this->assertEquals( 'funke', $item->tobias );
 		$this->assertGreaterThan( 0, $item->id );
+	}
+
+	function testMenuMeta() {
+		$term = self::_createTestMenu();
+		$menu_id = $term['term_id'];
+		add_term_meta($menu_id, 'nationality', 'Canadian');
+		$menu = new Timber\Menu($menu_id);
+		$string = Timber::compile_string('{{menu.meta("nationality")}}', array('menu' => $menu));
+		$this->assertEquals('Canadian', $string);
 	}
 
 	function testMenuItemWithHash() {
@@ -612,13 +628,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals('Child Page', $children[0]->title());
 	}
 
-	function testMenuItemMeta() {
-		$menu_info = $this->_createSimpleMenu();
-		$menu = new TimberMenu($menu_info['term_id']);
-		$item = $menu->items[0];
-		$this->assertEquals('molasses', $item->meta('flood'));
-	}
-
 	function testMenuName() {
 		self::_createTestMenu();
 		$menu = new TimberMenu();
@@ -754,4 +763,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		}
 		$this->assertEquals($tmis[4]->post_title, 'People');
 	}
+
+
 }


### PR DESCRIPTION
**Ticket**: #2000

## Issue
Custom metadata stored via ACF on a WordPress menu was not accessible in templates

## Solution
Since WordPress borrows the meta table and object for its menus, we should do the same. This PR simply adds a test and has `Menu` extend `Term` rather than `Core`

## Impact
Seemingly very light. The class inheritance of the `Menu` item changes, but nothing else

## Usage Changes
None

## Considerations
A second thought/voice on whether this change in class inheritance could have larger negative consequences. This definitely feels like a very elegant solution, but a downside is that now `Menu` has some functions/properties with it that might not be meaningful or relevant to it being a `Menu` and not a `Term`

## Testing
Wrote a new test to validate the meta behavior; all other tests pass
