### PR TITLE
Twig\Extension\CoreExtension::setEscaper() is deprecated

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -297,20 +297,37 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
-			return esc_url($string);
-		});
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
-			return wp_kses_post($string);
-		});
+		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+				return esc_url($string);
+			});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+				return wp_kses_post($string);
+			});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
-			return esc_html($string);
-		});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+				return esc_html($string);
+			});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
-			return esc_js($string);
-		});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+				return esc_js($string);
+			});
+		} else {
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+				return esc_url($string);
+			});
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+				return wp_kses_post($string);
+			});
+
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+				return esc_html($string);
+			});
+
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+				return esc_js($string);
+			});
+		}
 
 		return $twig;
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -296,41 +296,25 @@ class Twig {
 	 * @return \Twig\Environment
 	 */
 	public function add_timber_escapers( $twig ) {
+		$esc_url = function( \Twig\Environment $env, $string ) {
+			return esc_url( $string );
+		}
 
 		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
-			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
-				return esc_url($string);
-			});
-			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
-				return wp_kses_post($string);
-			});
-
-			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
-				return esc_html($string);
-			});
-
-			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
-				return esc_js($string);
-			});
+			$escaper = $twig->getExtension('Twig\Extension\EscaperExtension');
+			$escaper->setEscaper('esc_url', $esc_url);
+			$escaper->setEscaper('wp_kses_post', $esc_url);
+			$escaper->setEscaper('esc_html', $esc_url);
+			$escaper->setEscaper('esc_js', $esc_url);
 		} else {
-			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
-				return esc_url($string);
-			});
-			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
-				return wp_kses_post($string);
-			});
-
-			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
-				return esc_html($string);
-			});
-
-			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
-				return esc_js($string);
-			});
+			$escaper = $twig->getExtension('Twig\Extension\CoreExtension');
+			$escaper->setEscaper('esc_url', $esc_url);
+			$escaper->setEscaper('wp_kses_post', $esc_url);
+			$escaper->setEscaper('esc_html', $esc_url);
+			$escaper->setEscaper('esc_js', $esc_url);
 		}
 
 		return $twig;
