### PR TITLE
2043/2x term base class

### DIFF
--- a/lib/CoreTerm.php
+++ b/lib/CoreTerm.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Timber;
+
+abstract class CoreTerm extends Core {
+
+	public $PostClass = 'Timber\Post';
+
+	/**
+	 * @api
+	 * @var string the human-friendly name of the term (ex: French Cuisine)
+	 */
+	public $name;
+
+	/**
+	 * Gets a term meta value.
+	 *
+	 * Returns meta information stored with a term. This will use both data stored under (old) ACF
+	 * hacks and new (WP 4.6+) where term meta has its own table. If retrieving a special ACF field
+	 * (repeater, etc.) you can use the output immediately in Twig — no further processing is
+	 * required.
+	 *
+	 * @api
+	 * @example
+	 * ```twig
+	 * <div class="location-info">
+	 *   <h2>{{ term.name }}</h2>
+	 *   <p>{{ term.meta('address') }}</p>
+	 * </div>
+	 * ```
+	 *
+	 * @param string $field_name The field name for which you want to get the value.
+	 * @param array  $args       An array of arguments for getting the meta value. Third-party
+	 *                           integrations can use this argument to make their API arguments
+	 *                           available in Timber. Default empty.
+	 * @return mixed The meta field value.
+	 */
+	public function meta( $field_name, $args = array() ) {
+		/**
+		 * Filters the value for a term meta field before it is fetched from the database.
+		 *
+		 * @todo  Add description, example
+		 *
+		 * @see   \Timber\Term::meta()
+		 * @since 2.0.0
+		 *
+		 * @param string       $value      The field value. Passing a non-null value will skip
+		 *                                 fetching the value from the database. Default null.
+		 * @param int          $post_id    The post ID.
+		 * @param string       $field_name The name of the meta field to get the value for.
+		 * @param \Timber\Term $term       The term object.
+		 * @param array        $args       An array of arguments.
+		 */
+		$value = apply_filters(
+			'timber/term/pre_meta',
+			null,
+			$this->ID,
+			$field_name,
+			$this,
+			$args
+		);
+
+		if ( null === $value ) {
+			$value = get_term_meta($this->ID, $field_name, true);
+		}
+
+		/**
+		 * Filters the value for a term meta field.
+		 *
+		 * This filter is used by the ACF Integration.
+		 *
+		 * @todo  Add description, example
+		 *
+		 * @see   \Timber\Term::meta()
+		 * @since 0.21.9
+		 *
+		 * @param mixed        $value The field value.
+		 * @param int          $term_id     The term ID.
+		 * @param string       $field_name  The name of the meta field to get the value for.
+		 * @param \Timber\Term $term        The term object.
+		 * @param array        $args        An array of arguments.
+		 */
+		$value = apply_filters(
+			'timber/term/meta',
+			$value,
+			$this->ID,
+			$field_name,
+			$this,
+			$args
+		);
+
+		/**
+		 * Filters the value for a term meta field.
+		 *
+		 * @deprecated 2.0.0, use `timber/term/meta`
+		 */
+		$value = apply_filters_deprecated(
+			'timber/term/meta/field',
+			array( $value, $this->ID, $field_name, $this ),
+			'2.0.0',
+			'timber/term/meta'
+		);
+
+		/**
+		 * Filters the value for a term meta field.
+		 *
+		 * @deprecated 2.0.0, use `timber/term/meta`
+		 */
+		$value = apply_filters_deprecated(
+			'timber_term_get_meta_field',
+			array( $value, $this->ID, $field_name, $this ),
+			'2.0.0',
+			'timber/term/meta'
+		);
+
+		return $value;
+	}
+
+}

--- a/lib/Menu.php
+++ b/lib/Menu.php
@@ -7,10 +7,9 @@ namespace Timber;
  *
  * @api
  */
