### PR TITLE
Remove filter filter in 2.x

### DIFF
--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -518,4 +518,7 @@ The following Twig filters have been deprecated and will be removed in future ve
 * `get_class`
 * `print_r`
 
-In addition, the confusingly named (and non-functional) `get_type` filter has been removed.
+## Removed Twig filters
+
+* `get_type` was not only confusingly named, it was non-functional — goodbye!
+* `filter` Twig introduced its own filter filter in Twig 2.10 which you can use in Timber 2.x. However, Timber had its own version of a `filter` filter which was removed to not conflict with the native Twig API. If you need to use this older `filter` filter, you can add it manually to your project by copying the code in `lib/Twig.php`

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -230,7 +230,6 @@ class Twig {
 		$twig->addFilter(new TwigFilter('pluck', array('Timber\Helper', 'pluck')));
 		
 		/** 
-		 * @removed
 		 * @deprecated since 1.13 and removed in 2.0. Use Twig's native filter filter instead 
 		 * (which was introduced after Timber's version). In this instance we want to use the native
 		 * Twig API when available. If you want to continue to use the Timber 1.x version in your 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -228,7 +228,16 @@ class Twig {
 		$twig->addFilter(new TwigFilter('list', array($this, 'add_list_separators')));
 
 		$twig->addFilter(new TwigFilter('pluck', array('Timber\Helper', 'pluck')));
-		$twig->addFilter(new TwigFilter('filter', array('Timber\Helper', 'filter_array')));
+		
+		/** 
+		 * @removed
+		 * @deprecated since 1.13 and removed in 2.0. Use Twig's native filter filter instead 
+		 * (which was introduced after Timber's version). In this instance we want to use the native
+		 * Twig API when available. If you want to continue to use the Timber 1.x version in your 
+		 * project, you can copy-and-paste the deprecated line below into your functions.php file.
+		 * @ticket #1594 #2120
+		 */
+		//$twig->addFilter(new TwigFilter('filter', array('Timber\Helper', 'filter_array')));
 
 		$twig->addFilter(new TwigFilter('relative', function( $link ) {
 					return URLHelper::get_rel_url($link, true);


### PR DESCRIPTION
**Ticket**: #2120 #2121 

## Issue
In #1594 we made a custom filter filter (confusing yet?). Not long after, Twig introduced its own filter filter with a similar behavior (though different syntax):

https://twig.symfony.com/doc/2.x/filters/filter.html

## Solution
In #2121 I deprecated it in 1.x — here, we remove it all together. 

## Impact
Backwards compatibility will be shot in this particular issue; which makes me realize I should update the upgrade guide with a specific note.

## Usage Changes
Users will now use Twig's filter filter, and filter filter only.

## Considerations
I left the code intact as a comment so that users can grab that portion and throw it in their index.php if they want to ease an upgrade or just happen to love/prefer that syntax.
