### PR TITLE
phpstan: Level 1 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
 script:
     - if [ "$COVERAGE" == 1 ]; then mkdir -p build/logs; vendor/phpunit/phpunit/phpunit --coverage-clover build/logs/clover.xml -c phpunit.xml --verbose; else vendor/phpunit/phpunit/phpunit -c phpunit-nocover.xml --verbose; fi
-    - if [ "$STATIC_ANALYSIS" == 1 ]; then vendor/bin/phpstan analyze -l 0; fi
+    - if [ "$STATIC_ANALYSIS" == 1 ]; then vendor/bin/phpstan analyze -l 1; fi
 
 after_script:
     - if [ "$COVERAGE" == 1 ]; then php vendor/bin/coveralls -v; fi

--- a/lib/Comment.php
+++ b/lib/Comment.php
@@ -47,6 +47,11 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 	public $id;
 
 	/**
+	 * @var int
+	 */
+	public $comment_approved;
+
+	/**
 	 * @api
 	 * @var string
 	 */
@@ -69,6 +74,11 @@ class Comment extends Core implements CoreInterface, MetaInterface {
 	 * @var int
 	 */
 	public $comment_ID;
+
+	/**
+	 * @var int
+	 */
+	public $comment_parent;
 
 	/**
 	 * @api

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -133,8 +133,7 @@ class Image extends Attachment {
 			'Image::get_dimension',
 			'2.0.0'
 		);
-		$ds = array($this->width(), $this->height());
-		return $ds;
+		return array($this->width(), $this->height());
 	}
 
 	/**

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -133,16 +133,8 @@ class Image extends Attachment {
 			'Image::get_dimension',
 			'2.0.0'
 		);
-		if ( isset($this->_dimensions) ) {
-			return $this->get_dimensions_loaded($dim);
-		}
-		if ( file_exists($this->file_loc) && filesize($this->file_loc) ) {
-			list($width, $height) = getimagesize($this->file_loc);
-			$this->_dimensions = array();
-			$this->_dimensions[0] = $width;
-			$this->_dimensions[1] = $height;
-			return $this->get_dimensions_loaded($dim);
-		}
+		$ds = array($this->width(), $this->height());
+		return $ds;
 	}
 
 	/**
@@ -159,9 +151,9 @@ class Image extends Attachment {
 		);
 		$dim = strtolower($dim);
 		if ( $dim == 'h' || $dim == 'height' ) {
-			return $this->_dimensions[1];
+			return $this->height();
 		}
-		return $this->_dimensions[0];
+		return $this->width();
 	}
 
 	/**

--- a/lib/Integrations/CoAuthorsPlusUser.php
+++ b/lib/Integrations/CoAuthorsPlusUser.php
@@ -3,6 +3,12 @@
 namespace Timber\Integrations;
 
 class CoAuthorsPlusUser extends \Timber\User {
+
+	/**
+	 * @api
+	 * @var \Timber\Image of a user's avatar image. 
+	 */
+	public $avatar;
 	
 	/**
 	 * @param object $author co-author object

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -94,8 +94,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 		$this->import($data);
 		$this->import_classes($data);
 		$this->menu_object = $data;
-		$this->_name       = $this->name;
-		$this->name        = $this->name();
+		$this->_name       = $data->name;
 		$this->add_class('menu-item-'.$this->ID);
 
 		$this->object_id = (int) get_post_meta( $this->ID, '_menu_item_object_id', true );

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -74,6 +74,12 @@ class Site extends Core implements CoreInterface {
 	public $name;
 
 	/**
+	 * @deprecated 2.0.0, use $pingback_url
+	 * @var string for people who like trackback spam
+	 */
+	public $pingback;
+
+	/**
 	 * @api
 	 * @var string for people who like trackback spam
 	 */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,9 +11,7 @@ parameters:
         - %currentWorkingDirectory%/tests/phpstan/wp-cli-stubs-2.2.0.php
     ignoreErrors:
         # Uses func_get_args()
-        # '#^Function apply_filters invoked with [3456] parameters, 2 required\.$#'
-        # TODO Define properties!
-        # '#^Access to an undefined property Timber\\\S+$#'
+        - '#^Function apply_filters invoked with [3456] parameters, 2 required\.$#'
         # TODO Do not create a static instance of a non-final class.
         -
             message: '#^Unsafe usage of new static\(\)\.$#'


### PR DESCRIPTION
This branch / PR is meant to handle compliance with PHPStan Level 1 issues. Per @szepeviktor's [comment](https://github.com/timber/timber/pull/2165#issuecomment-573457549) in #2165, we won't be able to do anything about the `apply_filters` argument count errors (due to how WP declares that function) but we can get our house in order with declaring properties on various Timber classes.