### PR TITLE
Apply patch from #2199

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -27,7 +27,7 @@ class PostGetter {
 
 		$posts = self::get_posts($query, $PostClass);
 
-		if ( $post = reset($posts) ) {
+		if ( is_iterable($posts) && $post = reset($posts) ) {
 			return $post;
 		}
 


### PR DESCRIPTION
**Ticket**: #2199 

## Issue
`PostGetter::get_posts` can return `null`. When calling `reset()` on the result, we get an error because it's not an array or iterable.

## Solution
Add a sanity check for iterability

## Impact
Should be none, just another check

## Usage Changes
None

## Testing
No explicit test added for the scenario.  