### PR TITLE
Prevent double slashes in URLs

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -503,7 +503,7 @@ class ImageHelper {
 		if ( !$absolute ) {
 			$url = str_replace(site_url(), '', $url);
 		}
-		// $url = TimberURLHelper::remove_double_slashes( $url);
+		$url = TimberURLHelper::remove_double_slashes( $url);
 		return $url;
 	}
 

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -499,11 +499,10 @@ class ImageHelper {
 		if ( !empty($subdir) ) {
 			$url .= $subdir;
 		}
-		$url .= '/'.$filename;
+		$url = untrailingslashit($url).'/'.$filename;
 		if ( !$absolute ) {
 			$url = str_replace(site_url(), '', $url);
 		}
-		$url = TimberURLHelper::remove_double_slashes( $url);
 		return $url;
 	}
 


### PR DESCRIPTION
**Ticket**: #2118

## Issue
There are some situations where a double slash can occur (server or setting-specific?) in an image path. This removes them.

## Solution
Make sure the original URL doesn't end with a trailing slash. THEN apply one

## Impact
This seems to be a more elegant way of ensuring there aren't double slashes at a concatenation point, without applying the brute force-style `TimberURLHelper::remove_double_slashes` that was commented-out

## Usage Changes
None!

## Considerations
There could be another place in the code that's causing the error seen in #2118 — but this one seems promising

## Testing
No new tests required, let's see what Travis says ...
