### PR TITLE
2.x Fix some URLs in documentation

### DIFF
--- a/docs/v2/getting-started/setup.md
+++ b/docs/v2/getting-started/setup.md
@@ -5,7 +5,7 @@ description: "All about setting up Timber with your theme."
 
 ## Installation
 
-If you haven't already, please read the [Installation](/docs/installation/) article. This guide assumes you installed in your theme directory and picks up where that one leave off.
+If you haven't already, please read the [Installation](https://timber.github.io/docs/v2/installation/) article. This guide assumes you installed in your theme directory and picks up where that one leave off.
 
 ### Navigate to your WordPress themes directory
 
@@ -27,4 +27,4 @@ Navigate to the Manage Themes page in your WordPress admin (Appearance => Themes
 
 ### 3. Let’s write our theme!
 
-Continue ahead in [part 2 about Theming](https://timber.github.io/docs/getting-started/theming/).
+Continue ahead in [part 2 about Theming](https://timber.github.io/docs/v2/getting-started/theming/).

--- a/docs/v2/getting-started/video-tutorials.md
+++ b/docs/v2/getting-started/video-tutorials.md
@@ -6,8 +6,8 @@ title: "Video Tutorials"
 
 Follow the instructions in these articles:
 
-- [Installation](/docs/installation)
-- [Setup](/docs/getting-started/setup)
+- [Installation](https://timber.github.io/docs/v2/installation)
+- [Setup](https://timber.github.io/docs/v2/getting-started/setup)
 
 Now your environment is ready!
 

--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -27,7 +27,7 @@ Timber::render( 'single.twig', $data );
 <p>{{ message }}</p>
 ```
 
-Of course you don’t have to figure out all the variables you need for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`. 
+Of course you don’t have to figure out all the variables you need for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`.
 
 **single.php**
 
@@ -47,12 +47,12 @@ The global context is the context that is always set when you load it through `T
 
 Among others, the following variables will be available:
 
-- **site** – The `site` variable is a [`Timber\Site`](/docs/reference/timber-site/) object which will make it easier for you to retrieve infos about your WordPress site. If you’re used to using `blog_info( 'sitename' )` in PHP, you can use `{{ site.name }}` in Twig instead.
-- **request** - The `request` variable is a `Timber\Request` object, which will make it easier for you to access `$_GET` and `$_POST` variables in your context. Please be aware that you should always be very careful about using `$_GET` and `$_POST` variables in your templates directly. Read more about this in the [Escaping Guide](https://timber.github.io/docs/guides/escaping/).
-- **theme** - The `theme` variable is a [`Timber\Theme`](/docs/reference/timber-theme/) object and contains info about your theme.
-- **user** - The `user` variable will be a [`Timber\User`](/docs/reference/timber-user/) object if a user/visitor is currently logged in and otherwise it will be `false`.
+- **site** – The `site` variable is a [`Timber\Site`](https://timber.github.io/docs/v2/reference/timber-site/) object which will make it easier for you to retrieve infos about your WordPress site. If you’re used to using `blog_info( 'sitename' )` in PHP, you can use `{{ site.name }}` in Twig instead.
+- **request** - The `request` variable is a `Timber\Request` object, which will make it easier for you to access `$_GET` and `$_POST` variables in your context. Please be aware that you should always be very careful about using `$_GET` and `$_POST` variables in your templates directly. Read more about this in the [Escaping Guide](https://timber.github.io/docs/v2/guides/escaping/).
+- **theme** - The `theme` variable is a [`Timber\Theme`](https://timber.github.io/docs/v2/reference/timber-theme/) object and contains info about your theme.
+- **user** - The `user` variable will be a [`Timber\User`](https://timber.github.io/docs/v2/reference/timber-user/) object if a user/visitor is currently logged in and otherwise it will be `false`.
 
-For a full list of variables, go have a look at the reference for [`Timber::context()`](/docs/reference/timber-timber/#context).
+For a full list of variables, go have a look at the reference for [`Timber::context()`](https://timber.github.io/docs/v2/reference/timber-timber/#context).
 
 ### Hook into the global context
 
@@ -75,7 +75,7 @@ For menus to work, you will first need to [register them](https://codex.wordpres
 
 ### Context cache
 
-The global context will be cached. That’s why you need to define your `timber/context` filter before using `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data. 
+The global context will be cached. That’s why you need to define your `timber/context` filter before using `Timber::context()` for the first time. Otherwise, the cache will be set before you could add your own data.
 
 Having a cached global context can be useful if you need the context in other places. For example if you compile the template for a shortcode:
 
@@ -117,7 +117,7 @@ By calling `Timber::get_post()` without any arguments, Timber will use the `$pos
 
 #### Using a custom post class
 
-If you want to use [your own post class](/docs/guides/extending-timber/), you can use the [Post Class Map](/docs/guides/posts/#the-post-class-map) to register that class for your post type. `Timber::context()` will then automatically set the `post` variable using your class.
+If you want to use [your own post class](https://timber.github.io/docs/v2/guides/extending-timber/), you can use the [Post Class Map](https://timber.github.io/docs/v2/guides/posts/#the-post-class-map) to register that class for your post type. `Timber::context()` will then automatically set the `post` variable using your class.
 
 If you want to overwrite the existing `post` variable in the context, you can do that.
 
@@ -185,4 +185,4 @@ Timber will accept the parameters that can be found in WordPress’s [WP_Query c
 
 #### Use a custom post class
 
-By default, `Timber::get_posts()` will contain `Timber\Post` objects. If you want to control what class will be used for the posts, you can use the [Post Class Map](/docs/guides/posts#the-post-class-map).
+By default, `Timber::get_posts()` will contain `Timber\Post` objects. If you want to control what class will be used for the posts, you can use the [Post Class Map](https://timber.github.io/docs/v2/guides/posts#the-post-class-map).

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -5,7 +5,7 @@ order: "1000"
 
 Timber makes it damn easy to use an image in a tag.
 
-Automatically, Timber will interpret images attached to a post’s thumbnail field ("Featured Image" in the admin) and treat them as instances of [Timber\Image](https://timber.github.io/docs/reference/timber-image/). Then, in your Twig templates, you can access them via `{{ post.thumbnail }}`.
+Automatically, Timber will interpret images attached to a post’s thumbnail field ("Featured Image" in the admin) and treat them as instances of [Timber\Image](https://timber.github.io/docs/v2/reference/timber-image/). Then, in your Twig templates, you can access them via `{{ post.thumbnail }}`.
 
 ## Basic image stuff
 
@@ -41,7 +41,7 @@ The first parameter is `width`, the second is `height` (optional). So if you don
 
 All of these filters are written specifically to interact with WordPress’s image API. So don’t worry, no weird TimThumb stuff going on—this is all using WordPress’s internal image sizing stuff.
 
-Be aware of the limitations of this function [when working with a CDN](https://timber.github.io/docs/guides/cookbook-images/#limitations-when-working-with-a-cdn).
+Be aware of the limitations of this function [when working with a CDN](https://timber.github.io/docs/v2/guides/cookbook-images/#limitations-when-working-with-a-cdn).
 
 ## Letterboxing images
 

--- a/docs/v2/guides/cookbook-text.md
+++ b/docs/v2/guides/cookbook-text.md
@@ -76,4 +76,4 @@ Twig template:
 <p class="entry-meta">{{ function('twentytwelve_entry_meta') }}</p>
 ```
 
-You can read more about using functions in the [Functions](https://timber.github.io/docs/guides/functions/) guide.
+You can read more about using functions in the [Functions](https://timber.github.io/docs/v2/guides/functions/) guide.

--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -3,7 +3,7 @@ title: "Custom Fields"
 order: "600"
 ---
 
-Timber tries to make it as easy as possible for you to retrieve custom meta data for Post, Term, User and Comment objects. And it works with a range of plugins that make it easier for you to create custom fields, like Advanced Custom Fields. While most of this guide applies to everything you do with custom fields, we have separate guides in the [Integrations section](https://timber.github.io/docs/integrations/).
+Timber tries to make it as easy as possible for you to retrieve custom meta data for Post, Term, User and Comment objects. And it works with a range of plugins that make it easier for you to create custom fields, like Advanced Custom Fields. While most of this guide applies to everything you do with custom fields, we have separate guides in the [Integrations section](https://timber.github.io/docs/v2/integrations/).
 
 ## Accessing custom values
 
@@ -50,7 +50,7 @@ $my_custom_field = $post->raw_meta( 'my_custom_field' );
 
 ### Define your own method
 
-Sometimes you need to modify a meta value before it is returned. You can do that by [extending a Timber object](https://timber.github.io/docs/guides/extending-timber/) and defining your own method. In the following example, we set a custom `price()` method to format the price that’s saved in a custom field named `price`.
+Sometimes you need to modify a meta value before it is returned. You can do that by [extending a Timber object](https://timber.github.io/docs/v2/guides/extending-timber/) and defining your own method. In the following example, we set a custom `price()` method to format the price that’s saved in a custom field named `price`.
 
 **PHP**
 
@@ -61,7 +61,7 @@ class CustomPost extends Timber\Post {
      */
     public function price() {
         $price = $this->meta( 'price' );
-        
+
         // Remove decimal digits.
         return number_format( $price, 0, '', '' );
     }
@@ -76,7 +76,7 @@ In Twig, you would access it like this:
 {{ post.price }}
 ```
 
-You’ll know from looking at the code that you call a defined property or method. Be aware that through this method, you might overwrite a method that already exists on for a `Timber\Post` object (like [`date`](https://timber.github.io/docs/reference/timber-post/#date)), which is totally fine if you know what you’re doing.
+You’ll know from looking at the code that you call a defined property or method. Be aware that through this method, you might overwrite a method that already exists on for a `Timber\Post` object (like [`date`](https://timber.github.io/docs/v2/reference/timber-post/#date)), which is totally fine if you know what you’re doing.
 
 ### Direct access through custom field name
 
@@ -84,7 +84,7 @@ If a directly accessed property or method doesn’t exist, Timber will fall back
 
 **We don’t recommend to use this method, because you might run into conflicts with existing properties or methods on an object.**
 
-For example, when you use a custom field that you name `date` and try to get its value through `{{ post.date }}`, it won’t work. That’s because [`date`](https://timber.github.io/docs/reference/timber-post/#date) is a method of the `Timber\Post` object that returns the date a post was published.
+For example, when you use a custom field that you name `date` and try to get its value through `{{ post.date }}`, it won’t work. That’s because [`date`](https://timber.github.io/docs/v2/reference/timber-post/#date) is a method of the `Timber\Post` object that returns the date a post was published.
 
 In PHP, you’d access the property through `$post->date` and call the `date` method through `$post->date()`. But in Twig, you can call methods without using parentheses. And methods take precedence over properties. Timber uses a PHP technique called [Overloading](http://de.php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members) to get meta values using PHP’s [`__get` magic method](http://php.net/manual/en/language.oop5.overloading.php#object.get) on `Timber\Post`, `Timber\Term`, `Timber\User` and `Timber\Comment` objects. This means that when you use `{{ post.date }}`, it will ...
 

--- a/docs/v2/guides/functions.md
+++ b/docs/v2/guides/functions.md
@@ -3,7 +3,7 @@ title: "Functions"
 order: "800"
 ---
 
-My theme/plugin has some functions I need! Do I really have to re-write all of them?  
+My theme/plugin has some functions I need! Do I really have to re-write all of them?
 No, you don’t.
 
 ## function()
@@ -65,7 +65,7 @@ add_filter( 'timber/twig', 'add_to_twig' );
  */
  function add_to_twig( $twig ) {
     $twig->addFunction( new Twig\TwigFunction( 'edit_post_link', 'edit_post_link' ) );
-    
+
     return $twig;
 } );
 ```
@@ -94,7 +94,7 @@ In Timber versions lower than 1.3, you could use `function_wrapper` to make func
 
 The concept of Timber (and templating engines like Twig in general) is to prepare all the data before you pass it to a template. Some functions in WordPress echo their output directly. We don’t want this, because the output of this function would be echoed before we call `Timber:render()` and appear before every else on your website. There are two ways to work around this:
 
-- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](https://timber.github.io/docs/reference/timber-helper/#ob-function).
+- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](https://timber.github.io/docs/v2/reference/timber-helper/#ob-function).
 - If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) you can use `FunctionWrapper`:
 
 ```php

--- a/docs/v2/guides/internationalization.md
+++ b/docs/v2/guides/internationalization.md
@@ -50,7 +50,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 <p class="entry-meta">{{ __('Posted on %s', 'my-text-domain')|format(posted_on_date) }}</p>
 ```
 
-If you want to use the `sprintf` function in Twig, you have to [add it yourself](https://timber.github.io/docs/guides/functions/#make-functions-available-in-twig).
+If you want to use the `sprintf` function in Twig, you have to [add it yourself](https://timber.github.io/docs/v2/guides/functions/#make-functions-available-in-twig).
 
 ## Generating localization files
 
@@ -102,6 +102,6 @@ Another solution is [Twig Gettext Extractor](https://github.com/umpirsky/Twig-Ge
 
 ### Use a gulp script
 
-You can use [a gulp script to generate POT files](https://gist.github.com/luism-s/ebca42b8b8d70e81f8917f675a784060) instead of using Poedit. The script will convert gettext functions in Twig into PHP tags and save each file as a PHP file in a cache folder. It will then iterate over these cached files (including other PHP files in your project) and generate a POT file. This approach will also consider strings in HTML attributes. 
+You can use [a gulp script to generate POT files](https://gist.github.com/luism-s/ebca42b8b8d70e81f8917f675a784060) instead of using Poedit. The script will convert gettext functions in Twig into PHP tags and save each file as a PHP file in a cache folder. It will then iterate over these cached files (including other PHP files in your project) and generate a POT file. This approach will also consider strings in HTML attributes.
 
 You can find installation instructions in the comments of the gulpfile in the linked gist. Basic understanding of NPM is required.

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -16,7 +16,7 @@ You can still use plugins like [W3 Total Cache](https://wordpress.org/plugins/w3
 
 ## Cache the Entire Twig File and Data
 
-When rendering, use the `$expires` argument in [`Timber::render`](https://timber.github.io/docs/reference/timber/#render). For example:
+When rendering, use the `$expires` argument in [`Timber::render`](https://timber.github.io/docs/v2/reference/timber/#render). For example:
 
 ```php
 <?php
@@ -31,7 +31,7 @@ This method is very effective, but crude - the whole template is cached. So if y
 
 ### Set cache mode
 
-As a fourth parameter for [Timber::render()](https://timber.github.io/docs/reference/timber/#render), you can set the `$cache_mode`.
+As a fourth parameter for [Timber::render()](https://timber.github.io/docs/v2/reference/timber/#render), you can set the `$cache_mode`.
 
 ```php
 <?php
@@ -123,12 +123,12 @@ Thus, during development, you should enable the option for `auto_reload`:
 add_filter( 'timber/twig/environment/options', function( $options ) {
     $options['cache']       = true;
     $options['auto_reload'] = true;
-    
+
     return $options;
 });
 ```
 
-Enabling `Timber::$cache` works best as a last step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example) will not go live until the cache is flushed. 
+Enabling `Timber::$cache` works best as a last step in the production process. Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example) will not go live until the cache is flushed.
 
 Note that when `WP_DEBUG` is set to `true`, changes you make to `.twig` files will be reflected on the site regardless of the `Timber::$cache` value.
 

--- a/docs/v2/guides/wp-integration.md
+++ b/docs/v2/guides/wp-integration.md
@@ -54,7 +54,7 @@ function my_function_with_args( $foo, $post ){
 
 ## Filters
 
-Timber already comes with a [set of useful filters](/docs/guides/filters/). If you have your own WordPress filters that you want to easily apply in Twig, you can use `apply_filters`.
+Timber already comes with a [set of useful filters](https://timber.github.io/docs/v2/guides/filters/). If you have your own WordPress filters that you want to easily apply in Twig, you can use `apply_filters`.
 
 ```twig
 {{ post.content|apply_filters('default_message') }}

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -14,7 +14,7 @@ Timber 2.0 requires WordPress 5.3 or greater. This was in order to take advantag
 
 ## No more plugin support
 
-As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/getting-started/setup/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
+As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/v2/getting-started/setup/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
 
 ## Namespaced class names
 
@@ -123,20 +123,20 @@ The context variables `{{ wp_head }}` and `{{ wp_footer }}` were removed definit
 
 ### Template context
 
-Version 2.0 introduces the concept of template contexts for Timber. This means that Timber will automatically set `post` in your context for singular templates and `posts` for archive templates. Through the context, compatibility for third party plugins will be improved as well. Refer to the new [Context Guide](http://timber-docs.test/docs/guides/context/) to learn more.
+Version 2.0 introduces the concept of template contexts for Timber. This means that Timber will automatically set `post` in your context for singular templates and `posts` for archive templates. Through the context, compatibility for third party plugins will be improved as well. Refer to the new [Context Guide](https://timber.github.io/docs/v2/guides/context/) to learn more.
 
 In short:
 
 - If you use `context['post'] = Timber::get_post()` or `context['posts] = Timber::get_posts()` in your template files, you can probably omit these, because the context will do this for you. You might also benefit from better compatibility with third party plugins, because for singular templates, Timber will handle certain globals and hooks when setting up `post`.
 - If you decide to still use `context['post] = …` in your template file, then wrap your post with `Timber::context_post()`.
-- It’s now possible to [overwrite the default arguments](/docs/guides/context/#change-arguments-for-default-query) that are passed to the default query for `posts`.
+- It’s now possible to [overwrite the default arguments](https://timber.github.io/docs/v2/guides/context/#change-arguments-for-default-query) that are passed to the default query for `posts`.
 - When you need the global context in partials, then use `Timber::context_global()` to only load the global context.
 
 ## Twig
 
 ### Namespaced Twig locations
 
-You can now use namespaced Twig locations. Read more about this in the [Template Locations Guide](https://timber.github.io/docs/guides/template-locations/#register-your-own-namespaces).
+You can now use namespaced Twig locations. Read more about this in the [Template Locations Guide](https://timber.github.io/docs/v2/guides/template-locations/#register-your-own-namespaces).
 
 ### Better compatibility with Twig date functions
 
@@ -150,7 +150,7 @@ $twig = new \Twig\Environment($loader);
 $twig->getExtension(\Twig\Extension\CoreExtension::class)->setTimezone('Europe/Paris');
 ```
 
-Also refer to the new [Date/Time Guide](https://timber.github.io/docs/guides/date-time/) for extended information on working with dates in Timber.
+Also refer to the new [Date/Time Guide](https://timber.github.io/docs/v2/guides/date-time/) for extended information on working with dates in Timber.
 
 ### Deprecated Twig filters
 
@@ -208,11 +208,11 @@ This property was **removed** and you can **no longer access meta values through
 
 This is only recommended for development purposes, because it might affect your performance if you always request all values.
 
-The `meta()` and `raw_meta()` methods work the same way for all `Timber\Post`, `Timber\Term`, `Timber\User` and `Timber\Comment` objects. You can read more about this in the [Custom Fields Guide](https://timber.github.io/docs/guides/custom-fields) as well as the [ACF Integrations Guide](https://timber.github.io/docs/integrations/advanced-custom-fields).
+The `meta()` and `raw_meta()` methods work the same way for all `Timber\Post`, `Timber\Term`, `Timber\User` and `Timber\Comment` objects. You can read more about this in the [Custom Fields Guide](https://timber.github.io/docs/v2/guides/custom-fields) as well as the [ACF Integrations Guide](https://timber.github.io/docs/v2/integrations/advanced-custom-fields).
 
 ## Routes
 
-The Routing feature was removed in Timber 2.0. Routing in Timber is an edge case. Many of its use cases can usually be solved via existing WordPress functionality. In case you really need Routing, you can use one of the available libraries and hook it into your code. Follow the [Routing Guide](https://timber.github.io/docs/guides/routing/) for more information.
+The Routing feature was removed in Timber 2.0. Routing in Timber is an edge case. Many of its use cases can usually be solved via existing WordPress functionality. In case you really need Routing, you can use one of the available libraries and hook it into your code. Follow the [Routing Guide](https://timber.github.io/docs/v2/guides/routing/) for more information.
 
 ## No context argument when calling an action in Twig
 
@@ -284,7 +284,7 @@ The following functions were **removed from the codebase**, either because they 
 ### Timber\Timber
 
 - `add_route()` - The routes feature was completely removed in 2.0.
-- `get_pagination()` – Use `{{ posts.pagination }}` instead. Follow the [Pagination Guide](https://timber.github.io/docs/guides/pagination/) for more information.
+- `get_pagination()` – Use `{{ posts.pagination }}` instead. Follow the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/) for more information.
 
 ### Timber\Site
 
@@ -391,7 +391,7 @@ The following functions were **removed from the codebase**, either because they 
 
 **Timber\Menu**
 
-- `current_item()` – Gets the current menu item. Read more about this in the [functions’s documentation]() or the [Menu Guide](https://timber.github.io/docs/guides/menus/#the-current-menu-item).
+- `current_item()` – Gets the current menu item. Read more about this in the [functions’s documentation]() or the [Menu Guide](https://timber.github.io/docs/v2/guides/menus/#the-current-menu-item).
 - `current_top_level_item()` – Gets the top level parent of the current menu item.
 
 **Timber\MenuItem**
@@ -617,5 +617,5 @@ Read more about this in the [Escaping Guide](@todo).
 
 We added a couple of new guides:
 
-- [Context Guide](http://timber-docs.test/docs/guides/context/)
-- [Custom Fields Guide](https://timber.github.io/docs/guides/custom-fields), which is now decoupled from the [ACF Integrations Guide](https://timber.github.io/docs/integrations/advanced-custom-fields).
+- [Context Guide](https://timber.github.io/docs/v2/guides/context/)
+- [Custom Fields Guide](https://timber.github.io/docs/v2/guides/custom-fields), which is now decoupled from the [ACF Integrations Guide](https://timber.github.io/docs/v2/integrations/advanced-custom-fields).


### PR DESCRIPTION
Before I merge in https://github.com/timber/docs/pull/12 to put the new documentation online, I want to fix some links.

- Always use absolute URLs with `https://timber.github.io/docs/`, so that the URLs also work when we click them in GitHub and not lead to 404s.
- Make sure we use `https://timber.github.io/docs/v2/` for version 2 docs. As soon as we release v2, we will have to revert that and use `https://timber.github.io/docs/v1/` for version 1 docs.