### PR TITLE
Provide notice for min. WordPress version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "twig/cache-extension": "dev-master"
   },
   "require-dev": {
-    "johnpbloch/wordpress": "5.*",
+    "johnpbloch/wordpress": "5.3.*",
     "phpunit/phpunit": "5.7.16|6.*",
     "squizlabs/php_codesniffer": "3.*",
     "wp-coding-standards/wpcs": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "twig/cache-extension": "dev-master"
   },
   "require-dev": {
-    "johnpbloch/wordpress": "5.3.*",
+    "johnpbloch/wordpress": ">=5.3.0",
     "phpunit/phpunit": "5.7.16|6.*",
     "squizlabs/php_codesniffer": "3.*",
     "wp-coding-standards/wpcs": "^2.0",

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -11,6 +11,10 @@ Version 2.0 of Timber removes a lot of deprecated code and tries to make naming 
 
 Timber 2.0 requires you to use a PHP version >= `7.0`.
 
+## Drops WordPress 5.2 and earlier support
+
+Timber 2.0 requires WordPress 5.3 or greater. This was in order to take advantage of new [date/time improvements](https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/) built into WordPress. If you need to use WordPress 5.2 or earlier, please continue to use Timber 1.x.
+
 ## No more plugin support
 
 As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/getting-started/setup/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -8,19 +8,11 @@ namespace Timber;
 class Admin {
 
 	public static function init() {
-		$filter = add_filter('plugin_row_meta', array(__CLASS__, 'meta_links'), 10, 2);
-		$action = add_action('in_plugin_update_message-timber-library/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
-		$action = add_action('in_plugin_update_message-timber/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
 		global $wp_version;
 		if ( version_compare('5.3.0', $wp_version) === 1 ) {
 			// user is running something older that WordPress 5.3 show them an error
 			$upgrade_url = admin_url('update-core.php');
 			self::show_notice("<a href='https://github.com/timber/timber'>Timber 2.0</a> requires <strong>WordPress 5.3</strong> or greater, but you are running <strong>WordPress $wp_version</strong>. Please <a href='$upgrade_url'>upgrade WordPress</a> in order to use Timber 2.0.");
-		}
-
-
-		if ( $filter && $action ) {
-			return true;
 		}
 		return true;
 	}
@@ -39,119 +31,6 @@ class Admin {
 		add_action( 'admin_notices', function() use ( $text, $class ) {
 				echo '<div class="'.$class.'"><p>'.$text.'</p></div>';
 			}, 1 );
-	}
-
-	/**
-	 * @param array   $links
-	 * @param string  $file
-	 * @return array
-	 */
-	public static function meta_links( $links, $file ) {
-		if ( strstr($file, '/timber.php') ) {
-			unset($links[2]);
-			$links[] = '<a href="' . admin_url( '/wp-admin/plugin-install.php?tab=plugin-information&amp;plugin=timber-library&amp;TB_iframe=true&amp;width=600&amp;height=550' ) . '" class="thickbox" aria-label="More information about Timber" data-title="Timber">View details</a>';
-			$links[] = '<a href="http://upstatement.com/timber" target="_blank">Homepage</a>';
-			$links[] = '<a href="https://timber.github.io/docs/" target="_blank">Documentation</a>';
-			$links[] = '<a href="https://timber.github.io/docs/getting-started/setup/" target="_blank">Starter Guide</a>';
-			return $links;
-		}
-		return $links;
-	}
-
-	/**
-	 *	@codeCoverageIgnore
-	 */
-	protected static function disable_update() {
-		$m = '<br>Is your theme in active development? That is, is someone actively in PHP files writing new code? If you answered "no", then <i>DO NOT UPGRADE</i>. ';
-		$m .= "We're so serious about it, we've even disabled the update link. If you really really think you should upgrade you can still <a href='https://wordpress.org/plugins/timber-library/'>download from WordPress.org</a>, but that's on you!";
-		$m .= '<style>#timber-library-update .update-link {pointer-events: none;
-   cursor: default; opacity:0.3;}</style>';
-   		return $m;
-	}
-
-	/**
-	 *	@codeCoverageIgnore
-	 */
-	protected static function update_message_milestone() {
-		$m = '<br><b>Warning:</b> Timber 1.0 removed a number of features and methods. Before upgrading please test your theme on a local or staging site to ensure that your theme will work with the newest version.<br>
-
-			<br><strong>Is your theme in active development?</strong> That is, is someone actively in PHP files writing new code? If you answered "no", then <i>do not upgrade</i>. You will not benefit from Timber 1.0<br>';
-
-		$m .= '<br>Read the <strong><a href="https://timber.github.io/docs/upgrade-guides/1.0/">Upgrade Guide</a></strong> for more information<br>';
-
-		$m .= "<br>You can also <b><a href='https://downloads.wordpress.org/plugin/timber-library.0.22.6.zip'>upgrade to version 0.22.6</a></b> if you want to upgrade, but are unsure if you're ready for 1.0<br>";
-		$m .= self::disable_update();
-		return $m;
-	}
-
-	/**
-	 *	@codeCoverageIgnore
-	 */
-	protected static function update_message_major() {
-		$m = '<br><b>Warning:</b> This new version of Timber introduces some major new features which might have unknown effects on your site.';
-
-
-		$m .= self::disable_update();
-		return $m;
-	}
-
-	/**
-	 *	@codeCoverageIgnore
-	 */
-	protected static function update_message_minor() {
-		$m = "<br><b>Warning:</b> This new version of Timber introduces some new features which might have unknown effects on your site. We have automated tests to help us catch potential issues, but nothing is 100%. You're likely safe to upgrade, but do so very carefully and only if you have an experienced WordPress developer available to help you debug potential issues.";
-		return $m;
-	}
-
-	/**
-	 * Figure out how signficant the upgrade is
-	 *
-	 * @param string $current_version a version string ("1.3.6") that the user is currently on.
-	 * @param string $new_version a version string ("2.0") of what the user is potentially upgrading to.
-	 * @return string a version jump identifier compared against the current one (milestone, major or minor)
-	 */
-	public static function get_upgrade_magnitude( $current_version, $new_version ) {
-		$current_version_array = explode('.', (string) $current_version);
-		$new_version_array     = explode('.', (string) $new_version);
-		if ( $new_version_array[0] > $current_version_array[0] ) {
-			return 'milestone';
-		} elseif ( $new_version_array[1] > $current_version_array[1] ) {
-			return 'major';
-		} elseif ( isset($new_version_array[2]) && isset($current_version_array[2]) && $new_version_array[2] > $current_version_array[2] ) {
-			return 'minor';
-		}
-		return 'unknown';
-	}
-
-	/**
-	 * Displays an update message for plugin list screens.
-	 * Shows only the version updates from the current until the newest version
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @date    4/22/16
-	 *
-	 * @param array  $plugin_data
-	 * @param object $r
-	 */
-	public static function in_plugin_update_message( $plugin_data, $r ) {
-		$current_version = $plugin_data['Version'];
-		$new_version = $plugin_data['new_version'];
-		$upgrade_magnitude = self::get_upgrade_magnitude($current_version, $new_version);
-		if ( $upgrade_magnitude == 'milestone' ) {
-			$message = self::update_message_milestone();
-			echo '<br />'.sprintf($message);
-			return;
-		} elseif ( $upgrade_magnitude == 'major' ) {
-			//major version
-			$message = self::update_message_major();
-			echo '<br />'.sprintf($message);
-			return;
-		}
-		$message = self::update_message_minor();
-		echo '<br />'.($message);
-		return;
-
 	}
 
 }

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -11,9 +11,26 @@ class Admin {
 		$filter = add_filter('plugin_row_meta', array(__CLASS__, 'meta_links'), 10, 2);
 		$action = add_action('in_plugin_update_message-timber-library/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
 		$action = add_action('in_plugin_update_message-timber/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
+
+
+		global $wp_version;
+
+		if ( version_compare('5.3.0', $wp_version) === 1 ) {
+			// user is running something older that WordPress 5.3 show them an error
+			$upgrade_url = admin_url('update-core.php');
+			self::show_notice("<a href='https://github.com/timber/timber'>Timber 2.0</a> requires <strong>WordPress 5.3</strong> or greater, but you are running <strong>WordPress $wp_version</strong>. Please <a href='$upgrade_url'>upgrade WordPress</a> in order to use Timber 2.0.");
+		}
+
+
 		if ( $filter && $action ) {
 			return true;
 		}
+	}
+
+	protected static function show_notice( $text, $class = 'error') {
+		add_action( 'admin_notices', function() use ( $text, $class ) {
+				echo '<div class="'.$class.'"><p>'.$text.'</p></div>';
+			}, 1 );
 	}
 
 	/**

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -20,8 +20,6 @@ class Admin {
 	/**
 	 * Display a message in the admin.
 	 *
-	 * @codeCoverageIgnore
-	 *
 	 * @date    01/07/2020
 	 *
 	 * @param string  $text to display

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -11,10 +11,7 @@ class Admin {
 		$filter = add_filter('plugin_row_meta', array(__CLASS__, 'meta_links'), 10, 2);
 		$action = add_action('in_plugin_update_message-timber-library/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
 		$action = add_action('in_plugin_update_message-timber/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
-
-
 		global $wp_version;
-
 		if ( version_compare('5.3.0', $wp_version) === 1 ) {
 			// user is running something older that WordPress 5.3 show them an error
 			$upgrade_url = admin_url('update-core.php');
@@ -25,8 +22,19 @@ class Admin {
 		if ( $filter && $action ) {
 			return true;
 		}
+		return true;
 	}
 
+	/**
+	 * Display a message in the admin.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @date    01/07/2020
+	 *
+	 * @param string  $text to display
+	 * @param string  $class of the notice 'error' (red) or 'warning' (yellow)
+	 */
 	protected static function show_notice( $text, $class = 'error') {
 		add_action( 'admin_notices', function() use ( $text, $class ) {
 				echo '<div class="'.$class.'"><p>'.$text.'</p></div>';

--- a/tests/test-timber-admin.php
+++ b/tests/test-timber-admin.php
@@ -4,34 +4,6 @@ use Timber\Admin;
 
 class TestTimberAdmin extends Timber_UnitTestCase {
 
-	function testSettingsLinks() {
-        $links = apply_filters( 'plugin_row_meta', array(), 'timber/timber.php' );
-
-        $links = implode( ' ', $links );
-        $this->assertContains( 'Documentation', $links );
-
-        $links = apply_filters( 'plugin_row_meta', array(), 'foo/bar.php' );
-        if ( isset( $links ) ) {
-            $this->assertNotContains( 'Documentation', $links );
-        }
-    }
-
-    function testVersionMagnitude() {
-        $mag = Timber\Admin::get_upgrade_magnitude('1.1.2', '2.0');
-        $this->assertEquals('milestone', $mag);
-    }
-
-    function testVersionMagnitudeMajor() {
-        $mag = Timber\Admin::get_upgrade_magnitude('1.1.2', '1.2.0');
-        $this->assertEquals('major', $mag);
-        $mag = Timber\Admin::get_upgrade_magnitude('1.1.2', '1.2');
-        $this->assertEquals('major', $mag);
-    }
-
-    function testVersionMagnitudeMinor() {
-        $mag = Timber\Admin::get_upgrade_magnitude('1.1.2', '1.1.4');
-        $this->assertEquals('minor', $mag);
-    }
 
     function testAdminInit() {
     	$admin = Admin::init();


### PR DESCRIPTION
**Ticket**: #2151 

## Issue
As discussed in #2135, we're dropping support for WordPress versions prior to 5.3 in 2.x. To do this, we need to let people know.

## Solution
Let 'em know! Through the upgrade guide, ensuring the `require-dev` in composer is correct (we can't do comments/annotations in here, but this is one way to indicate) and an admin notice in case someone is running a WP version that's older than 5.3.

Once inside of the `Admin` class I realized we could get rid of the bulk of what's here since it modifies the plug-in entry for Timber (which we're also not supporting in 2.x, in favor of Composer/Packagist only)

## Impact
This helps let devs know to upgrade their WordPress.


## Considerations
We could copy over some of this code into 1.x (perhaps upon the last release to WP.org) to let people know that there won't be any further plugin support and to upgrade to both WP 5.3+ and Timber 2.x+ for new sites
