### PR TITLE
2.x Improve Helper::deprecated()

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -273,10 +273,15 @@ class Helper {
 	/**
 	 * Triggers a deprecation warning.
 	 *
+	 * If you want to catch errors like these in tests, then add the @expectedDeprecated tag to the
+	 * DocBlock. E.g.: "@expectedDeprecated {{ TimberImage() }}".
+	 *
 	 * @api
+	 *
 	 * @param string $function    The name of the deprecated function/method.
 	 * @param string $replacement Function to use instead.
 	 * @param string $version     When we deprecated this.
+	 *
 	 * @return void
 	 */
 	public static function deprecated( $function, $replacement, $version ) {

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -284,34 +284,38 @@ class Helper {
 			return;
 		}
 
-		 do_action( 'deprecated_function_run', $function, $replacement, $version );
+		do_action( 'deprecated_function_run', $function, $replacement, $version );
 
-	    /**
-	     * Filters whether to trigger an error for deprecated functions.
-	     *
-	     * @since 2.5.0
-	     *
-	     * @param bool $trigger Whether to trigger the error for deprecated functions. Default true.
-	     */
-	    if ( WP_DEBUG && apply_filters( 'deprecated_function_trigger_error', true ) ) {
-	        if ( function_exists( '__' ) ) {
-	            if ( ! is_null( $replacement ) ) {
-	                /* translators: 1: PHP function name, 2: version number, 3: alternative function name */
-	                trigger_error( sprintf( __('%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.'), $function, $version, $replacement ) );
-	            } else {
-	                /* translators: 1: PHP function name, 2: version number */
-	                trigger_error( sprintf( __('%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.'), $function, $version ) );
-	            }
-	        } else {
-	            if ( ! is_null( $replacement ) ) {
-	                trigger_error( sprintf( '%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.', $function, $version, $replacement ) );
-	            } else {
-	                trigger_error( sprintf( '%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.', $function, $version ) );
-	            }
-	        }
-	    }
+		/**
+		 * Filters whether to trigger an error for deprecated functions.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param bool $trigger Whether to trigger the error for deprecated functions. Default true.
+		 */
+		if ( apply_filters( 'deprecated_function_trigger_error', true ) ) {
+			return;
+		}
+
+		if ( ! is_null( $replacement ) ) {
+			$error_message = sprintf(
+				'%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.',
+				$function,
+				$version,
+				$replacement
+			);
+		} else {
+			$error_message = sprintf(
+				'%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.',
+				$function,
+				$version
+			);
+		}
+
+		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( $error_message );
 	}
-
 
 	/**
 	 * @api


### PR DESCRIPTION
## Issue

The `Timber\Helper::deprecated()` function contains some code that is unnecessary. And I saw some other optimizations that would make the function more readable.

## Solution

- Remove check for `__()` / handling of translated strings. We don’t have any translatable strings in Timber. Otherwise, we would need to have a `timber` text domain that we would have to add to strings.
- Remove unneeded check for `WP_DEBUG`.
- Use bailout instead of if-wrapping.
- Add info about using `@expectedDeprecated` in tests.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

Nope.