### PR TITLE
Remove debug attribute sent to TwigEnvironment based on #2084

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -152,7 +152,7 @@ class Loader {
 	 */
 	public function get_twig() {
 		$loader = $this->get_loader();
-		$params = array('debug' => WP_DEBUG, 'autoescape' => false);
+		$params = array('autoescape' => false);
 		if ( isset(Timber::$autoescape) ) {
 			$params['autoescape'] = Timber::$autoescape === true ? 'html' : Timber::$autoescape;
 		}

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -71,7 +71,8 @@ class Loader {
 			}
 			$data = apply_filters('timber_loader_render_data', $data);
 			$data = apply_filters('timber/loader/render_data', $data, $file);
-			$output = $twig->render($file, $data);
+			$template = $twig->load($file);
+			$output = $template->render($data);
 		}
 
 		if ( false !== $output && false !== $expires && null !== $key ) {
@@ -152,7 +153,7 @@ class Loader {
 	 */
 	public function get_twig() {
 		$loader = $this->get_loader();
-		$params = array('autoescape' => false);
+		$params = array('debug' => WP_DEBUG,'autoescape' => false);
 		if ( isset(Timber::$autoescape) ) {
 			$params['autoescape'] = Timber::$autoescape === true ? 'html' : Timber::$autoescape;
 		}


### PR DESCRIPTION
**Ticket**: #2084

## Issue
A false debug status seems to screw with something in new Twig versions, triggering a WSOD

## Solution
Don't tell the Twig Environment the value of `WP_DEBUG`

## Impact
Let's see — more investigation required following the results of automated test and review of Twig source (and changes in recent versions)

## Usage Changes
None

## Considerations
Let's see what Twig debugging is doing and whether it should be accessible from the Timber or WP layers

## Testing
No new tests