### PR TITLE
Update User.php

### DIFF
--- a/lib/User.php
+++ b/lib/User.php
@@ -148,6 +148,8 @@ class User extends Core implements CoreInterface {
 			if ( isset($data->roles) ) {
 				$this->roles = $this->get_roles($data->roles);
 			}
+		} else {
+			$this->display_user = '';
 		}
 		unset($this->user_pass);
 		$this->id = $this->ID = (int) $this->ID;


### PR DESCRIPTION
prevent template from crashing
```
Recoverable fatal error: Method Timber\User::__toString() must return a string value in /var/www/html/wp-content/plugins/timber-library/vendor/twig/twig/src/Environment.php(497) : eval()'d code on line 56 
```

This happened because i programmatically inserted some posts which had no user attached. Other parts of wordpress have no problem with this scenario.