### PR TITLE
2.x – Improve documentation for pagination

### DIFF
--- a/docs/v2/guides/pagination.md
+++ b/docs/v2/guides/pagination.md
@@ -5,15 +5,15 @@ order: "1100"
 
 There are three types of pagination, which all work differently, but can easily be confused with each other, because they use similar terms:
 
-1. Pagination for archive templates.
-2. Adjacent post pagination for singular templates.
-3. Paged content for posts.
+1. Pagination for archive templates
+2. Adjacent post pagination for singular templates
+3. Paged content within a post
 
 Let’s look at them in more detail.
 
 ## Pagination for archive templates
 
-The pagination for archive pages only works for template files with an active query of multiple posts, like **archive.php** or **home.php**. When you have a lot of posts, you wouldn’t list all of the posts on one page, because that would slow down your site too much. Instead, you would only show a defined number of results and use other pages that show the next set of results. Here’s an example:
+The pagination for archive pages applies to template files with an active query of multiple posts, like **archive.php** or **home.php**. When you have a lot of posts, you wouldn’t list all of the posts on one page, because that would slow down your site too much. Instead, you would only show a defined number of results and use other pages that show the next set of results. Here’s an example:
 
 - `posts/` – Shows first 10 posts.
 - `posts/page/2` – Shows posts 11-20.
