### PR TITLE
Some quick testing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,23 @@ addons:
     - libwebp-dev
 
 php:
-    - 7.2
     - 7.4
 
 env:
     global:
         - TMPDIR=/tmp
     matrix:
-        - WP_VERSION=5.3.2 WP_MULTISITE=0 IMG_LIBS=0 
-        - WP_VERSION=5.3.2 WP_MULTISITE=1 IMG_LIBS=0 
+        - WP_VERSION=5.3.2 WP_MULTISITE=0
+        - WP_VERSION=5.3.2 WP_MULTISITE=1
         - WP_VERSION=latest WP_MULTISITE=0 IMG_LIBS=1 COVERAGE=1 
         - WP_VERSION=latest WP_MULTISITE=1 IMG_LIBS=1 COVERAGE=1 STATIC_ANALYSIS=1
+
+matrix:
+    include:
+    - php: 7.2
+      env: WP_VERSION=5.3.2 WP_MULTISITE=0
+    - php: 7.2
+      env: WP_VERSION=latest WP_MULTISITE=0
 
 before_script:
     - pear config-set preferred_state beta; pecl channel-update pecl.php.net

--- a/tests/test-timber-post-getter.php
+++ b/tests/test-timber-post-getter.php
@@ -541,11 +541,6 @@ class TestTimberPostGetter extends Timber_UnitTestCase {
 
 		$this->assertEquals($first_pids, $wp_ids);
 
-		$other_query = Timber::get_posts(array('post__in' => $first_pids));
-		$timber_ids = array_map(function($post) {
-			return $post->ID;
-		}, $other_query);
-		$this->assertNotEquals($first_pids, $timber_ids);
 	}
 
 


### PR DESCRIPTION
## Issue
We can easily cut down the number of tests that are run on 2.x builds w/o sacrificing utility

## Solution
Remove two extra PHP 7.2 builds. Also removed part of a weird test that didn't really tell us anything, but failed 1% of the time just due to the math matching up.

## Impact
Tests should run about ~5 mins faster in total by dropping these

## Usage Changes
None.

## Testing
Everything passes locally ...