### PR TITLE
Get rid of IMG_LIBS variable in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       before_install:
         - phpenv config-rm xdebug.ini
         - pecl install pcov
-        # Install imagick library
+        # Install imagick PHP extension
         - pear config-set preferred_state beta
         - pecl channel-update pecl.php.net
         - yes '' | pecl install imagick

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,18 +26,24 @@ env:
 matrix:
     include:
     - php: 5.6
-      env: WP_VERSION=4.9.8 WP_MULTISITE=0 PREFER_LOWEST="--prefer-lowest --prefer-stable" IMG_LIBS=0 COVERAGE=1
+      env: WP_VERSION=4.9.8 WP_MULTISITE=0 PREFER_LOWEST="--prefer-lowest --prefer-stable" COVERAGE=1
     - php: 7.4
-      env: WP_VERSION=latest WP_MULTISITE=0 IMG_LIBS=1 COVERAGE=1
+      env: WP_VERSION=latest WP_MULTISITE=0 COVERAGE=1
+      before_install:
+        - phpenv config-rm xdebug.ini
+        - pecl install pcov
+        # Install imagick library
+        - pear config-set preferred_state beta
+        - pecl channel-update pecl.php.net
+        - yes '' | pecl install imagick
     - php: 7.4
-      env: WP_VERSION=latest WP_MULTISITE=1 IMG_LIBS=0 COVERAGE=1
+      env: WP_VERSION=latest WP_MULTISITE=1 COVERAGE=1
 
 before_install:
     # phpenv config-add myconfig.ini --with-webp-dir
     - if [ "$(phpenv version-name)" != 5.6 ]; then phpenv config-rm xdebug.ini; pecl install pcov; fi
 
 before_script:
-    - if [ "$IMG_LIBS" == 1 ]; then pear config-set preferred_state beta; pecl channel-update pecl.php.net; yes '' | pecl install imagick; fi
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
     - composer update $PREFER_LOWEST --dev --prefer-source
     - if [ "$(phpenv version-name)" != 5.6 ]; then composer require --dev 'pcov/clobber:^2.0'; vendor/bin/pcov clobber; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=0 COVERAGE=1
       before_install:
         - phpenv config-rm xdebug.ini
-        - pecl install pcov
+        - yes '' | pecl install pcov
         # Install imagick PHP extension
         - pear config-set preferred_state beta
         - pecl channel-update pecl.php.net


### PR DESCRIPTION
Basically conditionals should be avoided in all CI workflows.
CI jobs should be listed explicitly.

I plan to remove `$COVERAGE` after this one gets merged.