### PR TITLE
2.x refactor tests

### DIFF
--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -78,4 +78,9 @@
 			$wpdb->query("TRUNCATE TABLE $wpdb->posts;");
 		}
 
+		function truncate(string $table) {
+			global $wpdb;
+			$wpdb->query("TRUNCATE TABLE {$wpdb->$table}");
+		}
+
 	}

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -2,6 +2,9 @@
 
     use Timber\Cache\TimberKeyGeneratorInterface;
 
+  /**
+   * @group called-post-constructor
+   */
 	class TestTimberCache extends Timber_UnitTestCase {
 
         private function _generate_transient_name() {
@@ -130,7 +133,7 @@
         function testKeyGenerator(){
         	$kg = new Timber\Cache\KeyGenerator();
         	$post_id = $this->factory->post->create(array('post_title' => 'My Test Post'));
-        	$post = new Timber\Post($post_id);
+					$post = Timber::get_post($post_id);
         	$key = $kg->generateKey($post);
         	$this->assertStringStartsWith('Timber\Post|', $key);
         }
@@ -188,7 +191,7 @@
         	$this->assertFileNotExists($cache_dir);
         	Timber::$twig_cache = true;
         	$pid = $this->factory->post->create();
-        	$post = new Timber\Post($pid);
+					$post = Timber::get_post($pid);
         	Timber::compile('assets/single-post.twig', array('post' => $post));
         	sleep(1);
         	$this->assertFileExists($cache_dir);
@@ -209,7 +212,7 @@
         	$this->assertFileNotExists($cache_dir);
         	Timber::$cache = true;
         	$pid = $this->factory->post->create();
-        	$post = new Timber\Post($pid);
+					$post = Timber::get_post($pid);
         	Timber::compile('assets/single-post.twig', array('post' => $post));
         	sleep(1);
         	$this->assertFileExists($cache_dir);
@@ -238,7 +241,7 @@
 			add_filter( 'timber/twig/environment/options', $cache_enabler );
 
 	        $pid  = $this->factory->post->create();
-	        $post = new Timber\Post( $pid );
+	        $post = Timber::get_post( $pid );
 	        Timber::compile( 'assets/single-post.twig', array( 'post' => $post ) );
 	        sleep( 1 );
 
@@ -253,7 +256,7 @@
 
         function testTimberLoaderCache(){
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post), 600);
             $str_another = Timber::compile('assets/single-parent.twig', array('post' => $post, 'rand' => rand(0, 99)), 500);
             sleep(1);
@@ -274,7 +277,7 @@
             global $wp_object_cache;
             $_wp_using_ext_object_cache = true;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post), 600, \Timber\Loader::CACHE_OBJECT);
             sleep(1);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post), 600, \Timber\Loader::CACHE_OBJECT);
@@ -302,7 +305,7 @@
         function testTimberLoaderCacheTransients() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
             sleep($time + 1);
             $str_new = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);
@@ -317,7 +320,7 @@
             wp_set_current_user(1);
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $r1 = rand(0, 999999);
             $r2 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false));
@@ -342,7 +345,7 @@
         function testTimberLoaderCacheTransientsAdminLoggedOut() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $r1 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false));
             self::_swapFiles();
@@ -355,7 +358,7 @@
         function testTimberLoaderCacheTransientsAdminLoggedOutWithSiteCache() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $r1 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false), \Timber\Loader::CACHE_SITE_TRANSIENT);
             self::_swapFiles();
@@ -370,7 +373,7 @@
             $_wp_using_ext_object_cache = true;
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $r1 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post-rand.twig', array('post' => $post, 'rand' => $r1), array(600, false), \Timber\Loader::CACHE_OBJECT);
             self::_swapFiles();
@@ -386,7 +389,7 @@
             $_wp_using_ext_object_cache = true;
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             $r1 = rand(0, 999999);
             $r2 = rand(0, 999999);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => $r1), $time);
@@ -403,7 +406,7 @@
         function testTimberLoaderCacheTransientsButKeepOtherTransients() {
             $time = 1;
             $pid = $this->factory->post->create();
-            $post = new Timber\Post($pid);
+            $post = Timber::get_post($pid);
             set_transient( 'random_600', 'foo', 600 );
             $random_post = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), 600);
             $str_old = Timber::compile('assets/single-post.twig', array('post' => $post, 'rand' => rand(0, 99999)), $time);

--- a/tests/test-timber-comment-avatar.php
+++ b/tests/test-timber-comment-avatar.php
@@ -1,6 +1,6 @@
 <?php
 
