### PR TITLE
Add meta property for Timber\Theme

### DIFF
--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -58,7 +58,7 @@ class Theme extends Core {
 
 	/**
 	 * @api
-	 * @var array the slug of the theme (ex: `my-super-theme`)
+	 * @var array return an array of theme information (ex: author, author URI)
 	 */
 	public $meta;
 

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -57,6 +57,12 @@ class Theme extends Core {
 	public $uri;
 
 	/**
+	 * @api
+	 * @var array the slug of the theme (ex: `my-super-theme`)
+	 */
+	public $meta;
+
+	/**
 	 * @var WP_Theme the underlying WordPress native Theme object
 	 */
 	private $theme;
@@ -94,6 +100,13 @@ class Theme extends Core {
 		$this->slug = $this->theme->get_stylesheet();
 
 		$this->uri = $this->theme->get_template_directory_uri();
+
+		$this->meta = [
+			'ThemeURI' => $this->theme->get('ThemeURI'),
+			'Desc' => $this->theme->get('Description'),
+			'Author' => $this->theme->get('Author'),
+			'AuthorURI' => $this->theme->get('AuthorURI')
+		];
 
 		if ( $this->theme->parent()) {
 			$this->parent_slug = $this->theme->parent()->get_stylesheet();

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -102,10 +102,10 @@ class Theme extends Core {
 		$this->uri = $this->theme->get_template_directory_uri();
 
 		$this->meta = [
-			'ThemeURI' => $this->theme->get('ThemeURI'),
-			'Desc' => $this->theme->get('Description'),
-			'Author' => $this->theme->get('Author'),
-			'AuthorURI' => $this->theme->get('AuthorURI')
+			'theme_uri' => $this->theme->get('ThemeURI'),
+			'desc' => $this->theme->get('Description'),
+			'author' => $this->theme->get('Author'),
+			'author_uri' => $this->theme->get('AuthorURI')
 		];
 
 		if ( $this->theme->parent()) {

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -57,12 +57,6 @@ class Theme extends Core {
 	public $uri;
 
 	/**
-	 * @api
-	 * @var array return an array of theme information (ex: author, author URI)
-	 */
-	public $meta;
-
-	/**
 	 * @var WP_Theme the underlying WordPress native Theme object
 	 */
 	private $theme;
@@ -101,14 +95,7 @@ class Theme extends Core {
 
 		$this->uri = $this->theme->get_template_directory_uri();
 
-		$this->meta = [
-			'theme_uri' => $this->theme->get('ThemeURI'),
-			'desc' => $this->theme->get('Description'),
-			'author' => $this->theme->get('Author'),
-			'author_uri' => $this->theme->get('AuthorURI')
-		];
-
-		if ( $this->theme->parent()) {
+		if ( $this->theme->parent() ) {
 			$this->parent_slug = $this->theme->parent()->get_stylesheet();
 			$this->parent = new Theme($this->parent_slug);
 		}
@@ -148,5 +135,42 @@ class Theme extends Core {
 		return get_theme_mods();
 	}
 
+	/**
+	 * Gets a raw, unformatted theme header.
+	 * 
+	 * @api 
+	 * @see \WP_Theme::get()
+	 * @example
+	 * ```twig
+	 * {{ theme.get('Version') }}
+	 * ```
+	 *
+	 * @param string $header Name of the theme header. Name, Description, Author, Version,
+	 *                       ThemeURI, AuthorURI, Status, Tags.
+	 *
+	 * @return false|string String on success, false on failure.
+	 */
+	public function get( $header ) {
+		return $this->theme->get( $header );
+	}
+
+	/**
+	 * Gets a theme header, formatted and translated for display.
+	 *
+	 * @api
+	 * @see \WP_Theme::display()
+	 * @example
+	 * ```twig
+	 * {{ theme.display('Description') }}
+	 * ```
+	 *
+	 * @param string $header Name of the theme header. Name, Description, Author, Version,
+	 *                       ThemeURI, AuthorURI, Status, Tags.
+	 *
+	 * @return false|string
+	 */
+	public function display( $header ) {
+		return $this->theme->display( $header );
+	}
 }
 


### PR DESCRIPTION
Hello I would like to improve `Timber\Theme` object. 

## Issue
I need to get the theme author name but the current Timber could do that.
Detail: https://github.com/timber/timber/issues/2049

## Solution
Introduce new property for the [Theme](https://github.com/dtvn/timber/blob/master/lib/Theme.php).
```PHP
/**
* @api
* @var array return an array of theme information (ex: author, author URI)
*/
public $meta;
```

Collect data for `$meta` in `init` function:
```PHP
$this->meta = [
	'theme_uri' => $this->theme->get('ThemeURI'),
	'desc' => $this->theme->get('Description'),
	'author' => $this->theme->get('Author'),
	'author_uri' => $this->theme->get('AuthorURI')
];
```


## Impact
This code does no harm things or have great impact on the core. It just simply get more data from `wp_get_theme()`. Totally safe.


## Usage Changes
See **Solution**, that's all I got.


## Considerations
Please check my issue:  https://github.com/timber/timber/issues/2049


## Testing
Not yet... I don't even know how to do that :p 
