### PR TITLE
2.x Fix deprecated() function

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -298,7 +298,7 @@ class Helper {
 		 *
 		 * @param bool $trigger Whether to trigger the error for deprecated functions. Default true.
 		 */
-		if ( apply_filters( 'deprecated_function_trigger_error', true ) ) {
+		if ( ! apply_filters( 'deprecated_function_trigger_error', true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
**Ticket**: #2146, #2154

## Issue

There are many test errors in 2.x, because I got a bailout wrong in #2146. Sorry for that.

## Solution

Fix bailout.

## Impact

Tests should work again.

## Usage Changes

None.

## Considerations

None.

## Testing

None.