### PR TITLE
2203/post terms api

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -685,6 +685,10 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 			$query_args = [ 'taxonomy' => $query_args ];
 		}
 
+		/**
+		 * Handles backwards comaptability for users who use an array with a query property
+		 * @deprecated 2.0.0 use Post::terms( $query_args, $options )
+		 */
 		if ( is_array($query_args) && isset($query_args['query']) ) {
 			if ( isset($query_args['merge']) && !isset($options['merge']) ) {
 				$options['merge'] = $query_args['merge'];
@@ -728,7 +732,6 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 
 		return Timber::get_terms($query, $options);
 	}
-
 
 	/**
 	 * @api

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -726,7 +726,7 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 			return array_combine($taxonomies, $termGroups);
 		}
 
-		return Timber::get_terms($query);
+		return Timber::get_terms($query, $options);
 	}
 
 

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -631,7 +631,11 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 * {% for post in job %}
 	 *     <div class="job">
 	 *         <h2>{{ post.title }}</h2>
-	 *         <p>{{ post.terms( {query:{taxonomy:'category', orderby:'name', order: 'ASC'}} )|join(', ') }}</p>
+	 *         <p>{{ post.terms({
+	 *             taxonomy: 'category',
+	 *             orderby: 'name',
+	 *             order: 'ASC'
+	 *         })|join(', ') }}</p>
 	 *     </div>
 	 * {% endfor %}
 	 * </section>
@@ -656,37 +660,41 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 * $terms = $post->terms( array( 'books', 'movies' ) );
 	 *
 	 * // Use custom arguments for taxonomy query and options.
-	 * $terms = $post->terms( [ 'taxonomy' => 'custom_tax', 
-	 *                          'orderby'  => 'count' ],
-	 *                        [ 'merge'        => false ] );
-	 *
+	 * $terms = $post->terms( [
+	 *     'taxonomy' => 'custom_tax',
+	 *     'orderby'  => 'count'
+	 * ], [
+	 *     'merge' => false
+	 * ] );
 	 * ```
 	 *
-	 * @param string|array $query_args 	Any array of term query parameters for getting the terms. 
-	 *                                  See `WP_Term_Query::__construct()` for supported arguments. 
-	 *                                  Use the `taxonomy` argument to choose which taxonomies to 
-	 *                                  get. Defaults to querying all registered taxonomies for the 
-	 *                                  post type. You can use custom or built-in WordPress 
+	 * @param string|array $query_args 	Any array of term query parameters for getting the terms.
+	 *                                  See `WP_Term_Query::__construct()` for supported arguments.
+	 *                                  Use the `taxonomy` argument to choose which taxonomies to
+	 *                                  get. Defaults to querying all registered taxonomies for the
+	 *                                  post type. You can use custom or built-in WordPress
 	 *                                  taxonomies (category, tag). Timber plays nice and figures
-	 *                                  out that `tag`, `tags` or `post_tag` are all the same 
+	 *                                  out that `tag`, `tags` or `post_tag` are all the same
 	 *                                  (also for `categories` or `category`). For custom
 	 *                                  taxonomies you need to define the proper name.
-	 * @param array $options {         
-	 *     @type bool $merge        Whether the resulting array should be one big one (`true`) or
-	 *                              whether it should be an array of sub-arrays for each taxonomy
-	 *                              (`false`). Default `true`.
+	 * @param array $options {
+	 *     Optional. An array of options for the function.
+	 *
+	 *     @type bool $merge Whether the resulting array should be one big one (`true`) or whether
+	 *                       it should be an array of sub-arrays for each taxonomy (`false`).
+	 *                       Default `true`.
 	 * }
 	 * @return array An array of taxonomies.
 	 */
 	public function terms( $query_args = [], $options = [] ) {
-
 		// Make it possible to use a taxonomy or an array of taxonomies as a shorthand.
 		if ( ! is_array( $query_args ) || isset( $query_args[0] ) ) {
 			$query_args = [ 'taxonomy' => $query_args ];
 		}
 
 		/**
-		 * Handles backwards comaptability for users who use an array with a query property
+		 * Handles backwards compatibility for users who use an array with a query property.
+		 *
 		 * @deprecated 2.0.0 use Post::terms( $query_args, $options )
 		 */
 		if ( is_array($query_args) && isset($query_args['query']) ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -656,53 +656,53 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 * $terms = $post->terms( array( 'books', 'movies' ) );
 	 *
 	 * // Use custom arguments for taxonomy query and options.
-	 * $terms = $post->terms( [
-   *     'query' => [
-   *         'taxonomy' => 'custom_tax',
-   *         'orderby'  => 'count',
-   *     ],
-   *     'merge'        => false,
-   * ] );
+	 * $terms = $post->terms( [ 'taxonomy' => 'custom_tax', 
+	 *                          'orderby'  => 'count' ],
+	 *                        [ 'merge'        => false ] );
+	 *
 	 * ```
 	 *
-	 * @param string|array $args {
-	 *     Optional. Name of the taxonomy or array of arguments.
-	 *
-	 *     @type array $query       Any array of term query parameters for getting the terms. See
-	 *                              `WP_Term_Query::__construct()` for supported arguments. Use the
-	 *                              `taxonomy` argument to choose which taxonomies to get. Defaults
-	 *                              to querying all registered taxonomies for the post type. You can
-	 *                              use custom or built-in WordPress taxonomies (category, tag).
-	 *                              Timber plays nice and figures out that `tag`, `tags` or
-	 *                              `post_tag` are all the same (also for `categories` or
-	 *                              `category`). For custom taxonomies you need to define the
-	 *                              proper name.
+	 * @param string|array $query_args 	Any array of term query parameters for getting the terms. 
+	 *                                  See `WP_Term_Query::__construct()` for supported arguments. 
+	 *                                  Use the `taxonomy` argument to choose which taxonomies to 
+	 *                                  get. Defaults to querying all registered taxonomies for the 
+	 *                                  post type. You can use custom or built-in WordPress 
+	 *                                  taxonomies (category, tag). Timber plays nice and figures
+	 *                                  out that `tag`, `tags` or `post_tag` are all the same 
+	 *                                  (also for `categories` or `category`). For custom
+	 *                                  taxonomies you need to define the proper name.
+	 * @param array $options {         
 	 *     @type bool $merge        Whether the resulting array should be one big one (`true`) or
 	 *                              whether it should be an array of sub-arrays for each taxonomy
 	 *                              (`false`). Default `true`.
 	 * }
 	 * @return array An array of taxonomies.
 	 */
-	public function terms( $args = array() ) {
-		// Make it possible to use a category or an array of categories as a shorthand.
-		if ( ! is_array( $args ) || isset( $args[0] ) ) {
-			$args = array(
-				'query' => array(
-					'taxonomy' => $args,
-				),
-			);
+	public function terms( $query_args = [], $options = [] ) {
+
+		// Make it possible to use a taxonomy or an array of taxonomies as a shorthand.
+		if ( ! is_array( $query_args ) || isset( $query_args[0] ) ) {
+			$query_args = [ 'taxonomy' => $query_args ];
+		}
+
+		if ( is_array($query_args) && isset($query_args['query']) ) {
+			if ( isset($query_args['merge']) && !isset($options['merge']) ) {
+				$options['merge'] = $query_args['merge'];
+			}
+			$query_args = $query_args['query'];
 		}
 
 		// Defaults.
-		$args = wp_parse_args( $args, array(
-			'query' => array(
-				'taxonomy' => 'all',
-			),
-			'merge' => true,
-		) );
+		$query_args = wp_parse_args( $query_args, [
+			'taxonomy' => 'all'
+		] );
 
-		$taxonomies = $args['query']['taxonomy'];
-		$merge      = $args['merge'];
+		$options = wp_parse_args( $options, [
+			'merge' => true
+		] );
+
+		$taxonomies = $query_args['taxonomy'];
+		$merge      = $options['merge'];
 
 		if ( in_array($taxonomies, ['all', 'any', '']) ) {
 			$taxonomies = get_object_taxonomies($this->post_type);
@@ -712,7 +712,7 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 			$taxonomies = [$taxonomies];
 		}
 
-		$query = array_merge($args['query'], [
+		$query = array_merge($query_args, [
 			'object_ids' => [$this->ID],
 			'taxonomy'   => $taxonomies,
 		]);
@@ -728,6 +728,7 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 
 		return Timber::get_terms($query);
 	}
+
 
 	/**
 	 * @api


### PR DESCRIPTION
**Ticket**: #2203 

## Issue
The API between `Timber::get_terms` and `Post::terms()` was out of whack. We used a `query` array attribute in one, but not the other.

## Solution
Get `Post::terms`'s API to match `Timber::get_terms()` which follows the overall Factories pattern.

## Impact
No performance/query additions. The code is backwards compatibility, though I mark this section as deprecated.

## Usage Changes
Yes, noted in docs. Previous usage:

```php
$terms = $post->terms( [
      'query' => [
             'taxonomy' => 'custom_tax',
             'orderby'  => 'count',
         ],
         'merge'        => false,
        ] );
```

Revised usage:

```php
$terms = $post->terms( [ 'taxonomy' => 'custom_tax',
                         'orderby'  => 'count' ], 
                       [ 'merge'        => false ] );
```


## Considerations
As @gchtr we should also update `Term::posts` to match Factories as well and rectify that with #1931 

## Testing
Existing tests pass, added new test `TestTimberPostTerms::testPostTermsUsingUsingFactories` to validate new argument structure
