### PR TITLE
2.x Fix gettext-extraction merge bugs

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -154,7 +154,7 @@ class Loader {
 				'2.0.0',
 				'timber/loader/render_data'
 			);
-			
+
 			$template = $twig->load($file);
 			$output = $template->render($data);
 		}
@@ -481,6 +481,45 @@ class Loader {
 		 * @deprecated 2.0.0, use `timber/twig/filters`
 		 */
 		$twig = apply_filters_deprecated( 'twig_apply_filters', array( $twig ), '2.0.0', 'timber/twig/filters' );
+
+		/**
+		 * Filters the Twig environment used in the global context.
+		 *
+		 * You can use this filter if you want to add additional functionality to Twig, like global
+		 * variables, filters or functions.
+		 *
+		 * @since 0.21.9
+		 * @example
+		 * ```php
+		 * /**
+		 *  * Adds Twig functionality.
+		 *  *
+		 *  * @param \Twig\Environment $twig The Twig Environment to which you can add additional functionality.
+		 *  *\/
+		 * add_filter( 'timber/twig', function( $twig ) {
+		 *     // Make get_theme_file_uri() usable as {{ theme_file() }} in Twig.
+		 *     $twig->addFunction( new Twig\TwigFunction( 'theme_file', 'get_theme_file_uri' ) );
+		 *
+		 *     return $twig;
+		 * } );
+		 * ```
+		 *
+		 * ```twig
+		 * <a class="navbar-brand" href="{{ site.url }}">
+		 *     <img src="{{ theme_file( 'build/img/logo-example.svg' ) }}" alt="Logo {{ site.title }}">
+		 * </a>
+		 * ```
+		 *
+		 * @param \Twig\Environment $twig The Twig environment.
+		 */
+		$twig = apply_filters('timber/twig', $twig);
+
+		/**
+		 * Filters the Twig environment used in the global context.
+		 *
+		 * @deprecated 2.0.0
+		 */
+		$twig = apply_filters_deprecated( 'get_twig', array( $twig ), '2.0.0', 'timber/twig' );
 
 		return $twig;
 	}

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -18,12 +18,12 @@ class Twig {
 	 */
 	public static function init() {
 		$self = new self();
-    
-    add_action( 'timber/twig/filters', array( $self, 'add_timber_filters' ) );
+
+        add_action( 'timber/twig/filters', array( $self, 'add_timber_filters' ) );
 		add_action( 'timber/twig/functions', array( $self, 'add_timber_functions' ) );
 		add_action( 'timber/twig/escapers', array( $self, 'add_timber_escapers' ) );
-   
-    add_filter( 'timber/loader/twig', [ $self, 'set_defaults' ] );
+
+        add_filter( 'timber/loader/twig', [ $self, 'set_defaults' ] );
   }
 
 	/**
@@ -252,46 +252,6 @@ class Twig {
 
 					return apply_filters_ref_array($tag, $args);
 				} ));
-
-
-		/**
-		 * Filters the Twig environment used in the global context.
-		 *
-		 * You can use this filter if you want to add additional functionality to Twig, like global
-		 * variables, filters or functions.
-		 *
-		 * @since 0.21.9
-		 * @example
-		 * ```php
-		 * /**
-		 *  * Adds Twig functionality.
-		 *  *
-		 *  * @param \Twig\Environment $twig The Twig Environment to which you can add additional functionality.
-		 *  *\/
-		 * add_filter( 'timber/twig', function( $twig ) {
-		 *     // Make get_theme_file_uri() usable as {{ theme_file() }} in Twig.
-		 *     $twig->addFunction( new Twig\TwigFunction( 'theme_file', 'get_theme_file_uri' ) );
-		 *
-		 *     return $twig;
-		 * } );
-		 * ```
-		 *
-		 * ```twig
-		 * <a class="navbar-brand" href="{{ site.url }}">
-		 *     <img src="{{ theme_file( 'build/img/logo-example.svg' ) }}" alt="Logo {{ site.title }}">
-		 * </a>
-		 * ```
-		 *
-		 * @param \Twig\Environment $twig The Twig environment.
-		 */
-		$twig = apply_filters('timber/twig', $twig);
-
-		/**
-		 * Filters the Twig environment used in the global context.
-		 *
-		 * @deprecated 2.0.0
-		 */
-		$twig = apply_filters_deprecated( 'get_twig', array( $twig ), '2.0.0', 'timber/twig' );
 
 		return $twig;
 	}


### PR DESCRIPTION
**Ticket**: #2238

## Issue

Just as I expected, the filters weren’t merged properly, probably because of earlier filter refactors involving big DocBlocks.

## Solution

Move the filters to their proper place.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

None.