### PR TITLE
Remove useless error log for Class Maps

### DIFF
--- a/lib/PostGetter.php
+++ b/lib/PostGetter.php
@@ -174,13 +174,11 @@ class PostGetter {
 		if ( is_array($post_class) ) {
 			if ( isset($post_class[$post_type]) ) {
 				$post_class_use = $post_class[$post_type];
-			} else {
-				Helper::error_log($post_type.' not found in '.print_r($post_class, true));
 			}
 		} elseif ( is_string($post_class) ) {
 			$post_class_use = $post_class;
 		} else {
-			Helper::error_log('Unexpeted value for PostClass: '.print_r($post_class, true));
+			Helper::error_log('Unexpected value for PostClass: '.print_r($post_class, true));
 		}
 
 		if ( $post_class_use === '\Timber\Post' || $post_class_use === 'Timber\Post' ) {


### PR DESCRIPTION
## Issue

When a Class Map filter is used and Timber doesn’t find a post type in the Class Map, it will output a notice:

```
[ Timber ]posttype not found in Array
```

I think that the notice is unnecessary, because it’s possible to only add certain post types to the Class Map and let Timber fall back to the default `Timber\Post` for the ones that are not defined. I think the notice might even be confusing.

## Solution

Remove the error log. And fix a small spelling error.

## Impact

None.

## Usage Changes

None.

## Considerations

I wonder if there’s some other thinking to this, that I didn’t consider yet?

## Testing

No.