### PR TITLE
Fix .editorconfig syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,5 +20,8 @@ indent_size = 2
 [*.md]
 indent_style = space
 
-[*.txt,wp-config-sample.php]
+[*.txt]
+end_of_line = crlf
+
+[wp-config-sample.php]
 end_of_line = crlf


### PR DESCRIPTION
## Issue

PhpStorm flagged a syntax issue in the **.editorconfig** file. Apparently, listing multiple patterns with commas doesn’t seem to be possible?

```ini
[*.txt,wp-config-sample.php]
```

## Solution

Create separate rules instead of separating rules by comma.

## Impact

Rules should be applied.

## Usage Changes

None.

## Considerations

None?

## Testing

Nope.