### PR TITLE
A little more 2.x test coverage

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -452,6 +452,7 @@ class Timber {
 			/**
 			 * Filters the Twig file that should be rendered.
 			 *
+			 * @codeCoverageIgnore
 			 * @deprecated 2.0.0, use `timber/render/file`
 			 */
 			$file = apply_filters_deprecated(
@@ -482,7 +483,6 @@ class Timber {
 				'timber/compile/file'
 			);
 		}
-
 		$output = false;
 
 		if ($file !== false) {
@@ -500,10 +500,10 @@ class Timber {
 				 * @param string $file The name of the Twig template to render.
 				 */
 				$data = apply_filters( 'timber/render/data', $data, $file );
-
 				/**
 				 * Filters the data that should be passed for rendering a Twig template.
 				 *
+				 * @codeCoverageIgnore
 				 * @deprecated 2.0.0
 				 */
 				$data = apply_filters_deprecated(
@@ -666,7 +666,7 @@ class Timber {
 	 * @return bool|string The echoed output.
 	 */
 	public static function render( $filenames, $data = array(), $expires = false, $cache_mode = Loader::CACHE_USE_DEFAULT ) {
-		$output = self::compile($filenames, $data, $expires, $cache_mode);
+		$output = self::compile($filenames, $data, $expires, $cache_mode, true);
 		echo $output;
 	}
 

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -15,8 +15,7 @@ class TestTimberFilters extends Timber_UnitTestCase {
 		}, 10, 2);
 		ob_start();
 		Timber::render('assets/single-post.twig', array('fop' => 'wag'));
-		$str = ob_get_contents();
-		ob_end_clean();
+		$str = ob_get_clean();
 		$this->assertEquals('<h1>daaa</h1>', $str);
 	}
 

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -1,10 +1,23 @@
 <?php
 
 class TestTimberFilters extends Timber_UnitTestCase {
-	function testRenderDataFilter() {
+
+	function testLoaderRenderDataFilter() {
 		add_filter('timber/loader/render_data', array($this, 'filter_timber_render_data'), 10, 2);
 		$output = Timber::compile('assets/output.twig', array('output' => 14) );
 		$this->assertEquals('output.twig assets/output.twig', $output);
+	}
+
+	function testRenderDataFilter() {
+		add_filter('timber/render/data', function( $data, $file ){
+			$data['post'] = array('title' => 'daaa');
+			return $data;
+		}, 10, 2);
+		ob_start();
+		Timber::render('assets/single-post.twig', array('fop' => 'wag'));
+		$str = ob_get_contents();
+		ob_end_clean();
+		$this->assertEquals('<h1>daaa</h1>', $str);
 	}
 
 	function filter_timber_render_data($data, $file) {


### PR DESCRIPTION
Just a few touch-ups on some missing test coverage, uncovered a small error stemming from the removal of `Timber::fetch`