### PR TITLE
Extending for Google Storage

### DIFF
--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -207,7 +207,7 @@ class URLHelper {
 	 */
 	public static function remove_double_slashes( $url ) {
 		$url = str_replace('//', '/', $url);
-		$schemes_whitelist = array( 'http', 'https', 's3' );
+		$schemes_whitelist = array( 'http', 'https', 's3', 'gs' );
 		foreach ( $schemes_whitelist as $scheme ) {
 			if ( strstr($url, $scheme . ':') && !strstr($url, $scheme . '://') ) {
 				$url = str_replace( $scheme . ':/', $scheme . '://', $url );

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -207,7 +207,7 @@ class URLHelper {
 	 */
 	public static function remove_double_slashes( $url ) {
 		$url = str_replace('//', '/', $url);
-		$schemes_whitelist = array( 'http', 'https', 's3', 'gs' );
+		$schemes_whitelist = apply_filters( 'timber/url/schemes-whitelist', array( 'http', 'https', 's3', 'gs' )  );
 		foreach ( $schemes_whitelist as $scheme ) {
 			if ( strstr($url, $scheme . ':') && !strstr($url, $scheme . '://') ) {
 				$url = str_replace( $scheme . ':/', $scheme . '://', $url );

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -181,6 +181,13 @@
             $url = Timber\URLHelper::remove_double_slashes($url);
             $this->assertEquals($expected_url, $url);
         }
+		
+	function testDoubleSlashesWithGS() {
+            $url = 'gs://bucket/folder//thing.html';
+            $expected_url = 'gs://bucket/folder/thing.html';
+            $url = Timber\URLHelper::remove_double_slashes($url);
+            $this->assertEquals($expected_url, $url);
+        }
 
         function testUserTrailingSlashItFailure() {
             $link = 'http:///example.com';


### PR DESCRIPTION
## Issue
Handling image resizing for images with gs:// url

## Solution
Extending url whitelist with the 'gs'.

## Impact
none


## Usage Changes
Changes are same as it was in the case of s3 urls. Basically just copy-paste.


## Testing
The very same test as in the case of testDoubleSlashesWithS3.