### PR TITLE
2.x Improve Timber::get_post_by()

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -175,9 +175,16 @@ class Timber {
 	 *                                   for `title`, this parameter doesn’t need to be
 	 *                                   case-sensitive, because the `=` comparison is used in
 	 *                                   MySQL.
-	 * @param string|array $post_type    Optional. The post type or an array of post types to look
-	 *                                   for. Default `any`, which will look for posts in any post
-	 *                                   type.
+	 * @param array        $args {
+	 *     Optional. An array of arguments to configure what is returned.
+	 *
+	 * 	   @type string|array     $post_type   Optional. What WordPress post type to limit the 
+	 *                                         results to. Defaults to 'any'
+	 *     @type string           $order_by    Optional. The field to sort by. Defaults to 
+	 *                                         'post_date'
+	 *     @type string           $order       Optional. The sort to apply. Defaults to ASC
+	 *
+	 * }
 	 *
 	 * @return \Timber\Post|false A Timber post or `false` if no post could be found. If multiple
 	 *                            posts with the same slug or title were found, it will select the

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -183,16 +183,19 @@ class Timber {
 	 *                            posts with the same slug or title were found, it will select the
 	 *                            post with the oldest date.
 	 */
-	public static function get_post_by( $type, $search_value, $post_type = 'any' ) {
+	public static function get_post_by( $type, $search_value, $args = array() ) {
 		$post_id = false;
-
+		$args = wp_parse_args( $args, [
+			'post_type' => 'any',
+			'order_by'  => 'post_date',
+			'order'     => 'ASC'
+		] );
 		if ( 'slug' === $type ) {
-			$query = new \WP_Query( [
-				'post_type' => $post_type,
+			$args = wp_parse_args($args, [
 				'name'      => $search_value,
-				'fields'    => 'ids',
-				'order'		=> 'ASC',
-			] );
+				'fields'    => 'ids'
+			]);
+			$query = new \WP_Query( $args );
 
 			if ( $query->post_count < 1 ) {
 				return false;
@@ -214,15 +217,14 @@ class Timber {
 
 			$sql = "SELECT ID FROM $wpdb->posts WHERE post_title = %s";
 			$query_args = [ $search_value ];
-
-			if ( is_array( $post_type ) ) {
-				$post_type           = esc_sql( $post_type );
-				$post_type_in_string = "'" . implode( "','", $post_type ) . "'";
+			if ( is_array( $args['post_type'] ) ) {
+				$post_type           = esc_sql( $args['post_type'] );
+				$post_type_in_string = "'" . implode( "','", $args['post_type'] ) . "'";
 
 				$sql .= " AND post_type IN ($post_type_in_string)";
-			} elseif ( 'any' !== $post_type ) {
+			} elseif ( 'any' !== $args['post_type'] ) {
 				$sql .= ' AND post_type = %s';
-				$query_args[] = $post_type;
+				$query_args[] = $args['post_type'];
 			}
 
 			// Always return the oldest post first.

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -171,14 +171,17 @@ class Timber {
 	 * ```
 	 *
 	 * @param string       $type         The type to look for. One of `slug` or `title`.
-	 * @param string       $search_value The post slug or post title to search for. When search for
-	 *                                   `title`, this parameter doesn’t need to be case-sensitive,
-	 *                                   because the `=` comparison is used in MySQL.
+	 * @param string       $search_value The post slug or post title to search for. When searching
+	 *                                   for `title`, this parameter doesn’t need to be
+	 *                                   case-sensitive, because the `=` comparison is used in
+	 *                                   MySQL.
 	 * @param string|array $post_type    Optional. The post type or an array of post types to look
 	 *                                   for. Default `any`, which will look for posts in any post
 	 *                                   type.
 	 *
-	 * @return \Timber\Post|false A Timber post or `false` if no post could be found.
+	 * @return \Timber\Post|false A Timber post or `false` if no post could be found. If multiple
+	 *                            posts with the same slug or title were found, it will select the
+	 *                            post with the oldest date.
 	 */
 	public static function get_post_by( $type, $search_value, $post_type = 'any' ) {
 		$post_id = false;

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -35,6 +35,21 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->assertEquals( 'kill-bill', $post->post_name );
 	}
 
+	function testGetPostBySlugNewest(){
+		$post_id = $this->factory->post->create( [ 'post_type' => 'post', 
+												   'post_name' => 'privacy', 
+												   'post_date'  => '2018-01-10 02:58:18' ] );
+
+		$page_id = $this->factory->post->create( [ 'post_type' => 'page', 
+												   'post_name' => 'privacy', 
+												   'post_date'  => '2020-01-10 02:58:18' ] );
+
+		$post = Timber\Timber::get_post_by( 'slug', 'privacy', ['order' => 'DESC'] );
+
+		$this->assertEquals( 'privacy', $post->post_name );
+		$this->assertEquals( $page_id, $post->ID );
+	}
+
 	function testGetPostBySlugAndPostType(){
 
 		register_post_type('movie', array('public' => true));
@@ -48,8 +63,8 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 			'post_type' => 'page',
 		] );
 
-		$post_movie = Timber\Timber::get_post_by( 'slug', 'kill-bill', 'movie' );
-		$post_page  = Timber\Timber::get_post_by( 'slug', 'kill-bill', 'page' );
+		$post_movie = Timber\Timber::get_post_by( 'slug', 'kill-bill', ['post_type' => 'movie'] );
+		$post_page  = Timber\Timber::get_post_by( 'slug', 'kill-bill', ['post_type' => 'page'] );
 
 		$this->assertEquals( $post_id_movie, $post_movie->ID );
 		$this->assertEquals( $post_id_page, $post_page->ID );
@@ -108,10 +123,10 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 			'post_date'  => '2020-01-02 02:58:18'
 		] );
 
-		$post_movie        = Timber\Timber::get_post_by( 'title', $post_title, 'movie' );
-		$post_page         = Timber\Timber::get_post_by( 'title', $post_title, 'page' );
-		$post_multiple     = Timber\Timber::get_post_by( 'title', $post_title, [ 'page', 'book' ] );
-		$post_multiple_any = Timber\Timber::get_post_by( 'title', $post_title, 'any' );
+		$post_movie        = Timber\Timber::get_post_by( 'title', $post_title, ['post_type' => 'movie'] );
+		$post_page         = Timber\Timber::get_post_by( 'title', $post_title, ['post_type' => 'page'] );
+		$post_multiple     = Timber\Timber::get_post_by( 'title', $post_title, ['post_type' => [ 'page', 'book' ]] );
+		$post_multiple_any = Timber\Timber::get_post_by( 'title', $post_title, ['post_type' => 'any'] );
 
 		$this->assertEquals( $post_id_movie, $post_movie->ID );
 		$this->assertEquals( $post_id_page, $post_page->ID );

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -89,12 +89,6 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		register_post_type('book', array('public' => true));
 		register_post_type('movie', array('public' => true));
 		$post_title    = 'A Special Post Title containing Special Characters like # or ! or Ä or ç';
-		
-		$post_id_page  = $this->factory->post->create( [
-			'post_title' => $post_title,
-			'post_type'  => 'page',
-			'post_date'  => '2020-01-02 02:58:18'
-		] );
 
 		$post_id_movie = $this->factory->post->create( [
 			'post_title' => $post_title,
@@ -108,8 +102,14 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 			'post_date'  => '2020-01-13 02:58:18'
 		] );
 
-		$post_movie    = Timber\Timber::get_post_by( 'title', $post_title, 'movie' );
-		$post_page     = Timber\Timber::get_post_by( 'title', $post_title, 'page' );
+		$post_id_page  = $this->factory->post->create( [
+			'post_title' => $post_title,
+			'post_type'  => 'page',
+			'post_date'  => '2020-01-02 02:58:18'
+		] );
+
+		$post_movie        = Timber\Timber::get_post_by( 'title', $post_title, 'movie' );
+		$post_page         = Timber\Timber::get_post_by( 'title', $post_title, 'page' );
 		$post_multiple = Timber\Timber::get_post_by( 'title', $post_title, 'any' );
 
 		$this->assertEquals( $post_id_movie, $post_movie->ID );

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -110,13 +110,15 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 
 		$post_movie        = Timber\Timber::get_post_by( 'title', $post_title, 'movie' );
 		$post_page         = Timber\Timber::get_post_by( 'title', $post_title, 'page' );
-		$post_multiple = Timber\Timber::get_post_by( 'title', $post_title, 'any' );
+		$post_multiple     = Timber\Timber::get_post_by( 'title', $post_title, [ 'page', 'book' ] );
+		$post_multiple_any = Timber\Timber::get_post_by( 'title', $post_title, 'any' );
 
 		$this->assertEquals( $post_id_movie, $post_movie->ID );
 		$this->assertEquals( $post_id_page, $post_page->ID );
 
 		// Multiple post types should return the post with the oldest post date.
 		$this->assertEquals( $post_id_page, $post_multiple->ID );
+		$this->assertEquals( $post_id_page, $post_multiple_any->ID );
 	}
 
 	function testGetPostByTitleForNonexistentPost(){


### PR DESCRIPTION
**Ticket**: #2169

This pull request adds on top of #2169. But because I had to change more than I thought, this comes in a separate pull request so we can discuss it first.

In https://github.com/timber/timber/pull/2169/commits/302e08b78937fcc7ec0505d1e1592b78a38e4e99, you changed the order the posts were created. This go me thinking. If we want to check for the oldest post and make sure we ignore the post ID, which is an indicator of the order the posts were created in, then the post expect to be returned [shouldn’t be the first to be created](https://github.com/timber/timber/commit/8705f311e6fcdd854673d001bcec2d1a8f02a2b6).

In https://github.com/timber/timber/pull/2169/commits/58d24dd9657674f277fd6e7c6b155a580321f2c6, you changed the parameter in the test to `any`, which is not the same as an array of post types. Because of this, a different function to search for posts was used, making the tests pass. I think we [should check for both](https://github.com/timber/timber/commit/e599babc75636abc1e6e23fae302deb45dd278b7).

I figured out that `post_exists()` and `get_page_by_title()` won’t work if we go for the **oldest post** and don’t want to sort by ID. That’s why I replaced `post_exists()` and `get_page_by_title()` with our own query in https://github.com/timber/timber/commit/d6f95d303dada9126be2a775a5fbdbd3a4756e63.  I usually try to avoid creating direct queries, but I think there’s no easier way to search for a post title.

But by doing that, we open a new possibility to make the function more useful. We could add order arguments:

```php
public static function get_post_by( $type, $search_value, $args = [] ) {
    $args = wp_parse_args( $args, [
        'post_type' => 'any',
        'order_by'  => 'post_date',
        'order'     => 'ASC'
    ]

    // ...
}
```

This way, developers could decide on their own to change the logic a post is selected when there are multiple posts available.