### PR TITLE
Prefix error_log output with "[ Timber ]"

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -200,7 +200,7 @@ class Helper {
 		if ( is_object($error) || is_array($error) ) {
 			$error = print_r($error, true);
 		}
-		return error_log($error);
+		return error_log('[ Timber ]'.$error);
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: #621

## Issue
Errors dropped into the nginx/apache error log are not easily traced back to Timber.

## Solution
Prefix errors that come from Timber with `[ Timber ]`

## Impact
None. Will change the look of some error logs I guess?

## Usage Changes
Note

## Considerations
Should other warnings/output be similarly indicated?

## Testing
No new tests