### PR TITLE
Fix s3 url

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -207,13 +207,14 @@ class URLHelper {
 	 */
 	public static function remove_double_slashes( $url ) {
 		$url = str_replace('//', '/', $url);
-		if ( strstr($url, 'http:') && !strstr($url, 'http://') ) {
-			$url = str_replace('http:/', 'http://', $url);
+		$schemes_whitelist = array( 'http', 'https', 's3' );
+
+		foreach ( $schemes_whitelist as $scheme ) {
+			if ( strstr($url, $scheme . ':') && !strstr($url, $scheme . '://') ) {
+				$url = str_replace( $scheme . ':/', $scheme . '://', $url );
+				return $url;
+			}
 		}
-		if ( strstr($url, 'https:') && !strstr($url, 'https://') ) {
-			$url = str_replace('https:/', 'https://', $url);
-		}
-		return $url;
 	}
 
 	/**

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -208,7 +208,6 @@ class URLHelper {
 	public static function remove_double_slashes( $url ) {
 		$url = str_replace('//', '/', $url);
 		$schemes_whitelist = array( 'http', 'https', 's3' );
-
 		foreach ( $schemes_whitelist as $scheme ) {
 			if ( strstr($url, $scheme . ':') && !strstr($url, $scheme . '://') ) {
 				$url = str_replace( $scheme . ':/', $scheme . '://', $url );

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -212,9 +212,10 @@ class URLHelper {
 		foreach ( $schemes_whitelist as $scheme ) {
 			if ( strstr($url, $scheme . ':') && !strstr($url, $scheme . '://') ) {
 				$url = str_replace( $scheme . ':/', $scheme . '://', $url );
-				return $url;
 			}
 		}
+
+		return $url;
 	}
 
 	/**

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -214,7 +214,6 @@ class URLHelper {
 				$url = str_replace( $scheme . ':/', $scheme . '://', $url );
 			}
 		}
-
 		return $url;
 	}
 

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -175,6 +175,13 @@
             $this->assertEquals($expected_url, $url);
         }
 
+        function testDoubleSlashesWithS3() {
+            $url = 's3://bucket/folder//thing.html';
+            $expected_url = 's3://bucket/folder/thing.html';
+            $url = Timber\URLHelper::remove_double_slashes($url);
+            $this->assertEquals($expected_url, $url);
+        }
+
         function testUserTrailingSlashItFailure() {
             $link = 'http:///example.com';
             $url = Timber\URLHelper::user_trailingslashit($link);


### PR DESCRIPTION
## Issue
I'm using https://github.com/humanmade/S3-Uploads to handle file upload.  `Timber\URLHelper::remove_double_slashes` is breaking `resize` filter for any image with `s3://` prefix

## Solution
I'm just adding s3 to the schemes whitelist


## Impact
Shouldn't break anything

## Usage Changes
None

## Considerations
Maybe build url without scheme first, remove double slashes then prepend url scheme.


## Testing
Yes
