### PR TITLE
Twig extension coreextension set escape deprecated

### DIFF
--- a/bin/timber.php
+++ b/bin/timber.php
@@ -4,7 +4,7 @@ Plugin Name: Timber
 Description: The WordPress Timber Library allows you to write themes using the power of Twig templates.
 Plugin URI: http://timber.upstatement.com
 Author: Jared Novack + Upstatement
-Version: 1.10.1
+Version: 1.11.0
 Author URI: http://upstatement.com/
 */
 // we look for Composer files first in the plugins dir.

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -35,7 +35,7 @@ use Timber\Loader;
  */
 class Timber {
 
-	public static $version = '1.10.1';
+	public static $version = '1.11.0';
 	public static $locations;
 	public static $dirname = 'views';
 	public static $twig_cache = false;

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -244,20 +244,37 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
-			return esc_url($string);
-		});
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
-			return wp_kses_post($string);
-		});
+		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+				return esc_url($string);
+			});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+				return wp_kses_post($string);
+			});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
-			return esc_html($string);
-		});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+				return esc_html($string);
+			});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
-			return esc_js($string);
-		});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+				return esc_js($string);
+			});
+		} else {
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+				return esc_url($string);
+			});
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+				return wp_kses_post($string);
+			});
+
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+				return esc_html($string);
+			});
+
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+				return esc_js($string);
+			});
+		}
 
 		return $twig;
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Timber ===
-Contributors: jarednova, connorjburton, lggorman
+Contributors: jarednova
 Tags: template engine, templates, twig
 Requires at least: 4.7.12
-Tested up to: 5.2.1
-Stable tag: 1.10.1
+Tested up to: 5.2.3
+Stable tag: 1.11.0
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -29,6 +29,10 @@ _Twig is the template language powering Timber; if you need a little background 
 == Changelog ==
 
 = Develop (next release) =
+
+= 1.11.0 =
+**General Note**
+- If you use WPML with Timber, please upgrade to WPML 4.2.8. The WPML team has removed their included Twig version which means no more conflicts!
 
 **Fixes and improvements**
 - Fix to menu items getting incorrect classes in WPML and others #1974


### PR DESCRIPTION
see https://github.com/timber/timber/pull/2062

This adds a check to see if the new class exists in Twig