### PR TITLE
Twig filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=5.3.0|7.*",
-    "twig/twig": "^1.38|^2.4",
+    "twig/twig": "^1.41|^2.10",
     "upstatement/routes": "0.5",
     "composer/installers": "~1.0",
     "asm89/twig-cache-extension": "~1.0"

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -423,16 +423,38 @@ class Helper {
 
 	/**
 	 * Filters a list of objects, based on a set of key => value arguments.
+	 * Uses native Twig Filter.
+	 *
+	 * @since x.x.x
+	 * @param array                 $list to filter.
+	 * @param callback|string|array $arrow function used for filtering,
+	 *                              string or array for backward compatibility.
+	 * @param string                $operator to use (AND, NOT, OR). For backward compatibility.
+	 * @return array
+	 */
+	public static function filter_array( $list, $arrow, $operator = 'AND' ) {
+		if ( ! is_callable( $arrow ) ) {
+			self::warn( 'filter is using Twig\'s filter by default. If you want to use wp_filter_array use array|wp_list_filter.' );
+
+			return self::wp_filter_array( $list, $arrow, $operator );
+		}
+
+		return twig_array_filter( $list, $arrow );
+	}
+
+	/**
+	 * Filters a list of objects, based on a set of key => value arguments.
+	 * Uses WordPress WP_List_Util's filter.
 	 *
 	 * @since 1.5.3
 	 * @ticket #1594
 	 * @param array        $list to filter.
-	 * @param string|array $filter to search for.
+	 * @param string|array $args to search for.
 	 * @param string       $operator to use (AND, NOT, OR).
 	 * @return array
 	 */
-	public static function filter_array( $list, $args, $operator = 'AND' ) {
-		if ( ! is_array($args) ) {
+	public static function wp_filter_array( $list, $args, $operator = 'AND' ) {
+		if ( ! is_array( $args ) ) {
 			$args = array( 'slug' => $args );
 		}
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -434,8 +434,7 @@ class Helper {
 	 */
 	public static function filter_array( $list, $arrow, $operator = 'AND' ) {
 		if ( ! is_callable( $arrow ) ) {
-			self::warn( 'This filter is using Twig\'s filter by default. If you want to use wp_list_filter use array|wp_list_filter.' );
-
+			self::warn( 'This filter is using Twig\'s filter by default. If you want to use wp_list_filter use {{ my_array|wp_list_filter }}.' );
 			return self::wp_list_filter( $list, $arrow, $operator );
 		}
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -434,9 +434,9 @@ class Helper {
 	 */
 	public static function filter_array( $list, $arrow, $operator = 'AND' ) {
 		if ( ! is_callable( $arrow ) ) {
-			self::warn( 'filter is using Twig\'s filter by default. If you want to use wp_filter_array use array|wp_list_filter.' );
+			self::warn( 'This filter is using Twig\'s filter by default. If you want to use wp_list_filter use array|wp_list_filter.' );
 
-			return self::wp_filter_array( $list, $arrow, $operator );
+			return self::wp_list_filter( $list, $arrow, $operator );
 		}
 
 		return twig_array_filter( $list, $arrow );
@@ -453,7 +453,7 @@ class Helper {
 	 * @param string       $operator to use (AND, NOT, OR).
 	 * @return array
 	 */
-	public static function wp_filter_array( $list, $args, $operator = 'AND' ) {
+	public static function wp_list_filter( $list, $args, $operator = 'AND' ) {
 		if ( ! is_array( $args ) ) {
 			$args = array( 'slug' => $args );
 		}

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -208,6 +208,7 @@ class Twig {
 
 		$twig->addFilter(new Twig_Filter('pluck', array('Timber\Helper', 'pluck')));
 		$twig->addFilter(new Twig_Filter('filter', array('Timber\Helper', 'filter_array')));
+		$twig->addFilter(new Twig_Filter('wp_list_filter', array('Timber\Helper', 'wp_filter_array')));
 
 		$twig->addFilter(new Twig_Filter('relative', function( $link ) {
 					return URLHelper::get_rel_url($link, true);

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -214,7 +214,7 @@ class Twig {
 		 * @ticket #1594 #2120
 		 */
 		$twig->addFilter(new Twig_Filter('filter', array('Timber\Helper', 'filter_array')));
-		$twig->addFilter(new Twig_Filter('wp_list_filter', array('Timber\Helper', 'wp_filter_array')));
+		$twig->addFilter(new Twig_Filter('wp_list_filter', array('Timber\Helper', 'wp_list_filter')));
 
 		$twig->addFilter(new Twig_Filter('relative', function( $link ) {
 					return URLHelper::get_rel_url($link, true);

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -207,6 +207,10 @@ class Twig {
 		$twig->addFilter(new Twig_Filter('list', array($this, 'add_list_separators')));
 
 		$twig->addFilter(new Twig_Filter('pluck', array('Timber\Helper', 'pluck')));
+		
+		/**
+		 * @todo remove this in 2.x so that filter merely passes to Twig's filter without any modification
+		 */
 		$twig->addFilter(new Twig_Filter('filter', array('Timber\Helper', 'filter_array')));
 		$twig->addFilter(new Twig_Filter('wp_list_filter', array('Timber\Helper', 'wp_filter_array')));
 

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -213,17 +213,24 @@
 		}
 
 		/**
- 		 * @expectedException Twig\Error\RuntimeError
+		 * Updated to new syntax
+		 * @ticket #2124
 		 */
-		function testArrayFilter() {
+		function testNewArrayFilter() {
 			$posts = [];
 			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
 			$posts[] = $this->factory->post->create(array('post_title' => 'Snoop', 'post_content' => 'Felicia Pearson'));
 			$posts[] = $this->factory->post->create(array('post_title' => 'Cheese', 'post_content' => 'Method Man'));
 			$posts = Timber::get_posts($posts);
-			$template = '{% for post in posts | filter("snoop")%}{{ post.content|striptags }}{% endfor %}';
+			$template = '{% for post in posts | wp_list_filter("snoop")%}{{ post.content|striptags }}{% endfor %}';
 			$str = Timber::compile_string($template, array('posts' => $posts));
 			$this->assertEquals('Felicia Pearson', trim($str));
+		}
+
+		function testTwigFilterFilter() {
+			$template = "{% set sizes = [34, 36, 38, 40, 42] %}{{ sizes|filter(v => v > 38)|join(', ') }}";
+			$str = Timber::compile_string($template);
+			$this->assertEquals("40, 42", $str);
 		}
 
 		/**

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -212,6 +212,9 @@
 			$this->assertEquals(1984, $people[1]->year);
 		}
 
+		/**
+ 		 * @expectedException Twig\Error\RuntimeError
+		 */
 		function testArrayFilter() {
 			$posts = [];
 			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
@@ -223,6 +226,9 @@
 			$this->assertEquals('Felicia Pearson', trim($str));
 		}
 
+		/**
+ 		 * @expectedException Twig\Error\RuntimeError
+		 */
 		function testArrayFilterKeyValueUsingPostQuery() {
 			$posts = [];
 			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
@@ -235,6 +241,9 @@
 			$this->assertEquals('Cheese', trim($str));
 		}
 
+		/**
+ 		 * @expectedException Twig\Error\RuntimeError
+		 */
 		function testArrayFilterMulti() {
 			$posts = [];
 			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
@@ -246,6 +255,9 @@
 			$this->assertEquals('Stringer Bell Snoop', trim($str));
 		}
 
+		/**
+ 		 * @expectedException Twig\Error\RuntimeError
+		 */
 		function testArrayFilterWithBogusArray() {
 			$template = '{% for post in posts | filter({slug:"snoop", post_content:"Idris Elba"}, "OR")%}{{ post.title }} {% endfor %}';
 			$str = Timber::compile_string($template, array('posts' => 'foobar'));


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

**Ticket**: #2010 

## Issue
Twig and Timber have filter called `filter` and now we have a problem.


## Solution
Adds new filter called `wp_list_filter` and adds backward compatibility and warning to normal `filter`.


## Impact
User's that use the `filter` and with string or array as second param will get a warning.


## Usage Changes
The twig filter works a bit different - https://twig.symfony.com/doc/3.x/filters/filter.html.

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Not yet