-class Menu extends Core {
+class Menu extends CoreTerm {
 
 	public $MenuItemClass = 'Timber\MenuItem';
-	public $PostClass = 'Timber\Post';
 
 	/**
 	 * @api
@@ -28,25 +27,7 @@ class Menu extends Core {
 	 * @api
 	 * @var int The ID of the menu, corresponding to the wp_terms table.
 	 */
-	public $id;
-
-	/**
-	 * @api
-	 * @var int The ID of the menu, corresponding to the wp_terms table.
-	 */
-	public $ID;
-
-	/**
-	 * @api
-	 * @var int The ID of the menu, corresponding to the wp_terms table.
-	 */
 	public $term_id;
-
-	/**
-	 * @api
-	 * @var string The name of the menu (ex: `Main Navigation`).
-	 */
-	public $name;
 
 	/**
 	 * @api

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -38,7 +38,7 @@ namespace Timber;
  * </ul>
  * ```
  */
-class Term extends Core implements CoreInterface, MetaInterface {
+class Term extends CoreTerm implements CoreInterface, MetaInterface {
 
 	public $PostClass = 'Timber\Post';
 	public $TermClass = 'Term';
@@ -47,12 +47,6 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	public static $representation = 'term';
 
 	public $_children;
-
-	/**
-	 * @api
-	 * @var string the human-friendly name of the term (ex: French Cuisine)
-	 */
-	public $name;
 
 	/**
 	 * @api
@@ -412,110 +406,6 @@ class Term extends Core implements CoreInterface, MetaInterface {
 		);
 
 		return $link;
-	}
-
-	/**
-	 * Gets a term meta value.
-	 *
-	 * Returns meta information stored with a term. This will use both data stored under (old) ACF
-	 * hacks and new (WP 4.6+) where term meta has its own table. If retrieving a special ACF field
-	 * (repeater, etc.) you can use the output immediately in Twig — no further processing is
-	 * required.
-	 *
-	 * @api
-	 * @example
-	 * ```twig
-	 * <div class="location-info">
-	 *   <h2>{{ term.name }}</h2>
-	 *   <p>{{ term.meta('address') }}</p>
-	 * </div>
-	 * ```
-	 *
-	 * @param string $field_name The field name for which you want to get the value.
-	 * @param array  $args       An array of arguments for getting the meta value. Third-party
-	 *                           integrations can use this argument to make their API arguments
-	 *                           available in Timber. Default empty.
-	 * @return mixed The meta field value.
-	 */
-	public function meta( $field_name, $args = array() ) {
-		/**
-		 * Filters the value for a term meta field before it is fetched from the database.
-		 *
-		 * @todo  Add description, example
-		 *
-		 * @see   \Timber\Term::meta()
-		 * @since 2.0.0
-		 *
-		 * @param string       $value      The field value. Passing a non-null value will skip
-		 *                                 fetching the value from the database. Default null.
-		 * @param int          $post_id    The post ID.
-		 * @param string       $field_name The name of the meta field to get the value for.
-		 * @param \Timber\Term $term       The term object.
-		 * @param array        $args       An array of arguments.
-		 */
-		$value = apply_filters(
-			'timber/term/pre_meta',
-			null,
-			$this->ID,
-			$field_name,
-			$this,
-			$args
-		);
-
-		if ( null === $value ) {
-			$value = get_term_meta($this->ID, $field_name, true);
-		}
-
-		/**
-		 * Filters the value for a term meta field.
-		 *
-		 * This filter is used by the ACF Integration.
-		 *
-		 * @todo  Add description, example
-		 *
-		 * @see   \Timber\Term::meta()
-		 * @since 0.21.9
-		 *
-		 * @param mixed        $value The field value.
-		 * @param int          $term_id     The term ID.
-		 * @param string       $field_name  The name of the meta field to get the value for.
-		 * @param \Timber\Term $term        The term object.
-		 * @param array        $args        An array of arguments.
-		 */
-		$value = apply_filters(
-			'timber/term/meta',
-			$value,
-			$this->ID,
-			$field_name,
-			$this,
-			$args
-		);
-
-		/**
-		 * Filters the value for a term meta field.
-		 *
-		 * @deprecated 2.0.0, use `timber/term/meta`
-		 */
-		$value = apply_filters_deprecated(
-			'timber/term/meta/field',
-			array( $value, $this->ID, $field_name, $this ),
-			'2.0.0',
-			'timber/term/meta'
-		);
-
-		/**
-		 * Filters the value for a term meta field.
-		 *
-		 * @deprecated 2.0.0, use `timber/term/meta`
-		 */
-		$value = apply_filters_deprecated(
-			'timber_term_get_meta_field',
-			array( $value, $this->ID, $field_name, $this ),
-			'2.0.0',
-			'timber/term/meta'
-		);
-
-		return $value;
 	}
 
 	/**

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -463,13 +463,21 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals( '_self', $item->target() );
 	}
 
+
 	function testMenuMeta() {
-		self::_createTestMenu();
-		$menu = new Timber\Menu();
-		$items = $menu->get_items();
-		$item = $items[0];
-		$this->assertEquals( 'funke', $item->tobias );
-		$this->assertGreaterThan( 0, $item->id );
+		$term = self::_createTestMenu();
+		$menu_id = $term['term_id'];
+		add_term_meta($menu_id, 'nationality', 'Canadian');
+		$menu = new Timber\Menu($menu_id);
+		$string = Timber::compile_string('{{ menu.meta("nationality") }}', array('menu' => $menu));
+		$this->assertEquals('Canadian', $string);
+	}
+
+	function testMenuItemMetaAlt() {
+		$menu_info = $this->_createSimpleMenu();
+		$menu = new Timber\Menu($menu_info['term_id']);
+		$item = $menu->items[0];
+		$this->assertEquals('molasses', $item->meta('flood'));
 	}
 
 	function testMenuMetaSet() {

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -169,7 +169,7 @@
 
 		function testPagePreviewOnSearch() {
 			$pid = $this->factory->post->create(array('post_type' => 'page', 'post_content' => 'What a beautiful day for a ballgame!', 'post_excerpt' => ''));
-			$post = new TimberPost( $pid );
+			$post = new Timber\Post( $pid );
 			$template = '{{ post.preview }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('What a beautiful day for a ballgame!&hellip; <a href="http://example.org/?page_id='.$pid.'" class="read-more">Read More</a>', $str);


### PR DESCRIPTION
**Ticket**: #2000 #2043 

## Issue
Custom metadata stored via ACF on a WordPress menu was not accessible in templates

## Solution
Since WordPress borrows the meta table and object for its menus, we should do the same. This PR adds a test, and creates a `CoreTerm` class for both regular `Term`s and `Menu`s to feed off from. This differs from #2043 where `Menu` extends `Term` rather than `Core`

## Impact
Seemingly very light. Not quite as light as #2043. The class inheritance of the `Menu` and `Term` classes change, but nothing else

## Usage Changes
None.

## Considerations
After putting this together and writing the PR, I actually think #2043 should be merged and not this one. In #2043 the inheritance matches WP's native (where Menu is a special kind of `Term` but there's not an overall "basic term" class/concept. Plus, it's less code to solve the problem. This seems to bring up additional risk without any reward

## Testing
Wrote a new test to validate the meta behavior; all other tests pass
