### PR TITLE
2.x factories test fixes

### DIFF
--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -421,7 +421,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$post_id    = $this->factory->post->create();
 		$term_id    = $this->factory->term->create();
 		$user_id    = $this->factory->user->create();
-		$comment_id = $this->factory->comment->create();
+		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
 
 		update_post_meta( $post_id, 'public_method', 'I am a meta value' );
 		update_term_meta( $term_id, 'public_method', 'I am a meta value' );

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -483,7 +483,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$post_id    = $this->factory->post->create();
 		$term_id    = $this->factory->term->create();
 		$user_id    = $this->factory->user->create();
-		$comment_id = $this->factory->comment->create();
+		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
 
 		update_post_meta( $post_id, 'protected_method', 'I am a meta value' );
 		update_term_meta( $term_id, 'protected_method', 'I am a meta value' );
@@ -593,7 +593,9 @@ class TestTimberMeta extends Timber_UnitTestCase {
 	 * @expectedException \ArgumentCountError
 	 */
 	function testCommentMetaDirectAccessMethodWithRequiredParametersConflict() {
-		$comment_id = $this->factory->comment->create();
+
+		$post_id    = $this->factory->post->create();
+		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
 
 		update_comment_meta( $comment_id, 'public_method_with_args', 'I am a meta value' );
 
@@ -622,7 +624,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$post_id    = $this->factory->post->create();
 		$term_id    = $this->factory->term->create();
 		$user_id    = $this->factory->user->create();
-		$comment_id = $this->factory->comment->create();
+		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));
 
 		update_post_meta( $post_id, 'public_property', 'I am a meta value' );
 		update_term_meta( $term_id, 'public_property', 'I am a meta value' );


### PR DESCRIPTION
**Ticket**: #2073 

## Issue
Fixing some failing comment tests!


## Solution
Comments were being created w/o relationship to a post object. This meant when `CommentFactory::get_comment_class` went to try and figure out what class to use it was like, "well I can't match this up to a class b/c it doesn't have a post associated with it (thus no `post_type`)

Making this a PR to your branch so that you can double-check that I did things right and this is your intent