### PR TITLE
ref #2120 #1594 -- deprecate custom filter filter

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -207,6 +207,11 @@ class Twig {
 		$twig->addFilter(new Twig_Filter('list', array($this, 'add_list_separators')));
 
 		$twig->addFilter(new Twig_Filter('pluck', array('Timber\Helper', 'pluck')));
+
+		/** 
+		 * @deprecated since 1.13 (to be removed in 2.0). Use Twig's native filter filter instead
+		 * @ticket #1594 #2120
+		 */
 		$twig->addFilter(new Twig_Filter('filter', array('Timber\Helper', 'filter_array')));
 
 		$twig->addFilter(new Twig_Filter('relative', function( $link ) {


### PR DESCRIPTION
**Ticket**: #2120

## Issue
In #1594 we made a custom `filter` filter (confusing yet?). Not long after, Twig introduced its own `filter` filter with a similar behavior (though different syntax):

https://twig.symfony.com/doc/2.x/filters/filter.html

## Solution
Deprecate the filter in 1.x — I'm going to do another PR to remove it from 2.0 all together

## Usage Changes
No usage change. 1.x users would still use the "old" syntax to use `filter`. I can't think of a good way to let someone disable our custom `filter` filter w/o doing a whole mini-production

## Considerations
In a perfect world we would do that mini-production, but I think we should focus on ...
a) acknowledge the issue
b) truly resolve in 2.0

