### PR TITLE
Twig\Extension\CoreExtension::setEscaper() is deprecated

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -243,24 +243,40 @@ class Twig {
 	 * @return \Twig\Environment
 	 */
 	public function add_timber_escapers( $twig ) {
-
-		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
-			return esc_url($string);
-		});
-		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
-			return wp_kses_post($string);
-		});
-
-		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
-			return esc_html($string);
-		});
-
-		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
-			return esc_js($string);
-		});
-
+		if (class_exists('Twig\Extension\EscaperExtension')) {
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+				return esc_url($string);
+			});
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+				return wp_kses_post($string);
+			});
+			
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+				return esc_html($string);
+			});
+			
+			$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+				return esc_js($string);
+			});
+		} else {
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function (\Twig\Environment $env, $string) {
+				return esc_url($string);
+			});
+			
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function (\Twig\Environment $env, $string) {
+				return wp_kses_post($string);
+			});
+			
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function (\Twig\Environment $env, $string) {
+				return esc_html($string);
+			});
+			
+			$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function (\Twig\Environment $env, $string) {
+				return esc_js($string);
+			});
+		}
+		
 		return $twig;
-
 	}
 
 	/**

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -244,18 +244,18 @@ class Twig {
 	 */
 	public function add_timber_escapers( $twig ) {
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_url', function( \Twig\Environment $env, $string ) {
 			return esc_url($string);
 		});
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('wp_kses_post', function( \Twig\Environment $env, $string ) {
 			return wp_kses_post($string);
 		});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_html', function( \Twig\Environment $env, $string ) {
 			return esc_html($string);
 		});
 
-		$twig->getExtension('Twig\Extension\CoreExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
+		$twig->getExtension('Twig\Extension\EscaperExtension')->setEscaper('esc_js', function( \Twig\Environment $env, $string ) {
 			return esc_js($string);
 		});
 


### PR DESCRIPTION
Replaces stale PR #2062 (I deleted the fork...)


---
[As of Twig 2.11, the Twig\Extension\CoreExtension::setEscaper() and Twig\Extension\CoreExtension::getEscapers() are deprecated. Use the same methods on Twig\Extension\EscaperExtension instead.](https://twig.symfony.com/doc/2.x/deprecated.html#extensions)