-	// FIXME #1793 replace direct Timber\Comment instantiations
+	// @todo #1793 replace direct Timber\Comment instantiations
 	class TestTimberCommentAvatar extends Timber_UnitTestCase {
 
 		function testAvatarSize() {

--- a/tests/test-timber-comment-avatar.php
+++ b/tests/test-timber-comment-avatar.php
@@ -1,5 +1,6 @@
 <?php
 
+	// FIXME #1793 replace direct Timber\Comment instantiations
 	class TestTimberCommentAvatar extends Timber_UnitTestCase {
 
 		function testAvatarSize() {

--- a/tests/test-timber-comment-avatar.php
+++ b/tests/test-timber-comment-avatar.php
@@ -1,6 +1,6 @@
 <?php
 
-	// @todo #1793 replace direct Timber\Comment instantiations
+	// @todo #2094 replace direct Timber\Comment instantiations
 	class TestTimberCommentAvatar extends Timber_UnitTestCase {
 
 		function testAvatarSize() {

--- a/tests/test-timber-comment-thread.php
+++ b/tests/test-timber-comment-thread.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberCommentThread extends Timber_UnitTestCase {
 
 		function testCommentThreadWithArgs() {
@@ -28,12 +31,12 @@
 
 			$comment = get_comment($comment_id);
 
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals(0, count($post->comments()) );
 
 			$_GET['unapproved'] = $comment->comment_ID;
 			$_GET['moderation-hash'] = wp_hash($comment->comment_date_gmt);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			if ( !function_exists('wp_get_unapproved_comment_author_email') ) {
 				$this->assertEquals(0, count( $post->comments() ));
 			} else {

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -2,7 +2,7 @@
 
 /**
  * @group called-post-constructor
- * @todo #1793 replace direct Timber\Comment instantiations
+ * @todo #2094 replace direct Timber\Comment instantiations
  */
 class TestTimberComment extends Timber_UnitTestCase {
 

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -2,6 +2,7 @@
 
 /**
  * @group called-post-constructor
+ * FIXME #1793 replace direct Timber\Comment instantiations
  */
 class TestTimberComment extends Timber_UnitTestCase {
 

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberComment extends Timber_UnitTestCase {
 
 	function testComment(){
@@ -97,7 +100,7 @@ class TestTimberComment extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'These pretzels are making me thirsty.', 'user_id' => $kramer, 'comment_date' => '2015-08-21 03:24:07'));
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'Perhaps there’s more to Newman than meets the eye.', 'comment_date' => '2015-08-21 03:25:07'));
 		$child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'No, there’s less.', 'comment_parent' => $comment_id, 'comment_date' => '2015-08-21 03:26:07'));
-		$post = new Timber\Post($post_id);
+		$post = Timber::get_post($post_id);
 		$comments = $post->comments();
 		$this->assertEquals(2, count($comments));
 		$this->assertEquals(1, count($comments[1]->children()));

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -2,7 +2,7 @@
 
 /**
  * @group called-post-constructor
- * FIXME #1793 replace direct Timber\Comment instantiations
+ * @todo #1793 replace direct Timber\Comment instantiations
  */
 class TestTimberComment extends Timber_UnitTestCase {
 

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -3,6 +3,9 @@
 use Timber\Timber;
 use Timber\Post;
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberContext extends Timber_UnitTestCase {
 	/**
 	 * This throws an infite loop if memorization isn't working
@@ -27,7 +30,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 
 		$context = Timber::context();
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 
 		$this->assertArrayNotHasKey( 'posts', $context );
 		$this->assertEquals( $post, $context['post'] );

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -1,10 +1,13 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 	class TestTimberDates extends Timber_UnitTestCase {
 
 		function testDate(){
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = 'I am from {{post.date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.date('F j, Y'), $str);
@@ -22,7 +25,7 @@
 
 		function testTime(){
 			$pid = $this->factory->post->create(array('post_date' => '2016-07-07 20:03:00'));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = 'Posted at {{post.time}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('Posted at 8:03 pm', $str);
@@ -30,7 +33,7 @@
 
 		function testPostDisplayDate(){
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = 'I am from {{post.date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.date('F j, Y'), $str);
@@ -38,7 +41,7 @@
 
 		function testPostDate(){
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = 'I am from {{post.post_date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.$post->post_date, $str);
@@ -46,7 +49,7 @@
 
 		function testPostDateWithFilter(){
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = 'I am from {{post.post_date|date}}';
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I am from '.date('F j, Y'), $str);
@@ -55,7 +58,7 @@
 		function testModifiedDate(){
 			$date = date('F j, Y @ g:i a');
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = "I was modified {{ post.modified_date('F j, Y @ g:i a') }}";
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I was modified '.$date, $str);
@@ -63,7 +66,7 @@
 
 		function testModifiedDateFilter() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			add_filter('get_the_modified_date', function($the_date) {
 				return 'foobar';
 			});
@@ -75,7 +78,7 @@
 		function testModifiedTime(){
 			$date = date('F j, Y @ g:i a');
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$twig = "I was modified {{post.modified_time('F j, Y @ g:i a')}}";
 			$str = Timber::compile_string($twig, array('post' => $post));
 			$this->assertEquals('I was modified '.$date, $str);
@@ -90,7 +93,7 @@
 
 		function testModifiedTimeFilter() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			add_filter('get_the_modified_time', function($the_date) {
 				return 'foobar';
 			});

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberImageHelper extends TimberAttachment_UnitTestCase {
 
 		function testHTTPAnalyze() {
@@ -59,7 +62,7 @@
 			$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 			add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 			$data = array();
-			$data['post'] = new Timber\Post( $post_id );
+			$data['post'] = Timber::get_post( $post_id );
 			$data['size'] = $size;
 			$data['crop'] = 'default';
 			Timber::compile( $template, $data );
@@ -72,7 +75,7 @@
 			$exists = file_exists( $resized_path );
 			$this->assertTrue( $exists );
 		}
-		
+
 		/**
 		 * @doesNotPerformAssertions
 		 */

--- a/tests/test-timber-image-retina.php
+++ b/tests/test-timber-image-retina.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberImageRetina extends Timber_UnitTestCase {
 
 	function testImageRetina() {
@@ -29,7 +32,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$post = new Timber\Post( $post_id );
+		$post = Timber::get_post( $post_id );
 		$data['post'] = $post;
 		$str = '{{post.thumbnail.src|retina}}';
 		$compiled = Timber::compile_string($str, $data);
@@ -51,7 +54,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$post = new Timber\Post( $post_id );
+		$post = Timber::get_post( $post_id );
 		$data['post'] = $post;
 		$str = '{{post.thumbnail.src|retina(1.5)}}';
 		$compiled = Timber::compile_string($str, $data);
@@ -73,7 +76,7 @@ class TestTimberImageRetina extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$data['post'] = new Timber\Post( $post_id );
+		$data['post'] = Timber::get_post( $post_id );
 		$str = '{{post.thumbnail.src|resize(100, 50)|retina(3)}}';
 		$compiled = Timber::compile_string($str, $data);
 		$img = new Timber\Image($compiled);

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -2,8 +2,9 @@
 
 use Timber\Image\Operation as ImageOperation;
 
-require_once 'test-timber-attachment.php';
-
+/**
+ * @group called-post-constructor
+ */
 class TestTimberImage extends TimberAttachment_UnitTestCase {
 
 /* ----------------
@@ -15,7 +16,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$iid = self::get_attachment( $pid );
 		add_post_meta( $pid, '_thumbnail_id', $iid, true );
         add_post_meta( $iid, '_wp_attachment_metadata', wp_generate_attachment_metadata($iid, get_attached_file($iid)), true );
-		$post = new Timber\Post($pid);
+		$post = Timber::get_post($pid);
 		return $post;
 	}
 
@@ -298,7 +299,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$data['post'] = new Timber\Post( $post_id );
+		$data['post'] = Timber::get_post( $post_id );
 		$data['size'] = array( 'width' => 100, 'height' => 50 );
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/thumb-test.twig', $data );
@@ -325,7 +326,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		add_post_meta( $attach_id, '_wp_attachment_image_alt', $thumb_alt, true );
 		$data = array();
-		$data['post'] = new Timber\Post( $post_id );
+		$data['post'] = Timber::get_post( $post_id );
 		$this->assertEquals( $data['post']->thumbnail()->alt(), $thumb_alt );
 	}
 
@@ -718,7 +719,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$photo = Timber\URLHelper::get_rel_path($photo);
 		update_post_meta($pid, 'custom_photo', '/'.$photo);
 		$str = '{{ Image(post.custom_photo).width }}';
-		$post = new Timber\Post($pid);
+		$post = Timber::get_post($pid);
 		$rendered = Timber::compile_string( $str, array('post' => $post) );
 		$this->assertEquals( 1500, $rendered );
 	}
@@ -771,7 +772,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$attach_id = wp_insert_attachment($attachment, $filename, $post_id);
 		add_post_meta($post_id, '_thumbnail_id', $attach_id, true);
 		$data = array();
-		$data['post'] = new Timber\Post($post_id);
+		$data['post'] = Timber::get_post($post_id);
 		$data['size'] = 'timber-testPostThumbnailsNamed';
 		Timber::compile('assets/image-thumb-named.twig', $data);
 		$resized_path = $upload_dir['path'].'/flag-'.$width.'x'.$height.'-c-default.png';
@@ -793,7 +794,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$attach_id = wp_insert_attachment($attachment, $filename, $post_id);
 		add_post_meta($post_id, '_thumbnail_id', $attach_id, true);
 		$data = array();
-		$data['post'] = new Timber\Post($post_id);
+		$data['post'] = Timber::get_post($post_id);
 		$data['size'] = 'medium';
 		$result = Timber::compile('assets/image-thumb-named.twig', $data);
 		$filename = 'flag-300x300-c-default.png';
@@ -927,7 +928,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 
 	function testNoThumbnail() {
 		$pid = $this->factory->post->create();
-		$post = new Timber\Post($pid);
+		$post = Timber::get_post($pid);
 		$str = Timber::compile_string('Image?{{post.thumbnail.src}}', array('post' => $post));
 		$this->assertEquals('Image?', $str);
 	}

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -5,8 +5,8 @@ use Timber\Integrations\ACF;
 /**
  * @group called-post-constructor
  * @group called-term-constructor
- * FIXME #1793 replace direct Timber\User instantiations
- * FIXME #1793 replace direct Timber\Comment instantiations
+ * @todo #1793 replace direct Timber\User instantiations
+ * @todo #1793 replace direct Timber\Comment instantiations
  */
 class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFInit() {

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -5,8 +5,8 @@ use Timber\Integrations\ACF;
 /**
  * @group called-post-constructor
  * @group called-term-constructor
- * @todo #1793 replace direct Timber\User instantiations
- * @todo #1793 replace direct Timber\Comment instantiations
+ * @todo #2094 replace direct Timber\User instantiations
+ * @todo #2094 replace direct Timber\Comment instantiations
  */
 class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFInit() {

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -5,6 +5,8 @@ use Timber\Integrations\ACF;
 /**
  * @group called-post-constructor
  * @group called-term-constructor
+ * FIXME #1793 replace direct Timber\User instantiations
+ * FIXME #1793 replace direct Timber\Comment instantiations
  */
 class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFInit() {

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -2,6 +2,9 @@
 
 use Timber\Integrations\ACF;
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFInit() {
 		$acf = new ACF();
@@ -12,7 +15,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 		$pid = $this->factory->post->create();
 		update_field( 'subhead', 'foobar', $pid );
 		$str = '{{post.meta("subhead")}}';
-		$post = new Timber\Post( $pid );
+		$post = Timber::get_post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals( 'foobar', $str );
 	}
@@ -20,7 +23,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFHasFieldPostFalse() {
 		$pid = $this->factory->post->create();
 		$str = '{% if post.has_field("heythisdoesntexist") %}FAILED{% else %}WORKS{% endif %}';
-		$post = new Timber\Post( $pid );
+		$post = Timber::get_post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals('WORKS', $str);
 	}
@@ -29,7 +32,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 		$pid = $this->factory->post->create();
 		update_post_meta($pid, 'best_radiohead_album', 'in_rainbows');
 		$str = '{% if post.has_field("best_radiohead_album") %}In Rainbows{% else %}OK Computer{% endif %}';
-		$post = new Timber\Post( $pid );
+		$post = Timber::get_post( $pid );
 		$str = Timber::compile_string( $str, array( 'post' => $post ) );
 		$this->assertEquals('In Rainbows', $str);
 	}
@@ -73,7 +76,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 		update_field( 'thinger', 'foo', $pid );
 		update_field( '_thinger', $key, $pid );
 
-		$post     = new Timber\Post($pid);
+		$post     = Timber::get_post($pid);
 		$template = '{{ post.meta("thinger") }} / {{ post.field_object("thinger").key }}';
 		$str      = Timber::compile_string($template, array( 'post' => $post ));
 
@@ -104,7 +107,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 		) );
 
 		$post_id = $this->factory->post->create();
-		$post    = new Timber\Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		update_field( 'lead', 'Murder Spagurders are dangerous sneks.', $post_id );
 
 		$string = trim( Timber::compile_string( "{{ post.meta('lead') }}", [ 'post' => $post ] ) );
@@ -119,7 +122,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	 */
 	function testPostGetFieldDeprecated() {
 		$post_id = $this->factory->post->create();
-		$post    = new Timber\Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 
 		$post->get_field( 'field_name' );
 	}

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -4,6 +4,7 @@ use Timber\Integrations\ACF;
 
 /**
  * @group called-post-constructor
+ * @group called-term-constructor
  */
 class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFInit() {
@@ -38,8 +39,9 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	}
 
 	function testACFGetFieldTermCategory() {
-		update_field( 'color', 'blue', 'category_1' );
-		$cat = new Timber\Term( 1 );
+		$tid = $this->factory->term->create();
+		update_field( 'color', 'blue', "category_${tid}" );
+		$cat = Timber::get_term( $tid );
 		$this->assertEquals( 'blue', $cat->color );
 		$str = '{{term.color}}';
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $cat ) ) );
@@ -48,7 +50,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFCustomFieldTermTag() {
 		$tid = $this->factory->term->create();
 		update_field( 'color', 'green', 'post_tag_'.$tid );
-		$term = new Timber\Term( $tid );
+		$term = Timber::get_term( $tid );
 		$str = '{{term.color}}';
 		$this->assertEquals( 'green', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}
@@ -56,7 +58,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	function testACFGetFieldTermTag() {
 		$tid = $this->factory->term->create();
 		update_field( 'color', 'blue', 'post_tag_'.$tid );
-		$term = new Timber\Term( $tid );
+		$term = Timber::get_term( $tid );
 		$str = '{{term.meta("color")}}';
 		$this->assertEquals( 'blue', Timber::compile_string( $str, array( 'term' => $term ) ) );
 	}
@@ -132,7 +134,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase {
 	 */
 	function testTermGetFieldDeprecated() {
 		$term_id = $this->factory->term->create();
-		$term    = new Timber\Term( $term_id );
+		$term    = Timber::get_term( $term_id );
 
 		$term->get_field( 'field_name' );
 	}

--- a/tests/test-timber-integrations-coauthors.php
+++ b/tests/test-timber-integrations-coauthors.php
@@ -2,7 +2,7 @@
 
   /**
 	 * @group called-post-constructor
-	 * @todo #1793 replace direct Timber\User instantiations
+	 * @todo #2094 replace direct Timber\User instantiations
 	 */
 	class TestTimberIntegrationsCoAuthors extends Timber_UnitTestCase {
 

--- a/tests/test-timber-integrations-coauthors.php
+++ b/tests/test-timber-integrations-coauthors.php
@@ -1,5 +1,8 @@
 <?php
 
+  /**
+	 * @group called-post-constructor
+	 */
 	class TestTimberIntegrationsCoAuthors extends Timber_UnitTestCase {
 
 		/**
@@ -59,7 +62,7 @@
 			$uids[] = $this->factory->user->create(array('display_name' => 'Mike Swartz', 'user_login' => 'm_swartz'));
 			$uids[] = $this->factory->user->create(array('display_name' => 'JP Boneyard', 'user_login' => 'jpb'));
 			$pid = $this->factory->post->create(array('post_author' => $uids[0]));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$cap = new CoAuthors_Plus();
 			$added = $cap->add_coauthors($pid, array('mbottitta', 'm_swartz', 'jpb'));
 			$this->assertTrue($added);
@@ -77,7 +80,7 @@
 		function testAuthors() {
 			$uid = $this->factory->user->create(array('display_name' => 'Jen Weinman', 'user_login' => 'aquajenus'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$template_string = '{% for author in post.authors %}{{author.name}}{% endfor %}';
 			$str = Timber::compile_string($template_string, array('post' => $post));
 			$this->assertEquals('Jen Weinman', $str);
@@ -85,7 +88,7 @@
 
 		function testGuestAuthor(){
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$user_login = 'bmotia';
 			$display_name = 'Motia';
@@ -105,7 +108,7 @@
 		function testGuestAuthorWithRegularAuthor(){
 			$uid = $this->factory->user->create(array('display_name' => 'Alexander Hamilton', 'user_login' => 'ahamilton'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$user_login = 'bmotia';
 			$display_name = 'Motia';
@@ -129,7 +132,7 @@
 			global $coauthors_plus;
 
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$user_login = 'truelogin';
 			$display_name = 'True Name';
@@ -162,7 +165,7 @@
 
 		function testGuestAuthorAvatar(){
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$user_login = 'withfeaturedimage';
 			$display_name = 'Have Featured';
 			$email = 'admin@admin.com';

--- a/tests/test-timber-integrations-coauthors.php
+++ b/tests/test-timber-integrations-coauthors.php
@@ -2,7 +2,7 @@
 
   /**
 	 * @group called-post-constructor
-	 * FIXME #1793 replace direct Timber\User instantiations
+	 * @todo #1793 replace direct Timber\User instantiations
 	 */
 	class TestTimberIntegrationsCoAuthors extends Timber_UnitTestCase {
 

--- a/tests/test-timber-integrations-coauthors.php
+++ b/tests/test-timber-integrations-coauthors.php
@@ -2,6 +2,7 @@
 
   /**
 	 * @group called-post-constructor
+	 * FIXME #1793 replace direct Timber\User instantiations
 	 */
 	class TestTimberIntegrationsCoAuthors extends Timber_UnitTestCase {
 

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -18,7 +18,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPPostConvert() {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
-		// FIXME #1793 factories
+		// @todo #1793 factories
 		$post = new Timber\Post();
 		$timber_post = $post->convert( $wp_post );
 		$this->assertTrue( $timber_post instanceof Timber\Post );

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -2,6 +2,9 @@
 
 use Timber\Integrations\Command;
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberIntegrations extends Timber_UnitTestCase {
 
 	function testIntegrationClasses() {
@@ -15,6 +18,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPPostConvert() {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
+		// FIXME #1793 factories
 		$post = new Timber\Post();
 		$timber_post = $post->convert( $wp_post );
 		$this->assertTrue( $timber_post instanceof Timber\Post );
@@ -37,7 +41,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
     	$this->assertFileNotExists($cache_dir);
     	Timber::$twig_cache = true;
     	$pid = $this->factory->post->create();
-    	$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
     	Timber::compile('assets/single-post.twig', array('post' => $post));
     	sleep(1);
     	$this->assertFileExists($cache_dir);
@@ -62,7 +66,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		add_filter( 'timber/twig/environment/options', $cache_enabler );
 
 		$pid  = $this->factory->post->create();
-		$post = new Timber\Post( $pid );
+		$post = Timber::get_post( $pid );
 		Timber::compile( 'assets/single-post.twig', array( 'post' => $post ) );
 		sleep( 1 );
 		$this->assertFileExists( $cache_dir );
@@ -83,7 +87,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
     	$this->assertFileNotExists($cache_dir);
     	Timber::$twig_cache = true;
     	$pid = $this->factory->post->create();
-    	$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
     	Timber::compile('assets/single-post.twig', array('post' => $post));
     	sleep(1);
     	$this->assertFileExists($cache_dir);
@@ -111,7 +115,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		add_filter( 'timber/twig/environment/options', $cache_enabler );
 
 		$pid  = $this->factory->post->create();
-		$post = new Timber\Post( $pid );
+		$post = Timber::get_post( $pid );
 		Timber::compile( 'assets/single-post.twig', array( 'post' => $post ) );
 		sleep( 1 );
 		$this->assertFileExists( $cache_dir );
@@ -132,7 +136,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
     	$this->assertFileNotExists($cache_dir);
     	Timber::$twig_cache = true;
     	$pid = $this->factory->post->create();
-    	$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
     	Timber::compile('assets/single-post.twig', array('post' => $post));
     	sleep(1);
     	$this->assertFileExists($cache_dir);
@@ -163,7 +167,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		add_filter( 'timber/twig/environment/options', $cache_enabler );
 
 		$pid  = $this->factory->post->create();
-		$post = new Timber\Post( $pid );
+		$post = Timber::get_post( $pid );
 		Timber::compile( 'assets/single-post.twig', array( 'post' => $post ) );
 		sleep( 1 );
 		$this->assertFileExists( $cache_dir );

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -18,7 +18,7 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 	function testWPPostConvert() {
 		$pid = $this->factory->post->create();
 		$wp_post = get_post( $pid );
-		// @todo #1793 factories
+		// @todo #2094 factories
 		$post = new Timber\Post();
 		$timber_post = $post->convert( $wp_post );
 		$this->assertTrue( $timber_post instanceof Timber\Post );

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberMenu extends Timber_UnitTestCase {
 
 	const MENU_NAME = 'Menu One';
@@ -64,7 +67,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $child_menu_item, '_menu_item_object_id', $child_id );
 		update_post_meta( $child_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $child_menu_item, '_menu_item_url', '' );
-		$post = new Timber\Post( $child_menu_item );
+		$post = Timber::get_post( $child_menu_item );
 		$menu_items[] = $child_menu_item;
 
 		/* make a grandchild page */
@@ -85,7 +88,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
 		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
-		$post = new Timber\Post( $grandchild_menu_item );
+		$post = Timber::get_post( $grandchild_menu_item );
 		$menu_items[] = $grandchild_menu_item;
 
 		/* make another grandchild page */
@@ -106,7 +109,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		update_post_meta( $grandchild_menu_item, '_menu_item_object_id', $grandchild_id );
 		update_post_meta( $grandchild_menu_item, '_menu_item_object', 'page' );
 		update_post_meta( $grandchild_menu_item, '_menu_item_url', '' );
-		$post = new Timber\Post( $grandchild_menu_item );
+		$post = Timber::get_post( $grandchild_menu_item );
 		$menu_items[] = $grandchild_menu_item;
 
 		$root_url_link_id = wp_insert_post(
@@ -312,7 +315,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		add_post_meta( $pid, '_thumbnail_id', $iid, true );
 
 		// Lets confirm this post has a thumbnail on it!
-		$post = new Timber\Post($pid);
+		$post = Timber::get_post($pid);
 		$this->assertEquals('http://example.org/wp-content/uploads/' . date( 'Y/m' ) . '/arch.jpg', $post->thumbnail());
 
 		$nav_menu = new Timber\Menu( $menu_term['term_id'] );

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -2,6 +2,7 @@
 
 /**
  * @group called-post-constructor
+ * FIXME #1793 replace direct Timber\Menu instantiations
  */
 class TestTimberMenu extends Timber_UnitTestCase {
 

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -2,7 +2,7 @@
 
 /**
  * @group called-post-constructor
- * @todo #1793 replace direct Timber\Menu instantiations
+ * @todo #2094 replace direct Timber\Menu instantiations
  */
 class TestTimberMenu extends Timber_UnitTestCase {
 

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -2,7 +2,7 @@
 
 /**
  * @group called-post-constructor
- * FIXME #1793 replace direct Timber\Menu instantiations
+ * @todo #1793 replace direct Timber\Menu instantiations
  */
 class TestTimberMenu extends Timber_UnitTestCase {
 

--- a/tests/test-timber-meta-deprecated.php
+++ b/tests/test-timber-meta-deprecated.php
@@ -9,6 +9,7 @@ use Timber\Integrations\ACF;
 
 /**
  * Class TestTimberMeta
+ * @group called-post-constructor
  */
 class TestTimberMetaDeprecated extends Timber_UnitTestCase {
 	public function setUp() {
@@ -35,7 +36,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase {
 		add_filter( 'timber_post_get_meta_field_pre', $filter, 10, 4 );
 
 		$post_id = $this->factory->post->create();
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 
 		update_post_meta( $post_id, 'name', 'A girl has no name.' );
 
@@ -56,7 +57,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase {
 		add_action( 'timber_post_get_meta_pre', $action, 10, 3 );
 
 		$post_id = $this->factory->post->create();
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 
 		update_post_meta( $post_id, 'name', 'A girl has no name.' );
 
@@ -80,7 +81,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase {
 		add_filter( 'timber_post_get_meta_field', $filter, 10, 4 );
 
 		$post_id = $this->factory->post->create();
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 
 		update_post_meta( $post_id, 'name', 'A girl has no name.' );
 
@@ -103,7 +104,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase {
 		add_filter( 'timber_post_get_meta', $filter, 10, 3 );
 
 		$post_id = $this->factory->post->create();
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 
 		update_post_meta( $post_id, 'name', 'A girl has no name.' );
 

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -10,6 +10,7 @@ use Timber\Integrations\ACF;
 
 /**
  * Class TestTimberMeta
+ * @group called-post-constructor
  */
 class TestTimberMeta extends Timber_UnitTestCase {
 	/**
@@ -53,7 +54,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		update_comment_meta( $comment_id, 'meta1', 'Meta 1' );
 		update_comment_meta( $comment_id, 'meta2', 'Meta 2' );
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -77,7 +78,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$user_id    = $this->factory->user->create();
 		$comment_id = $this->factory->comment->create();
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -107,7 +108,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$user_id    = $this->factory->user->create();
 		$comment_id = $this->factory->comment->create();
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -167,7 +168,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$term_id    = $this->factory->term->create();
 		$comment_id = $this->factory->comment->create();
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$comment = new Comment( $comment_id );
 
@@ -215,7 +216,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$user_id    = $this->factory->user->create();
 		$comment_id = $this->factory->comment->create();
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -250,7 +251,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		update_user_meta( $user_id, 'my_custom_property', 'Sweet Honey' );
 		update_comment_meta( $comment_id, 'my_custom_property', 'Sweet Honey' );
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -300,7 +301,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		update_user_meta( $user_id, 'meta_value', 'I am a meta value' );
 		update_comment_meta( $comment_id, 'meta_value', 'I am a meta value' );
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -332,7 +333,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$user_id    = $this->factory->user->create();
 		$comment_id = $this->factory->comment->create();
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -377,7 +378,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		update_user_meta( $user_id, 'my_custom_property', 'Sweet Honey' );
 		update_comment_meta( $comment_id, 'my_custom_property', 'Sweet Honey' );
 
-		$post    = new Post( $post_id );
+		$post    = Timber::get_post( $post_id );
 		$term    = new Term( $term_id );
 		$user    = new User( $user_id );
 		$comment = new Comment( $comment_id );
@@ -686,7 +687,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 
 		update_post_meta( $post_id, 'inaccessible', 'Boo!' );
 
-		$post   = new Post( $post_id );
+		$post   = Timber::get_post( $post_id );
 		$string = Timber::compile_string( '{{ post.custom.inaccessible }}', array( 'post' => $post ) );
 
 		$this->assertEquals( '', $string );

--- a/tests/test-timber-pages.php
+++ b/tests/test-timber-pages.php
@@ -9,7 +9,7 @@ class TestTimberPages extends Timber_UnitTestCase {
 	function testTimberPostOnCategoryPage() {
 		$post_id = $this->factory->post->create();
 		$category_id = $this->factory->term->create(array('taxonomy' => 'category', 'name' => 'News'));
-		// @todo #1793 factories
+		// @todo #2094 factories
 		$cat = new Timber\Term($category_id);
 		$this->go_to($cat->path());
 		$term = new Timber\Term();

--- a/tests/test-timber-pages.php
+++ b/tests/test-timber-pages.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberPages extends Timber_UnitTestCase {
 
 	function testTimberPostOnCategoryPage() {
@@ -9,6 +12,7 @@ class TestTimberPages extends Timber_UnitTestCase {
 		$this->go_to($cat->path());
 		$term = new Timber\Term();
 		$this->assertEquals($category_id, $term->ID);
+		// FIXME #1793 factories
 		$post = new Timber\Post();
 		$this->assertEquals(0, $post->ID);
 	}

--- a/tests/test-timber-pages.php
+++ b/tests/test-timber-pages.php
@@ -9,7 +9,7 @@ class TestTimberPages extends Timber_UnitTestCase {
 	function testTimberPostOnCategoryPage() {
 		$post_id = $this->factory->post->create();
 		$category_id = $this->factory->term->create(array('taxonomy' => 'category', 'name' => 'News'));
-		// FIXME #1793 factories
+		// @todo #1793 factories
 		$cat = new Timber\Term($category_id);
 		$this->go_to($cat->path());
 		$term = new Timber\Term();

--- a/tests/test-timber-pages.php
+++ b/tests/test-timber-pages.php
@@ -2,17 +2,18 @@
 
 /**
  * @group called-post-constructor
+ * @group called-term-constructor
  */
 class TestTimberPages extends Timber_UnitTestCase {
 
 	function testTimberPostOnCategoryPage() {
 		$post_id = $this->factory->post->create();
 		$category_id = $this->factory->term->create(array('taxonomy' => 'category', 'name' => 'News'));
+		// FIXME #1793 factories
 		$cat = new Timber\Term($category_id);
 		$this->go_to($cat->path());
 		$term = new Timber\Term();
 		$this->assertEquals($category_id, $term->ID);
-		// FIXME #1793 factories
 		$post = new Timber\Post();
 		$this->assertEquals(0, $post->ID);
 	}

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -2,6 +2,19 @@
 
 class TestTimberPagination extends Timber_UnitTestCase {
 
+	public function setUp() {
+		parent::setUp();
+
+		$this->setPermalinkStructure('/%postname%/');
+		register_post_type( 'portfolio' );
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		unregister_post_type('portfolio');
+	}
+
 	/**
 	 * @expectedDeprecated get_pagination
 	 */
@@ -13,27 +26,10 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( user_trailingslashit(home_url().esc_url('/?paged=5&s=post')), $pagination['pages'][4]['link'] );
 	}
 
-	/* This test is for the concept of linking query_posts and get_pagination
-	function testPaginationWithQueryPosts() {
-		register_post_type( 'portfolio' );
-		$pids = $this->factory->post->create_many( 33 );
-		$pids = $this->factory->post->create_many( 55, array( 'post_type' => 'portfolio' ) );
-		$this->go_to( home_url( '/' ) );
-		Timber::query_posts('post_type=portfolio');
-		$pagination = Timber::get_pagination();
-
-		global $timber;
-		$timber->active_query = false;
-		unset($timber->active_query);
-		$this->assertEquals(6, count($pagination['pages']));
-	}
-	*/
-
 	/**
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationWithGetPosts() {
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 33 );
 		$pids = $this->factory->post->create_many( 55, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/' ) );
@@ -50,7 +46,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationWithPostQuery() {
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 33 );
 		$pids = $this->factory->post->create_many( 55, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/' ) );
@@ -69,8 +64,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationOnLaterPage() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 55, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/portfolio/page/3' ) );
 		query_posts('post_type=portfolio&paged=3');
@@ -82,8 +75,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testSanitizeNextPagination() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 55, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/portfolio/page/3?whscheck="><svg/onload=alert()>' ) );
 		query_posts('post_type=portfolio&paged=3');
@@ -95,8 +86,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testMaliciousGetParameter() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$this->factory->post->create_many( 33, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/portfolio/page/3?wx9um%2522%253e%253cscript%253ealert%25281%2529%253c%252fscript%
 253eaq86s=1' ) );
@@ -109,8 +98,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testMaliciousGetParameter2() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$this->factory->post->create_many( 33, array( 'post_type' => 'portfolio' ) );
 
 		$encoded_once = '?%22%3E%3Cscript%3Ealert(%22XSS%20XSS%22)%3C%2Fscript%3E%3D1';
@@ -126,8 +113,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	}
 
 	function testDoubleEncodedPaginationUrl() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$this->factory->post->create_many( 33, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/portfolio/page/3?wx9um%2522%253e%253cscript%253ealert%25281%2529%253c%252fscript%
 253eaq86s=1' ) );
@@ -140,8 +125,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	}
 
 	function testDoubleEncodedPaginationUrlWithEscHTML() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$this->factory->post->create_many( 33, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/portfolio/page/3?wx9um%2522%253e%253cscript%253ealert%25281%2529%253c%252fscript%
 253eaq86s=1' ) );
@@ -157,8 +140,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationWithSize() {
-		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 99, array( 'post_type' => 'portfolio' ) );
 		query_posts('post_type=portfolio');
 		$pagination = Timber::get_pagination(4);
@@ -169,7 +150,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationSearchPrettyWithPostname() {
-		$this->setPermalinkStructure('/%postname%/');
 		$posts = $this->factory->post->create_many( 55 );
 		$archive = home_url( '?s=post' );
 		$this->go_to( $archive );
@@ -182,7 +162,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationSearchPrettyWithPostnameNext() {
-		$this->setPermalinkStructure('/%postname%/');
 		$posts = $this->factory->post->create_many( 55 );
 		$archive = home_url( '?s=post' );
 		$this->go_to( $archive );
@@ -195,7 +174,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationSearchPrettyWithPostnamePrev() {
-		$this->setPermalinkStructure('/%postname%/');
 		$posts = $this->factory->post->create_many( 55 );
 		$archive = home_url( 'page/4/?s=post' );
 		$this->go_to( $archive );
@@ -208,8 +186,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	 * @expectedDeprecated get_pagination
 	 */
 	function testPaginationSearchPrettyx() {
-		$struc = '/blog/%year%/%monthnum%/%postname%/';
-		$this->setPermalinkStructure( $struc );
+		$this->setPermalinkStructure( '/blog/%year%/%monthnum%/%postname%/' );
 		$posts = $this->factory->post->create_many( 55 );
 		$archive = home_url( '?s=post' );
 		$this->go_to( $archive );
@@ -241,8 +218,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( 'http://example.org/page/2', $pagination['next']['link'] );
 	}
 
-	function testPaginationInCategory( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
+	function testPaginationInCategory() {
 		$no_posts = $this->factory->post->create_many( 73 );
 		$posts = $this->factory->post->create_many( 31 );
 		$news_id = wp_insert_term( 'News', 'category' );
@@ -261,8 +237,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	/**
 	 * @expectedDeprecated get_pagination
 	 */
-	function testPaginationNextUsesBaseAndFormatArgs( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
+	function testPaginationNextUsesBaseAndFormatArgs() {
 		$posts = $this->factory->post->create_many( 55 );
 		$this->go_to( home_url( '/' ) );
 		$pagination = Timber::get_pagination( array( 'base' => '/apricot/%_%', 'format' => '?pagination=%#%' ) );
@@ -272,8 +247,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	/**
 	 * @expectedDeprecated get_pagination
 	 */
-	function testPaginationPrevUsesBaseAndFormatArgs( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
+	function testPaginationPrevUsesBaseAndFormatArgs() {
 		$posts = $this->factory->post->create_many( 55 );
 		$this->go_to( home_url( '/apricot/page=3' ) );
 		query_posts('paged=3');
@@ -285,8 +259,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	/**
 	 * @expectedDeprecated get_pagination
 	 */
-	function testPaginationWithMoreThan10Pages( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
+	function testPaginationWithMoreThan10Pages() {
 		$posts = $this->factory->post->create_many( 150 );
 		$this->go_to( home_url( '/page/13' ) );
 		$pagination = Timber::get_pagination();
@@ -317,9 +290,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	}
 
 	function testCollectionPaginationOnLaterPage() {
-		$struc = '/%postname%/';
-		$this->setPermalinkStructure( $struc );
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 55, array( 'post_type' => 'portfolio' ) );
 		$this->go_to( home_url( '/portfolio/page/3' ) );
 		$posts = new Timber\PostQuery( array(
@@ -331,7 +301,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 
 	function testCollectionPaginationWithSize() {
 		$this->setPermalinkStructure('/%postname%/');
-		register_post_type( 'portfolio' );
 		$pids = $this->factory->post->create_many( 99, array( 'post_type' => 'portfolio' ) );
 		$posts = new Timber\PostQuery( array(
 			'query' => 'post_type=portfolio&posts_per_page=20',
@@ -376,7 +345,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	}
 
 	function testCollectionPaginationSearchPrettyWithPostnamePrev() {
-		$this->setPermalinkStructure('/%postname%/');
 		$posts = $this->factory->post->create_many( 55 );
 		$archive = home_url( 'page/4/?s=post' );
 		$this->go_to( $archive );
@@ -388,8 +356,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	}
 
 	function testCollectionPaginationSearchPretty() {
-		$struc = '/blog/%year%/%monthnum%/%postname%/';
-		$this->setPermalinkStructure( $struc );
+		$this->setPermalinkStructure( '/blog/%year%/%monthnum%/%postname%/' );
 		$posts = $this->factory->post->create_many( 55 );
 		$archive = home_url( '?s=post' );
 		$this->go_to( $archive );
@@ -398,9 +365,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( 'http://example.org/page/5/?s=post', $pagination->pages[4]['link'] );
 	}
 
-	function testCollectionPaginationNextUsesBaseAndFormatArgs( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
-
+	function testCollectionPaginationNextUsesBaseAndFormatArgs() {
 		$posts = $this->factory->post->create_many( 55 );
 		$this->go_to( home_url( '/' ) );
 		$posts = new Timber\PostQuery();
@@ -408,9 +373,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( '/apricot/page/2/', $pagination->next['link'] );
 	}
 
-	function testCollectionPaginationPrevUsesBaseAndFormatArgs( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
-		//$posts = $this->factory->post->create_many( 55 );
+	function testCollectionPaginationPrevUsesBaseAndFormatArgs() {
 		for($i=0; $i<30; $i++) {
 			$this->factory->post->create(array('post_title' => 'post'.$i, 'post_date' => '2014-02-'.$i));
 		}
@@ -421,9 +384,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( '/apricot/?pagination=2', $pagination->prev['link'] );
 	}
 
-	function testCollectionPaginationPrevUsesBaseAndFormatArgsPage( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
-		//$posts = $this->factory->post->create_many( 55 );
+	function testCollectionPaginationPrevUsesBaseAndFormatArgsPage() {
 		for($i=0; $i<30; $i++) {
 			$this->factory->post->create(array('post_title' => 'post'.$i, 'post_date' => '2014-02-'.$i));
 		}
@@ -434,8 +395,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		$this->assertEquals( '/apricot/?page=2', $pagination->prev['link'] );
 	}
 
-	function testCollectionPaginationWithMoreThan10Pages( $struc = '/%postname%/' ) {
-		$this->setPermalinkStructure( $struc );
+	function testCollectionPaginationWithMoreThan10Pages() {
 		$posts = $this->factory->post->create_many( 150 );
 		$this->go_to( home_url( '/page/13' ) );
 		$posts = new Timber\PostQuery();
@@ -446,6 +406,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 
 	function testPostCollectionPaginationForMultiplePostTypes() {
 		register_post_type( 'recipe' );
+
 		$pids = $this->factory->post->create_many( 43, array( 'post_type' => 'recipe' ) );
 		$recipes = new Timber\PostQuery(array(
 			'query' => array(
@@ -462,6 +423,9 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		) );
 		$pagination = $posts->pagination();
 		$this->assertEquals( 2, count( $pagination->pages ) );
+
+		// clean up
+		unregister_post_type( 'recipe' );
 	}
 
 

--- a/tests/test-timber-parent-child.php
+++ b/tests/test-timber-parent-child.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberParentChild extends Timber_UnitTestCase {
 
 		function testParentChildGeneral(){
@@ -11,7 +14,7 @@
 			$dest_dir = WP_CONTENT_DIR.'/themes/twentyfifteen';
 			copy(__DIR__.'/assets/single-course.twig', $dest_dir.'/views/single-course.twig');
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile(array('single-course.twig', 'single.twig'), array( 'post' => $post ));
 			$this->assertEquals('I am single course', $str);
 		}

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -1,11 +1,14 @@
 <?php
 
+  /**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostComments extends Timber_UnitTestCase {
 
 		function testComments() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
 			$comment_id_array = $this->factory->comment->create_many( 5, array('comment_post_ID' => $post_id) );
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals( 5, count($post->comments()) );
 			$this->assertEquals( 5, $post->comment_count() );
 		}
@@ -13,7 +16,7 @@
 		function testCommentCount() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
 			$comment_id_array = $this->factory->comment->create_many( 5, array('comment_post_ID' => $post_id) );
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals( 2, count($post->comments(2)) );
 			$this->assertEquals( 5, count($post->comments()) );
 		}
@@ -21,7 +24,7 @@
 		function testCommentCountZero() {
 			$quote = 'Named must your fear be before banish it you can.';
             $post_id = $this->factory->post->create(array('post_content' => $quote));
-            $post = new Timber\Post($post_id);
+            $post = Timber::get_post($post_id);
             $this->assertEquals(0, $post->get_comment_count());
 		}
 
@@ -31,10 +34,10 @@
 			wp_set_current_user( $uid );
 			$quote = "You know, I always wanted to pretend I was an architect";
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote, 'user_id' => $uid, 'comment_approved' => 0));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals(1, count($post->comments()));
 			wp_set_current_user( 0 );
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals(0, count($post->comments()));
 		}
 
@@ -42,7 +45,7 @@
 			require_once(__DIR__.'/php/timber-custom-comment.php');
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
 			$comment_id_array = $this->factory->comment->create_many( 5, array('comment_post_ID' => $post_id) );
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$comments = $post->comments(null, 'wp', 'comment', 'approve', 'CustomComment');
 			$this->assertEquals('CustomComment', get_class($comments[0]));
 		}
@@ -56,7 +59,7 @@
 			$commenter = wp_get_current_commenter();
 			$quote = "And in that moment, I was a marine biologist";
 			$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => $quote,'comment_approved' => 0, 'comment_author_email' => 'jarednova@upstatement.com'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals(1, count($post->comments()));
 		}
 
@@ -69,7 +72,7 @@
 			$child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $comment_id));
 			$grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $child_id));
 			$grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $child_id));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$comments = $post->comments();
 			$this->assertEquals(1, count($comments));
 			$children = $comments[0]->children();
@@ -85,7 +88,7 @@
 			$parent_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_date' => '2016-11-28 14:00:00', 'comment_content' => 'i am the Parent'));
 			$child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $parent_id, 'comment_date' => '2016-11-28 15:00:00', 'comment_content' => 'I am the child'));
 			$grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $child_id, 'comment_date' => '2016-11-28 16:00:00', 'comment_content' => 'I am the GRANDchild'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$comments = $post->comments();
 			$children = $comments[1]->children();
 			$this->assertEquals($parent_id, $children[0]->comment_parent);
@@ -100,7 +103,7 @@
 			$comment2_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_content' => 'second!', 'comment_date' => '2016-11-28 13:58:18'));
 			$comment2_child_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $comment2_id, 'comment_content' => 'response', 'comment_date' => '2016-11-28 14:58:18'));
 			$comment2_grandchild_id = $this->factory->comment->create(array('comment_post_ID' => $post_id, 'comment_parent' => $comment2_child_id, 'comment_content' => 'Respond2Respond', 'comment_date' => '2016-11-28 15:58:18'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$str = Timber::compile('assets/comments-thread.twig', array('post' => $post));
 		}
 

--- a/tests/test-timber-post-convert.php
+++ b/tests/test-timber-post-convert.php
@@ -1,10 +1,13 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostConvert extends Timber_UnitTestCase {
 
 		function testConvertWP_Post() {
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post_id = $this->factory->post->create(array('post_title' => 'Maybe Child Post'));
 			$posts = get_posts(array('post__in' => array($post_id)));
 			$converted = $post->convert($posts[0]);
@@ -14,7 +17,7 @@
 
 		function testConvertSingleItemArray() {
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post_id = $this->factory->post->create(array('post_title' => 'Maybe Child Post'));
 			$posts = get_posts(array('post__in' => array($post_id)));
 			$converted = $post->convert($posts);
@@ -26,7 +29,7 @@
 			$post_ids = $this->factory->post->create_many(8, array('post_title' => 'Sample Post '.rand(1, 999)));
 
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$posts = get_posts(array('post__in' => $post_ids, 'orderby' => 'post__in'));
 			$converted = $post->convert($posts);
 			$this->assertEquals($post_ids[2], $converted[2]->id);
@@ -37,7 +40,7 @@
 			$post_ids = $this->factory->post->create_many(8, array('post_title' => 'Sample Post '.rand(1, 999)));
 
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$posts = get_posts(array('post__in' => $post_ids, 'orderby' => 'post__in'));
 			$arr = array($post, $posts);
 

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberPostGetter extends Timber_UnitTestCase {
 
 
@@ -59,7 +62,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$cats = $this->factory->post->create_many(3, array('post_category' => array($cat)) );
 		$cat_post = $this->factory->post->create(array('post_category' => array($cat)) );
 
-		$cat_post = new Timber\Post($cat_post);
+		$cat_post = Timber::get_post($cat_post);
 		$this->assertEquals('News', $cat_post->category()->title());
 
 		$posts = new Timber\PostQuery( array(
@@ -99,7 +102,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$cats = $this->factory->post->create_many(3, array('post_category' => array($cat)) );
 		$cat_post = $this->factory->post->create(array('post_category' => array($cat)) );
 
-		$cat_post = new Timber\Post($cat_post);
+		$cat_post = Timber::get_post($cat_post);
 		$this->assertEquals('News', $cat_post->category()->title());
 
 		$posts = new Timber\PostQuery( array(
@@ -263,7 +266,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 		$attach_id = wp_insert_attachment( $attachment, $filename, $post_id );
 		add_post_meta( $post_id, '_thumbnail_id', $attach_id, true );
 		$data = array();
-		$data['post'] = new Timber\Post( $post_id );
+		$data['post'] = Timber::get_post( $post_id );
 		$data['size'] = array( 'width' => 100, 'height' => 50 );
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/thumb-test.twig', $data );
@@ -340,7 +343,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 
 	function testQueryPost() {
 		$posts = $this->factory->post->create_many( 6 );
-		$post = new Timber\Post( $posts[3] );
+		$post = Timber::get_post( $posts[3] );
 		$this->go_to( home_url( '/?p='.$posts[2] ) );
 		$this->assertNotEquals( get_the_ID(), $post->ID );
 		$post = Timber::query_post( $posts[3] );
@@ -411,7 +414,7 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 	function testCustomPostTypeAndClassOnSinglePage() {
 		register_post_type('job');
 		$post_id = $this->factory->post->create( array( 'post_type' => 'job' ) );
-		$post = new Timber\Post($post_id);
+		$post = Timber::get_post($post_id);
 		$this->go_to('?p='.$post->ID);
 		$jobs = $this->factory->post->create_many( 10, array('post_type' => 'job'));
 		$jobPosts = new Timber\PostQuery( array(

--- a/tests/test-timber-post-password.php
+++ b/tests/test-timber-post-password.php
@@ -1,11 +1,14 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostPassword extends Timber_UnitTestCase {
 
 		function testPasswordedContentDefault(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post->post_content = $quote;
 			$post->post_password = 'burrito';
 			wp_update_post($post);
@@ -19,7 +22,7 @@
 			});
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post->post_content = $quote;
 			$post->post_password = 'burrito';
 			wp_update_post($post);
@@ -36,7 +39,7 @@
 			}, 10, 2);
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create(array('post_title' => 'Secrets!'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post->post_content = $quote;
 			$post->post_password = 'burrito';
 			wp_update_post($post);

--- a/tests/test-timber-post-preview-object.php
+++ b/tests/test-timber-post-preview-object.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostPreviewObject extends Timber_UnitTestCase {
 
 		protected $gettysburg = 'Four score and seven years ago our fathers brought forth on this continent a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal.';
@@ -7,7 +10,7 @@
 		function test1886Error() {
 			$expected = '<p>Govenment:</p> <ul> <li>of the <strong>people</strong></li> <li>by the people</li> <li>for the people</li> </ul>';
 			$post_id = $this->factory->post->create(array('post_content' => $expected.'<blockquote>Lincoln</blockquote>', 'post_excerpt' => false));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = "{{ post.preview.strip('<p><strong><ul><ol><li><br>') }}";
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals($expected.' <p>Lincoln</p>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
@@ -16,7 +19,7 @@
 		function test1886ErrorWithForce() {
 			$expected = '<p>Govenment:</p> <ul> <li>of the <strong>people</strong></li> <li>by the people</li> <li>for the people</li> </ul>';
 			$post_id = $this->factory->post->create(array('post_excerpt' => $expected, 'post_content' => $this->gettysburg));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = "{{ post.preview.strip('<ul><li>').length(10).force }}";
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Govenment: <ul> <li>of the people</li> <li>by the people</li> <li>for the</li></ul>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
@@ -36,7 +39,7 @@
 				)
 			);
 			$post_id = $wpdb->insert_id;
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = '{{ post.preview.length(9).read_more(false).strip(true) }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Yo. Four score and seven years ago our fathers&hellip;', $str);
@@ -44,7 +47,7 @@
 
 		function testPreviewTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = '{{post.preview.length(3).read_more(false).strip(false)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertNotContains('</p>', $str);
@@ -53,7 +56,7 @@
 		function testPostPreviewObjectWithCharAndWordLengthWordsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(2).chars(20) }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -61,7 +64,7 @@
 		function testPostPreviewObjectWithCharAndWordLengthCharsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(20).chars(20) }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score and seven&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -69,7 +72,7 @@
 		function testPostPreviewObjectWithCharLength() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.chars(20) }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score and seven&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -77,7 +80,7 @@
 		function testPostPreviewObjectWithLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(4) }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Lauren is a duck&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -85,7 +88,7 @@
 		function testPostPreviewObjectWithForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.force.length(3) }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -93,7 +96,7 @@
 		function testPostPreviewObject() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -101,7 +104,7 @@
 		function testPostPreviewObjectStrip() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview.strip(false) }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
@@ -109,7 +112,7 @@
 		function testPostPreviewObjectWithReadMore() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.read_more("Keep Reading") }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
@@ -117,27 +120,27 @@
 		function testPostPreviewObjectWithEverything() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.length(6).force.end("-->").read_more("Keep Reading") }}';
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable--> <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
 
 		function testPreviewWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 
 			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
 		function testPreviewWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
 		}
 
 		function testPreviewWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$template = '{{post.preview.length(3).force}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $str);
@@ -145,7 +148,7 @@
 
 		function testPreviewWithStripAndClosingPTag() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$template = '{{post.preview.strip(false)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('<p>Lauren is a duck, but a great duck let me tell you why <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a></p>', $str);
@@ -153,7 +156,7 @@
 
 		function testPreviewWithStripAndClosingPTagForced() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$template = '{{post.preview.strip(false).force(4)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('<p>Lauren is a duck, but a great duck let me tell you why&hellip;  <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a></p>', $str);
@@ -161,7 +164,7 @@
 
 		function testEmptyPreview() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '', 'post_content' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$template = '{{ post.preview }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('', $str);
@@ -169,7 +172,7 @@
 
 		function testPagePreviewOnSearch() {
 			$pid = $this->factory->post->create(array('post_type' => 'page', 'post_content' => 'What a beautiful day for a ballgame!', 'post_excerpt' => ''));
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$template = '{{ post.preview }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('What a beautiful day for a ballgame!&hellip; <a href="http://example.org/?page_id='.$pid.'" class="read-more">Read More</a>', $str);

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 	class TestTimberPostPreview extends Timber_UnitTestCase {
 
 		/**
@@ -7,7 +10,7 @@
 		 */
 		function testDoubleEllipsis(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post->post_excerpt = 'this is super dooper trooper long words';
 			$prev = $post->get_preview(3, true);
 			$this->assertEquals(1, substr_count($prev, '&hellip;'));
@@ -21,7 +24,7 @@
 				return $class . ' and-foo';
 			});
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$text = $post->get_preview(10);
 			$this->assertContains('and-foo', (string) $text);
 		}
@@ -31,7 +34,7 @@
 		 */
 		function testPreviewTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$text = $post->get_preview(20, false, '', false);
 			$this->assertNotContains('</p>', (string) $text);
 		}
@@ -45,12 +48,12 @@
 			$wp_rewrite->permalink_structure = $struc;
 			update_option('permalink_structure', $struc);
 			$post_id = $this->factory->post->create(array('post_content' => 'this is super dooper trooper long words'));
-			$post               = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 
 			// no excerpt
 			$post->post_excerpt = '';
-			$preview            = $post->get_preview(3);
-			$str 				= Timber::compile_string('{{post.get_preview(3)}}', array('post' => $post));
+			$preview = $post->get_preview(3);
+			$str = Timber::compile_string('{{post.get_preview(3)}}', array('post' => $post));
 			$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $str);
 
 			// excerpt set, force is false, no read more
@@ -75,7 +78,7 @@
 				return 'mythangy';
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [mythang]', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
@@ -84,7 +87,7 @@
 				return 'Quack!';
 			});
 			$pid = $this->factory->post->create( array('post_content' => 'jared [duck] <!--more--> joojoo', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
@@ -93,7 +96,7 @@
 		 */
 		function testPreviewWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true));
 		}
 
@@ -102,7 +105,7 @@
 		 */
 		function testPreviewWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
 		}
 
@@ -111,7 +114,7 @@
 		 */
 		function testPreviewWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->get_preview());
 		}
 
@@ -120,7 +123,7 @@
 		 */
 		function testPreviewWithCustomEnd() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck', 'post_excerpt' => '') );
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$this->assertEquals('Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true, 'Read More', true, ' ???'));
 		}
 
@@ -131,7 +134,7 @@
 			$pid = $this->factory->post->create(array(
 				'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
 			));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$post->post_excerpt = '';
 			$preview = $post->get_preview(6, true, 'Read More', '<span>');
 			$this->assertEquals('<span>Even in the world of make-believe</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', (string) $preview);

--- a/tests/test-timber-post-terms.php
+++ b/tests/test-timber-post-terms.php
@@ -1,10 +1,13 @@
 <?php
 
+  /**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostTerms extends Timber_UnitTestCase {
 
 		function testPostTerms() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			// create a new tag and associate it with the post
 			$dummy_tag = wp_insert_term('whatever', 'post_tag');
@@ -18,7 +21,7 @@
 			) );
 			$this->assertEquals( 'MyTimberTerm', get_class($terms[0]) );
 
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$terms = $post->terms( array(
 				'query' => array(
 					'taxonomy' => 'post_tag',
@@ -35,7 +38,7 @@
 		function testTermExceptions() {
 			self::enable_error_log(false);
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$terms = $post->terms('dfasdf');
 			$this->assertInstanceOf('WP_Error', $terms);
 			self::enable_error_log(true);
@@ -48,7 +51,7 @@
 			self::enable_error_log(false);
 			register_taxonomy('foobar', 'post');
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$terms = $post->terms('foobar');
 			$this->assertEquals(array(), $terms);
 			self::enable_error_log(true);
@@ -63,7 +66,7 @@
 			$dummy_cat = wp_insert_term('thingy', 'category');
 			wp_set_object_terms($pid, $dummy_cat['term_id'], 'category', true);
 
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$terms = $post->terms( array(
 				'query' => array(
 					'taxonomy' => 'all'

--- a/tests/test-timber-post-title.php
+++ b/tests/test-timber-post-title.php
@@ -1,10 +1,13 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostTitle extends Timber_UnitTestCase {
 
 		function testAmpersandInTitle() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Jared & Lauren'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals(get_the_title($post_id), $post->title());
 			$this->assertEquals(get_the_title($post_id), $post->post_title);
 		}

--- a/tests/test-timber-post-type.php
+++ b/tests/test-timber-post-type.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPostType extends Timber_UnitTestCase {
 
 		function testPostTypeObject() {
@@ -9,13 +12,13 @@
 
 		function testPostTypeProperty(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals('post', $post->post_type);
 		}
 
 		function testPostTypeMethodInTwig() {
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = '{{post.post_type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('post', $str);
@@ -23,7 +26,7 @@
 
 		function testTypeMethodInTwig() {
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = '{{post.type}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('post', $str);
@@ -31,7 +34,7 @@
 
 		function testTypeMethodInTwigLabels() {
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$template = '{{post.type.labels.name}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Posts', $str);

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -2,6 +2,7 @@
 
 	/**
 	 * @group called-post-constructor
+	 * @group called-term-constructor
 	 */
 	class TestTimberPost extends Timber_UnitTestCase {
 
@@ -597,7 +598,7 @@
 
 			// test expected tags
 			$timber_tags = $post->terms('post_tag');
-			$dummy_timber_tag = new Timber\Term($dummy_tag['term_id'], 'post_tag');
+			$dummy_timber_tag = Timber::get_term($dummy_tag['term_id'], 'post_tag');
 			$this->assertEquals('whatever', $timber_tags[0]->slug);
 			$this->assertEquals($dummy_timber_tag, $timber_tags[0]);
 
@@ -654,7 +655,7 @@
 					'taxonomy' => 'post_tag',
 				),
 			) );
-			$dummy_timber_tag = new Timber\Term( $dummy_tag['term_id'], 'post_tag' );
+			$dummy_timber_tag = Timber::get_term( $dummy_tag['term_id'], 'post_tag' );
 			$this->assertEquals( 'whatever', $timber_tags[0]->slug );
 			$this->assertEquals( $dummy_timber_tag, $timber_tags[0] );
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -1,27 +1,30 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberPost extends Timber_UnitTestCase {
 
 		function testPostObject(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals('Timber\Post', get_class($post));
 			$this->assertEquals($post_id, $post->ID);
 		}
 
 		function testPostPasswordReqd(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertFalse($post->password_required());
 
 			$post_id = $this->factory->post->create(array('post_password' => 'jiggypoof'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertTrue($post->password_required());
 		}
 
 		function testNameMethod() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Battlestar Galactica'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals('Battlestar Galactica', $post->name());
 		}
 
@@ -31,7 +34,7 @@
 			$attachment = array( 'post_title' => 'The Arch', 'post_content' => '' );
 			$iid = wp_insert_attachment( $attachment, $filename, $post_id );
 			update_post_meta($post_id, 'landmark', $iid);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$image = $post->meta('landmark');
 			$image = new Timber\Image($image);
 			$this->assertEquals('The Arch', $image->title());
@@ -39,7 +42,7 @@
 
 		function testPostString() {
 			$post_id = $this->factory->post->create(array('post_title' => 'Gobbles'));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$str = Timber::compile_string('<h1>{{post}}</h1>', array('post' => $post));
 			$this->assertEquals('<h1>Gobbles</h1>', $str);
 		}
@@ -59,7 +62,7 @@
 		function testPostOnSingle(){
 			$post_id = $this->factory->post->create();
 			$this->go_to(home_url('/?p='.$post_id));
-			$post = new Timber\Post();
+			$post = Timber::get_post();
 			$this->assertEquals($post_id, $post->ID);
 		}
 
@@ -80,25 +83,15 @@
 			$this->assertEquals($post_id, get_the_ID());
 		}
 
-		// function testPostOnBuddyPressPage(){
-		// 	$post_id = $this->factory->post->create();
-		// 	global $post;
-		// 	$this->go_to(home_url('/?p='.$post_id));
-		// 	$_post = $post;
-		// 	$post = false;
-		// 	$my_post = new Timber\Post();
-		// 	$this->assertEquals($post_id, $my_post->ID);
-		// }
-
 		function testNonexistentProperty(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post( $post_id );
+			$post = Timber::get_post( $post_id );
 			$this->assertFalse( $post->zebra );
 		}
 
 		function testNonexistentMethod(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post( $post_id );
+			$post = Timber::get_post( $post_id );
 			$template = '{{post.donkey}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('', $str);
@@ -111,8 +104,8 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$firstPost = new Timber\Post($posts[0]);
-			$nextPost = new Timber\Post($posts[1]);
+			$firstPost = Timber::get_post($posts[0]);
+			$nextPost = Timber::get_post($posts[1]);
 			$this->assertEquals($firstPost->next()->ID, $nextPost->ID);
 		}
 
@@ -124,8 +117,8 @@
 			}
 			wp_set_object_terms($posts[0], 'TestMe', 'category', false);
 			wp_set_object_terms($posts[2], 'TestMe', 'category', false);
-			$firstPost = new Timber\Post($posts[0]);
-			$nextPost = new Timber\Post($posts[2]);
+			$firstPost = Timber::get_post($posts[0]);
+			$nextPost = Timber::get_post($posts[2]);
 			$this->assertEquals($firstPost->next('category')->ID, $nextPost->ID);
 		}
 
@@ -143,8 +136,8 @@
 				wp_set_object_terms($posts[0], 'Cheese', 'pizza', false);
 				wp_set_object_terms($posts[2], 'Cheese', 'pizza', false);
 				wp_set_object_terms($posts[3], 'Mushroom', 'pizza', false);
-				$firstPost = new Timber\Post($posts[0]);
-				$nextPost = new Timber\Post($posts[2]);
+				$firstPost = Timber::get_post($posts[0]);
+				$nextPost = Timber::get_post($posts[2]);
 				$this->assertEquals($firstPost->next('pizza')->ID, $nextPost->ID);
 			}
 		}
@@ -155,8 +148,8 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$lastPost = new Timber\Post($posts[1]);
-			$prevPost = new Timber\Post($posts[0]);
+			$lastPost = Timber::get_post($posts[1]);
+			$prevPost = Timber::get_post($posts[0]);
 			$this->assertEquals($lastPost->prev()->ID, $prevPost->ID);
 		}
 
@@ -174,13 +167,7 @@
 				$cat = wp_insert_term('Cheese', 'pizza');
 				self::set_object_terms($posts[0], $cat, 'pizza', false);
 				self::set_object_terms($posts[2], $cat, 'pizza', false);
-				$lastPost = new Timber\Post($posts[2]);
-				// echo "\n".'$lastPost'."\n";
-				// print_r($lastPost);
-				// echo "\n".'$lastPost->prev(pizza)'."\n";
-				// print_r($lastPost->prev('pizza'));
-				// echo "posts\n";
-				// print_r($posts);
+				$lastPost = Timber::get_post($posts[2]);
 				$this->assertEquals($posts[0], $lastPost->prev('pizza')->ID);
 			}
 		}
@@ -194,8 +181,8 @@
 			$cat = wp_insert_term('TestMe', 'category');
 			self::set_object_terms($posts[0], $cat, 'category', false);
 			self::set_object_terms($posts[2], $cat, 'category', false);
-			$lastPost = new Timber\Post($posts[2]);
-			$prevPost = new Timber\Post($posts[0]);
+			$lastPost = Timber::get_post($posts[2]);
+			$prevPost = Timber::get_post($posts[0]);
 			$this->assertEquals($lastPost->prev('category')->ID, $prevPost->ID);
 		}
 
@@ -205,9 +192,9 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$firstPost = new Timber\Post($posts[0]);
-			$nextPost = new Timber\Post($posts[1]);
-			$nextPostAfter = new Timber\Post($posts[2]);
+			$firstPost = Timber::get_post($posts[0]);
+			$nextPost = Timber::get_post($posts[1]);
+			$nextPostAfter = Timber::get_post($posts[2]);
 			wp_update_post( array('ID' =>$nextPost->ID, 'post_status' => 'draft') );
 			$this->assertEquals($nextPostAfter->ID, $firstPost->next()->ID);
 		}
@@ -218,8 +205,8 @@
 				$j = $i + 1;
 				$posts[] = $this->factory->post->create(array('post_date' => '2014-02-0'.$j.' 12:00:00'));
 			}
-			$firstPost = new Timber\Post($posts[0]);
-			$nextPost = new Timber\Post($posts[1]);
+			$firstPost = Timber::get_post($posts[0]);
+			$nextPost = Timber::get_post($posts[1]);
 			$nextPost->post_status = 'draft';
 			wp_update_post($nextPost);
 			$nextPostTest = $firstPost->next();
@@ -228,7 +215,7 @@
 		function testPostInitObject(){
 			$post_id = $this->factory->post->create();
 			$post = get_post($post_id);
-			$post = new Timber\Post($post);
+			$post = Timber::get_post($post);
 			$this->assertEquals($post->ID, $post_id);
 		}
 
@@ -237,15 +224,15 @@
 		 */
 		function testPostByName(){
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
-			$post2 = new Timber\Post($post->post_name);
+			$post = Timber::get_post($post_id);
+			$post2 = Timber::get_post($post->post_name);
 			$this->assertEquals($post2->id, $post_id);
 		}
 
 		function testCanEdit(){
 			wp_set_current_user(1);
 			$post_id = $this->factory->post->create(array('post_author' => 1));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertTrue($post->can_edit());
 			wp_set_current_user(0);
 		}
@@ -253,7 +240,7 @@
 		function testTitle(){
 			$title = 'Fifteen Million Merits';
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post->post_title = $title;
 			wp_update_post($post);
 			$this->assertEquals($title, trim(strip_tags($post->title())));
@@ -335,7 +322,7 @@
 		function testContent(){
 			$quote = 'The way to do well is to do well.';
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$post->post_content = $quote;
 			wp_update_post($post);
 			$this->assertEquals($quote, trim(strip_tags($post->content())));
@@ -347,7 +334,7 @@
             $quote .= $page2 = "And do not let your tongue get ahead of your mind.";
 
             $post_id = $this->factory->post->create();
-            $post = new Timber\Post($post_id);
+            $post = Timber::get_post($post_id);
             $post->post_content = $quote;
             wp_update_post($post);
 
@@ -367,14 +354,14 @@
             // @todo The below should work magically when the iterators are merged
             setup_postdata( get_post( $post_id ) );
 
-            $post = new Timber\Post();
+            $post = Timber::get_post();
 			$this->assertEquals($page1, trim(strip_tags( $post->paged_content() )));
 
             $pagination = $post->pagination();
             $this->go_to( $pagination['pages'][1]['link'] );
 
             setup_postdata( get_post( $post_id ) );
-            $post = new Timber\Post();
+            $post = Timber::get_post();
 
 			$this->assertEquals($page2, trim(strip_tags( $post->paged_content() )));
 		}
@@ -382,20 +369,20 @@
 		function testPostParent(){
 			$parent_id = $this->factory->post->create();
 			$child_id = $this->factory->post->create(array('post_parent' => $parent_id));
-			$child_post = new Timber\Post($child_id);
+			$child_post = Timber::get_post($child_id);
 			$this->assertEquals($parent_id, $child_post->parent()->ID);
 		}
 
 		function testPostSlug(){
 			$pid = $this->factory->post->create(array('post_name' => 'the-adventures-of-tom-sawyer'));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('the-adventures-of-tom-sawyer', $post->slug);
 		}
 
 		function testPostAuthor(){
 			$author_id = $this->factory->user->create(array('display_name' => 'Jared Novack', 'user_login' => 'jared-novack'));
 			$pid = $this->factory->post->create(array('post_author' => $author_id));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('jared-novack', $post->author()->slug());
 			$this->assertEquals('Jared Novack', $post->author()->name());
 			$template = 'By {{post.author}}';
@@ -409,7 +396,7 @@
 		function testPostAuthorInTwig(){
 			$author_id = $this->factory->user->create(array('display_name' => 'Jon Stewart', 'user_login' => 'jon-stewart'));
 			$pid = $this->factory->post->create(array('post_author' => $author_id));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('jon-stewart', $post->author()->slug());
 			$this->assertEquals('Jon Stewart', $post->author()->name());
 			$template = 'By {{post.author}}';
@@ -424,7 +411,7 @@
 			$author_id = $this->factory->user->create(array('display_name' => 'Woodward', 'user_login' => 'bob-woodward'));
 			$mod_author_id = $this->factory->user->create(array('display_name' => 'Bernstein', 'user_login' => 'carl-bernstein'));
 			$pid = $this->factory->post->create(array('post_author' => $author_id));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('bob-woodward', $post->author()->slug());
 			$this->assertEquals('bob-woodward', $post->modified_author()->slug());
 			$this->assertEquals('Woodward', $post->author()->name());
@@ -456,7 +443,7 @@
 			add_theme_support( 'post-formats', array( 'aside', 'gallery' ) );
 			$pid = $this->factory->post->create();
 			set_post_format($pid, 'aside');
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('aside', $post->format());
 		}
 
@@ -464,7 +451,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string("{{ post.class }}", array('post' => $post));
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $str);
 		}
@@ -473,7 +460,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->post_class());
 		}
 
@@ -481,7 +468,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->css_class());
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized additional-css-class', $post->css_class('additional-css-class'));
 		}
@@ -490,7 +477,7 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->class());
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized additional-css-class', $post->class('additional-css-class'));
 		}
@@ -499,14 +486,14 @@
 			$pid = $this->factory->post->create();
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category', true);
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('post-'.$pid.' post type-post status-publish format-standard hentry category-uncategorized', $post->class);
 		}
 
 		function testPostChildren(){
 			$parent_id = $this->factory->post->create();
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id));
-			$parent = new Timber\Post($parent_id);
+			$parent = Timber::get_post($parent_id);
 			$this->assertEquals(8, count($parent->children()));
 		}
 
@@ -515,7 +502,7 @@
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id));
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id,
 			                                                       'post_status' => 'inherit'));
-			$parent = new Timber\Post($parent_id);
+			$parent = Timber::get_post($parent_id);
 			$this->assertEquals(8, count($parent->children()));
 		}
 
@@ -523,7 +510,7 @@
 			$parent_id = $this->factory->post->create(array('post_type' => 'foo'));
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id));
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id, 'post_type' => 'foo'));
-			$parent = new Timber\Post($parent_id);
+			$parent = Timber::get_post($parent_id);
 			$this->assertEquals(4, count($parent->children('parent')));
 		}
 
@@ -531,21 +518,21 @@
 			$parent_id = $this->factory->post->create(array('post_type' => 'foo'));
 			$children = $this->factory->post->create_many(8, array('post_parent' => $parent_id, 'post_type' => 'bar'));
 			$children = $this->factory->post->create_many(4, array('post_parent' => $parent_id, 'post_type' => 'foo'));
-			$parent = new Timber\Post($parent_id);
+			$parent = Timber::get_post($parent_id);
 			$this->assertEquals(12, count($parent->children(array('foo', 'bar'))));
 		}
 
 		function testPostNoConstructorArgument(){
 			$pid = $this->factory->post->create();
 			$this->go_to('?p='.$pid);
-			$post = new Timber\Post();
+			$post = Timber::get_post();
 			$this->assertEquals($pid, $post->ID);
 		}
 
 		function testPostPathUglyPermalinks(){
 			update_option('permalink_structure', '');
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('http://example.org/?p='.$pid, $post->link());
 			$this->assertEquals('/?p='.$pid, $post->path());
 		}
@@ -554,7 +541,7 @@
 			$struc = '/blog/%year%/%monthnum%/%postname%/';
 			update_option('permalink_structure', $struc);
 			$pid = $this->factory->post->create(array('post_date' => '2014-05-28'));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertStringStartsWith('http://example.org/blog/2014/05/post-title', $post->link());
 			$this->assertStringStartsWith('/blog/2014/05/post-title', $post->path());
 		}
@@ -563,7 +550,7 @@
 			$cat = wp_insert_term('News', 'category');
 			$pid = $this->factory->post->create();
 			self::set_object_terms($pid, $cat, 'category');
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('News', $post->category()->name);
 		}
 
@@ -571,7 +558,7 @@
 			$pid = $this->factory->post->create();
 			$cat = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $cat, 'category');
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$category_names = array('News', 'Sports', 'Obits');
 
 			// Uncategorized is applied by default
@@ -587,7 +574,7 @@
 
 		function testPostTags() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$tag_names = array('News', 'Sports', 'Obits');
 
 			foreach ( $tag_names as $tag_name ) {
@@ -600,7 +587,7 @@
 
 		function testPostTerms() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$category = wp_insert_term('Uncategorized', 'category');
 			self::set_object_terms($pid, $category, 'category');
 
@@ -653,7 +640,7 @@
 
 		function testPostTermsArgumentStyle() {
 			$pid      = $this->factory->post->create();
-			$post     = new Timber\Post( $pid );
+			$post     = Timber::get_post( $pid );
 			$category = wp_insert_term( 'Uncategorized', 'category' );
 			self::set_object_terms( $pid, $category, 'category' );
 
@@ -725,7 +712,7 @@
 
 		function testPostTermsMerge() {
 			$pid  = $this->factory->post->create();
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 
 			// register a custom taxonomy, create some terms in it and associate to post
 			register_taxonomy( 'team', 'post' );
@@ -756,7 +743,7 @@
 
 		function testPostTermQueryArgs() {
 			$pid  = $this->factory->post->create();
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 
 			// register a custom taxonomy, create some terms in it and associate to post
 			register_taxonomy( 'team', 'post' );
@@ -827,7 +814,7 @@
 
 			// create new post
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			// create a new tag, associate with post
 			$dummy_tag = wp_insert_term('whatever', 'post_tag');
@@ -846,42 +833,42 @@
 		function testPostContentLength() {
 			$crawl = "The evil leaders of Planet Spaceball having foolishly spuandered their precious atmosphere, have devised a secret plan to take every breath of air away from their peace-loving neighbor, Planet Druidia. Today is Princess Vespa's wedding day. Unbeknownest to the princess, but knowest to us, danger lurks in the stars above...";
 			$pid = $this->factory->post->create(array('post_content' => $crawl));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$content = trim(strip_tags($post->content(0, 6)));
 			$this->assertEquals("The evil leaders of Planet Spaceball&hellip;", $content);
 		}
 
 		function testPostTypeObject() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$pto = $post->type();
 			$this->assertEquals('Posts', $pto->label);
 		}
 
 		function testPage() {
 			$pid = $this->factory->post->create(array('post_type' => 'page', 'post_title' => 'My Page'));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals($pid, $post->ID);
 			$this->assertEquals('My Page', $post->title());
 		}
 
 		function testCommentFormOnPost() {
 			$post_id = $this->factory->post->create();
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$form = $post->comment_form();
 			$this->assertStringStartsWith('<div id="respond"', trim($form));
 		}
 
 		function testPostWithoutGallery() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$this->assertEquals(null, $post->gallery());
 		}
 
 		function testPostWithoutAudio() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$this->assertEquals(array(), $post->audio());
 		}
@@ -892,7 +879,7 @@
 			$quote .= "No, try not. Do or do not. There is no try.";
 
 			$pid = $this->factory->post->create(array('post_content' => $quote));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$expected = array(
 				'<audio class="wp-audio-shortcode" id="audio-1-1" preload="none" style="width: 100%;" controls="controls"><source type="audio/mpeg" src="http://www.noiseaddicts.com/samples_1w72b820/280.mp3?_=1" /><a href="http://www.noiseaddicts.com/samples_1w72b820/280.mp3">http://www.noiseaddicts.com/samples_1w72b820/280.mp3</a></audio>',
 			);
@@ -910,13 +897,13 @@
 			$expected = array(
 				'<audio class="wp-audio-shortcode" id="audio-1-2" preload="none" style="width: 100%;" controls="controls"><source type="audio/mpeg" src="http://www.noiseaddicts.com/samples_1w72b820/280.mp3?_=2" /><a href="http://www.noiseaddicts.com/samples_1w72b820/280.mp3">http://www.noiseaddicts.com/samples_1w72b820/280.mp3</a></audio>',
 			);
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals($expected, $post->audio());
 		}
 
 		function testPostWithoutVideo() {
 			$pid = $this->factory->post->create();
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$this->assertEquals(array(), $post->video());
 		}
@@ -927,7 +914,7 @@
 			$quote .= "No, try not. Do or do not. There is no try.";
 
 			$pid = $this->factory->post->create(array('post_content' => $quote));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 
 			$video    = $post->video();
 			$value    = array_shift( $video );
@@ -949,7 +936,7 @@
 
             /* test */
             $pid = $this->factory->post->create(array('post_name' => 'my-cool-post'));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$this->assertEquals('http://example.org:3000/my-cool-post/', $post->link());
 			$this->assertEquals('/my-cool-post/', $post->path());
 
@@ -971,7 +958,7 @@
 
 			$uid = $this->factory->user->create(array('display_name' => 'Franklin Delano Roosevelt', 'user_login' => 'fdr'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$edit_url = $post->edit_link();
 			$this->assertEquals('', $edit_url);
 			$user = wp_set_current_user($uid);
@@ -988,7 +975,7 @@
 			$attachment_id = TestTimberImage::get_attachment( $post_id );
 			add_post_meta( $post_id, '_thumbnail_id', $attachment_id, true );
 
-			$post = new Timber\Post( $post_id );
+			$post = Timber::get_post( $post_id );
 
 			$this->assertEquals( $attachment_id, $post->thumbnail_id() );
 		}
@@ -1002,7 +989,7 @@
 			$attachment_id = TestTimberImage::get_attachment( $post_id );
 			add_post_meta( $post_id, '_thumbnail_id', $attachment_id, true );
 
-			$post = new Timber\Post( $post_id );
+			$post = Timber::get_post( $post_id );
 
 			$this->assertEquals( $attachment_id, $post->_thumbnail_id );
 		}

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -3,6 +3,8 @@
 /**
  * @group called-post-constructor
  * @group called-term-constructor
+ * FIXME #1793 replace direct Timber\User instantiations
+ * FIXME #1793 replace direct Timber\Comment instantiations
  */
 class TestTimberProperty extends Timber_UnitTestCase {
 

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -2,6 +2,7 @@
 
 /**
  * @group called-post-constructor
+ * @group called-term-constructor
  */
 class TestTimberProperty extends Timber_UnitTestCase {
 
@@ -13,7 +14,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$term_id = $term_id['term_id'];
 		$post = Timber::get_post( $post_id );
 		$user = new Timber\User( $user_id );
-		$term = new Timber\Term( $term_id );
+		$term = Timber::get_term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
 		$this->assertEquals( $post_id, $post->ID );
 		$this->assertEquals( $post_id, $post->id );
@@ -34,7 +35,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$term_id = $term_id['term_id'];
 		$post = Timber::get_post( $post_id );
 		$user = new Timber\User( $user_id );
-		$term = new Timber\Term( $term_id );
+		$term = Timber::get_term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
 		$site = new Timber\Site();
 		return array( 'post' => $post, 'user' => $user, 'term' => $term, 'comment' => $comment, 'site' => $site );

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -3,8 +3,8 @@
 /**
  * @group called-post-constructor
  * @group called-term-constructor
- * @todo #1793 replace direct Timber\User instantiations
- * @todo #1793 replace direct Timber\Comment instantiations
+ * @todo #2094 replace direct Timber\User instantiations
+ * @todo #2094 replace direct Timber\Comment instantiations
  */
 class TestTimberProperty extends Timber_UnitTestCase {
 

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberProperty extends Timber_UnitTestCase {
 
 	function testPropertyID() {
@@ -8,7 +11,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 		$term_id = wp_insert_term( 'baseball', 'post_tag' );
 		$term_id = $term_id['term_id'];
-		$post = new Timber\Post( $post_id );
+		$post = Timber::get_post( $post_id );
 		$user = new Timber\User( $user_id );
 		$term = new Timber\Term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
@@ -29,7 +32,7 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$comment_id = $this->factory->comment->create( array( 'comment_post_ID' => $post_id ) );
 		$term_id = wp_insert_term( 'baseball', 'post_tag' );
 		$term_id = $term_id['term_id'];
-		$post = new Timber\Post( $post_id );
+		$post = Timber::get_post( $post_id );
 		$user = new Timber\User( $user_id );
 		$term = new Timber\Term( $term_id );
 		$comment = new Timber\Comment( $comment_id );
@@ -62,13 +65,13 @@ class TestTimberProperty extends Timber_UnitTestCase {
 		$user->update( 'john', 'kennedy' );
 		$comment->update( 'george', 'washington' );
 		$this->assertEquals( 'jefferson', $post->thomas );
-		
+
 		$this->assertEquals( 'roosevelt', $user->teddy );
 		$this->assertEquals( 'washington', $comment->george );
 		$this->assertEquals( 'clinton', $site->bill );
 
 		$this->assertEquals( 'jefferson', Timber::compile_string( '{{post.thomas}}', array( 'post' => $post ) ) );
-		
+
 		$this->assertEquals( 'roosevelt', Timber::compile_string( '{{user.teddy}}', array( 'user' => $user ) ) );
 		$this->assertEquals( 'washington', Timber::compile_string( '{{comment.george}}', array( 'comment' => $comment ) ) );
 		$this->assertEquals( 'clinton', Timber::compile_string( '{{site.bill}}', array( 'site' => $site ) ) );

--- a/tests/test-timber-properties.php
+++ b/tests/test-timber-properties.php
@@ -3,8 +3,8 @@
 /**
  * @group called-post-constructor
  * @group called-term-constructor
- * FIXME #1793 replace direct Timber\User instantiations
- * FIXME #1793 replace direct Timber\Comment instantiations
+ * @todo #1793 replace direct Timber\User instantiations
+ * @todo #1793 replace direct Timber\Comment instantiations
  */
 class TestTimberProperty extends Timber_UnitTestCase {
 

--- a/tests/test-timber-revisions.php
+++ b/tests/test-timber-revisions.php
@@ -74,7 +74,7 @@
 
 
 			self::setRevision($post_id);
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$revision = new Timber\Post();
 
 			$this->assertEquals('I am revised', trim(strip_tags($revision->content())) );
@@ -114,7 +114,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$post = new Timber\Post();
 			$this->assertEquals( $original_post->class(), $post->class() );
 		}
@@ -207,7 +207,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$post = new Timber\Post();
 			$this->assertEquals( $quote . 'Yes', trim(strip_tags($post->content())) );
 		}
@@ -246,7 +246,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$post = new Timber\Post();
 			$this->assertEquals('I am the one', trim(strip_tags($post->content())) );
 		}

--- a/tests/test-timber-revisions.php
+++ b/tests/test-timber-revisions.php
@@ -74,7 +74,7 @@
 
 
 			self::setRevision($post_id);
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$revision = new Timber\Post();
 
 			$this->assertEquals('I am revised', trim(strip_tags($revision->content())) );
@@ -114,7 +114,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$post = new Timber\Post();
 			$this->assertEquals( $original_post->class(), $post->class() );
 		}
@@ -207,7 +207,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$post = new Timber\Post();
 			$this->assertEquals( $quote . 'Yes', trim(strip_tags($post->content())) );
 		}
@@ -246,7 +246,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$post = new Timber\Post();
 			$this->assertEquals('I am the one', trim(strip_tags($post->content())) );
 		}

--- a/tests/test-timber-revisions.php
+++ b/tests/test-timber-revisions.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberRevisions extends Timber_UnitTestCase {
 
 		public function setRevision( $post_id ) {
@@ -64,13 +67,14 @@
 				'post_content' => 'I am revised'
 			));
 
-			$post = new Timber\Post($post_id);
-			$parent = new Timber\Post($parent_id);
+			$post = Timber::get_post($post_id);
+			$parent = Timber::get_post($parent_id);
 
 			//$this->assertEquals($parent_id, $post->parent()->id);
 
 
 			self::setRevision($post_id);
+			// FIXME #1793 factories
 			$revision = new Timber\Post();
 
 			$this->assertEquals('I am revised', trim(strip_tags($revision->content())) );
@@ -102,7 +106,7 @@
 				'user_pass' => 'timber',
 			));
 
-			$original_post = new Timber\Post($post_id);
+			$original_post = Timber::get_post($post_id);
 			$user = wp_set_current_user($uid);
 
 			$user->add_role('administrator');
@@ -110,6 +114,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
+			// FIXME #1793 factories
 			$post = new Timber\Post();
 			$this->assertEquals( $original_post->class(), $post->class() );
 		}
@@ -140,7 +145,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals( 'I call it fromage', $post->title() );
 		}
 
@@ -171,7 +176,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals( $quote . 'Yes', trim(strip_tags($post->content())) );
 		}
 
@@ -202,6 +207,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
+			// FIXME #1793 factories
 			$post = new Timber\Post();
 			$this->assertEquals( $quote . 'Yes', trim(strip_tags($post->content())) );
 		}
@@ -240,6 +246,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
+			// FIXME #1793 factories
 			$post = new Timber\Post();
 			$this->assertEquals('I am the one', trim(strip_tags($post->content())) );
 		}
@@ -272,7 +279,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$str_getfield = Timber::compile_string('{{post.meta(\'test_field\')}}', array('post' => $post));
 			$this->assertEquals( $assertCustomFieldVal, $str_getfield );
 		}
