### PR TITLE
Add hack to set expires to false vs. 0

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -54,6 +54,10 @@ class Loader {
 			}
 		}
 
+		if ( $expires === 0 ) {
+			$expires = false;
+		}
+
 		$key = null;
 		$output = false;
 		if ( false !== $expires ) {


### PR DESCRIPTION
**Ticket**: #1834 

## Issue
A bunch of `DELETE` commands are sent to the database in certain situations where Timber is trying to clear its own cache.


## Solution
@chads2000 noticed a situation where an `$expires` value of `0` is being strictly compared to `false` which might be throwing off the logic of the cache inside of `Loader::render`

## Impact
Need to watch out to see how this works inside other caching and compile/render tests

## Usage Changes
None

## Considerations
The WP VIP team has asked me to removing caching entirely in order to be truly compatible with their platform. Ideally this can patch the problem behavior. But I think the future for Timber caching is relying on external caching tools rather than some secondary caching internal to Timber.

## Testing
No new tests, let's see what happens to the old ones!