@@ -141,7 +141,7 @@ A pagination for singular templates works different, because unlike for archive 
 
 The posts are sorted by default. But if you use a plugin like [Simple Custom Post Order](https://wordpress.org/plugins/simple-custom-post-order/) to order posts manually, it will affect the order for `{{ post.next }}` and `{{ post.prev }}` as well.
 
-## Paged content for posts
+## Paged content within a post
 
 Paged content is yet another form of pagination that appears in WordPress. You can split the content of a single post into multiple pages and use a pagination to add links to the next and previous pages of the post.
 

--- a/docs/v2/guides/pagination.md
+++ b/docs/v2/guides/pagination.md
@@ -9,7 +9,7 @@ There are three types of pagination, which all work differently, but can easily 
 2. Adjacent post pagination for singular templates.
 3. Paged content for posts.
 
-Let’s look at the two in more detail.
+Let’s look at them in more detail.
 
 ## Pagination for archive templates
 

--- a/docs/v2/guides/pagination.md
+++ b/docs/v2/guides/pagination.md
@@ -3,79 +3,185 @@ title: "Pagination"
 order: "1100"
 ---
 
-Do you like pagination? Stupid question, of course you do. Well, here's how you do it.
+There are three types of pagination, which all work differently, but can easily be confused with each other, because they use similar terms:
 
-## Default pagination
+1. Pagination for archive templates.
+2. Adjacent post pagination for singular templates.
+3. Paged content for posts.
 
-This will only work in a php file with an active query (like `archive.php` or `home.php`):
+Let’s look at the two in more detail.
+
+## Pagination for archive templates
+
+The pagination for archive pages only works for template files with an active query of multiple posts, like **archive.php** or **home.php**. When you have a lot of posts, you wouldn’t list all of the posts on one page, because that would slow down your site too much. Instead, you would only show a defined number of results and use other pages that show the next set of results. Here’s an example:
+
+- `posts/` – Shows first 10 posts.
+- `posts/page/2` – Shows posts 11-20.
+
+### Default pagination
+
+**archive.php**
 
 ```php
-	<?php
-	$context = Timber::context();
-	$context['posts'] = new Timber\PostQuery();
-	Timber::render('archive.twig', $context);
+<?php
+
+$context = Timber::context();
+
+Timber::render( 'archive.twig', $context );
 ```
 
-You can then markup the output like so  (of course, the exact markup is up to YOU):
+Because we’re on an archive page, Timber already prepared a `posts` variable in the context for us. You could then markup the output like so:
+
+**archive.twig**
 
 ```twig
 <div class="tool-pagination">
 	{% if posts.pagination.prev %}
-		<a href="{{posts.pagination.prev.link}}" class="prev {{posts.pagination.prev.link|length ? '' : 'invisible'}}">Prev</a>
+		<a
+            href="{{ posts.pagination.prev.link }}"
+            class="prev {{ posts.pagination.prev.link|length ? '' : 'invisible' }}"
+        >Previous</a>
 	{% endif %}
+
 	<ul class="pages">
 		{% for page in posts.pagination.pages %}
 			<li>
 				{% if page.link %}
-					<a href="{{page.link}}" class="{{page.class}}">{{page.title}}</a>
+					<a
+                        href="{{ page.link }}"
+                        class="{{ page.class }}"
+                    >{{ page.title }}</a>
 				{% else %}
-					<span class="{{page.class}}">{{page.title}}</span>
+					<span class="{{ page.class }}">{{ page.title }}</span>
 				{% endif %}
 			</li>
 		{% endfor %}
 	</ul>
+
 	{% if posts.pagination.next %}
-		<a href="{{posts.pagination.next.link}}" class="next {{posts.pagination.next.link|length ? '' : 'invisible'}}">Next</a>
+		<a
+            href="{{ posts.pagination.next.link }}"
+            class="next {{ posts.pagination.next.link|length ? '' : 'invisible' }}"
+        >Next</a>
 	{% endif %}
 </div>
 ```
 
-## What if I'm not using the default query?
+### What if I’m not using the default query?
+
+If you want to overwrite the default query, you can do that by overwriting `posts` in the context with a new query. Make sure to include the `paged` parameter in the query.
+
+**archive-event.php**
 
 ```php
-	<?php
-	global $paged;
-	if (!isset($paged) || !$paged){
-		$paged = 1;
-	}
-	$context = Timber::context();
-	$args = array(
-		'post_type' => 'event',
-		'posts_per_page' => 5,
-		'paged' => $paged
-	);
-	$context['posts'] = new Timber\PostQuery($args);
-	Timber::render('page-events.twig', $context);
+<?php
+
+global $paged;
+
+if ( ! isset( $paged ) || ! $paged ) {
+    $paged = 1;
+}
+
+$context = Timber::context();
+
+$context['posts'] = Timber::get_posts( [
+    'post_type'      => 'event',
+    'posts_per_page' => 5,
+    'paged'          => $paged
+] );
+
+Timber::render( 'archive-event.twig', $context );
 ```
 
-## Pagination with pre_get_posts
+### Pagination with `pre_get_posts`
 
 Custom `query_posts` sometimes shows 404 on example.com/page/2. In that case you can also use `pre_get_posts` in your functions.php file:
 
 ```php
-	<?php
-	function my_home_query( $query ) {
-	  if ( $query->is_main_query() && !is_admin() ) {
-		$query->set( 'post_type', array( 'movie', 'post' ));
-	  }
-	}
-	add_action( 'pre_get_posts', 'my_home_query' );
+<?php
+
+function my_home_query( $query ) {
+    if ( $query->is_main_query() && ! is_admin() ) {
+        $query->set( 'post_type', [ 'movie', 'post' ] );
+    }
+}
+
+add_action( 'pre_get_posts', 'my_home_query' );
 ```
-In your archive.php or home.php template:
+
+Your **archive.php** or **home.php** template wouldn’t change:
 
 ```php
-	<?php
-	$context = Timber::context();
-	$context['posts'] = new Timber\PostQuery();
-	Timber::render('archive.twig', $context);
+<?php
+
+$context = Timber::context();
+
+Timber::render( 'archive.twig', $context );
+```
+
+## Adjacent post pagination for singular templates
+
+A pagination for singular templates works different, because unlike for archive pages, you don’t have a collection of posts. But you can show links to the previous and next posts – they are called **adjacent posts** – with `{{ post.next }}` and `{{ post.prev }}`. These two functions are available on every instance of `Timber\Post`.
+
+**single.twig**
+
+```twig
+{% if post.prev %}
+    <h3>Previous article</h3>
+
+    <a href="{{ post.prev.link }}">{{ post.prev.title }}</a>
+{% endif %}
+
+{% if post.next %}
+    <h3>Next article</h3>
+
+    <a href="{{ post.next.link }}">{{ post.next.title }}</a>
+{% endif %}
+```
+
+The posts are sorted by default. But if you use a plugin like [Simple Custom Post Order](https://wordpress.org/plugins/simple-custom-post-order/) to order posts manually, it will affect the order for `{{ post.next }}` and `{{ post.prev }}` as well.
+
+## Paged content for posts
+
+Paged content is yet another form of pagination that appears in WordPress. You can split the content of a single post into multiple pages and use a pagination to add links to the next and previous pages of the post.
+
+- If you use the **Classic Editor**, you can insert `<!--nextpage-->` wherever you want to add a page break.
+- If you use the Block Editor, you can’t use `<!--nextpage-->`. Instead, use the **Page Break** block.
+
+Then, instead of using `{{ post.content }}`, use `{{ post.paged_content }}` to display only the content of the current page.
+
+```twig
+{{ post.paged_content }}
+```
+
+To display the links for the next and previous pages, you will use `{{ post.pagination }}`. Here’s an example where you would display the links to the next and previous pages.
+
+```twig
+{% if post.pagination.next is not empty %}
+	<a href="{{ post.pagination.next.link|e('esc_url') }}">Go to next page</a>
+{% endif %}
+
+{% if post.pagination.prev is not empty %}
+	<a href="{{ post.pagination.prev.link|e('esc_url') }}">Go to previous page</a>
+{% endif %}
+```
+
+You can also display links to all pages, using an accessible pagination markup.
+
+```twig
+{% if post.pagination.pages is not empty %}
+    <nav aria-label="pagination">
+        <ul>
+            {% for page in post.pagination.pages %}
+                <li>
+                    {% if page.current %}
+                        <span aria-current="page">Page {{ page.title }}</span>
+                    {% else %}
+                        <a href="{{ page.link|e('esc_url') }}">Page {{ page.title }}</a>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
+{% endif %}
 ```

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1450,17 +1450,28 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
-	 * Gets the actual content of a WP Post, as opposed to post_content this will run the hooks/filters attached to the_content. \This guy will return your posts content with WordPress filters run on it (like for shortcodes and wpautop).
+	 * Gets the actual content of a WordPress post.
+	 *
+	 * As opposed to using `{{ post.post_content }}`, this will run the hooks/filters attached to
+	 * the `the_content` filter. It will return your post’s content with WordPress filters run on it
+	 * – which means it will parse blocks, convert shortcodes or run `wpautop()` on the content.
+	 *
+	 * If you use page breaks in your content to split your post content into multiple pages,
+	 * use `{{ post.paged_content }}` to display only the content for the current page.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
-	 * <div class="article">
-	 *     <h2>{{post.title}}</h2>
+	 * <article>
+	 *     <h1>{{ post.title }}</h1>
+	 *
 	 *     <div class="content">{{ post.content }}</div>
-	 * </div>
+	 * </article>
 	 * ```
-	 * @param int $page
+	 *
+	 * @param int $page Optional. The page to show if the content of the post is split into multiple
+	 *                  pages. Read more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-for-posts). Default `0`.
+	 *
 	 * @return string
 	 */
 	public function content( $page = 0, $len = -1 ) {
@@ -1493,8 +1504,8 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
-	 * Handles for an circumstance with the Block editor where a "more" block has an option to 
-	 * "Hide the excerpt on the full content page" which hides everything prior to the inserted 
+	 * Handles for an circumstance with the Block editor where a "more" block has an option to
+	 * "Hide the excerpt on the full content page" which hides everything prior to the inserted
 	 * "more" block
 	 * @ticket #2218
 	 * @param string $content
@@ -1509,7 +1520,19 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
-	 * @return string
+	 * Gets the paged content for a post.
+	 *
+	 * You will use this, if you use `<!--nextpage-->` in your post content or the Page Break block
+	 * in the Block Editor. Use `{{ post.pagination }}` to create a pagination for your paged
+	 * content. Learn more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-for-posts).
+	 *
+	 * @example
+	 * ```twig
+	 * {{ post.paged_content }}
+	 * ```
+	 *
+	 * @return string The content for the current page. If there’s no page break found in the
+	 *                content, the whole content is returned.
 	 */
 	public function paged_content() {
 		global $page;
@@ -1813,8 +1836,21 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
+	 * Gets the next post that is adjacent to the current post in a collection.
+	 *
+	 * Works pretty much the same as
+	 * [`get_next_post()`](https://developer.wordpress.org/reference/functions/get_next_post/).
+	 *
 	 * @api
-	 * @param bool|string $in_same_term
+	 * @example
+	 * ```twig
+	 * {% if post.next %}
+	 *     <a href="{{ post.next.link }}">{{ post.next.title }}</a>
+	 * {% endif %}
+	 * ```
+	 * @param bool|string $in_same_term Whether the post should be in a same taxonomy term. Default
+	 *                                  `false`.
+	 *
 	 * @return mixed
 	 */
 	public function next( $in_same_term = false ) {
@@ -1840,10 +1876,42 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
-	 * Get a data array of pagination so you can navigate to the previous/next for a paginated post.
+	 * Gets a data array to display a pagination for your paginated post.
+	 *
+	 * Use this in combination with `{{ post.paged_content }}`.
 	 *
 	 * @api
-	 * @return array
+	 * @example
+	 * Using simple links to the next an previous page.
+	 * ```twig
+	 * {% if post.pagination.next is not empty %}
+	 *     <a href="{{ post.pagination.next.link|e('esc_url') }}">Go to next page</a>
+	 * {% endif %}
+	 *
+	 * {% if post.pagination.prev is not empty %}
+	 *     <a href="{{ post.pagination.prev.link|e('esc_url') }}">Go to previous page</a>
+	 * {% endif %}
+	 * ```
+	 * Using a pagination for all pages.
+	 * ```twig
+	 * {% if post.pagination.pages is not empty %}
+	 *    <nav aria-label="pagination">
+	 *        <ul>
+	 *            {% for page in post.pagination.pages %}
+	 *                <li>
+	 *                    {% if page.current %}
+	 *                        <span aria-current="page">Page {{ page.title }}</span>
+	 *                    {% else %}
+	 *                        <a href="{{ page.link|e('esc_url') }}">Page {{ page.title }}</a>
+	 *                    {% endif %}
+	 *                </li>
+	 *            {% endfor %}
+	 *        </ul>
+	 *    </nav>
+	 * {% endif %}
+	 * ```
+	 *
+	 * @return array An array with data to build your paginated content.
 	 */
 	public function pagination() {
 		global $post, $page, $numpages, $multipage;
@@ -1930,18 +1998,21 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 		return URLHelper::get_rel_url($this->link());
 	}
 
-
 	/**
-	 * Get the previous post in a set
+	 * Get the previous post that is adjacent to the current post in a collection.
+	 *
+	 * Works pretty much the same as
+	 * [`get_previous_post()`](https://developer.wordpress.org/reference/functions/get_previous_post/).
 	 *
 	 * @api
 	 * @example
 	 * ```twig
-	 * <h4>Prior Entry:</h4>
-	 * <h3>{{post.prev.title}}</h3>
-	 * <p>{{post.prev.preview(25)}}</p>
+	 * {% if post.prev %}
+	 *     <a href="{{ post.prev.link }}">{{ post.prev.title }}</a>
+	 * {% endif %}
 	 * ```
-	 * @param string|boolean $in_same_term
+	 * @param bool|string $in_same_term Whether the post should be in a same taxonomy term. Default
+	 *                                  `false`.
 	 * @return mixed
 	 */
 	public function prev( $in_same_term = false ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1470,7 +1470,7 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 * ```
 	 *
 	 * @param int $page Optional. The page to show if the content of the post is split into multiple
-	 *                  pages. Read more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-for-posts). Default `0`.
+	 *                  pages. Read more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-within-a-post). Default `0`.
 	 *
 	 * @return string
 	 */