@@ -305,7 +312,7 @@
 			$wp_query->queried_object = get_post($post_id);
 			$_GET['preview'] = true;
 			$_GET['preview_nonce'] = wp_create_nonce('post_preview_' . $post_id);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$str_direct = Timber::compile_string('{{ post.meta("test_field") }}', array('post' => $post));
 			$this->assertEquals( $assertCustomFieldVal, $str_direct );
 		}
@@ -337,7 +344,7 @@
 
 			$wp_query->queried_object_id = $post_id;
 			$wp_query->queried_object = get_post($post_id);
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 
 			$str_direct = Timber::compile_string('{{post.test_field}}', array('post' => $post));
 			$str_getfield = Timber::compile_string('{{post.meta(\'test_field\')}}', array('post' => $post));

--- a/tests/test-timber-sidebar.php
+++ b/tests/test-timber-sidebar.php
@@ -1,12 +1,15 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberSidebar extends Timber_UnitTestCase {
 
 		function testTwigSidebar(){
 			$context = Timber::context();
 			$sidebar_post = $this->factory->post->create(array('post_title' => 'Sidebar post content'));
 			$sidebar_context = array();
-			$sidebar_context['post'] = new Timber\Post($sidebar_post);
+			$sidebar_context['post'] = Timber::get_post($sidebar_post);
 			$context['sidebar'] = Timber::get_sidebar('assets/sidebar.twig', $sidebar_context);
 			$result = Timber::compile('assets/main-w-sidebar.twig', $context);
 			$this->assertEquals('I am the main stuff <h4>Sidebar post content</h4>', trim($result));

--- a/tests/test-timber-static.php
+++ b/tests/test-timber-static.php
@@ -35,7 +35,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$this->go_to(home_url('/'));
 		global $wp_query;
 		$wp_query->queried_object_id = $page_id;
-		// FIXME #1793 factories
+		// @todo #1793 factories
 		$page = new Timber\Post();
 		$this->assertEquals($page_id, $page->ID);
 	}
@@ -68,7 +68,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$this->go_to(home_url('/?p='.$page_id));
 			$post = Timber::get_post($post_id);
 			$this->assertEquals($post_id, $post->ID);
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
@@ -80,7 +80,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$this->go_to(home_url('/?p='.$page_id));
 			$posts = Timber::get_posts();
 			$this->assertEquals(0, count($posts));
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
@@ -89,7 +89,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$page_id = $this->factory->post->create(array('post_title' => 'Mister Slave', 'post_type' => 'page'));
 			$children = $this->factory->post->create_many(10, array('post_title' => 'Timmy'));
 			$this->go_to(home_url('/?p='.$page_id));
-			// FIXME #1793 factories
+			// @todo #1793 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 			$posts = Timber::get_posts();

--- a/tests/test-timber-static.php
+++ b/tests/test-timber-static.php
@@ -35,7 +35,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$this->go_to(home_url('/'));
 		global $wp_query;
 		$wp_query->queried_object_id = $page_id;
-		// @todo #1793 factories
+		// @todo #2094 factories
 		$page = new Timber\Post();
 		$this->assertEquals($page_id, $page->ID);
 	}
