### PR TITLE
2.x Update Extending Timber Guide

### DIFF
--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -138,7 +138,7 @@ add_filter( 'timber/post/classmap', function( $classmap ) {
 } );
 ```
 
-### Move your logic from your template files to your classes
+## Move your logic from your template files to your classes
 
 In the Getting Started Guide for [Archive Pages](/docs/v2/getting-started/a-post-archive/), we looked at how you can load related posts and add them to the context.
 
@@ -252,7 +252,7 @@ class BlogPost extends \Timber\Post {
 }
 ```
 
-### Magazine example
+## Magazine example
 
 Let’s look at an example where you work with a post’s relationship to other WordPress objects. In the following example, each post is a part of an "issue" of a magazine. We want an easy way to reference the issue in the Twig file:
 
@@ -303,13 +303,13 @@ class MagazinePost extends \Timber\Post {
 
 So now we’ve got an easy way to refer to `{{ post.issue }}` in our Twig templates.
 
-### Working with meta fields
+## Working with meta fields
 
 A very common use case is to use custom methods for handling meta values. Also refer to the [Custom Fields Guide](/docs/v2/guides/custom-fields/) for more information.
 
 Here, we take an custom post type `event` an example.
 
-#### Keep your logic in PHP
+### Keep your logic in PHP
 
 An event probably has a date that you define in the meta field `date_start`. You could get the date and manipulate the output format through Twig’s `date` filter.
 
@@ -399,7 +399,7 @@ class Event extends \Timber\Post {
 ```
 
 
-#### Extending IDs to Timber objects
+### Extending IDs to Timber objects
 
 Imagine that each `event` has a meta field that contains an array of post IDs of posts of the post type `sponsor`, with which you can select all the organizations that make your event possible with their donations.
 

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -5,7 +5,7 @@ order: "1600"
 
 There’s a myth that Timber is for making simple themes, but in fact it’s for making incredibly complex themes _look_ easy. But yes, you can also make simple sites from it.
 
-The beauty of Timber is that the object-oriented nature lets you extend it to match the exact requirements of your theme.
+The beauty of Timber is that its object-oriented nature lets you extend it to match the exact requirements of your theme.
 
 ## Extending Timber classes
 
@@ -44,7 +44,7 @@ class BlogPost extends \Timber\Post {
 }
 ```
 
-Because we extend `Timber\Post`, we have all the methods from that class available to us by using `$this->method_name()`. In this example, we get posts content through `$this->content()`.
+By extending `Timber\Post`, we have all the methods from that class available to us by using `$this->method_name()`. In the example, we get the post’s content through `$this->content()`.
 
 ### Use Class Maps
 
@@ -86,7 +86,7 @@ Now, in Twig, you can use this new method using `{{ post.reading_time }}`.
 </header>
 ```
 
-Your custom methods could get pretty complex. And that’s the beauty. The complexity lives inside the context of the object, but looks very simple when it comes to your Twig templates.
+Your custom methods can get pretty complex. And that’s the beauty. The complexity lives inside the context of the object, but looks very simple when it comes to your Twig templates.
 
 ### Register a custom namespace in Composer
 
@@ -96,7 +96,7 @@ To make it a little easier to load your custom classes, you could either require
 require_once 'inc/BlogPost.php';
 ```
 
-Or, because you already use Composer to handle dependencies, you can register your own [namespace](https://www.php.net/manual/en/language.namespaces.php)  that should be autoloaded there. For example, you could add a **src** folder to your project and declare it as the `Theme` namespace.
+Or, because you already use Composer to handle dependencies, you can register your own [namespace](https://www.php.net/manual/en/language.namespaces.php) to be autoloaded. For example, you could add a **src** folder to your project and declare it as the `Theme` namespace.
 
 **composer.json**
 
@@ -358,7 +358,7 @@ This is better, because
 
 Additionally, if there’s more logic, you probably shouldn’t write it in Twig anyway. Twig is powerful, but it shouldn’t replace PHP.
 
-Consider that you might also have an end date for the event that you save in a meta field `date_end`. And suddenly you would have many more cases to handle. You might have to account for empty end dates or maybe display the date a little different if there’s an end date present. Maybe you would want to say `May 30 – June 4 2020`, but `4 – 6 June 2020` instead of `June 4 – June 6 2020` if the month of the two dates is the same.
+Consider that you might also have an end date for the event that you save in a meta field `date_end`. Suddenly, you have many more cases to handle. You might have to account for empty end dates or maybe display the date a little different if there’s an end date present. Maybe you would want to say `May 30 – June 4 2020`, but `4 – 6 June 2020` instead of `June 4 – June 6 2020` if the month of the two dates is the same.
 
 You can also make the date formats a little more dynamic here by using an arguments array. By using [`wp_parse_args()`](https://developer.wordpress.org/reference/functions/wp_parse_args/), you can make sure that all arguments you need are there, even when you only want to overwrite one of the date formats.
 
@@ -573,7 +573,7 @@ function whateverify( $text ) {
 This can now be called in your twig files with:
 
 ```twig
-<h2 id="{{ post.title|slugify }}">{{ post.title|whateverify }}</h2>
+<h2 id="{{ post.title | slugify }}">{{ post.title | whateverify }}</h2>
 ```
 
 Which will output:

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -34,7 +34,6 @@ class BlogPost extends \Timber\Post {
     */
     public function reading_time() {
         $words_per_minute = 228;
-        $words_per_second = $words_per_minute / 60;
 
         $words   = str_word_count( wp_strip_all_tags( $this->content() ) );
         $minutes = round( $words / $words_per_minute );
@@ -94,7 +93,7 @@ Your custom methods could get pretty complex. And that’s the beauty. The compl
 To make it a little easier to load your custom classes, you could either require that class in your **functions.php** to make it available for Timber to use:
 
 ```php
-require_once( 'inc/BlogPost.php' );
+require_once 'inc/BlogPost.php';
 ```
 
 Or, because you already use Composer to handle dependencies, you can register your own [namespace](https://www.php.net/manual/en/language.namespaces.php)  that should be autoloaded there. For example, you could add a **src** folder to your project and declare it as the `Theme` namespace.

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -573,7 +573,7 @@ function whateverify( $text ) {
 This can now be called in your twig files with:
 
 ```twig
-<h2 id="{{ post.title | slugify }}">{{ post.title | whateverify }}</h2>
+<h2 id="{{ post.title|slugify }}">{{ post.title|whateverify }}</h2>
 ```
 
 Which will output:

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -3,107 +3,471 @@ title: "Extending Timber"
 order: "1600"
 ---
 
-Myth: Timber is for making simple themes. Fact: It's for making incredibly complex themes _look_ easy. But yes, you can also make simple sites from it.
+There’s a myth that Timber is for making simple themes, but in fact it’s for making incredibly complex themes _look_ easy. But yes, you can also make simple sites from it.
 
 The beauty of Timber is that the object-oriented nature lets you extend it to match the exact requirements of your theme.
 
-## An example that extends Timber\Post
+## Extending Timber objects
 
-Timber's objects like `Timber\Post`, `Timber\Term`, etc. are a great starting point to build your own subclass from. For example, on this project each post was a part of an "issue" of a magazine. I wanted an easy way to reference the issue in the twig file:
+One of the main concepts for extending Timber is to extend its objects. You can add your custom methods and properties to Posts, Terms and other objects. This way, you can reduce the amount of logic in your template files as well as your Twig files.
 
+Let’s look at how we could add a method to **calculate the reading time for a blog post.** First, let’s create a `BlogPost` class with a method that calculates the reading time.
+
+**src/BlogPost.php**
+
+```php
+<?php
+
+/**
+ * Class BlogPost
+ */
+class BlogPost extends \Timber\Post {
+   /**
+    * Estimates time required to read a post.
+    *
+    * The words per minute are based on the English language, which e.g. is much
+    * faster than German or French.
+    *
+    * @link https://www.irisreading.com/average-reading-speed-in-various-languages/
+    *
+    * @return string
+    */
+    public function reading_time() {
+        $words_per_minute = 228;
+        $words_per_second = $words_per_minute / 60;
+
+        $words   = str_word_count( wp_strip_all_tags( $this->content() ) );
+        $minutes = round( $words / $words_per_minute );
+
+        /* translators: %s: Time duration in minute or minutes. */
+        return sprintf( _n( '%s minute', '%s minutes', $minutes ), (int) $minutes );
+    }
+}
+```
+
+Because we extend `Timber\Post`, we have all the methods from that class available to us by using `$this->method_name()`. In this example, we get posts content through `$this->content()`.
+
+### Use Class Maps
+
+To register your own objects with Timber, you use Class Maps. Refer to the [Class Maps Guide](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
+
+**functions.php**
+
+```php
+require_once( 'src/BlogPost.php' );
+
+add_filter( 'timber/post/classmap', function( $classmap ) {
+    $custom_classmap = [
+        'post' => BlogPost::class,
+    ];
+
+    return array_merge( $classmap, $custom_classmap );
+} );
+```
+
+With that, Timber will use the `BlogPost` class for all your posts with the post type `post`, whenever you use a Timber function that returns a `Timber\Post`.
+
+### Use it in Twig
+
+Now, in Twig, you can use this new method using `{{ post.reading_time }}`.
 
 ```twig
-<h1>{{ post.title }}</h1>
-<h3>From the {{ post.issue.title }} issue</h3>
+<header>
+    <h1>{{ post.title }}</h1>
+
+    <p>
+        {{ post.reading_time }} to read <span>&bull;</span>
+
+        Written by {{ post.author.name }} <span>&bull;</span>
+
+        <time
+            datetime="{{ post.date('Y-m-d H:i:s') }}"
+        >{{ post.date }}</time>
+    <p>
+</header>
 ```
 
-Of course, `Timber\Post` has no built-in concept of an issue (which I've built as a custom taxonomy called "issues"). So we're going to extend `Timber\Post` to give it one:
+Your custom methods could get pretty complex. And that’s the beauty. The complexity lives inside the context of the object, but looks very simple when it comes to your Twig templates.
 
+### Register a custom namespace in Composer
+
+To make it a little easier to load your custom classes, you could either require that class in your **functions.php** to make it available for Timber to use:
+
+```php
+require_once( 'inc/BlogPost.php' );
+```
+
+Or, because you already use Composer to handle dependencies, you can register your own [namespace](https://www.php.net/manual/en/language.namespaces.php)  that should be autoloaded there. For example, you could add a **src** folder to your project and declare it as the `Theme` namespace.
+
+**composer.json**
+
+```json
+"autoload": {
+  "psr-4": {
+    "Theme\\": "src/"
+  }
+},
+```
+
+Then, you would use that namespace for your `BlogPost` class.
+
+
+**src/BlogPost.php**
 
 ```php
 <?php
-class MySitePost extends Timber\Post {
 
-	var $_issue;
+namespace Theme;
 
+
+class BlogPost {
+    // ...
+}
+```
+
+And in your Class Map, you could reference that class with the `use` statement.
+
+```php
+use Theme\BlogPost;
+
+add_filter( 'timber/post/classmap', function( $classmap ) {
+    $custom_classmap = [
+        'post' => BlogPost::class,
+    ];
+
+    return array_merge( $classmap, $custom_classmap );
+} );
+```
+
+### Move your logic from your template files to your objects
+
+In the Getting Started Guide for [Archive Pages](/docs/v2/getting-started/a-post-archive/), we looked at how you can load related posts and add them to the context.
+
+```php
+<?php
+
+$context = Timber::context();
+
+$post = $context['post'];
+
+$context['related_posts'] = Timber::get_posts( [
+	'post_type'      => 'post',
+    'posts_per_page' => 3,
+    'orderby'        => 'date',
+    'order'          => 'DESC',
+    'post__not_in'   => [ $post->ID ],
+    'category__in'   => $post->terms( [
+        'taxonomy' => 'category',
+        'fields'   => 'ids',
+    ] ),
+] );
+
+Timber::render( 'single.twig', $context );
+```
+
+We can move this function over to the `BlogPost` class. The only difference is that instead of using `$post`, you would use `$this` to reference properties and methods.
+
+```php
+<?php
+
+/**
+ * Class BlogPost
+ */
+class BlogPost extends \Timber\Post {
+    /**
+     * Gets related posts for that post object.
+     *
+     * @return \Timber\PostCollection
+     */
+    public function related_posts() {
+        return Timber::get_posts( [
+            'post_type'      => $this->post_type,
+            'posts_per_page' => 3,
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'post__not_in'   => [ $this->ID ],
+            'category__in'   => $this->terms( [
+                'taxonomy' => 'category',
+                'fields'   => 'ids',
+            ] ),
+        ] );
+    }
+}
+```
+
+Now, you can still loop over your related posts in your Twig template:
+
+**single.twig**
+
+```twig
+{% if post.related_posts is not empty %}
+    <ul>
+        {% for post in post.related_posts %}
+            <li>{{ include('teaser.twig') }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+```
+
+However, because of the if-statement, we call the `related_posts()` method twice. This might be bad for performance, because we call `Timber::get_posts()` twice. So let’s add a small cache via a `related_posts` property. This way, we can call `related_posts()` as many times as we need.
+
+```php
+<?php
+
+/**
+ * Class BlogPost
+ */
+class BlogPost extends \Timber\Post {
+    /**
+     * Related posts cache.
+     *
+     * @var \Timber\PostCollection|null
+     */
+    protected $related_posts;
+
+    /**
+     * Gets related posts for that post object.
+     *
+     * @return \Timber\PostCollection
+     */
+    public function related_posts() {
+        // Return related posts early if we already loaded them.
+        if ( ! empty( $this->related_posts ) ) {
+            return $this->related_posts;
+        }
+
+        $this->related_posts = Timber::get_posts( [
+            'post_type'      => $this->post_type,
+            'posts_per_page' => 3,
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'post__not_in'   => [ $this->ID ],
+            'category__in'   => $this->terms( [
+                'taxonomy' => 'category',
+                'fields'   => 'ids',
+            ] ),
+        ] );
+
+        return $this->related_posts;
+    }
+}
+```
+
+### Magazine example
+
+Let’s look at an example where you work with a post’s relationship to other WordPress objects. In the following example, each post is a part of an "issue" of a magazine. We want an easy way to reference the issue in the Twig file:
+
+**single-post.twig**
+
+```twig
+<header>
+    <h1>{{ post.title }}</h1>
+    <p>From the {{ post.issue.title }} issue</p>
+</header>
+```
+
+Of course, `Timber\Post` has no built-in concept of an issue. Imagine there’s a custom taxonomy called `issue`. So we're going to extend `Timber\Post` to give it an `issue()` method.
+
+```php
+<?php
+
+class MagazinePost extends \Timber\Post {
+    /**
+     * Issue cache.
+     *
+     * @var \Timber\Term
+     */
+	protected $issue;
+
+    /**
+     * Gets a magazine’s issue.
+     *
+     * @return \Timber|Term|false;
+     */
 	public function issue() {
-		$issues = $this->get_terms('issues');
-		if (is_array($issues) && count($issues)) {
-			return $issues[0];
-		}
+        if ( ! empty( $this->_issue ) ) {
+            return $this->issue;
+        }
+
+        $issues = $this->terms( [
+            'taxonomy' => 'issues'
+        ] );
+
+		if ( is_array( $issues ) && ! empty( $issues ) ) {
+			$this->issue = $issues[0];
+        }
+
+        return $this->issue;
 	}
 }
 ```
 
-So now I've got an easy way to refer to the {{ post.issue }} in our twig templates. If you want to make this production-ready I recommend a bit of internal caching so that you don't re-query every time you need to get the
-issue data:
+So now we’ve got an easy way to refer to `{{ post.issue }}` in our Twig templates.
+
+### Working with meta fields
+
+A very common use case is to use custom methods for handling meta values. Also refer to the [Custom Fields Guide](/docs/v2/guides/custom-fields/) for more information.
+
+Here, we take an custom post type `event` an example.
+
+#### Keep your logic in PHP
+
+An event probably has a date that you define in the meta field `date_start`. You could get the date and manipulate the output format through Twig’s `date` filter.
+
+```twig
+{{ post.meta('date_start')|date('F j Y') }}
+```
+
+But you could also define your own `date_display` method to display that date.
 
 ```php
-<?php
-class MySitePost extends Timber\Post {
+/**
+ * Class Event
+ */
+class Event extends \Timber\Post {
+    /**
+	 * Gets display date.
+	 *
+	 * @return string
+	 */
+    public function date_display() {
+        $date_start = DateTimeImmutable::createFromFormat( 'Ymd', $this->meta( 'date_start' ) );
 
-	var $_issue;
-
-	public function issue() {
-		if (!$this->_issue) {
-			$issues = $this->get_terms('issues');
-			if (is_array($issues) && count($issues)) {
-				$this->_issue = $issues[0];
-			}
+        if ( empty( $date_start ) ) {
+			return '';
 		}
-		return $this->_issue;
-	}
+
+        return wp_date( 'F j Y', $date_start->getTimestamp() );
+    }
 }
 ```
 
-Right now I'm in the midst of building a complex site for a hybrid foundation and publication. The posts on the site have some very specific requirements that requires a fair amount of logic. I can take the simple `Timber\Post` object and extend it to make it work perfectly for this theme.
+And use it in Twig:
 
-For example, I have a plugin that let's people insert manually related posts, but if they don't, WordPress will pull some automatically based on how the post is tagged.
+```twig
+{{ post.date_display }}
+```
+
+This is better, because
+
+1. You now have a clear name for your functionality.
+2. You can use it everywhere where an `Event` post is used.
+
+Additionally, if there’s more logic, you probably shouldn’t write it in Twig anyway. Twig is powerful, but it shouldn’t replace PHP.
+
+Consider that you might also have an end date for the event that you save in a meta field `date_end`. And suddenly you would have many more cases to handle. You might have to account for empty end dates or maybe display the date a little different if there’s an end date present. Maybe you would want to say `May 30 – June 4 2020`, but `4 – 6 June 2020` instead of `June 4 – June 6 2020` if the month is the same.
 
 ```php
-	<?php
-	class MySitePost extends Timber\Post {
+/**
+ * Class Event
+ */
+class Event extends \Timber\Post {
+    /**
+	 * Gets display date.
+	 *
+	 * @return string
+	 */
+	public function date_display() {
+		$date_start = DateTimeImmutable::createFromFormat( 'Ymd', $this->meta( 'date_start' ) );
+		$date_end   = DateTimeImmutable::createFromFormat( 'Ymd', $this->meta( 'date_end' ) );
 
-		function get_related_auto() {
-			$tags = $this->tags();
-			if (is_array($tags) && count($tags)) {
-				$search_tag = $tags[0];
-				$related = new Timber\PostQuery('tag_id='.$search_tag->ID);
-				return $related;
+		if ( empty( $date_start ) ) {
+			return '';
+		}
+
+		if ( empty( $date_end ) ) {
+			$date_string = wp_date( 'F j Y', $date_start->getTimestamp() );
+		} else {
+			// Different format if month is the same.
+			if ( $date_start->format( 'm' ) === $date_end->format( 'm' ) ) {
+				$date_string = sprintf(
+                    '%1$s &ndash %2$s',
+                    wp_date( 'j', $date_start->getTimestamp() ),
+                    wp_date( 'j F Y', $date_end->getTimestamp() )
+                );
 			} else {
-				//not tagged, cant do related on it
-				return false;
+                $date_string = sprintf(
+                    '%1$s &ndash %2$s',
+                    wp_date( 'F j', $date_start->getTimestamp() ),
+                    wp_date( 'F j Y', $date_end->getTimestamp() )
+                );
 			}
 		}
 
-		function get_related_manual() {
-			if (isset($this->related_manual) && is_array($this->related_manual)){
-				foreach($this->related_manual as &$related){
-					$related = new MySitePost($related);
-				}
-				return $this->related_manual;
-			}
-			return false;
-		}
-
-		function related($limit = 3) {
-			$related = $this->get_related_manual();
-			if (!$related){
-				$related = $this->get_related_auto();
-			}
-			if (is_array($related)) {
-				array_splice($related, 0, $limit);
-			}
-			return $related;
-		}
+		return $date_string;
 	}
+}
 ```
 
-These can get pretty complex. And that's the beauty. The complexity lives inside the context of the object, but very simple when it comes to your templates.
 
-## Adding to Twig
+#### Extending IDs to Timber objects
 
-You can extend Twig by adding custom functionality like functions or filters.
+Imagine that each `event` has a meta field that contains an array of post IDs of posts of the post type `sponsor`, with which you can select all the organizations that make your event possible with their donations.
+
+You could do this in Twig and use `get_posts()` to convert your IDs to `Timber\Post` objects:
+
+```twig
+{% set sponsors = get_posts(post.meta('sponsors')) %}
+
+{% if sponsors %}
+    <h2>Many thanks to our generous sponsors</h2>
+
+    <ul>
+        {% for post in sponsors %}
+            <li>{{ sponsor.title }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+```
+
+But you could also reduce the logic you have in Twig an move it your custom class.
+
+```php
+/**
+ * Class Event
+ */
+class Event extends \Timber\Post {
+    /**
+     * Sponsors cache.
+     *
+     * @var \Timber\PostCollection|null
+     */
+    protected $sponsors;
+
+    /**
+     * Gets event sponsors.
+     *
+     * @return \Timber\PostCollection
+     */
+    public function sponsors() {
+        if ( empty( $this->sponsors ) ) {
+            return $this->sponsors;
+        }
+
+        $this->sponsors = Timber::get_posts( $this->meta( 'sponsors' ) )
+
+        return $this->sponsors;
+    }
+}
+```
+
+In Twig:
+
+```twig
+{% if post.sponsors %}
+    <h2>Many thanks to our generous sponsors</h2>
+
+    <ul>
+        {% for post in post.sponsors %}
+            <li>{{ sponsor.title }}</li>
+        {% endfor %}
+    </ul>
+{% endif %}
+```
+
+## Extending Twig
+
+You can also extend Twig by adding custom functionality like functions or filters.
 
 ```php
 <?php
@@ -112,26 +476,26 @@ add_filter( 'timber/twig', 'add_to_twig' );
 
 /**
  * Adds functionality to Twig.
- * 
+ *
  * @param \Twig\Environment $twig The Twig environment.
  * @return \Twig\Environment
  */
 function add_to_twig( $twig ) {
     // Adding a function.
     $twig->addFunction( new \Twig\TwigFunction( 'edit_post_link', 'edit_post_link' ) );
-    
+
     // Adding functions as filters.
     $twig->addFilter( new \Twig\TwigFilter( 'whateverify', 'whateverify' ) );
     $twig->addFilter( new \Twig\TwigFilter( 'slugify', function( $title ) {
         return sanitize_title( $title );
     } ) );
-    
+
     return $twig;
 }
 
 function whateverify( $text ) {
     $text .= ' or whatever';
-    
+
     return $text;
 }
 ```

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -7,9 +7,9 @@ There’s a myth that Timber is for making simple themes, but in fact it’s for
 
 The beauty of Timber is that the object-oriented nature lets you extend it to match the exact requirements of your theme.
 
-## Extending Timber objects
+## Extending Timber classes
 
-One of the main concepts for extending Timber is to extend its objects. You can add your custom methods and properties to Posts, Terms and other objects. This way, you can reduce the amount of logic in your template files as well as your Twig files.
+One of the main concepts for extending Timber is to extend its classes. You can add your custom methods and properties to Posts, Terms and other objects. This way, you can reduce the amount of logic in your template files as well as your Twig files.
 
 Let’s look at how we could add a method to **calculate the reading time for a blog post.** First, let’s create a `BlogPost` class with a method that calculates the reading time.
 
@@ -49,7 +49,7 @@ Because we extend `Timber\Post`, we have all the methods from that class availab
 
 ### Use Class Maps
 
-To register your own objects with Timber, you use Class Maps. Refer to the [Class Maps Guide](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
+To register your own classes with Timber, you use Class Maps. Refer to the [Class Maps Guide](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
 
 **functions.php**
 
@@ -139,7 +139,7 @@ add_filter( 'timber/post/classmap', function( $classmap ) {
 } );
 ```
 
-### Move your logic from your template files to your objects
+### Move your logic from your template files to your classes
 
 In the Getting Started Guide for [Archive Pages](/docs/v2/getting-started/a-post-archive/), we looked at how you can load related posts and add them to the context.
 


### PR DESCRIPTION
## Issue

With 2.x, the concept of extending Timber with your own classes is becoming more prominent and relevant, especially because everything will evolve around Class Maps. While the new [Class Maps Guide](https://github.com/timber/timber/blob/2.x-docs-api/docs/v2/guides/class-maps.md) is good for showing the different Class Maps and how to work with them, we could still show some more real-world examples for how to use your custom methods.

## Solution

You can look at the updated [Extending Timber Guide](https://github.com/timber/timber/blob/2.x-docs-extending-timber/docs/v2/guides/extending-timber.md).

What’s new:

- I started out with an example for a more basic custom method in a custom class and how to add it to the Class Maps.
- Added an example for how to move from adding to `$context` to using a custom method. In this case, I used an example for fetching related posts, because that’s one of the more typical use cases I have seen in the wild.
- Refined the Magazine example and removed the special mention of the mini cache with a property, because I moved that explanation to the Related Posts example
- Added two examples for working with meta fields. The first is exploring how to working with date fields and the second one is exploring how to extend an array of post IDs to Timber objects.

## Impact

More developers using their custom object classes.

## Usage Changes

None.

## Considerations

For the future: I figured that when adding custom methods that fetch posts, what we recommend now is to add a small caching mechanism with properties. We could think about how we could automate this. Caching shouldn’t happen automatically, though. For example:

```php
Timber::get_posts( $this->meta( 'sponsors' ), [
  'cache' => true,
] );
```

## Testing

No unit tests.