-
 	}
 
 	/**

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -301,17 +301,17 @@ class Twig {
 		}
 
 		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
-			$escaperExtension = $twig->getExtension('Twig\Extension\EscaperExtension');
-			$escaperExtension->setEscaper('esc_url', $esc_url);
-			$escaperExtension->setEscaper('wp_kses_post', $esc_url);
-			$escaperExtension->setEscaper('esc_html', $esc_url);
-			$escaperExtension->setEscaper('esc_js', $esc_url);
+			$escaper_extension = $twig->getExtension('Twig\Extension\EscaperExtension');
+			$escaper_extension->setEscaper('esc_url', $esc_url);
+			$escaper_extension->setEscaper('wp_kses_post', $esc_url);
+			$escaper_extension->setEscaper('esc_html', $esc_url);
+			$escaper_extension->setEscaper('esc_js', $esc_url);
 		} else {
-			$escaperExtension = $twig->getExtension('Twig\Extension\CoreExtension');
-			$escaperExtension->setEscaper('esc_url', $esc_url);
-			$escaperExtension->setEscaper('wp_kses_post', $esc_url);
-			$escaperExtension->setEscaper('esc_html', $esc_url);
-			$escaperExtension->setEscaper('esc_js', $esc_url);
+			$escaper_extension = $twig->getExtension('Twig\Extension\CoreExtension');
+			$escaper_extension->setEscaper('esc_url', $esc_url);
+			$escaper_extension->setEscaper('wp_kses_post', $esc_url);
+			$escaper_extension->setEscaper('esc_html', $esc_url);
+			$escaper_extension->setEscaper('esc_js', $esc_url);
 		}
 
 		return $twig;

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -300,21 +300,34 @@ class Twig {
 			return esc_url( $string );
 		}
 
+		$wp_kses_post = function( \Twig\Environment $env, $string ) {
+			return wp_kses_post( $string );
+		}
+
+		$esc_html = function( \Twig\Environment $env, $string ) {
+			return esc_html( $string );
+		}
+
+		$esc_js = function( \Twig\Environment $env, $string ) {
+			return esc_js( $string );
+		}
+
 		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
 			$escaper_extension = $twig->getExtension('Twig\Extension\EscaperExtension');
 			$escaper_extension->setEscaper('esc_url', $esc_url);
-			$escaper_extension->setEscaper('wp_kses_post', $esc_url);
-			$escaper_extension->setEscaper('esc_html', $esc_url);
-			$escaper_extension->setEscaper('esc_js', $esc_url);
+			$escaper_extension->setEscaper('wp_kses_post', $wp_kses_post);
+			$escaper_extension->setEscaper('esc_html', $esc_html);
+			$escaper_extension->setEscaper('esc_js', $esc_js);
 		} else {
 			$escaper_extension = $twig->getExtension('Twig\Extension\CoreExtension');
 			$escaper_extension->setEscaper('esc_url', $esc_url);
-			$escaper_extension->setEscaper('wp_kses_post', $esc_url);
-			$escaper_extension->setEscaper('esc_html', $esc_url);
-			$escaper_extension->setEscaper('esc_js', $esc_url);
+			$escaper_extension->setEscaper('wp_kses_post', $wp_kses_post);
+			$escaper_extension->setEscaper('esc_html', $esc_html);
+			$escaper_extension->setEscaper('esc_js', $esc_js);
 		}
 
 		return $twig;
+
 	}
 
 	/**

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -301,17 +301,17 @@ class Twig {
 		}
 
 		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
-			$escaper = $twig->getExtension('Twig\Extension\EscaperExtension');
-			$escaper->setEscaper('esc_url', $esc_url);
-			$escaper->setEscaper('wp_kses_post', $esc_url);
-			$escaper->setEscaper('esc_html', $esc_url);
-			$escaper->setEscaper('esc_js', $esc_url);
+			$escaperExtension = $twig->getExtension('Twig\Extension\EscaperExtension');
+			$escaperExtension->setEscaper('esc_url', $esc_url);
+			$escaperExtension->setEscaper('wp_kses_post', $esc_url);
+			$escaperExtension->setEscaper('esc_html', $esc_url);
+			$escaperExtension->setEscaper('esc_js', $esc_url);
 		} else {
-			$escaper = $twig->getExtension('Twig\Extension\CoreExtension');
-			$escaper->setEscaper('esc_url', $esc_url);
-			$escaper->setEscaper('wp_kses_post', $esc_url);
-			$escaper->setEscaper('esc_html', $esc_url);
-			$escaper->setEscaper('esc_js', $esc_url);
+			$escaperExtension = $twig->getExtension('Twig\Extension\CoreExtension');
+			$escaperExtension->setEscaper('esc_url', $esc_url);
+			$escaperExtension->setEscaper('wp_kses_post', $esc_url);
+			$escaperExtension->setEscaper('esc_html', $esc_url);
+			$escaperExtension->setEscaper('esc_js', $esc_url);
 		}
 
 		return $twig;

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -298,19 +298,19 @@ class Twig {
 	public function add_timber_escapers( $twig ) {
 		$esc_url = function( \Twig\Environment $env, $string ) {
 			return esc_url( $string );
-		}
+		};
 
 		$wp_kses_post = function( \Twig\Environment $env, $string ) {
 			return wp_kses_post( $string );
-		}
+		};
 
 		$esc_html = function( \Twig\Environment $env, $string ) {
 			return esc_html( $string );
-		}
+		};
 
 		$esc_js = function( \Twig\Environment $env, $string ) {
 			return esc_js( $string );
-		}
+		};
 
 		if ( class_exists( 'Twig\Extension\EscaperExtension' ) ) {
 			$escaper_extension = $twig->getExtension('Twig\Extension\EscaperExtension');


### PR DESCRIPTION
_let's try this from the proper base branch 🤦‍♂_ 

see : https://github.com/timber/timber/pull/2062

This adds on `class_exists( 'Twig\Extension\EscaperExtension' )`

[As of Twig 2.11, the Twig\Extension\CoreExtension::setEscaper() and Twig\Extension\CoreExtension::getEscapers() are deprecated. Use the same methods on Twig\Extension\EscaperExtension instead.](https://twig.symfony.com/doc/2.x/deprecated.html#extensions)