### PR TITLE
Add Timber\Post class as a return type to query_post

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -157,7 +157,7 @@ class Timber {
 	 * @api
 	 * @param mixed   $query
 	 * @param string  $PostClass
-	 * @return array|bool|null
+	 * @return Post|array|bool|null
 	 */
 	public static function query_post( $query = false, $PostClass = 'Timber\Post' ) {
 		return PostGetter::query_post($query, $PostClass);


### PR DESCRIPTION
##  Issue
Autocompletion fails with phpStorm because it can't derive the correct class.

## Solution
This helps with autocompletion when working with phpStorm.
