### PR TITLE
Resolve issue with more tags from Gutenberg

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1224,9 +1224,26 @@ class Post extends Core implements CoreInterface {
 				$content = $contents[$page];
 			}
 		}
+		$content = $this->content_handle_no_teaser_block( $content );
 		$content = apply_filters('the_content', ($content));
 		if ( $len == -1 && $page == 0 ) {
 			$this->___content = $content;
+		}
+		return $content;
+	}
+
+	/**
+	 * Handles for an circumstance with the Block editor where a "more" block has an option to 
+	 * "Hide the excerpt on the full content page" which hides everything prior to the inserted 
+	 * "more" block
+	 * @ticket #2218
+	 * @param string $content
+	 * @return string
+	 */
+	protected function content_handle_no_teaser_block( $content ) {
+		if ( strpos($content, 'noTeaser:true') !== false ) {
+			$arr = explode('<!--noteaser-->', $content);
+			return $arr[1];
 		}
 		return $content;
 	}

--- a/tests/test-timber-post-content.php
+++ b/tests/test-timber-post-content.php
@@ -1,0 +1,68 @@
+<?php
+
+	class TestTimberPostContent extends Timber_UnitTestCase {
+
+
+	function testContent(){
+		$quote = 'The way to do well is to do well.';
+		$post_id = $this->factory->post->create();
+		$post = new TimberPost($post_id);
+		$post->post_content = $quote;
+		wp_update_post($post);
+		$this->assertEquals($quote, trim(strip_tags($post->content())));
+		$this->assertEquals($quote, trim(strip_tags($post->get_content())));
+	}
+
+	function testContentPaged(){
+		$quote = $page1 = 'The way to do well is to do well.';
+		$quote .= '<!--nextpage-->';
+		$quote .= $page2 = "And do not let your tongue get ahead of your mind.";
+
+		$post_id = $this->factory->post->create();
+		$post = new TimberPost($post_id);
+		$post->post_content = $quote;
+		wp_update_post($post);
+
+		$this->assertEquals($page1, trim(strip_tags($post->content(1))));
+		$this->assertEquals($page2, trim(strip_tags($post->content(2))));
+		$this->assertEquals($page1, trim(strip_tags($post->get_content(0,1))));
+		$this->assertEquals($page2, trim(strip_tags($post->get_content(0,2))));
+	}
+
+	function testPagedContent(){
+		$quote = $page1 = 'Named must your fear be before banish it you can.';
+		$quote .= '<!--nextpage-->';
+		$quote .= $page2 = "No, try not. Do or do not. There is no try.";
+
+		$post_id = $this->factory->post->create(array('post_content' => $quote));
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		// @todo The below should work magically when the iterators are merged
+		setup_postdata( get_post( $post_id ) );
+
+		$post = Timber::get_post();
+			$this->assertEquals($page1, trim(strip_tags( $post->paged_content() )));
+
+		$pagination = $post->pagination();
+		$this->go_to( $pagination['pages'][1]['link'] );
+
+		setup_postdata( get_post( $post_id ) );
+		$post = Timber::get_post();
+
+		$this->assertEquals($page2, trim(strip_tags( $post->get_paged_content() )));
+	}
+
+	/**
+	 * @ticket 2218
+	 */
+	function testGutenbergExcerptOption() {
+		$content_1 = '<!-- wp:paragraph --><p>Here is the start to my post! This should not show when noTeaser:true</p><!-- /wp:paragraph -->
+<!-- wp:more {"noTeaser":true} --><!--more--><!--noteaser-->';
+		$content_2 = '<!-- /wp:more --><!-- wp:paragraph --><p>WHEN noTeaser:true, ONLY this shows on the single page</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>And this too!</p><!-- /wp:paragraph -->';
+		$post_id = $this->factory->post->create(['post_content' => $content_1.$content_2 ]);
+		$post = new \Timber\Post($post_id);
+		$this->assertEquals($content_2, $post->content());
+	}
+
+}

--- a/tests/test-timber-post-content.php
+++ b/tests/test-timber-post-content.php
@@ -57,11 +57,16 @@
 	 * @ticket 2218
 	 */
 	function testGutenbergExcerptOption() {
+		global $wp_version;
+		if ( $wp_version < 5.0 ) {
+			$this->markTestSkipped('Only applies to Block editor which is avaialble in WP 5.x');
+		}
 		$content_1 = '<!-- wp:paragraph --><p>Here is the start to my post! This should not show when noTeaser:true</p><!-- /wp:paragraph -->
 <!-- wp:more {"noTeaser":true} --><!--more--><!--noteaser-->';
 		$content_2 = '<!-- /wp:more --><!-- wp:paragraph --><p>WHEN noTeaser:true, ONLY this shows on the single page</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>And this too!</p><!-- /wp:paragraph -->';
 		$post_id = $this->factory->post->create(['post_content' => $content_1.$content_2 ]);
 		$post = new \Timber\Post($post_id);
+		
 		$this->assertEquals($content_2, $post->content());
 	}
 


### PR DESCRIPTION
**Ticket**: #2218

## Issue
Using a Gutenberg "More" block you can set an option for "Hide the excerpt on the full content page":

![Screen Shot 2020-06-03 at 8 47 57 PM](https://user-images.githubusercontent.com/1298086/83702756-8f5ed880-a5db-11ea-9f24-37a4c8559b96.png)

However, Timber doesn't respect carry this through to the single content page because it's handled for in some way outside of `the_content` filters and other things used by Timber (in tests the `twentynineteen` theme handled correctly.

## Solution
I wrote a function in `Timber\Post` that handles for this (edge?)case

## Impact
This will correct a bug. All old tests pass, I'd consider it fully backwards-compatible. (The only theoretical error is if someone used the tags generated by Gutenberg in a manual way hoping for them to have the opposite effect).

## Usage Changes
None.

## Considerations
We could fully reverse-engineer how WP is doing it so that it hooks into the exact logic. I'm comfortable with this step unless something more thorough proves necessary.

## Testing
Old tests pass; new test written