@@ -68,7 +68,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$this->go_to(home_url('/?p='.$page_id));
 			$post = Timber::get_post($post_id);
 			$this->assertEquals($post_id, $post->ID);
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
@@ -80,7 +80,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$this->go_to(home_url('/?p='.$page_id));
 			$posts = Timber::get_posts();
 			$this->assertEquals(0, count($posts));
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
@@ -89,7 +89,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$page_id = $this->factory->post->create(array('post_title' => 'Mister Slave', 'post_type' => 'page'));
 			$children = $this->factory->post->create_many(10, array('post_title' => 'Timmy'));
 			$this->go_to(home_url('/?p='.$page_id));
-			// @todo #1793 factories
+			// @todo #2094 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 			$posts = Timber::get_posts();

--- a/tests/test-timber-static.php
+++ b/tests/test-timber-static.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberStaticPages extends Timber_UnitTestCase {
 
 	function tearDown() {
@@ -13,7 +16,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$page_id = $this->factory->post->create(array('post_type' => 'page'));
 		update_option('page_for_posts', $page_id);
 		$this->go_to(home_url('/?page_id='.$page_id));
-		$page = new Timber\Post();
+		$page = Timber::get_post();
 		$this->assertEquals($page_id, $page->ID);
 	}
 
@@ -21,7 +24,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$pids = $this->factory->post->create_many(6);
 		$page_id = $this->factory->post->create(array('post_title' => 'Foobar', 'post_name' => 'foobar', 'post_type' => 'page'));
 		$this->go_to(home_url('/?page_id='.$page_id));
-		$page = new Timber\Post();
+		$page = Timber::get_post();
 		$this->assertEquals($page_id, $page->ID);
 	}
 
