### PR TITLE
Make strings in time_ago() translatable

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -208,7 +208,7 @@ class Twig {
 
 		$twig->addFilter(new Twig_Filter('pluck', array('Timber\Helper', 'pluck')));
 
-		/** 
+		/**
 		 * @deprecated since 1.13 (to be removed in 2.0). Use Twig's native filter filter instead
      *  @todo remove this in 2.x so that filter merely passes to Twig's filter without any modification
 		 * @ticket #1594 #2120
@@ -353,13 +353,33 @@ class Twig {
 	}
 
 	/**
-	 * @param int|string $from
-	 * @param int|string $to
-	 * @param string $format_past
-	 * @param string $format_future
+	 * Returns the difference between two times in a human readable format.
+	 *
+	 * Differentiates between past and future dates.
+	 *
+	 * @see \human_time_diff()
+	 *
+	 * @param int|string $from          Base date as a timestamp or a date string.
+	 * @param int|string $to            Optional. Date to calculate difference to as a timestamp or
+	 *                                  a date string. Default to current time.
+	 * @param string     $format_past   Optional. String to use for past dates. To be used with
+	 *                                  `sprintf()`. Default `%s ago`.
+	 * @param string     $format_future Optional. String to use for future dates. To be used with
+	 *                                  `sprintf()`. Default `%s from now`.
+	 *
 	 * @return string
 	 */
-	public static function time_ago( $from, $to = null, $format_past = '%s ago', $format_future = '%s from now' ) {
+	public static function time_ago( $from, $to = null, $format_past = null, $format_future = null ) {
+		if ( null === $format_past ) {
+			/* translators: %s: Human-readable time difference. */
+			$format_past = __( '%s ago' );
+		}
+
+		if ( null === $format_future ) {
+			/* translators: %s: Human-readable time difference. */
+			$format_future = __( '%s from now' );
+		}
+
 		$to = $to === null ? time() : $to;
 		$to = is_int($to) ? $to : strtotime($to);
 		$from = is_int($from) ? $from : strtotime($from);

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ _Twig is the template language powering Timber; if you need a little background 
 = Develop (next release) =
 
 **Fixes and improvements**
-
+* Allows for translation of time_ago Twig filter #2214 #2215 (thanks @gchtr)
 
 **Changes for Theme Developers**
 

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -171,6 +171,11 @@
 		 * @param string $locale
 		 */
 		function change_locale( $locale = 'de_DE' ) {
+			// Check if the translation is already installed.
+			if ( ! in_array( $locale, get_available_languages() ) ) {
+				self::install_translation( $locale );
+			}
+
 			switch_to_locale( $locale );
 		}
 

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -79,6 +79,84 @@
 		}
 
 		/**
+		 * Installs a translation.
+		 *
+		 * Deletes already installed translation first.
+		 *
+		 * @param string $locale The locale to install.
+		 */
+		public static function install_translation( $locale ) {
+			require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
+
+			self::uninstall_translation( $locale );
+			wp_download_language_pack( $locale );
+		}
+
+		/**
+		 * Deletes translation files for a locale.
+		 *
+		 * Logic borrowed from WP CLI Language Command
+		 *
+		 * @link https://github.com/wp-cli/language-command/blob/master/src/Core_Language_Command.php
+		 *
+		 * @param string $locale The locale to delete.
+		 *
+		 * @return bool Whether the locale was deleted.
+		 */
+		public static function uninstall_translation( $locale ) {
+			global $wp_filesystem;
+
+			$available    = wp_get_installed_translations( 'core' );
+			$translations = array_keys( $available['default'] );
+
+			if ( ! in_array( $locale, $translations, true ) ) {
+				return false;
+			}
+
+			$files = scandir( WP_LANG_DIR );
+
+			if ( ! $files ) {
+				return false;
+			}
+
+			$current_locale = get_locale();
+			if ( $locale === $current_locale ) {
+				// Language is active.
+				return true;
+			}
+
+			// As of WP 4.0, no API for deleting a language pack
+			WP_Filesystem();
+			$deleted = false;
+			foreach ( $files as $file ) {
+
+				if ( '.' === $file[0] || is_dir( $file ) ) {
+					continue;
+				}
+
+				$extension_length = strlen( $locale ) + 4;
+				$ending           = substr( $file, -$extension_length );
+				$starting = substr( $file, 0, strlen( $locale ) );
+
+				if ( ! in_array( $file, [ $locale . '.po', $locale . '.mo' ], true )
+					&& ! in_array( $ending, [ '-' . $locale . '.po', '-' . $locale . '.mo' ], true )
+					&& $locale !== $starting
+				) {
+					continue;
+				}
+
+				/** @var WP_Filesystem_Base $wp_filesystem */
+				$deleted = $wp_filesystem->delete( trailingslashit( WP_LANG_DIR ) . $file );
+			}
+
+			if ( $deleted ) {
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
 		 * Changes to a different locale.
 		 *
 		 * The translations for the locale you might want to use maybe don’t exist yet. You will

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -78,4 +78,30 @@
 			$wpdb->query("TRUNCATE TABLE $wpdb->posts;");
 		}
 
+		/**
+		 * Changes to a different locale.
+		 *
+		 * The translations for the locale you might want to use maybe don’t exist yet. You will
+		 * have to download it first through wp_download_language_pack(). Check the bootstrap.php
+		 * file to see how it works.
+		 *
+		 * After you used this function in a test, don’t forget to restore the current locale using
+		 * $this->restore_locale().
+		 *
+		 * @see \Timber_UnitTestCase::restore_locale()
+		 *
+		 * @param string $locale
+		 */
+		function change_locale( $locale = 'de_DE' ) {
+			switch_to_locale( $locale );
+		}
+
+		/**
+		 * Restores the locale after it was changed by $this->change_locale().
+		 *
+		 * @see \Timber_UnitTestCase::change_locale()
+		 */
+		function restore_locale() {
+			restore_current_locale();
+		}
 	}

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -168,9 +168,9 @@
 		 *
 		 * @see \Timber_UnitTestCase::restore_locale()
 		 *
-		 * @param string $locale
+		 * @param string $locale The locale to switch to.
 		 */
-		function change_locale( $locale = 'de_DE' ) {
+		function change_locale( $locale ) {
 			// Check if the translation is already installed.
 			if ( ! in_array( $locale, get_available_languages() ) ) {
 				self::install_translation( $locale );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,4 +32,5 @@ if ( !function_exists('is_post_type_viewable') ) {
  	}
 }
 
+// Make sure translations are installed.
 Timber_UnitTestCase::install_translation( 'de_DE' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,14 +26,10 @@ require_once __DIR__.'/TimberImage_UnitTestCase.php';
 
 error_log('Use http://build.starter-theme.dev/ for testing with UI');
 
-/**
- * Download German language pack.
- */
-require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
-wp_download_language_pack( 'de_DE' );
-
 if ( !function_exists('is_post_type_viewable') ) {
 	function is_post_type_viewable( $post_type_object ) {
  		return $post_type_object->publicly_queryable || ( $post_type_object->_builtin && $post_type_object->public );
  	}
 }
+
+Timber_UnitTestCase::install_translation( 'de_DE' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,12 @@ require_once __DIR__.'/TimberImage_UnitTestCase.php';
 
 error_log('Use http://build.starter-theme.dev/ for testing with UI');
 
+/**
+ * Download German language pack.
+ */
+require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
+wp_download_language_pack( 'de_DE' );
+
 if ( !function_exists('is_post_type_viewable') ) {
 	function is_post_type_viewable( $post_type_object ) {
  		return $post_type_object->publicly_queryable || ( $post_type_object->_builtin && $post_type_object->public );

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -21,7 +21,7 @@
 		}
 
 		function testTimeAgoFutureTranslated() {
-			$this->change_locale();
+			$this->change_locale( 'de_DE' );
 
 			$str = Timber\Twig::time_ago( '2016-12-01 20:00:00', '2016-11-30, 20:00:00' );
 			$this->assertEquals( '1 Tag ab jetzt', $str );
@@ -30,7 +30,7 @@
 		}
 
 		function testTimeAgoPastTranslated() {
-			$this->change_locale();
+			$this->change_locale( 'de_DE' );
 
 			$str = Timber\Twig::time_ago( '2016-11-29 20:00:00', '2016-11-30, 20:00:00' );
 			$this->assertEquals( 'vor 1 Tag', $str );

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -20,6 +20,24 @@
 			$this->assertEquals('1 day ago', $str);
 		}
 
+		function testTimeAgoFutureTranslated() {
+			$this->change_locale();
+
+			$str = Timber\Twig::time_ago( '2016-12-01 20:00:00', '2016-11-30, 20:00:00' );
+			$this->assertEquals( '1 Tag ab jetzt', $str );
+
+			$this->restore_locale();
+		}
+
+		function testTimeAgoPastTranslated() {
+			$this->change_locale();
+
+			$str = Timber\Twig::time_ago( '2016-11-29 20:00:00', '2016-11-30, 20:00:00' );
+			$this->assertEquals( 'vor 1 Tag', $str );
+
+			$this->restore_locale();
+		}
+
 		function testTime(){
 			$pid = $this->factory->post->create(array('post_date' => '2016-07-07 20:03:00'));
 			$post = new TimberPost($pid);

--- a/tests/test-timber-dates.php
+++ b/tests/test-timber-dates.php
@@ -21,21 +21,33 @@
 		}
 
 		function testTimeAgoFutureTranslated() {
-			$this->change_locale( 'de_DE' );
+			if ( version_compare( get_bloginfo( 'version' ), 5, '>=' ) ) {
+				$this->change_locale( 'de_DE' );
 
-			$str = Timber\Twig::time_ago( '2016-12-01 20:00:00', '2016-11-30, 20:00:00' );
-			$this->assertEquals( '1 Tag ab jetzt', $str );
+				$str = Timber\Twig::time_ago( '2016-12-01 20:00:00', '2016-11-30, 20:00:00' );
+				$this->assertEquals( '1 Tag ab jetzt', $str );
 
-			$this->restore_locale();
+				$this->restore_locale();
+
+				return;
+			}
+
+			$this->markTestSkipped( 'The string `%s from now` is not available in this WordPress version' );
 		}
 
 		function testTimeAgoPastTranslated() {
-			$this->change_locale( 'de_DE' );
+			if ( version_compare( get_bloginfo( 'version' ), 5, '>=' ) ) {
+				$this->change_locale( 'de_DE' );
 
-			$str = Timber\Twig::time_ago( '2016-11-29 20:00:00', '2016-11-30, 20:00:00' );
-			$this->assertEquals( 'vor 1 Tag', $str );
+				$str = Timber\Twig::time_ago( '2016-11-29 20:00:00', '2016-11-30, 20:00:00' );
+				$this->assertEquals( 'vor 1 Tag', $str );
 
-			$this->restore_locale();
+				$this->restore_locale();
+
+				return;
+			}
+
+			$this->markTestSkipped( 'The string `%s ago` is not available in this WordPress version' );
 		}
 
 		function testTime(){

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -10,6 +10,7 @@ class TestTimberSite extends Timber_UnitTestCase {
 	}
 
 	function testLanguageAttributes() {
+		$this->restore_locale();
 		$site = new TimberSite();
 		$lang = $site->language_attributes();
 		$this->assertEquals('lang="en-US"', $lang);


### PR DESCRIPTION
**Ticket**: #2214

## Issue

The `time_ago()` method has two parameters that aren’t translated yet.

## Solution

Use WordPress Core translations when default parameters are used.

I’ve thought about whether relying on the Core Translations is a good idea, because it’s actually not advised by WordPress. WordPress suggests introducing your own text domain for your translations, because WordPress translations might change.

I then checked what translations Timber actually uses, and it’s really only a couple of Core Translations:

- `%1$s %2$d`
- `%1$s`
- `&hellip;`

And then there are translations that are never really used, because they are only used as defaults:

- `&laquo; Previous`
- `Next &raquo;`

https://github.com/timber/timber/blob/a882871a2174e4d17fbccdb7448a9df9366f72d8/lib/Pagination.php#L115-L116

I think these translations are very unlikely to change. But still, we should be cautious and still add tests to check whether the translations work correctly.

## Impact

The proper translation will be returned when parameters aren’t passed explicitly.

## Usage Changes

None.

## Considerations

Discussed under **Solution**.

## Testing

Yes! I thought this would be going to be very complicated, but there’s actually a `wp_download_language_pack()` function. Let’s see how it runs in the automated tests.