### PR TITLE
2.x Add documentation for new Pages Menu API

### DIFF
--- a/docs/guides/class-maps.md
+++ b/docs/guides/class-maps.md
@@ -285,7 +285,7 @@ add_filter( 'timber/pages_menu/classmap', function( $class ) {
 } );
 ```
 
-The Menu Class Map receives the default `Timber\PagesMenu` class name as an argument.
+The Pages Menu Class Map receives the default `Timber\PagesMenu` class name as an argument.
 
 ## The User Class Map
 

--- a/docs/guides/class-maps.md
+++ b/docs/guides/class-maps.md
@@ -265,6 +265,28 @@ add_filter( 'timber/menuitem/classmap', function( $class, $menu ) {
 }, 10, 2 );
 ```
 
+## The Pages Menu Class Map
+
+With the `timber/pages_menu/classmap` filter, you can tell Timber which class it should use for pages menu object.
+
+The Pages Menu Class Map is used:
+
+- When you get a menu through `Timber::get_pages_menu()`.
+
+Here’s an a example for a basic filter where you would always return your custom `ExtendedMenu` class.
+
+**functions.php**
+
+```php
+use ExtendedPagesMenu;
+
+add_filter( 'timber/pages_menu/classmap', function( $class ) {
+    return ExtendedPagesMenu::class;
+} );
+```
+
+The Menu Class Map receives the default `Timber\PagesMenu` class name as an argument.
+
 ## The User Class Map
 
 With the `timber/user/classmap` filter, you can tell Timber which class it should use for user objects.

--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -38,7 +38,7 @@ $menu = Timber::get_menu( 'primary' );
 
 What you get in return is a [`Timber\Menu`](https://timber.github.io/docs/reference/timber-menu/) object that holds a collection of [`Timber\MenuItem`](https://timber.github.io/docs/reference/timber-menuitem/) objects. If no menu can be found with the argument you provided, the function will return `false`.
 
-In earlier versions of Timber, it was possible to pass in nothing. We’ve removed that functionality because it led to confusing cases where the wrong menu was returned.
+In earlier versions of Timber, it was possible to pass in nothing. We’ve removed that functionality because it led to confusing cases where a menu built from your pages was returned. If you still want to get a menu from your existing pages, use [`Timber::get_pages_menu()`](#pages-menu).
 
 ### Options
 
@@ -94,6 +94,27 @@ $menu = Timber::get_menu( 'primary' );
 ```
 
 In the same way that you [can’t instantiate post objects directly](https://timber.github.io/docs/guides/posts/#extending-timber-post), you **can’t** instantiate `Timber\Menu` or `Timber\MenuItem` objects or an object that extends this class with a constructor. Timber will use the [Menu Class Map](https://timber.github.io/docs/guides/class-maps/#the-menu-class-map) and the [MenuItem Class Map](https://timber.github.io/docs/guides/class-maps/#the-menuitem-class-map) to sort out which class it should use.
+
+## Pages Menu
+
+Timber includes a function to create menu from your pages, without having to register menus first. This is a quick way to create a menu if you have a small website with only a couple of pages.
+
+```php
+$menu = Timber::get_pages_menu();
+```
+
+This function will return an instance of `Timber\PagesMenu`, which is not quite the same as `Timber\Menu`, but it contains the same `Timber\MenuItem` objects as you know them.
+
+If you want to extend a pages menu, you would do it like this:
+
+
+```php
+class CustomPagesMenu extends Timber\PagesMenu {
+
+}
+```
+
+There’s a special [PagesMenu Class Map](https://timber.github.io/docs/guides/class-maps/#the-pages-menu-class-map) which you can use to make Timber use your custom class.
 
 ## Setting up a menu globally
 

--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -109,7 +109,7 @@ If you want to extend a pages menu, you would do it like this:
 
 
 ```php
-class CustomPagesMenu extends Timber\PagesMenu {
+class ExtendedPagesMenu extends \Timber\PagesMenu {
 
 }
 ```

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -347,6 +347,8 @@ $menu = new Timber\Menu();
 $menu = Timber::get_pages_menu();
 ```
 
+If `Timber::get_menu()` can’t find a menu with the parameters you used, it will now return `false`.
+
 ---
 
 ### Users

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -333,7 +333,7 @@ $menu = Timber::get_menu( 'primary' );
 
 #### The Pages Menu
 
-If you didn’t provide a parameter and didn’t have any menus registered, Timber would build **a menu from your existing pages**. This still works, but you have to use the new `Timber::get_pages_menu()` function.
+Previously, if you didn’t provide a parameter to `Timber\Menu()` and didn’t have any menus registered, Timber would build **a menu from your existing pages**. To achieve this same functionality, you must now use the new `Timber::get_pages_menu()` function.
 
 **Old**
 

--- a/docs/upgrade-guides/2.0.md
+++ b/docs/upgrade-guides/2.0.md
@@ -331,7 +331,21 @@ Always pass a parameter.
 $menu = Timber::get_menu( 'primary' );
 ```
 
-@TODO
+#### The Pages Menu
+
+If you didn’t provide a parameter and didn’t have any menus registered, Timber would build **a menu from your existing pages**. This still works, but you have to use the new `Timber::get_pages_menu()` function.
+
+**Old**
+
+```php
+$menu = new Timber\Menu();
+```
+
+**New**
+
+```php
+$menu = Timber::get_pages_menu();
+```
 
 ---
 
@@ -473,6 +487,10 @@ Up until now, there was only a representation for WordPress image attachments in
 - We’ve added new methods for `Timber\Attachment`. See the section below (@todo: Add anchor link)
 - We’ve added a new Twig function `Attachment()`. (@todo: Add link to documentation)
 
+## New PagesMenu class
+
+To handle cases where you wanted to build a menu from your existing pages separately, we added a `Timber\PagesMenu` class that will be used when you use the new `Timber::get_pages_menu()` function.
+
 ## Deprecated functions and variables
 
 The following functions are being deprecated and will be removed in a future version of Timber.
@@ -592,6 +610,8 @@ The following functions were **removed from the codebase**, either because they 
 - `context_global()` - Gets the global context.
 - `context_post()` - Gets post context for a singular template.
 - `context_posts()` - Gets posts context for an archive template.
+- `get_menu()` – Gets a menu object for a specific menu.
+- `get_pages_menu()` – Gets a menu object built from your existing pages.
 
 **Timber\Post**
 
@@ -742,6 +762,9 @@ If you’ve used `timber/term/meta` before, you might have to switch to `timer/t
 We added new hooks that let you filter stuff you couldn’t filter before:
 
 - `timber/term/classmap`
+- `timber/menu/classmap`
+- `timber/menuitem/classmap`
+- `timber/pages_menu/classmap`
 - `timber/user/classmap`
 - `timber/comment/classmap`
 - `timber/twig/environment/options`


### PR DESCRIPTION
**Ticket**: #2089

## Issue

As discussed in https://github.com/timber/timber/issues/2089#issuecomment-629852632, we need documentation for the new Pages Menu.

## Solution

Add documentation in the Menus Guide, the Class Maps Guide and the Upgrade Guide.

## Usage Changes

A new API to create a menu from the existing pages dynamically:

* A `Timber\PagesMenu` class. 
* A `timber/pages_menu/classmap` filter.
* A `Timber::get_pages_menu()` function.

## Considerations

I didn’t come up with big examples, because I think this will feature will be mainly for simpler sites, where custom classes might often not be needed anyways. Or may I just felt like a lazy dog.

## Testing

No.