@@ -32,6 +35,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		$this->go_to(home_url('/'));
 		global $wp_query;
 		$wp_query->queried_object_id = $page_id;
+		// FIXME #1793 factories
 		$page = new Timber\Post();
 		$this->assertEquals($page_id, $page->ID);
 	}
@@ -42,7 +46,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 		update_option('show_on_front', 'page');
 		update_option('page_on_front', $page_id);
 		$this->go_to(home_url('/'));
-		$post = new Timber\Post();
+		$post = Timber::get_post();
 		$this->assertEquals($page_id, $post->ID);
 	}
 
@@ -62,8 +66,9 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			update_option('page_for_posts', $page_id);
 			$post_id = $this->factory->post->create(array('post_title' => 'My Real post', 'post_type' => 'post'));
 			$this->go_to(home_url('/?p='.$page_id));
-			$post = new Timber\Post($post_id);
+			$post = Timber::get_post($post_id);
 			$this->assertEquals($post_id, $post->ID);
+			// FIXME #1793 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
@@ -75,6 +80,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$this->go_to(home_url('/?p='.$page_id));
 			$posts = Timber::get_posts();
 			$this->assertEquals(0, count($posts));
+			// FIXME #1793 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 		}
@@ -83,6 +89,7 @@ class TestTimberStaticPages extends Timber_UnitTestCase {
 			$page_id = $this->factory->post->create(array('post_title' => 'Mister Slave', 'post_type' => 'page'));
 			$children = $this->factory->post->create_many(10, array('post_title' => 'Timmy'));
 			$this->go_to(home_url('/?p='.$page_id));
+			// FIXME #1793 factories
 			$page = new Timber\Post();
 			$this->assertEquals($page_id, $page->ID);
 			$posts = Timber::get_posts();

--- a/tests/test-timber-term-getter.php
+++ b/tests/test-timber-term-getter.php
@@ -5,15 +5,10 @@
 	class TestTimberTermGetter extends Timber_UnitTestCase {
 
 		function setUp() {
-			global $wpdb;
-			$query = "truncate $wpdb->term_relationships";
-			$wpdb->query($query);
-			$query = "truncate $wpdb->term_taxonomy";
-			$wpdb->query($query);
-			$query = "truncate $wpdb->terms";
-			$wpdb->query($query);
-			$query = "truncate $wpdb->termmeta";
-			$wpdb->query($query);
+			$this->truncate('term_relationships');
+			$this->truncate('term_taxonomy');
+			$this->truncate('terms');
+			$this->truncate('termmeta');
 		}
 
 		function testGetSingleTerm() {

--- a/tests/test-timber-term-getter.php
+++ b/tests/test-timber-term-getter.php
@@ -66,12 +66,6 @@
 			$terms = Timber::get_terms();
 			$this->assertCount(3, $terms);
 
-			$terms = Timber::get_terms('categories');
-			$this->assertCount(1, $terms);
-
-			$terms = Timber::get_terms(array('tag'));
-			$this->assertCount(2, $terms);
-
 			$query = array('taxonomy' => array('category'));
 			$terms = Timber::get_terms($query);
 			$this->assertEquals('Uncategorized', $terms[0]->name);
@@ -83,5 +77,20 @@
 			$terms = Timber::get_terms(array($new_id, $term_id));
 			$this->assertCount(2, $terms);
 			$this->assertEquals('My Term', $terms[1]->name);
+		}
+
+		function testGetTermsWithCorrections() {
+			$category = $this->factory->term->create(array('name' => 'Uncategorized', 'taxonomy' => 'category'));
+			$other_term = $this->factory->term->create(array('name' => 'Bogus Term', 'taxonomy' => 'post_tag'));
+			$term_id = $this->factory->term->create(array('name' => 'My Term', 'taxonomy' => 'post_tag'));
+
+			$terms = Timber::get_terms('categories');
+			$this->assertCount(1, $terms);
+
+			$terms = Timber::get_terms(array('tags'));
+			$this->assertCount(2, $terms);
+
+			$terms = Timber::get_terms(array('tag'));
+			$this->assertCount(2, $terms);
 		}
 	}

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -47,21 +47,12 @@
 			$this->assertEquals('Zebra', $string);
 		}
 
