### PR TITLE
2.x Add a Users Guide

### DIFF
--- a/docs/guides/class-maps.md
+++ b/docs/guides/class-maps.md
@@ -50,7 +50,7 @@ add_filter( 'timber/post/classmap', function() {
             if ( $post->id === 3 ) {
                 return PreciousBook::class;
             }
-            
+
             return Book::class;
         },
     ];
@@ -71,7 +71,7 @@ add_filter( 'timber/post/classmap', function() {
             if ( 'book' === get_post_type( $post->post_parent ) {
                 return BookAttachment::class;
             }
-            
+
             return Attachment::class;
         },
     ];
@@ -114,7 +114,7 @@ add_filter( 'timber/term/classmap', function() {
             if ( $term->term_id === 2 ) {
                 return ComedyGenre::class;
             }
-            
+
             return Genre::class;
         },
     ];
@@ -162,7 +162,7 @@ add_filter( 'timber/comment/classmap', function() {
             if ( 0 !== $post->post_parent ) {
                 return BookChildComment::class;
             }
-            
+
             return BookComment::class;
         },
     ];
@@ -191,4 +191,54 @@ add_filter( 'timber/user/classmap', function( $class, \WP_User $user ) {
 }, 10, 2 );
 ```
 
-The User Class Map receives the default `Timber\User` class and a `WP_User` object. You should be able to decide which class to use based on that user object. In case you need a different User class based on the current you’re displaying, you can use [Conditional Tags](https://developer.wordpress.org/themes/references/list-of-conditional-tags/).
+The User Class Map receives the default `Timber\User` class and a `WP_User` object. You should be able to decide which class to use based on that user object.
+
+In case you need a different User class based on the current template you’re displaying, you can use [Conditional Tags](https://developer.wordpress.org/themes/references/list-of-conditional-tags/).
+
+```php
+use Author;
+
+add_filter( 'timber/user/classmap', function( $class, \WP_User $user ) {
+    // Use Author class for single post template.
+    if ( is_singular( 'post' ) ) {
+        return Author::class;
+    }
+
+    return $class;
+}, 10, 2 );
+```
+
+If you need to have a special class based on the capabilities a user has, work with `$user->has_cap()`.
+
+```php
+use Administrator;
+use Editor;
+
+add_filter( 'timber/user/classmap', function( $class, \WP_User $user ) {
+    if ( $user->has_cap( 'manage_options' ) ) {
+        return Administrator::class;
+    } elseif ( $user->has_cap( 'edit_pages' ) ) {
+        return Editor::class;
+    }
+
+    return $class;
+}, 10, 2 );
+```
+
+If you need check for user roles, check the `$user->roles` array. Don’t work with `$user->has_cap()` to check for roles, because it may lead to unreliable results.
+
+
+```php
+use Administrator;
+use Editor;
+
+add_filter( 'timber/user/classmap', function( $class, \WP_User $user ) {
+    if ( in_array( 'editor', $user->roles, true ) ) {
+        return Editor::class;
+    } elseif ( $in_array( 'author', $user->roles, true ) ) {
+        return Author::class;
+    }
+
+    return $class;
+}, 10, 2 );
+```

--- a/docs/guides/class-maps.md
+++ b/docs/guides/class-maps.md
@@ -173,7 +173,7 @@ The callback function receives a `WP_Comment` object and should return the name 
 
 ## The User Class Map
 
-When you extend a `Timber\User` object…
+With the `timber/user/classmap` filter, you can tell Timber which class it should use for user objects.
 
 The User Class Map is used:
 
@@ -235,7 +235,7 @@ use Editor;
 add_filter( 'timber/user/classmap', function( $class, \WP_User $user ) {
     if ( in_array( 'editor', $user->roles, true ) ) {
         return Editor::class;
-    } elseif ( $in_array( 'author', $user->roles, true ) ) {
+    } elseif ( in_array( 'author', $user->roles, true ) ) {
         return Author::class;
     }
 

--- a/docs/guides/users.md
+++ b/docs/guides/users.md
@@ -1,0 +1,142 @@
+---
+title: "Users"
+---
+
+To get a user object in Timber, you use `Timber::get_user()` and pass the WordPress user ID as an argument.
+
+```php
+$post = Timber::get_user( $user_id );
+```
+
+This function is similar to [`get_userdata()`](https://developer.wordpress.org/reference/functions/get_userdata/) and accepts one argument: a user ID. If you don’t pass in any argument, Timber will use `get_current_user_id()` to work with the currently logged in user.
+
+```php
+$post = Timber::get_user();
+
+// Is the same as…
+
+$post = Timber::get_user( get_current_user_id() );
+```
+
+What you get in return is a [`Timber\User`](https://timber.github.io/docs/reference/timber-user/) object, which is similar to `WP_User`.
+
+## Get user by field
+
+If you don’t have a user ID, you can also get a user by other fields, like `email` or `login` through `Timber::get_user_by()`.
+
+```php
+// Get a user by email.
+$user = Timber::get_user_by( 'email', 'user@example.com' );
+
+// Get a user by login.
+$user = Timber::get_user_by( 'login', 'keanu-reeves' );
+```
+
+## Twig
+
+You can convert user IDs to user objects in Twig using the `get_user()` function.
+
+```twig
+{% set user = get_user(user_id) %}
+```
+
+It also works if you have an array of user IDs that you want to convert to `Timber\User` objects. Use the `get_users()` function.
+
+```twig
+{% for user in get_users(user_ids) %}
+
+{% endfor %}
+```
+
+## Invalid user
+
+If no user can be found with the user ID you provided, the `Timber::get_user()` function will return `null`. With this, you can always check for valid users in a template a simple if statement.
+
+```php
+$user = Timber::get_user( $user_id );
+
+if ( $user ) {
+    // Handle post.
+}
+```
+
+Or in Twig:
+
+```twig
+{% if user %}
+    {{ user.name }}
+{% endif %}
+```
+
+## Login state
+
+Similar to checking for valid users, you can also check whether a user is currently logged in to WordPress. When you don’t provide an ID for `Timber::get_user()`, it will return `null` if no user is currently logged in.
+
+```php
+$user = Timber::get_user();
+
+if ( $user ) {
+    // A user is logged in.
+} else {
+    // No user is logged in.
+}
+```
+
+This allows you to check for login state with an if statement.
+
+```twig
+{% if user %}
+    Hello {{ user.name }}!
+{% else %}
+    Hello visitor!
+{% endif %}
+```
+
+## Extending `Timber\User`
+
+If you need additional functionality that the `Timber\User` class doesn’t provide or if you want to have cleaner Twig templates, you can extend the `Timber\User` class with your own classes:
+
+```php
+class Author extends Timber\User {
+
+}
+```
+
+To initiate your new `Author` user, you also use `Timber::get_user()`.
+
+```php
+$author = Timber::get_user( $user_id );
+```
+
+You **can’t** instantiate a `Timber\User` object or an object that extends this class with a constructor – you can’t use `$author = new Author( $user_id )`. In Timber, we’ve chosen to go a different way to prevent a lot of problems that would come with direct instantiation.
+
+So, how does Timber know about your `User` class? Timber will use the [User Class Map](https://timber.github.io/docs/guides/class-maps/#the-user-class-map) to sort out which class it should use.
+
+## Querying Users
+
+If you want to get an array of users, you can use `Timber::get_user()`.
+
+```php
+$users = Timber::get_users( $query );
+```
+
+You can use this function in a similar way to how you use [`WP_User_Query`](https://developer.wordpress.org/reference/classes/wp_user_query/).
+
+```php
+// Get all users that only have a subscriber role.
+$subscribers = Timber::get_users( [
+    'role' => 'subscriber',
+] );
+
+// Get all users that have published posts.
+$post_authors = Timber::get_users( [
+    'has_published_posts' => [ 'post' ],
+] );
+```
+
+If you don’t pass in any argument, `Timber::get_users()` will do nothing and return an empty array.
+
+```php
+// Returns an empty array.
+$users = Timber::get_users();
+```

--- a/docs/guides/users.md
+++ b/docs/guides/users.md
@@ -134,6 +134,12 @@ $post_authors = Timber::get_users( [
 ] );
 ```
 
+Instead of a query, you can also pass and **array of user IDs**.
+
+```php
+$users = Timber::get_users( [ 27, 83, 161 ] );
+```
+
 If you don’t pass in any argument, `Timber::get_users()` will do nothing and return an empty array.
 
 ```php

--- a/docs/guides/users.md
+++ b/docs/guides/users.md
@@ -5,17 +5,17 @@ title: "Users"
 To get a user object in Timber, you use `Timber::get_user()` and pass the WordPress user ID as an argument.
 
 ```php
-$post = Timber::get_user( $user_id );
+$user = Timber::get_user( $user_id );
 ```
 
 This function is similar to [`get_userdata()`](https://developer.wordpress.org/reference/functions/get_userdata/) and accepts one argument: a user ID. If you don’t pass in any argument, Timber will use `get_current_user_id()` to work with the currently logged in user.
 
 ```php
-$post = Timber::get_user();
+$user = Timber::get_user();
 
 // Is the same as…
 
-$post = Timber::get_user( get_current_user_id() );
+$user = Timber::get_user( get_current_user_id() );
 ```
 
 What you get in return is a [`Timber\User`](https://timber.github.io/docs/reference/timber-user/) object, which is similar to `WP_User`.
@@ -56,7 +56,7 @@ If no user can be found with the user ID you provided, the `Timber::get_user()` 
 $user = Timber::get_user( $user_id );
 
 if ( $user ) {
-    // Handle post.
+    // Handle user.
 }
 ```
 

--- a/docs/guides/users.md
+++ b/docs/guides/users.md
@@ -50,7 +50,7 @@ It also works if you have an array of user IDs that you want to convert to `Timb
 
 ## Invalid user
 
-If no user can be found with the user ID you provided, the `Timber::get_user()` function will return `null`. With this, you can always check for valid users in a template a simple if statement.
+If no user can be found with the user ID you provided, the `Timber::get_user()` function will return `false`. With this, you can always check for valid users in a template a simple if statement.
 
 ```php
 $user = Timber::get_user( $user_id );
@@ -70,7 +70,7 @@ Or in Twig:
 
 ## Login state
 
-Similar to checking for valid users, you can also check whether a user is currently logged in to WordPress. When you don’t provide an ID for `Timber::get_user()`, it will return `null` if no user is currently logged in.
+Similar to checking for valid users, you can also check whether a user is currently logged in to WordPress. When you don’t provide an ID for `Timber::get_user()`, it will return `false` if no user is currently logged in.
 
 ```php
 $user = Timber::get_user();


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/pull/2160#issuecomment-572745383

## Issue

We already have new guides for Posts and Terms in #2073. We should have one for Users as well.

## Solution

Add Users Guide and clarify working with User Class Maps.

## Impact

None.

## Usage Changes

None.

## Considerations

None?

## Testing

None needed.