### PR TITLE
Fix bug where field named "content" could overwrite post.content

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -80,9 +80,9 @@ class Post extends Core implements CoreInterface {
 
 	/**
 	 * @internal
-	 * @var string $_content stores the processed content internally
+	 * @var string $___content stores the processed content internally
 	 */
-	protected $_content;
+	protected $___content;
 
 	/**
 	 * @var string $_permalink the returned permalink from WP's get_permalink function
@@ -1210,8 +1210,8 @@ class Post extends Core implements CoreInterface {
 		if ( $form = $this->maybe_show_password_form() ) {
 			return $form;
 		}
-		if ( $len == -1 && $page == 0 && $this->_content ) {
-			return $this->_content;
+		if ( $len == -1 && $page == 0 && $this->___content ) {
+			return $this->___content;
 		}
 		$content = $this->post_content;
 		if ( $len > 0 ) {
@@ -1226,7 +1226,7 @@ class Post extends Core implements CoreInterface {
 		}
 		$content = apply_filters('the_content', ($content));
 		if ( $len == -1 && $page == 0 ) {
-			$this->_content = $content;
+			$this->___content = $content;
 		}
 		return $content;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,7 @@ _Twig is the template language powering Timber; if you need a little background 
 = Develop (next release) =
 
 **Fixes and improvements**
+- Fixed an issue where a custom field named "content" could conflict with `{{ post.content }}`
 
 **Changes for Theme Developers**
 

--- a/tests/test-timber-integrations.php
+++ b/tests/test-timber-integrations.php
@@ -38,6 +38,25 @@ class TestTimberIntegrations extends Timber_UnitTestCase {
 		$this->assertEquals('WORKS', $str);
 	}
 
+	function testCustomTimeField() {
+		$pid = $this->factory->post->create(array('post_content' => 'Cool content bro!', 'post_date' => '2020-02-07 08:03:00'));
+		update_field( '_time', 'I am custom time', $pid );
+		update_field( 'time', 'I am custom time', $pid );
+		$str = '{{ post.time }}';
+		$post = new Timber\Post( $pid );
+		$str = Timber::compile_string( $str, array( 'post' => $post ) );
+		$this->assertEquals( '8:03 am', trim($str) );
+	}
+
+	function testCustomContentField() {
+		$pid = $this->factory->post->create(array('post_content' => 'Cool content bro!'));
+		update_field( '_content', 'I am custom content', $pid );
+		$str = '{{ post.content }}';
+		$post = new Timber\Post( $pid );
+		$str = Timber::compile_string( $str, array( 'post' => $post ) );
+		$this->assertEquals( '<p>Cool content bro!</p>', trim($str) );
+	}
+
 	function testACFHasFieldPostTrue() {
 		$pid = $this->factory->post->create();
 		update_post_meta($pid, 'best_radiohead_album', 'in_rainbows');


### PR DESCRIPTION
**Ticket**: #2143 

## Issue
A field named "content" made by ACF overwrites the Post objects `$post->_content` variable because ACF uses an underscore naming pattern.

## Solution
Rename `$post->_content` ==> `$post->___content` to avoid the collision.

## Impact
Anyone relying the current "buggy" code will have their shit broke.

## Considerations
Even though the meta/raw_meta stuff in 2.x is still fixed — we should make sure a similar `_content` issue isn't present there.

## Testing
Wrote a new test to confirm buggy behavior and that this resolves