### PR TITLE
Fix non-relative site url

### DIFF
--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -21,7 +21,7 @@ class Admin {
 	public static function meta_links( $links, $file ) {
 		if ( strstr($file, '/timber.php') ) {
 			unset($links[2]);
-			$links[] = '<a href="' . get_site_url(). '/wp-admin/plugin-install.php?tab=plugin-information&amp;plugin=timber-library&amp;TB_iframe=true&amp;width=600&amp;height=550" class="thickbox" aria-label="More information about Timber" data-title="Timber">View details</a>';
+			$links[] = '<a href="' . admin_url( '/wp-admin/plugin-install.php?tab=plugin-information&amp;plugin=timber-library&amp;TB_iframe=true&amp;width=600&amp;height=550' ) . '" class="thickbox" aria-label="More information about Timber" data-title="Timber">View details</a>';
 			$links[] = '<a href="http://upstatement.com/timber" target="_blank">Homepage</a>';
 			$links[] = '<a href="https://timber.github.io/docs/" target="_blank">Documentation</a>';
 			$links[] = '<a href="https://timber.github.io/docs/getting-started/setup/" target="_blank">Starter Guide</a>';

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -21,7 +21,7 @@ class Admin {
 	public static function meta_links( $links, $file ) {
 		if ( strstr($file, '/timber.php') ) {
 			unset($links[2]);
-			$links[] = '<a href="/wp-admin/plugin-install.php?tab=plugin-information&amp;plugin=timber-library&amp;TB_iframe=true&amp;width=600&amp;height=550" class="thickbox" aria-label="More information about Timber" data-title="Timber">View details</a>';
+			$links[] = '<a href="' . get_site_url(). '/wp-admin/plugin-install.php?tab=plugin-information&amp;plugin=timber-library&amp;TB_iframe=true&amp;width=600&amp;height=550" class="thickbox" aria-label="More information about Timber" data-title="Timber">View details</a>';
 			$links[] = '<a href="http://upstatement.com/timber" target="_blank">Homepage</a>';
 			$links[] = '<a href="https://timber.github.io/docs/" target="_blank">Documentation</a>';
 			$links[] = '<a href="https://timber.github.io/docs/getting-started/setup/" target="_blank">Starter Guide</a>';

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -35,7 +35,7 @@ use Timber\Loader;
  */
 class Timber {
 
-	public static $version = '1.12.0';
+	public static $version = '1.12.1';
 	public static $locations;
 	public static $dirname = 'views';
 	public static $twig_cache = false;


### PR DESCRIPTION
**Ticket**: #2112

## Issue
The view details link on the plugins screen is 'hardcoded' and is always relative to root. If you install WPP in a subfolder it'll break.

## Solution
Solution explained [here](https://github.com/timber/timber/issues/2112#issue-524300512)

## Impact
None


## Usage Changes
None that I can see

## Testing
No