@@ -1524,7 +1524,7 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 *
 	 * You will use this, if you use `<!--nextpage-->` in your post content or the Page Break block
 	 * in the Block Editor. Use `{{ post.pagination }}` to create a pagination for your paged
-	 * content. Learn more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-for-posts).
+	 * content. Learn more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-within-a-post).
 	 *
 	 * @example
 	 * ```twig


### PR DESCRIPTION
## Issue

When looking at a couple of issues here in Timber, I felt that there was often confusion about pagination, because there are actually 3 types of pagination (that I know of).

## Solution

I tried to describe the different sorts of pagination and provide examples for how to use them. You can have a look at the updated guide here: https://github.com/timber/timber/blob/2.x-docs-pagination/docs/v2/guides/pagination.md.

I also updated some of the DocBlocks for the related methods.

I’m doing the pull request against the `2.x-docs-api` branch (#2073), because this affects the pagination for posts, which should work with `Timber::get_posts()` in the future. In v1, it only worked with `Timber\PostQuery`.

## Impact

Hopefully, this will provide better guidance.

## Usage Changes

None.

## Considerations

I wonder whether we actually need `Timber\Post::paged_content()`, or whether this could be baked into `Timber\Post::content()` so developers wouldn’t have to use a different method to make this work. In earlier versions of WordPress, you had to know about `<!--nextpage-->` to use this feature, but with the Block Editor, the Page Break block is always available. So this is not a hidden feature anymore. It could be confusing for end users if it doesn’t do anything when `{{ post.content }}` is used.

## Testing

Tested the code snippets in combination with the starter theme.