### PR TITLE
fix(ImageHelper): apply URLHelper filter to home_url

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -33,7 +33,8 @@ class ImageHelper {
 	static $home_url;
 
 	public static function init() {
-		self::$home_url = get_home_url();
+		$home_url = get_home_url();
+		self::$home_url = apply_filters('timber/URLHelper/get_content_subdir/home_url', $home_url);
 		add_action('delete_attachment', array(__CLASS__, 'delete_attachment'));
 		add_filter('wp_generate_attachment_metadata', array(__CLASS__, 'generate_attachment_metadata'), 10, 2);
 		add_filter('upload_dir', array(__CLASS__, 'add_relative_upload_dir_key'), 10, 2);


### PR DESCRIPTION
## Issue
With WPML enabled and set to use subdirectories for languages, the relative image path is not resolved correctly. Instead it is an absolute url including the WPML language code. This leads to 404s if you rely on it.


## Solution
Apply the existing URLHelper filter `timber/URLHelper/get_content_subdir/home_url` that takes care of stripping the language code from the home url.


## Impact
This only uses existing functionality. The relative path was broken before. There should not be any other impact.

## Testing
I could not any test coverage regarding the relative path in the first place. So I did not at any new test.

Cheers.