### PR TITLE
Add details regarding Timber::cache to docs

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -103,7 +103,7 @@ if ( class_exists( 'Timber' ) ){
 }
 ```
 
-You can look in your your `/wp-content/plugins/timber/cache/twig` directory to see what these files look like.
+You can look in your `/wp-content/plugins/timber/cache/twig` directory to see what these files look like.
 
 This does not cache the _contents_ of the variables. 
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -103,9 +103,21 @@ if ( class_exists( 'Timber' ) ){
 }
 ```
 
-You can look in your your `/wp-content/plugins/timber/twig-cache` directory to see what these files look like.
+You can look in your your `/wp-content/plugins/timber/cache/twig` directory to see what these files look like.
 
-This does not cache the _contents_ of the variables. This is recommended as a last-step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example) will not go live until the cache is flushed.
+This does not cache the _contents_ of the variables. 
+
+Enabling `Timber::$cache` works best as a last step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example ) will not go live until the cache is flushed. 
+
+Note that when `WP_DEBUG` is set to `true`, changes you make to `.twig` files will be reflected on the site regardless of the `Timber::$cache` value.
+
+To flush the Twig cache you can do this:
+
+```php
+<?php
+$loader = new Timber\Loader();
+$loader->clear_cache_twig();
+```
 
 ## Cache the PHP data
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -107,7 +107,7 @@ You can look in your your `/wp-content/plugins/timber/cache/twig` directory to s
 
 This does not cache the _contents_ of the variables. 
 
-Enabling `Timber::$cache` works best as a last step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example ) will not go live until the cache is flushed. 
+Enabling `Timber::$cache` works best as a last step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example) will not go live until the cache is flushed. 
 
 Note that when `WP_DEBUG` is set to `true`, changes you make to `.twig` files will be reflected on the site regardless of the `Timber::$cache` value.
 

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -5,10 +5,10 @@ menu:
     parent: "guides"
 ---
 
-Among its other special powers, Timber includes modern routing in the Express.js/Ruby on Rails mold, making it easy for you to implement custom pagination--and anything else you might imagine in your wildest dreams of URLs and parameters. OMG so easy!
+Among its other special powers, Timber includes modern routing in the Express.js/Ruby on Rails mold, making it easy for you to implement custom pagination — and anything else you might imagine in your wildest dreams of URLs and parameters. OMG so easy!
 
 ## Some examples
-In your functions.php file, this can be called anywhere (don't hook it to init or another action or it might be called too late)
+In your functions.php file, this can be called anywhere (don't hook it to `init` or another action or it might be called too late)
 
 ```php
 <?php


### PR DESCRIPTION
Added some documentation around `Timber::$cache` based on [this discussion](https://github.com/timber/timber/issues/399#issuecomment-512699932).

I was not sure whether to include a more comprehensive solution to clearing the cache on a live website. I was thinking along the lines of:

```php
<?php
Routes::map('maintenance/clear-twig-cache', function() {
	if (is_user_logged_in()) {
		$loader = new Timber\Loader();
		$loader->clear_cache_twig();
		echo 'Twig cache cleared.';
		exit(0);
	}
});
```

...but since I'm not fluent in PHP / WP conventions, I'm not sure whether this is an idiomatic approach to the problem. 