### PR TITLE
Twig\Extension\CoreExtension::setEscaper() is deprecated

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -244,18 +244,18 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
 			return esc_url($string);
 		});
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
 			return wp_kses_post($string);
 		});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
 			return esc_html($string);
 		});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
 			return esc_js($string);
 		});
 


### PR DESCRIPTION
[As of Twig 2.11, the Twig\Extension\CoreExtension::setEscaper() and Twig\Extension\CoreExtension::getEscapers() are deprecated. Use the same methods on Twig\Extension\EscaperExtension instead.
](https://twig.symfony.com/doc/2.x/deprecated.html#extensions)
