### PR TITLE
2.x Improve error handling

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -337,7 +337,7 @@ class Helper {
 			}
 
 			$message .= sprintf(
-				' Please see <a href="%s">Debugging in WordPress</a> as well as <a href="%2$s">Debugging in Timber</a> for more information.',
+				' Please see Debugging in WordPress (%1$s) as well as Debugging in Timber (%2$s) for more information.',
 				'https://wordpress.org/support/article/debugging-in-wordpress/',
 				'https://timber.github.io/docs/guides/debugging/'
 			);

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -351,7 +351,7 @@ class Helper {
 
 			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-			trigger_error( $error_message );
+			trigger_error( '[ Timber ] ' . $error_message );
 		}
 	}
 
@@ -412,7 +412,7 @@ class Helper {
 
 		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		trigger_error( $error_message );
+		trigger_error( '[ Timber ] ' . $error_message );
 	}
 
 	/**

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -285,17 +285,25 @@ class Helper {
 	 * @api
 	 * @since 2.0.0
 	 * @since WordPress 3.1.0
+	 * @see \_doing_it_wrong()
 	 *
 	 * @param string $function The function that was called.
 	 * @param string $message  A message explaining what has been done incorrectly.
 	 * @param string $version  The version of Timber where the message was added.
 	 */
 	public static function doing_it_wrong( $function, $message, $version ) {
+		/**
+		 * Fires when the given function is being used incorrectly.
+		 *
+		 * @param string $function The function that was called.
+		 * @param string $message  A message explaining what has been done incorrectly.
+		 * @param string $version  The version of WordPress where the message was added.
+		 */
+		do_action( 'doing_it_wrong_run', $function, $message, $version );
+
 		if ( ! WP_DEBUG ) {
 			return;
 		}
-
-		do_action( 'doing_it_wrong_run', $function, $message, $version );
 
 		/**
 		 * Filters whether to trigger an error for _doing_it_wrong() calls.
@@ -354,19 +362,27 @@ class Helper {
 	 * DocBlock. E.g.: "@expectedDeprecated {{ TimberImage() }}".
 	 *
 	 * @api
+	 * @see \_deprecated_function()
 	 *
 	 * @param string $function    The name of the deprecated function/method.
-	 * @param string $replacement Function to use instead.
-	 * @param string $version     When we deprecated this.
+	 * @param string $replacement The name of the function/method to use instead.
+	 * @param string $version     The version of Timber when the function was deprecated.
 	 *
 	 * @return void
 	 */
 	public static function deprecated( $function, $replacement, $version ) {
+		/**
+		 * Fires when a deprecated function is being used.
+		 *
+		 * @param string $function    The function that was called.
+		 * @param string $replacement The name of the function/method to use instead.
+		 * @param string $version     The version of Timber where the message was added.
+		 */
+		do_action( 'deprecated_function_run', $function, $replacement, $version );
+
 		if ( ! WP_DEBUG ) {
 			return;
 		}
-
-		do_action( 'deprecated_function_run', $function, $replacement, $version );
 
 		/**
 		 * Filters whether to trigger an error for deprecated functions.

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -271,6 +271,83 @@ class Helper {
 	}
 
 	/**
+	 * Marks something as being incorrectly called.
+	 *
+	 * There is a hook {@see 'doing_it_wrong_run'} that will be called that can be used
+	 * to get the backtrace up to what file and function called the deprecated
+	 * function.
+	 *
+	 * The current behavior is to trigger a user error if `WP_DEBUG` is true.
+	 *
+	 * If you want to catch errors like these in tests, then add the @expectedIncorrectUsage tag.
+	 * E.g.: "@expectedIncorrectUsage Timber::get_posts()".
+	 *
+	 * @api
+	 * @since 2.0.0
+	 * @since WordPress 3.1.0
+	 *
+	 * @param string $function The function that was called.
+	 * @param string $message  A message explaining what has been done incorrectly.
+	 * @param string $version  The version of Timber where the message was added.
+	 */
+	public static function doing_it_wrong( $function, $message, $version ) {
+		if ( ! WP_DEBUG ) {
+			return;
+		}
+
+		do_action( 'doing_it_wrong_run', $function, $message, $version );
+
+		/**
+		 * Filters whether to trigger an error for _doing_it_wrong() calls.
+		 *
+		 * This filter is mainly used by unit tests.
+		 *
+		 * @since WordPress 3.1.0
+		 * @since WordPress 5.1.0 Added the $function, $message and $version parameters.
+		 *
+		 * @param bool   $trigger  Whether to trigger the error for _doing_it_wrong() calls. Default true.
+		 * @param string $function The function that was called.
+		 * @param string $message  A message explaining what has been done incorrectly.
+		 * @param string $version  The version of WordPress where the message was added.
+		 */
+		$should_trigger_error = apply_filters(
+			'doing_it_wrong_trigger_error',
+			true,
+			$function,
+			$message,
+			$version
+		);
+
+		if ( $should_trigger_error ) {
+			if ( is_null( $version ) ) {
+				$version = '';
+			} else {
+				$version = sprintf(
+					'(This message was added in Timber version %s.)',
+					$version
+				);
+			}
+
+			$message .= sprintf(
+				' Please see <a href="%s">Debugging in WordPress</a> as well as <a href="%2$s">Debugging in Timber</a> for more information.',
+				'https://wordpress.org/support/article/debugging-in-wordpress/',
+				'https://timber.github.io/docs/guides/debugging/'
+			);
+
+			$error_message = sprintf(
+				'%1$s was called <strong>incorrectly</strong>. %2$s %3$s',
+				$function,
+				$message,
+				$version
+			);
+
+			// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+			trigger_error( $error_message );
+		}
+	}
+
+	/**
 	 * Triggers a deprecation warning.
 	 *
 	 * If you want to catch errors like these in tests, then add the @expectedDeprecated tag to the

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -397,14 +397,14 @@ class Helper {
 
 		if ( ! is_null( $replacement ) ) {
 			$error_message = sprintf(
-				'%1$s is <strong>deprecated</strong> since Timber version %2$s! Use %3$s instead.',
+				'%1$s is deprecated since Timber version %2$s! Use %3$s instead.',
 				$function,
 				$version,
 				$replacement
 			);
 		} else {
 			$error_message = sprintf(
-				'%1$s is <strong>deprecated</strong> since Timber version %2$s with no alternative available.',
+				'%1$s is deprecated since Timber version %2$s with no alternative available.',
 				$function,
 				$version
 			);

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -205,9 +205,9 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 		}
 
 		if ( '_thumbnail_id' === $field ) {
-			Helper::deprecated(
+			Helper::doing_it_wrong(
 				"Accessing the thumbnail ID through {{ {$this->object_type}._thumbnail_id }}",
-				"{{ {$this->object_type}.thumbnail_id }}",
+				"You can retrieve the thumbnail ID via the thumbnail object {{ {$this->object_type}.thumbnail.id }}. If you need the id as stored on this post's postmeta you can use {{ {$this->object_type}.meta('_thumbnail_id') }}",
 				'2.0.0'
 			);
 		}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -310,5 +310,15 @@
 			$this->assertEquals('Sport', get_class($sport_post));
 			$this->assertEquals('ESPN', $sport_post->channel());
  		}
+ 		 /**
+ 		 * @expectedIncorrectUsage Accessing the thumbnail ID through {{ post._thumbnail_id }}
+ 		 */
+ 		function testDoingItWrong() {
+ 			$post_id = $this->factory->post->create();
+ 			$posts = Timber::get_posts();
+ 			update_post_meta($post_id, '_thumbnail_id', '707');
+ 			$post = new Timber\Post($post_id);
+ 			$thumbnail_id = $post->_thumbnail_id;
+ 		}  
 
 	}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -310,7 +310,8 @@
 			$this->assertEquals('Sport', get_class($sport_post));
 			$this->assertEquals('ESPN', $sport_post->channel());
  		}
