### PR TITLE
Throws warning on invalid template

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -200,7 +200,7 @@ class Helper {
 		if ( is_object($error) || is_array($error) ) {
 			$error = print_r($error, true);
 		}
-		return error_log('[ Timber ]'.$error);
+		return error_log('[ Timber ] '.$error);
 	}
 
 	/**

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -333,7 +333,7 @@ class Timber {
 
 			$output = $loader->render($file, $data, $expires, $cache_mode);
 		} else {
-			Helper::warn( 'Error loading your template file, make sure the file exists.' );
+			Helper::error_log( 'Error loading your template file, make sure the file exists.' );
 		}
 
 		do_action('timber_compile_done');

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -333,7 +333,10 @@ class Timber {
 
 			$output = $loader->render($file, $data, $expires, $cache_mode);
 		} else {
-			Helper::error_log( 'Error loading your template file, make sure the file exists.' );
+			if ( is_array($filenames) ) {
+				$filenames = implode(", ", $filenames);
+			}
+			Helper::error_log( 'Error loading your template files: '.$filenames.'. Make sure one of these files exists.' );
 		}
 
 		do_action('timber_compile_done');

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -278,6 +278,7 @@ class Timber {
 	 * Compile a Twig file.
 	 *
 	 * Passes data to a Twig file and returns the output.
+	 * If the template file doesn't exist it will throw a warning when WP_DEBUG is enabled.
 	 *
 	 * @api
 	 * @example
@@ -331,6 +332,8 @@ class Timber {
 			}
 
 			$output = $loader->render($file, $data, $expires, $cache_mode);
+		} else {
+			Helper::warn( 'Error loading your template file, make sure the file exists.' );
 		}
 
 		do_action('timber_compile_done');

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -21,6 +21,11 @@
 			$this->assertFalse($str);
 		}
 
+		function testTemplateChainWithMissingTwigFiles() {
+			$str = Timber::compile( array('assets/lonestar.twig', 'assets/single.twig') );
+			$this->assertEquals('I am single.twig', trim($str));
+		}
+
 		function testWhitespaceTrimForTemplate(){
 			$str = Timber::compile('assets/single.twig ', array());
 			$this->assertEquals('I am single.twig', trim($str));


### PR DESCRIPTION
**Ticket**: #2224 

## Issue
If the twig file doesn't exist than it fails silently.


## Solution
Throwing a warning if a template doesn't exist.


## Impact
Shouldn't have any. `compile()` still return false

