### PR TITLE
Provide a non-functional definition for Twig's `dump` function

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -174,6 +174,10 @@ class Loader {
 		$twig = new \Twig\Environment($loader, $params);
 		if ( WP_DEBUG ) {
 			$twig->addExtension(new \Twig\Extension\DebugExtension());
+		} else {
+			$twig->addFunction(new Twig_Function('dump', function() {
+				return null;
+			}));
 		}
 		$twig->addExtension($this->_get_cache_extension());
 

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 
+* Add a catch so that `{{ dump() }}` when WP_DEBUG = FALSE doesn't cause a fatal error (#2217, #2282)
+
 **Changes for Theme Developers**
 
 = 1.16.0 =


### PR DESCRIPTION
**Ticket**: #2217 

## Issue
When using the `{{ dump() }}` function with WP_DEBUG set to false, the site throws Fatal error: Uncaught Twig\Error\SyntaxError: Unknown "dump" function. This causes a problem if one of these statements is accidentally committed and then rendered in an environment that does not have debug set to true - whether that's production, staging, or even another dev's local install.

## Solution
Supply a dummy definition to `{{ dump() }}` so no fatal error results


## Impact
Should make it easier for when a dev has forgotten to remove a dump function (which they should). But a WSOD seems like an excessive punishment.

## Usage Changes
None.

## Considerations
One could argue this promotes laziness, but I think it helps match the reality that many of us code against. In terms of the solutions discussed in #2217, this is the "lightest touch" in terms of new code or dependencies to introduce. 

## Testing
No new tests