-		function testConstructorWithObject() {
+		function testGetTerm() {
 			register_taxonomy('arts', array('post'));
 
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
-
-			$term_obj = get_term($term_id);
-			$term = Timber::get_term($term_obj, 'arts');
-			$this->assertEquals('Zong', $term->title());
-		}
-
-		function testConstructor() {
-			register_taxonomy('arts', array('post'));
-
-			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
-			$term = Timber::get_term($term_id, 'arts');
+			// @todo #2087 get this to work w/o $taxonomy param
+			$term = Timber::get_term($term_id, '');
 			$this->assertEquals('Zong', $term->title());
 			$template = '{% set zp_term = Term("'.$term->ID.'", "arts") %}{{ zp_term.name }}';
 			$string = Timber::compile_string($template);
@@ -101,14 +92,6 @@
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots', 'description' => $desc));
 			$term = Timber::get_term($term_id, 'post_tag');
 			$this->assertEquals($desc, $term->description());
-		}
-
-		// @todo #1793 factories
-		// this test should probably be deleted altogether...
-		function testTermConstructWithName() {
-			$term_id = $this->factory->term->create(array('name' => 'St. Louis Cardinals'));
-			$term = new Timber\Term('St. Louis Cardinals');
-			$this->assertNull($term->ID);
 		}
 
 		function testTermInitObject() {

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -85,13 +85,13 @@
 
 		function testTermConstructWithSlug() {
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots'));
-			$term = new Timber\Term('new-england-patriots');
+			$term = Timber::get_term($term_id);
 			$this->assertEquals($term->ID, $term_id);
 		}
 
 		function testTermToString() {
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots'));
-			$term = new Timber\Term('new-england-patriots');
+			$term = Timber::get_term($term_id);
 			$str = Timber::compile_string('{{term}}', array('term' => $term));
 			$this->assertEquals('New England Patriots', $str);
 		}
@@ -103,6 +103,8 @@
 			$this->assertEquals($desc, $term->description());
 		}
 
+		// FIXME #1793 factories
+		// this test should probably be deleted altogether...
 		function testTermConstructWithName() {
 			$term_id = $this->factory->term->create(array('name' => 'St. Louis Cardinals'));
 			$term = new Timber\Term('St. Louis Cardinals');
@@ -147,7 +149,7 @@
 
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
 			$posts = $this->factory->post->create_many(5, array('post_type' => 'portfolio' ));
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id, 'arts');
 			foreach($posts as $post_id) {
 				wp_set_object_terms($post_id, $term_id, 'arts', true);
 			}
@@ -306,7 +308,7 @@
 			$local = $this->factory->term->create(array('name' => 'Local', 'parent' => $parent_id, 'taxonomy' => 'category'));
 			$int = $this->factory->term->create(array('name' => 'International', 'parent' => $parent_id, 'taxonomy' => 'category'));
 
-			$term = new Timber\Term($parent_id);
+			$term = Timber::get_term($parent_id, 'category');
 			$children = $term->children();
 			$this->assertEquals(2, count($children));
 			$this->assertEquals('Local', $children[0]->name);
@@ -318,7 +320,7 @@
 		function testTermWithNativeMeta() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
 			add_term_meta($tid, 'foo', 'bar');
-			$term = new Timber\Term($tid);
+			$term = Timber::get_term($tid, 'category');
 			$template = '{{term.foo}}';
 			$compiled = Timber::compile_string($template, array('term' => $term));
 			$this->assertEquals('bar', $compiled);
@@ -330,7 +332,7 @@
 		function testTermWithNativeMetaFalse() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
 			add_term_meta($tid, 'foo', false);
-			$term = new Timber\Term($tid);
+			$term = Timber::get_term($tid, 'category');
 			$this->assertEquals('', $term->meta('foo'));
 		}
 