- 		 /**
+
+ 		/**
  		 * @expectedIncorrectUsage Accessing the thumbnail ID through {{ post._thumbnail_id }}
  		 */
  		function testDoingItWrong() {

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -1005,8 +1005,8 @@
 		}
 
 		/**
-		 * @expectedDeprecated Accessing the thumbnail ID through {{ post._thumbnail_id }}
-		 */
+ 		 * @expectedIncorrectUsage Accessing the thumbnail ID through {{ post._thumbnail_id }}
+ 		 */
 		function testDeprecatedPostThumbnailIdProperty() {
 			// Add attachment to post.
 			$post_id       = $this->factory->post->create();


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/pull/2073#issuecomment-586538864, #2145

## Issue

In https://github.com/timber/timber/pull/2073#issuecomment-580343556 and the following comments, we discussed whether we should use Exceptions or work with calls to `Helper::doing_it_wrong()`.

## Solution

This pull request pulls out the `Helper::doing_it_wrong()` function I added in #2145 and adds improvements.

I would like to go with the solution that @acobster suggested in https://github.com/timber/timber/pull/2073#issuecomment-586538864 and move the calls to `doing_it_wrong_run` and `deprecated_function_run` in front of the bailout check with `WP_DEBUG`.

## Impact

To say it in @acobster’s words:

> This gives folks an escape hatch for refactoring (which I consider the main use-case for `doing_it_wrong` to begin with) where they can throw exceptions, log to an external service, or whatever else to their hearts' content.

When we look at `_doing_it_wrong()` and `_deprecated_function()` in WordPress Core, the two action hooks `doing_it_wrong_run` and `deprecated_function_run` also run before a check to `WP_DEBUG`, so this change will make error handling work the same as in WordPress, which is a good thing.

## Usage Changes

~~This will make it possible for developers to hook into their favorite logging service, be it with PHP Exceptions itself:~~


```php
add_action( 'doing_it_wrong_run', function( $function, $message, $version ) {
    throw new \Exception( $message );
}, 10, 3 );
```

~~Or, for example, with a service like [Bugsnag](https://www.bugsnag.com/):~~

```php
add_action( 'doing_it_wrong_run', function( $function, $message, $version ) {
    if ( ! class_exists( 'Bugsnag_Wordpress' ) ) {
        return;
    }

    /**
     * Bugsnag Instance.
     *
     * @var \Bugsnag_WordPress|\Bugsnag_Client $bugsnagWordpress
     */
    global $bugsnagWordpress;

    $bugsnagWordpress->notifyError(
        'Doing it wrong!',
        $message,
        null,
        'warning'
    );
}, 10, 3 );
```

Ignore the code examples above. It’s not clear yet what the best way is for developers to hook into this.

## Considerations

We should probably add documentation about this. I wonder whether the [Debugging Guide](https://timber.github.io/docs/guides/debugging/) is the right place for this or whether

- We should add a separate Error Handling / Logging Guide?
- We should rename and extend the Debugging Guide with a section about Error Handling / Logging?

## Testing

Not directly. But if something won’t work, it will show up in testing, because a lot of tests that run functions including calls to `Helper::doing_it_wrong()` and `Helper::deprecated()` will require these two functions to work properly.