### PR TITLE
WordPress VIP Compatibility Requests

### DIFF
--- a/docs/guides/hosts-servers.md
+++ b/docs/guides/hosts-servers.md
@@ -1,0 +1,41 @@
+---
+title: "Hosts & Servers"
+menu:
+  main:
+    parent: "guides"
+---
+
+This guide serves as reference for any host or server-specific information we gather. If you have experience hosting WordPress with a particular host, stack, or service (AWS, Azure, etc.) please add that information here so it can be shared.
+
+
+## WordPress VIP
+
+Automattic offers a paid service called [WordPress VIP](https://wpvip.com/) for enterprise customers. To get Timber to play nice with their stack, we need to disable functionality related to caching and writes to the filesystem:
+
+**functions.php**
+
+```php
+add_filter('timber/cache/mode', function() {
+	return 'none';
+});
+```
+
+```php
+add_filter('timber/allow_fs_write', function() {
+	return false;
+});
+```
+
+This means you will not be able to use on-the-fly image resizing through Timber. Don't despair! You can set custom image sizes for WordPress to use:
+
+**functions.php**
+```php
+add_image_size( 'my_custom_size', 220, 220, array( 'left', 'top' ) );
+```
+
+**single.twig**
+```twig
+<img src="{{ post.thumbnail.src('my_custom_size') }}" alt="{{ post.thumbnail.alt() }}">
+```
+
+WordPress VIP has its own caching mechanisms. So when we disable caching, we're only disabling Timber and Twig's caching — not other layers that WP VIP applies.

--- a/docs/guides/hosts-servers.md
+++ b/docs/guides/hosts-servers.md
@@ -21,9 +21,7 @@ add_filter('timber/cache/mode', function() {
 ```
 
 ```php
-add_filter('timber/allow_fs_write', function() {
-	return false;
-});
+add_filter( 'timber/allow_fs_write', '__return_false' );
 ```
 
 This means you will not be able to use on-the-fly image resizing through Timber. Don't despair! You can set custom image sizes for WordPress to use:

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -572,6 +572,13 @@ class ImageHelper {
 		if ( empty($src) ) {
 			return '';
 		}
+
+		$allow_fs_write = apply_filters('timber/allow_fs_write', true);
+
+		if ( $allow_fs_write === false ) {
+			return $src;
+		}
+		
 		$external = false;
 		// if external image, load it first
 		if ( URLHelper::is_external_content($src) ) {

--- a/tests/test-timber-wp-vip.php
+++ b/tests/test-timber-wp-vip.php
@@ -3,20 +3,19 @@
 	class TestTimberWPVIP extends TimberImage_UnitTestCase {
 
 		function testDisableCache() {
-			add_filter('timber/cache/mode', function() {
-				return 'none';
-			});
-
+			$filter = function() {
+			    return 'none';
+			};
+			add_filter( 'timber/cache/mode', $filter );
 			$loader = new Timber\Loader();
 			$cache = $loader->set_cache('test', 'foobar');
 			$cache = $loader->get_cache('test');
 			$this->assertFalse($cache);
+			remove_filter( 'timber/cache/mode', $filter );
 		}
 
 		function testImageResize() {
-			add_filter('timber/allow_fs_write', function() {
-				return false;
-			});
+			add_filter( 'timber/allow_fs_write', '__return_false' );
 			$data = array();
 			$data['size'] = array( 'width' => 600, 'height' => 400 );
 			$upload_dir = wp_upload_dir();
@@ -27,23 +26,21 @@
 			Timber::compile( 'assets/image-test.twig', $data );
 			$resized_path = $upload_dir['path'].'/arch-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.jpg';
 			$this->assertFileNotExists( $resized_path );
+			remove_filter( 'timber/allow_fs_write', '__return_false' );
 		}
 
 		function testImageResizeInTwig() {
-			add_filter('timber/allow_fs_write', function() {
-				return false;
-			});
+			add_filter( 'timber/allow_fs_write', '__return_false' );
 			$pid = $this->factory->post->create(array('post_type' => 'post'));
  			$attach_id = TestTimberImage::get_image_attachment($pid, 'arch.jpg');
  			$template = '<img src="{{Image(img).src|resize(200, 200)}}">';
  			$str = Timber::compile_string($template, array('img' => $attach_id));
  			$this->assertEquals('<img src="http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg">', $str);
+ 			remove_filter( 'timber/allow_fs_write', '__return_false' );
 		}
 
 		function testImageSrcThumbnail() {
-			add_filter('timber/allow_fs_write', function() {
-				return false;
-			});
+			add_filter( 'timber/allow_fs_write', '__return_false' );
 			require_once('wp-overrides.php');
 			$filename = __DIR__.'/assets/arch.jpg';
 			$filesize = filesize($filename);
@@ -59,6 +56,7 @@
 			$result = Timber::compile_string($str, array('image' => $image));
 			$upload_dir = wp_upload_dir();
 			$this->assertEquals('<img src="'.$upload_dir['url'].'/'.$image->sizes['medium']['file'].'" />', trim($result));
+			remove_filter( 'timber/allow_fs_write', '__return_false' );
 		}
 
 

--- a/tests/test-timber-wp-vip.php
+++ b/tests/test-timber-wp-vip.php
@@ -1,0 +1,69 @@
+<?php
+
+	class TestTimberWPVIP extends TimberImage_UnitTestCase {
+
+		function testDisableCache() {
+			add_filter('timber/cache/mode', function() {
+				return 'none';
+			});
+
+			$loader = new Timber\Loader();
+			$cache = $loader->set_cache('test', 'foobar');
+			$cache = $loader->get_cache('test');
+			$this->assertFalse($cache);
+		}
+
+		function testImageResize() {
+			add_filter('timber/allow_fs_write', function() {
+				return false;
+			});
+			$data = array();
+			$data['size'] = array( 'width' => 600, 'height' => 400 );
+			$upload_dir = wp_upload_dir();
+			TestTimberImage::copyTestImage();
+			$url = $upload_dir['url'].'/arch.jpg';
+			$data['test_image'] = $url;
+			$data['crop'] = 'default';
+			Timber::compile( 'assets/image-test.twig', $data );
+			$resized_path = $upload_dir['path'].'/arch-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.jpg';
+			$this->assertFileNotExists( $resized_path );
+		}
+
+		function testImageResizeInTwig() {
+			add_filter('timber/allow_fs_write', function() {
+				return false;
+			});
+			$pid = $this->factory->post->create(array('post_type' => 'post'));
+ 			$attach_id = TestTimberImage::get_image_attachment($pid, 'arch.jpg');
+ 			$template = '<img src="{{Image(img).src|resize(200, 200)}}">';
+ 			$str = Timber::compile_string($template, array('img' => $attach_id));
+ 			$this->assertEquals('<img src="http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg">', $str);
+		}
+
+		function testImageSrcThumbnail() {
+			add_filter('timber/allow_fs_write', function() {
+				return false;
+			});
+			require_once('wp-overrides.php');
+			$filename = __DIR__.'/assets/arch.jpg';
+			$filesize = filesize($filename);
+			$data = array('tmp_name' => $filename, 'name' => 'arch.jpg', 'type' => 'image/jpg', 'size' => $filesize, 'error' => 0);
+			$this->assertTrue(file_exists($filename));
+			$_FILES['tester'] = $data;
+			$file_id = WP_Overrides::media_handle_upload('tester', 0, array(), array( 'test_form' => false));
+			if (!is_int($file_id)) {
+				error_log(print_r($file_id, true));
+			}
+			$image = new Timber\Image($file_id);
+			$str = '<img src="{{image.src(\'medium\')}}" />';
+			$result = Timber::compile_string($str, array('image' => $image));
+			$upload_dir = wp_upload_dir();
+			$this->assertEquals('<img src="'.$upload_dir['url'].'/'.$image->sizes['medium']['file'].'" />', trim($result));
+		}
+
+
+
+
+
+
+	}


### PR DESCRIPTION
## Issue
The WordPress VIP team requested the ability to disable file writes in order to make Timber play nice with their tech stack.

## Solution
Add a `timber/allow_fs_write` filter that any dev can control. Defaults to true.

## Impact
Should have no backwards compatibility effect. This defaults to true, so it will have the same behavior in all existing installs.


## Usage Changes
Rather than create a guide _just_ for WP VIP, I added a new guide for "Hosts & Servers" that describes the steps WP VIP users will need to consider. This can be expanded as people contribute any platform-specific notes (both hosts like Pantheon, but also services like AWS/Azure).

## Considerations

1. For WP VIP: we should investigate how `resize` can play with the [Photon API](https://developer.wordpress.com/docs/photon/api/). Shouldn't be too hard, but I think it's for a future PR.
2. I already have experience with a few hosts that I can add to the Hosts & Servers guides, but holding back for now (all are "works great w/o modification") — Kinsta, Pantheon and WP Engine


## Testing
Yes, new test class for WP VIP
