### PR TITLE
Gettext extraction

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -178,6 +178,14 @@ class Loader {
 		$twig = apply_filters('timber/twig/functions', $twig);
 		$twig = apply_filters('timber/twig/escapers', $twig);
 		$twig = apply_filters('timber/loader/twig', $twig);
+
+		$twig = apply_filters('timber/twig', $twig);
+
+		/**
+		 * get_twig is deprecated, use timber/twig
+		 */
+		$twig = apply_filters('get_twig', $twig);
+
 		return $twig;
 	}
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -108,7 +108,9 @@ class Timber {
 	 */
 	protected static function init() {
 		if ( class_exists('\WP') && !defined('TIMBER_LOADED') ) {
-			Twig::init();
+			$twig = new Twig();
+			$twig->init();
+
 			ImageHelper::init();
 			Admin::init();
 			new Integrations();

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -108,9 +108,7 @@ class Timber {
 	 */
 	protected static function init() {
 		if ( class_exists('\WP') && !defined('TIMBER_LOADED') ) {
-			$twig = new Twig();
-			$twig->init();
-
+			Twig::init();
 			ImageHelper::init();
 			Admin::init();
 			new Integrations();

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -227,12 +227,6 @@ class Twig {
 					return apply_filters_ref_array($tag, $args);
 				} ));
 
-
-		$twig = apply_filters('timber/twig', $twig);
-		/**
-		 * get_twig is deprecated, use timber/twig
-		 */
-		$twig = apply_filters('get_twig', $twig);
 		return $twig;
 	}
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -10,25 +10,18 @@ use Timber\Term;
 use Timber\Image;
 use Timber\User;
 
-
 class Twig {
-
 	public static $dir_name;
 
 	/**
 	 * @codeCoverageIgnore
 	 */
 	public static function init() {
-		new self();
-	}
+		$self = new self();
 
-	/**
-	 * @codeCoverageIgnore
-	 */
-	public function __construct() {
-		add_action('timber/twig/filters', array($this, 'add_timber_filters'));
-		add_action('timber/twig/functions', array($this, 'add_timber_functions'));
-		add_action('timber/twig/escapers', array($this, 'add_timber_escapers'));
+		add_action( 'timber/twig/filters', array( $self, 'add_timber_filters' ) );
+		add_action( 'timber/twig/functions', array( $self, 'add_timber_functions' ) );
+		add_action( 'timber/twig/escapers', array( $self, 'add_timber_escapers' ) );
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**: #1754

## Issue

To make gettext extraction work, the `Timber\Twig` class needs to be instantiated without a WordPress environment. For this, we need to remove / work around WordPress functions in the `Timber\Twig::add_timber_functions()` method.

## Solution

This pull request

- Moves the hooks out of the constructor.
- Moves the `timber/twig` filter to the `Timber\Loader` class.

## Impact

There should be no impact.

By moving the `timber/twig` filter into the `Timber\Loader` class, we make sure that custom functionality is added to the Twig Environment as a last step, which is probably what most would expect.

If a duplicate filter or function is added to Twig, the order doesn’t matter, there will always be a `LogicException`. However, if your custom function or filter causes the error, the error log would probably make more sense, since it’s your code that will be flagged, and not Timber’s.

## Usage Changes

None.

## Considerations

This pull request is not about proper handling of the Twig Environment. This could probably be improved by the ideas proposed in #1493.

Using an `init()` function for adding hooks is a pattern that we often see in WordPress development. Also see [this blog post](https://carlalexander.ca/designing-class-wordpress-hooks/). I don’t know however whether it’s better to use a static pattern or a non-static pattern.

```php
// Static

Twig::init();

class Twig {
    public static function init() {
        $self = new self();

        add_action( 'example', [ $self, 'example' ] );        
    }
}

// Static with __CLASS__

Twig::init();

class Twig {
    public static function init() {
        add_action( 'example', [ __CLASS__, 'example' ] );        
    }
}

// Non-static

$twig = new Twig();
$twig->init();

class Twig {
    public function init() {
        add_action( 'example', [ $this, 'example' ] );
	}
}
```

Of course these are not all popular patterns that exist out there. The pattern using `__CLASS__` is common in order to make it easier to unhook any hooks. But then, we would have to change the functions that are being called by the hooks to be static. Maybe @pascalknecht has some insight and experience with this? I’m not sure whether it’s better to let people unhook some hooks (and possibly run into side effects) or whether there should be a different way to control functionality in case something needs to be disabled.

## Testing

No additional tests added.

@drzraf Can you check if the pull requests adds the changes we need with the5 [`gettext-extraction`](https://github.com/timber/timber/tree/gettext-extraction) branch.