@@ -347,7 +349,7 @@
 			$valid_wp_native_value = get_term_meta($tid, 'bar', true);
 			$valid_acf_native_value = get_field('bar', 'category_'.$tid);
 
-			$term = new Timber\Term($tid);
+			$term = Timber::get_term($tid, 'category');
 
 			//test baseline "bar" data
 			$this->assertEquals('qux', $valid_wp_native_value);
@@ -364,7 +366,7 @@
 		function testTermEditLink() {
 			wp_set_current_user(1);
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
-			$term = new Timber\Term($tid);
+			$term = Timber::get_term($tid, 'category');
 			$links = array();
 
 			$links[] = 'http://example.org/wp-admin/term.php?taxonomy=category&tag_ID='.$tid.'&post_type=post';

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -1,5 +1,9 @@
 <?php
 
+  /**
+   * @group called-post-constructor
+   * @group called-term-constructor
+   */
 	class TestTimberTerm extends Timber_UnitTestCase {
 
 		function testTermFrom() {
@@ -49,7 +53,7 @@
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
 
 			$term_obj = get_term($term_id);
-			$term = new Timber\Term($term_obj, 'arts');
+			$term = Timber::get_term($term_obj, 'arts');
 			$this->assertEquals('Zong', $term->title());
 		}
 
@@ -57,7 +61,7 @@
 			register_taxonomy('arts', array('post'));
 
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
-			$term = new Timber\Term($term_id, 'arts');
+			$term = Timber::get_term($term_id, 'arts');
 			$this->assertEquals('Zong', $term->title());
 			$template = '{% set zp_term = Term("'.$term->ID.'", "arts") %}{{ zp_term.name }}';
 			$string = Timber::compile_string($template);
@@ -66,7 +70,7 @@
 
 		function testTerm() {
 			$term_id = $this->factory->term->create();
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$this->assertEquals('Timber\Term', get_class($term));
 		}
 
@@ -74,7 +78,7 @@
 			$term_id = $this->factory->term->create(array('name' => 'Famous Commissioners'));
 			$term_data = get_term($term_id, 'post_tag');
 			$this->assertTrue( in_array( get_class($term_data), array('WP_Term', 'stdClass') ) );
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$this->assertEquals('Famous Commissioners', $term->title());
 			$this->assertEquals('Timber\Term', get_class($term));
 		}
@@ -95,7 +99,7 @@
 		function testTermDescription() {
 			$desc = 'An honest football team';
 			$term_id = $this->factory->term->create(array('name' => 'New England Patriots', 'description' => $desc));
-			$term = new Timber\Term($term_id, 'post_tag');
+			$term = Timber::get_term($term_id, 'post_tag');
 			$this->assertEquals($desc, $term->description());
 		}
 
@@ -108,19 +112,19 @@
 		function testTermInitObject() {
 			$term_id = $this->factory->term->create();
 			$term = get_term($term_id, 'post_tag');
-			$term = new Timber\Term($term);
+			$term = Timber::get_term($term);
 			$this->assertEquals($term->ID, $term_id);
 		}
 
 		function testTermLink() {
 			$term_id = $this->factory->term->create();
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$this->assertContains('http://', $term->link());
 		}
 
 		function testTermPath() {
 			$term_id = $this->factory->term->create();
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$this->assertFalse(strstr($term->path(), 'http://'));
 		}
 
@@ -129,7 +133,7 @@
 			$term_id = $this->factory->term->create(array('name' => 'Zong'));
 			$posts = $this->factory->post->create_many(3, array('post_type' => 'post', 'tags_input' => 'zong') );
 			$posts = $this->factory->post->create_many(5, array('post_type' => 'portfolio', 'tags_input' => 'zong') );
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$posts_gotten = $term->posts('posts_per_page=4');
 			$this->assertEquals(4, count($posts_gotten));
 
@@ -166,7 +170,7 @@
 			foreach($posts as $post_id){
 				wp_set_object_terms($post_id, $term_id, 'post_tag', true);
 			}
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$gotten_posts = $term->get_posts();
 			$this->assertEquals(count($posts), count($gotten_posts));
 		}
@@ -181,7 +185,7 @@
 				set_post_type($post_id, 'page');
 				wp_set_object_terms($post_id, $term_id, 'post_tag', true);
 			}
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$gotten_posts = $term->posts(count($posts), 'page');
 			$this->assertEquals(count($posts), count($gotten_posts));
 			$gotten_posts = $term->posts(count($posts), 'any');
@@ -204,7 +208,7 @@
 				set_post_type($post_id, 'page');
 				wp_set_object_terms($post_id, $term_id, 'post_tag', true);
 			}
-			$term = new Timber\Term($term_id);
+			$term = Timber::get_term($term_id);
 			$gotten_posts = $term->get_posts('post_type=page');
 			$this->assertEquals(count($posts), count($gotten_posts));
 
@@ -229,7 +233,7 @@
 				wp_set_object_terms( $post_id, $term_id, 'post_tag', true );
 			}
 
