### PR TITLE
2.x Docs – Update section data to fix doc search

### DIFF
--- a/docs/v1/getting-started/getting-started.json
+++ b/docs/v1/getting-started/getting-started.json
@@ -1,4 +1,4 @@
 {
-  "title": "Getting Started",
+  "sectionTitle": "Getting Started",
   "layout": "page"
 }

--- a/docs/v1/guides/guides.json
+++ b/docs/v1/guides/guides.json
@@ -1,4 +1,4 @@
 {
-  "title": "Guides",
+  "sectionTitle": "Guides",
   "layout": "page"
 }

--- a/docs/v1/reference/reference.json
+++ b/docs/v1/reference/reference.json
@@ -1,4 +1,4 @@
 {
-  "title": "Reference",
+  "sectionTitle": "Reference",
   "layout": "page"
 }

--- a/docs/v1/upgrade-guides/upgrade-guides.json
+++ b/docs/v1/upgrade-guides/upgrade-guides.json
@@ -1,4 +1,4 @@
 {
-  "title": "Upgrade Guides",
+  "sectionTitle": "Upgrade Guides",
   "layout": "page"
 }

--- a/docs/v2/getting-started/getting-started.json
+++ b/docs/v2/getting-started/getting-started.json
@@ -1,4 +1,4 @@
 {
-  "title": "Getting Started",
+  "sectionTitle": "Getting Started",
   "layout": "page"
 }

--- a/docs/v2/guides/guides.json
+++ b/docs/v2/guides/guides.json
@@ -1,4 +1,4 @@
 {
-  "title": "Guides",
+  "sectionTitle": "Guides",
   "layout": "page"
 }

--- a/docs/v2/hooks/hooks.json
+++ b/docs/v2/hooks/hooks.json
@@ -1,4 +1,4 @@
 {
-  "title": "Hooks",
+  "sectionTitle": "Hooks",
   "layout": "page"
 }

--- a/docs/v2/installation/installation.json
+++ b/docs/v2/installation/installation.json
@@ -1,4 +1,4 @@
 {
-  "title": "Installation",
+  "sectionTitle": "Installation",
   "layout": "page"
 }

--- a/docs/v2/integrations/integrations.json
+++ b/docs/v2/integrations/integrations.json
@@ -1,4 +1,4 @@
 {
-  "title": "Integrations",
+  "sectionTitle": "Integrations",
   "layout": "page"
 }

--- a/docs/v2/reference/reference.json
+++ b/docs/v2/reference/reference.json
@@ -1,4 +1,4 @@
 {
-  "title": "Reference",
+  "sectionTitle": "Reference",
   "layout": "page"
 }

--- a/docs/v2/upgrade-guides/upgrade-guides.json
+++ b/docs/v2/upgrade-guides/upgrade-guides.json
@@ -1,4 +1,4 @@
 {
-  "title": "Upgrade Guides",
+  "sectionTitle": "Upgrade Guides",
   "layout": "page"
 }


### PR DESCRIPTION
## Issue

Currently, when searchin the Docs, the sections are messed up, because I obviously used a selector that isnt’t unique on a page.

In the following example, you can see that a search for "Comments" is marked under the sections "Upgrade Guides" and "Contributing".

![Bildschirmfoto 2020-07-25 um 13 25 00](https://user-images.githubusercontent.com/2084481/88455974-49572000-ce7a-11ea-9a40-890582e14cd7.png)

This is because the section title is determined by the `.navMain-sectionTitle` selector, which appears multiple times. Algolia obviously has no way to know which section we’re in.

## Solution

This pull request changes the the title in the data from `title` to `sectionTitle` so we can reference it in the sidebar and use a unique CSS class that hopefully solves this issue. If we’d continue using `title`, it would always be overriden by a page’s title. So I had to use another name.

## Impact

Hopefully fixes search.

## Usage Changes

None.

## Considerations

None yet.

## Tests

I already put the changes live in https://github.com/timber/docs/commit/d593e247acb761ae951e63673dba0d7600eb2b88. I can check tomorrow if Algolia picked up the changes.