### PR TITLE
Remove duplicate Helper::deprecated code

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -274,7 +274,8 @@ class Helper {
 	 * Triggers a deprecation warning.
 	 *
 	 * If you want to catch errors like these in tests, then add the @expectedDeprecated tag to the
-	 * DocBlock. E.g.: "@expectedDeprecated {{ TimberImage() }}".
+	 * DocBlock. E.g.: "@expectedDeprecated {{ TimberImage() }}". This wraps WordPress's 
+	 * `deprecated_function_run` action.
 	 *
 	 * @api
 	 *
@@ -290,37 +291,8 @@ class Helper {
 		}
 
 		do_action( 'deprecated_function_run', $function, $replacement, $version );
-
-		/**
-		 * Filters whether to trigger an error for deprecated functions.
-		 *
-		 * @since 2.5.0
-		 *
-		 * @param bool $trigger Whether to trigger the error for deprecated functions. Default true.
-		 */
-		if ( apply_filters( 'deprecated_function_trigger_error', true ) ) {
-			return;
-		}
-
-		if ( ! is_null( $replacement ) ) {
-			$error_message = sprintf(
-				'%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.',
-				$function,
-				$version,
-				$replacement
-			);
-		} else {
-			$error_message = sprintf(
-				'%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.',
-				$function,
-				$version
-			);
-		}
-
-		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		trigger_error( $error_message );
 	}
+
 
 	/**
 	 * @api


### PR DESCRIPTION
**Ticket**: #2146 

## Issue
@gchtr's fix in #2146 uncovered that we had a bunch of duplicate code from WordPress. Before his fix, the function was such a mess of spaghetti that you couldn't tell that half of it was never executing. After being reorganized, it DID properly execute — creating a ton of errors.

The second part of the old `Helper::deprecated` function was ripped from WordPress's `_deprecated_function` function:

https://developer.wordpress.org/reference/functions/_deprecated_function/

We were both calling this code through the `deprecated_function_run` hook AND then calling a ripped version of it manually.

## Solution
Remove the duplicate instance of those `trigger_error` calls, have it just run the WP hook:

```php
do_action( 'deprecated_function_run', $function, $replacement, $version );
```


## Impact
Slimmer!

## Usage Changes
None.


## Considerations
This is what it should have been all along. As for the existence of this function in the first place, I think it 
SHOULD still remain so that we have a way to universally control the flow of these notices from Timber to WP.

## Testing
Tests seem to pass locally, let's see what Travis says