-			$term = new Timber\Term( $term_id );
+			$term = Timber::get_term( $term_id );
 
 			$term_posts = $term->posts( [
 				'posts_per_page' => 2,
@@ -255,7 +259,7 @@
 				wp_set_object_terms( $post_id, $term_id, 'post_tag', true );
 			}
 
-			$term = new Timber\Term( $term_id );
+			$term = Timber::get_term( $term_id );
 
 			$term_posts = $term->posts( [
 				'posts_per_page' => 2,
@@ -285,7 +289,7 @@
 				wp_set_object_terms( $post_id, $term_id, 'post_tag', true );
 			}
 
-			$term = new Timber\Term( $term_id );
+			$term = Timber::get_term( $term_id );
 
 			$term_posts = $term->posts( [
 				'posts_per_page' => 2,

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -17,36 +17,6 @@
 			$this->assertEquals('Cardinals', $baseball_teams[0]->title());
 		}
 
-		function testConstructorWithClass() {
-			register_taxonomy('arts', array('post'));
-
-			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'post_tag'));
-			$term = new \Timber\Term($term_id);
-
-			$template = '{% set zp_term = Term("'.$term_id.'", "Arts") %}{{ zp_term.name }} {{ zp_term.taxonomy }}';
-			$string = Timber::compile_string($template);
-			$this->assertEquals('Zong post_tag', $string);
-
-			$template = '{% set zp_term = Term('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
-			$string = Timber::compile_string($template);
-			$this->assertEquals('Zebra', $string);
-		}
-
-		function testConstructorWithClassAndTaxonomy() {
-			register_taxonomy('arts', array('post'));
-
-			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
-			$term = new \Timber\Term($term_id);
-
-			$template = '{% set zp_term = Term("'.$term_id.'", "arts", "Arts") %}{{ zp_term.name }} {{ zp_term.taxonomy }}';
-			$string = Timber::compile_string($template);
-			$this->assertEquals('Zong arts', $string);
-
-			$template = '{% set zp_term = Term('.$term_id.', "Arts") %}{{ zp_term.foobar }}';
-			$string = Timber::compile_string($template);
-			$this->assertEquals('Zebra', $string);
-		}
-
 		function testGetTerm() {
 			register_taxonomy('arts', array('post'));
 
@@ -72,12 +42,6 @@
 			$term = Timber::get_term($term_id);
 			$this->assertEquals('Famous Commissioners', $term->title());
 			$this->assertEquals('Timber\Term', get_class($term));
-		}
-
-		function testTermConstructWithSlug() {
-			$term_id = $this->factory->term->create(array('name' => 'New England Patriots'));
-			$term = Timber::get_term($term_id);
-			$this->assertEquals($term->ID, $term_id);
 		}
 
 		function testTermToString() {

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -132,7 +132,6 @@
 
 			$term_id = $this->factory->term->create(array('name' => 'Zong', 'taxonomy' => 'arts'));
 			$posts = $this->factory->post->create_many(5, array('post_type' => 'portfolio' ));
-			$term = Timber::get_term($term_id, 'arts');
 			foreach($posts as $post_id) {
 				wp_set_object_terms($post_id, $term_id, 'arts', true);
 			}
@@ -291,7 +290,8 @@
 			$local = $this->factory->term->create(array('name' => 'Local', 'parent' => $parent_id, 'taxonomy' => 'category'));
 			$int = $this->factory->term->create(array('name' => 'International', 'parent' => $parent_id, 'taxonomy' => 'category'));
 
-			$term = Timber::get_term($parent_id, 'category');
+			// @todo #2087 get this to work w/o $taxonomy param
+			$term = Timber::get_term($parent_id, '');
 			$children = $term->children();
 			$this->assertEquals(2, count($children));
 			$this->assertEquals('Local', $children[0]->name);
@@ -303,7 +303,8 @@
 		function testTermWithNativeMeta() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
 			add_term_meta($tid, 'foo', 'bar');
-			$term = Timber::get_term($tid, 'category');
+			// @todo #2087 get this to work w/o $taxonomy param
+			$term = Timber::get_term($tid, '');
 			$template = '{{term.foo}}';
 			$compiled = Timber::compile_string($template, array('term' => $term));
 			$this->assertEquals('bar', $compiled);
@@ -315,7 +316,8 @@
 		function testTermWithNativeMetaFalse() {
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
 			add_term_meta($tid, 'foo', false);
-			$term = Timber::get_term($tid, 'category');
+			// @todo #2087 get this to work w/o $taxonomy param
+			$term = Timber::get_term($tid, '');
 			$this->assertEquals('', $term->meta('foo'));
 		}
 
@@ -332,7 +334,8 @@
 			$valid_wp_native_value = get_term_meta($tid, 'bar', true);
 			$valid_acf_native_value = get_field('bar', 'category_'.$tid);
 
-			$term = Timber::get_term($tid, 'category');
+			// @todo #2087 get this to work w/o $taxonomy param
+			$term = Timber::get_term($tid, '');
 
 			//test baseline "bar" data
 			$this->assertEquals('qux', $valid_wp_native_value);
@@ -349,7 +352,8 @@
 		function testTermEditLink() {
 			wp_set_current_user(1);
 			$tid = $this->factory->term->create(array('name' => 'News', 'taxonomy' => 'category'));
-			$term = Timber::get_term($tid, 'category');
+			// @todo #2087 get this to work w/o $taxonomy param
+			$term = Timber::get_term($tid, '');
 			$links = array();
 
 			$links[] = 'http://example.org/wp-admin/term.php?taxonomy=category&tag_ID='.$tid.'&post_type=post';

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -103,7 +103,7 @@
 			$this->assertEquals($desc, $term->description());
 		}
 
-		// FIXME #1793 factories
+		// @todo #1793 factories
 		// this test should probably be deleted altogether...
 		function testTermConstructWithName() {
 			$term_id = $this->factory->term->create(array('name' => 'St. Louis Cardinals'));

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberTwig extends Timber_UnitTestCase {
 
 		function tearDown() {
@@ -95,7 +98,7 @@
 			add_filter('protected_title_format', function($title){
 				return 'Protected: '.$title;
 			});
-			$context['post'] = new Timber\Post($post_id);
+			$context['post'] = Timber::get_post($post_id);
 			if (post_password_required($post_id)){
 				$this->assertTrue(true);
 				$str = Timber::compile('assets/test-wp-filters.twig', $context);
@@ -129,7 +132,7 @@
 		 */
 		function testFilterFunction() {
 			$pid = $this->factory->post->create(array('post_title' => 'Foo'));
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$str = 'I am a {{post | get_class }}';
 			$this->assertEquals('I am a Timber\Post', Timber::compile_string($str, array('post' => $post)));
 		}
@@ -208,7 +211,7 @@
      	*/
 		function testSetObject() {
 			$pid = $this->factory->post->create(array('post_title' => 'Spaceballs'));
-			$post = new Timber\Post( $pid );
+			$post = Timber::get_post( $pid );
 			$result = Timber::compile('assets/set-object.twig', array('post' => $post));
 			$this->assertEquals('Spaceballs: may the schwartz be with you', trim($result));
 		}

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -2,6 +2,7 @@
 
 	/**
 	 * @group called-post-constructor
+	 * FIXME #1793 replace direct Timber\User instantiations
 	 */
 	class TestTimberUser extends Timber_UnitTestCase {
 

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -2,7 +2,7 @@
 
 	/**
 	 * @group called-post-constructor
-	 * @todo #1793 replace direct Timber\User instantiations
+	 * @todo #2094 replace direct Timber\User instantiations
 	 */
 	class TestTimberUser extends Timber_UnitTestCase {
 

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -2,7 +2,7 @@
 
 	/**
 	 * @group called-post-constructor
-	 * FIXME #1793 replace direct Timber\User instantiations
+	 * @todo #1793 replace direct Timber\User instantiations
 	 */
 	class TestTimberUser extends Timber_UnitTestCase {
 

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -1,5 +1,8 @@
 <?php
 
+	/**
+	 * @group called-post-constructor
+	 */
 	class TestTimberUser extends Timber_UnitTestCase {
 
 		function testInitWithID(){
@@ -35,7 +38,7 @@
 			$user = new Timber\User($uid);
 			$this->assertEquals('Sixteenth President', $user->meta('description'));
 			$pid = $this->factory->post->create(array('post_author' => $uid));
-			$post = new Timber\Post($pid);
+			$post = Timber::get_post($pid);
 			$str = Timber::compile_string("{{post.author.meta('description')}}", array('post' => $post));
 			$this->assertEquals('Sixteenth President', $str);
 		}

--- a/tests/test-timber-wpml.php
+++ b/tests/test-timber-wpml.php
@@ -2,6 +2,7 @@
 
 /**
  * Mocked function for testing menus in WPML
+ * FIXME #1793 replace direct Timber\Menu instantiations
  */
 function wpml_object_id_filter( $element_id, $element_type = 'post', $return_original_if_missing = false, $language_code = null ) {
 	$locations = get_nav_menu_locations();

--- a/tests/test-timber-wpml.php
+++ b/tests/test-timber-wpml.php
@@ -2,7 +2,7 @@
 
 /**
  * Mocked function for testing menus in WPML
- * @todo #1793 replace direct Timber\Menu instantiations
+ * @todo #2094 replace direct Timber\Menu instantiations
  */
 function wpml_object_id_filter( $element_id, $element_type = 'post', $return_original_if_missing = false, $language_code = null ) {
 	$locations = get_nav_menu_locations();

--- a/tests/test-timber-wpml.php
+++ b/tests/test-timber-wpml.php
@@ -2,7 +2,7 @@
 
 /**
  * Mocked function for testing menus in WPML
- * FIXME #1793 replace direct Timber\Menu instantiations
+ * @todo #1793 replace direct Timber\Menu instantiations
  */
 function wpml_object_id_filter( $element_id, $element_type = 'post', $return_original_if_missing = false, $language_code = null ) {
 	$locations = get_nav_menu_locations();

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -188,6 +188,14 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->markTestSkipped();
 	}
 
+	function testGetTermWithSlug(){
+		// @todo #2087
+		$this->markTestSkipped();
+		$term_id = $this->factory->term->create(array('name' => 'New England Patriots'));
+		$term = Timber::get_term('new-england-patriots');
+		$this->assertEquals($term->ID, $term_id);
+	}
+
 	function testGetTerms(){
 		$posts = $this->factory->post->create_many(15, array( 'post_type' => 'post' ) );
 		$tags = array();

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -173,6 +173,21 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 	}
 
 	/* Terms */
+	function testGetTerm(){
+		// @todo #2087
+		$this->markTestSkipped();
+	}
+
+	function testGetTermWithTaxonomyParam(){
+		// @todo #2087
+		$this->markTestSkipped();
+	}
+
+	function testGetTermWithObject(){
+		// @todo #2087
+		$this->markTestSkipped();
+	}
+
 	function testGetTerms(){
 		$posts = $this->factory->post->create_many(15, array( 'post_type' => 'post' ) );
 		$tags = array();

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -212,9 +212,7 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 			$results[] = $term->name;
 		}
 		sort($results);
-		$this->assertTrue(arrays_are_similar($results, $tags));
-
-		//lets add one more occurance in..
+		$this->assertEquals($results, $tags);
 
 	}
 
@@ -282,20 +280,4 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->assertEquals('Timber\Post', get_class($post));
 	}
 
-}
-
-function arrays_are_similar($a, $b) {
-  	// if the indexes don't match, return immediately
-	if (count(array_diff_assoc($a, $b))) {
-		return false;
-	}
-	// we know that the indexes, but maybe not values, match.
-	// compare the values between the two arrays
-	foreach($a as $k => $v) {
-		if ($v !== $b[$k]) {
-			return false;
-		}
-	}
-	// we have identical indexes, and no unequal values
-	return true;
 }

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -2,6 +2,9 @@
 
 use Timber\LocationManager;
 
+/**
+ * @group called-post-constructor
+ */
 class TestTimberMainClass extends Timber_UnitTestCase {
 
 	function testSample() {
@@ -11,27 +14,18 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 
 	function testGetPostNumeric(){
 		$post_id = $this->factory->post->create();
-		$post = new Timber\Post($post_id);
-		$this->assertEquals('Timber\Post', get_class($post));
-		/** Test deprecated method */
 		$post = Timber::get_post($post_id);
 		$this->assertEquals('Timber\Post', get_class($post));
 	}
 
 	function testGetPostString(){
 		$this->factory->post->create();
-		$post = new Timber\Post('post_type=post');
-		$this->assertEquals('Timber\Post', get_class($post));
-		/** Test deprecated method */
 		$post = Timber::get_post('post_type=post');
 		$this->assertEquals('Timber\Post', get_class($post));
 	}
 
 	function testGetPostBySlug(){
 		$this->factory->post->create(array('post_name' => 'kill-bill'));
-		$post = new Timber\Post('kill-bill');
-		$this->assertEquals('kill-bill', $post->post_name);
-		/** Test deprecated method */
 		$post = Timber::get_post('kill-bill');
 		$this->assertEquals('kill-bill', $post->post_name);
 	}
@@ -42,7 +36,6 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$post = new TimberAlert($wp_post);
 		$this->assertEquals('TimberAlert', get_class($post));
 		$this->assertEquals($pid, $post->ID);
-		/** Test deprecated method */
 		$post = Timber::get_post($wp_post, 'TimberAlert');
 		$this->assertEquals('TimberAlert', get_class($post));
 		$this->assertEquals($pid, $post->ID);
@@ -58,7 +51,6 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		) );
 		$this->assertEquals('TimberAlert', get_class($posts[0]));
 		$this->assertEquals($pid, $posts[0]->ID);
-		/** Test deprecated method */
 		$post = Timber::get_post(array('post_type' => 'post'), 'TimberAlert');
 		$this->assertEquals('TimberAlert', get_class($post));
 		$this->assertEquals($pid, $post->ID);
@@ -71,7 +63,6 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->assertEquals('TimberAlert', get_class($post));
 		$this->assertEquals($pid, $post->ID);
 		$this->assertEquals('event', $post->post_type);
-		/** Test deprecated method */
 		$post = Timber::get_post($pid, 'TimberAlert');
 		$this->assertEquals('TimberAlert', get_class($post));
 		$this->assertEquals($pid, $post->ID);
@@ -81,7 +72,6 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 	function testGetPostWithCustomPostTypeNotPublic() {
 		register_post_type('event', array('public' => false));
 		$pid = $this->factory->post->create(array('post_type' => 'event'));
-		/** Test deprecated method */
 		$post = Timber::get_post($pid, 'TimberAlert');
 		$this->assertEquals('TimberAlert', get_class($post));
 		$this->assertEquals($pid, $post->ID);
@@ -105,38 +95,11 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->assertEquals('Timber\Post', get_class($posts[0]));
 	}
 
-	/**
-	 * This tests some ridiculous notion I had of using DOM style selection for WP posts (like "#my-post"). There's no way anyone uses it.
-	 * @deprecated since 2.0
-	 */
-	// function testGetPostsFromSlugWithHash(){
-	// 	$post_id = $this->factory->post->create();
-	// 	/** Test deprecated method */
-	// 	$post = Timber::get_post($post_id);
-	// 	$str = '#'.$post->post_name;
-	// 	$post = Timber::get_post($str);
-	// 	$this->assertEquals($post_id, $post->ID);
-	// }
-
-	/**
-	 * This tests some ridiculous notion I had of using DOM style selection for WP posts (like "my-post-type#my-post"). There's no way anyone uses it.
-	 * @deprecated since 2.0
-	 */
-	// function testGetPostsFromSlugWithHashAndPostType(){
-	// 	$post_id = $this->factory->post->create();
-	// 	/** Test deprecated method */
-	// 	$post = Timber::get_post($post_id);
-	// 	$str = $post->post_type.'#'.$post->post_name;
-	// 	$post = Timber::get_post($str);
-	// 	$this->assertEquals($post_id, $post->ID);
-	// }
-
 	function testGetPostsFromSlug(){
 		$post_id = $this->factory->post->create(array('post_name' => 'mycoolpost'));
-		$post    = new Timber\Post('mycoolpost');
+		$post    = Timber::get_post('mycoolpost');
 		$this->assertEquals($post_id, $post->ID);
 
-		/** Test deprecated method */
 		$post = Timber::get_post('mycoolpost');
 		$this->assertEquals($post_id, $post->ID);
 	}
@@ -243,18 +206,13 @@ class TestTimberMainClass extends Timber_UnitTestCase {
         $_GET['preview']    = true;
         $_GET['preview_id'] = $post_id;
 
-        /** This doesn't work in unit tests, but works fine in tests on dev sites */
-        //$the_post = new Timber\Post( $post_id );
-        //$this->assertEquals( 'New Stuff Goes here', $the_post->post_content );
-
-        /** Test deprecated method */
         $the_post = Timber::get_post( $post_id );
         $this->assertEquals( 'New Stuff Goes here', $the_post->post_content );
     }
 
     function testTimberRenderString() {
     	$pid = $this->factory->post->create(array('post_title' => 'Zoogats'));
-        $post = new Timber\Post($pid);
+        $post = Timber::get_post($pid);
         ob_start();
         Timber::render_string('<h2>{{post.title}}</h2>', array('post' => $post));
        	$data = ob_get_contents();
@@ -264,7 +222,7 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 
     function testTimberRender() {
     	$pid = $this->factory->post->create(array('post_title' => 'Foobar'));
-        $post = new Timber\Post($pid);
+        $post = Timber::get_post($pid);
         ob_start();
         Timber::render('assets/single-post.twig', array('post' => $post));
        	$data = ob_get_contents();
@@ -283,7 +241,7 @@ class TestTimberMainClass extends Timber_UnitTestCase {
     	$this->assertEquals('I am single course', $str);
     }
 
-    /**
+  /**
 	 * @ticket 1660
 	 */
 	function testDoubleInstantiationOfSubclass() {


### PR DESCRIPTION
**Ticket**: #1793 

## Issue

We're moving to a new API that will restrict direct instantiation of core Timber objects (`Post`, `User`, `Menu`, etc.) in favor of corresponding `Timber::get_*` calls.

## Solution

This refactors away most direct instantiations within the tests. Some refactors we'll need to do eventually are impossible right now, since the `Timber` class lacks some `get_*` methods we'll need to replace the calls with. I don't want to add any code just yet, so I'm just taking care of the low hanging fruit right now.

## Impact

None.

## Usage Changes

No changes to production code in this PR; only tests.

## Considerations

???

## Testing

You know I'm all about those tests tho.