### PR TITLE
Avoid post content bypassing by ACF named 'content'

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -67,7 +67,7 @@ abstract class Core {
 				}
 				if ( !empty($key) && $force ) {
 					$this->$key = $value;
-				} else if ( !empty($key) && !method_exists($this, $key) ) {
+				} else if ( !empty($key) && !method_exists($this, $key) && $key !== '_content' ) {
 					$this->$key = $value;
 				}
 			}

--- a/lib/Core.php
+++ b/lib/Core.php
@@ -57,6 +57,9 @@ abstract class Core {
 	 * @param array|object $info an object or array you want to grab data from to attach to the Timber object
 	 */
 	public function import( $info, $force = false ) {
+		$disallowed_properties = array();
+		$disallowed_properties = apply_filters('timber/post/disallowed_properties', $disallowed_properties);
+
 		if ( is_object($info) ) {
 			$info = get_object_vars($info);
 		}
@@ -67,7 +70,7 @@ abstract class Core {
 				}
 				if ( !empty($key) && $force ) {
 					$this->$key = $value;
-				} else if ( !empty($key) && !method_exists($this, $key) && $key !== '_content' ) {
+				} else if ( !empty($key) && !method_exists($this, $key) && !in_array($key, $disallowed_properties)) {
 					$this->$key = $value;
 				}
 			}

--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -16,6 +16,7 @@ class ACF {
 		add_filter('timber_post_get_meta', array( $this, 'post_get_meta' ), 10, 2);
 		add_filter('timber_post_get_meta_field', array( $this, 'post_get_meta_field' ), 10, 3);
 		add_filter('timber/post/meta_object_field', array( $this, 'post_meta_object' ), 10, 3);
+		add_filter('timber/post/disallowed_properties', array( $this, 'post_disallowed_properties' ), 10, 1);
 		add_filter('timber/term/meta', array( $this, 'term_get_meta' ), 10, 3);
 		add_filter('timber/term/meta/field', array( $this, 'term_get_meta_field' ), 10, 4);
 		add_filter('timber_user_get_meta_field_pre', array( $this, 'user_get_meta_field' ), 10, 3);
@@ -37,6 +38,10 @@ class ACF {
 	public function term_get_meta_field( $value, $term_id, $field_name, $term ) {
 		$searcher = $term->taxonomy . '_' . $term->ID;
 		return get_field($field_name, $searcher);
+	}
+
+	public function post_disallowed_properties( $properties ) {
+		return $properties;
 	}
 
 	public function term_set_meta( $value, $field, $term_id, $term ) {

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -208,7 +208,7 @@ class Twig {
 
 		$twig->addFilter(new Twig_Filter('pluck', array('Timber\Helper', 'pluck')));
 
-		/** 
+		/**
 		 * @deprecated since 1.13 (to be removed in 2.0). Use Twig's native filter filter instead
      *  @todo remove this in 2.x so that filter merely passes to Twig's filter without any modification
 		 * @ticket #1594 #2120
@@ -392,5 +392,4 @@ class Twig {
 		}
 		return $list;
 	}
-
 }

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -88,6 +88,15 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$acf = new ACF();
 		$this->assertInstanceOf( 'Timber\Integrations\ACF', $acf );
 	}
+	
+	function testACFContentField() {
+		$pid = $this->factory->post->create(array('post_content' => 'Cool content bro!'));
+		update_field( '_content', 'I am custom content', $pid );
+		$str = '{{ post.content }}';
+		$post = new Timber\Post( $pid );
+		$str = Timber::compile_string( $str, array( 'post' => $post ) );
+		$this->assertEquals( '<p>Cool content bro!</p>', trim($str) );
+	}
 
 	function testWPCLIClearCacheTimber(){
 		$str = Timber::compile('assets/single.twig', array('rand' => 4004), 600);


### PR DESCRIPTION
Proposal to avoid bypassing post content with the ACF named 'content'.

**Ticket**: #2142 

## Issue
When we create ACF field named 'content', the post content output doesn't work and the field id was displayed.

## Solution
Create special condition to get the_content with filters applied with {{ post.content }} (without override).

And if you want, you can use post.meta('content') to get the ACF field content.

I don't know if it's the best solution, but at the moment it's working very well on a project.
