### PR TITLE
2.x Guides optimizations

### DIFF
--- a/docs/v1/guides/gutenberg.md
+++ b/docs/v1/guides/gutenberg.md
@@ -1,10 +1,10 @@
 ---
-title: "Gutenberg"
+title: "Block Editor (Gutenberg)"
 ---
 
-## Using Gutenberg with Timber
+## Using the Block Editor with Timber
 
-Timber works with Gutenberg out of the box. If you use `{{ post.content }}`, Timber will render all the Gutenberg blocks.
+Timber works with the Block Editor (also called Gutenberg) out of the box. If you use `{{ post.content }}`, Timber will render all the Gutenberg blocks.
 
 ## ACF Blocks
 
@@ -112,7 +112,7 @@ function my_acf_block_editor_style() {
 add_action( 'enqueue_block_assets', 'my_acf_block_editor_style' );
 ```
 
-For more details about enqueueing assets read the [Gutenberg Handbook](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).
+For more details about enqueueing assets read the [Block Editor Handbook](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).
 
 ### Using repeaters
 

--- a/docs/v1/guides/hosts-servers.md
+++ b/docs/v1/guides/hosts-servers.md
@@ -1,12 +1,8 @@
 ---
 title: "Hosts & Servers"
-menu:
-  main:
-    parent: "guides"
 ---
 
 This guide serves as reference for any host or server-specific information we gather. If you have experience hosting WordPress with a particular host, stack, or service (AWS, Azure, etc.) please add that information here so it can be shared.
-
 
 ## WordPress VIP
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -1,10 +1,11 @@
 ---
-title: "Gutenberg"
+title: "Block Editor (Gutenberg)"
+order: "1550"
 ---
 
-## Using Gutenberg with Timber
+## Using the Block Editor with Timber
 
-Timber works with Gutenberg out of the box. If you use `{{ post.content }}`, Timber will render all the Gutenberg blocks.
+Timber works with the Block Editor (also called Gutenberg) out of the box. If you use `{{ post.content }}`, Timber will render all the Gutenberg blocks.
 
 ## ACF Blocks
 
@@ -45,15 +46,13 @@ Next, you you have to create your `render_callback()` function:
 ```php
 /**
  *  This is the callback that displays the block.
- *  
+ *
  * @param   array  $block      The block settings and attributes.
  * @param   string $content    The block content (emtpy string).
  * @param   bool   $is_preview True during AJAX preview.
  */
 function my_acf_block_render_callback( $block, $content = '', $is_preview = false ) {
-
-    $context = Timber::context_global();
-
+    $context = Timber::context();
 
     // Store block values.
     $context['block'] = $block;
@@ -114,7 +113,7 @@ function my_acf_block_editor_style() {
 add_action( 'enqueue_block_assets', 'my_acf_block_editor_style' );
 ```
 
-For more details about enqueueing assets read the [Gutenberg Handbook](https://wordpress.org/gutenberg/handbook/blocks/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).
+For more details about enqueueing assets read the [Block Editor Handbook](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).
 
 ### Using repeaters
 

--- a/docs/v2/guides/hosts-servers.md
+++ b/docs/v2/guides/hosts-servers.md
@@ -1,0 +1,36 @@
+---
+title: "Hosts & Servers"
+order: "1700"
+---
+
+This guide serves as reference for any host or server-specific information we gather. If you have experience hosting WordPress with a particular host, stack, or service (AWS, Azure, etc.) please add that information here so it can be shared.
+
+## WordPress VIP
+
+Automattic offers a paid service called [WordPress VIP](https://wpvip.com/) for enterprise customers. To get Timber to play nice with their stack, we need to disable functionality related to caching and writes to the filesystem:
+
+**functions.php**
+
+```php
+add_filter('timber/cache/mode', function() {
+	return 'none';
+});
+```
+
+```php
+add_filter( 'timber/allow_fs_write', '__return_false' );
+```
+
+This means you will not be able to use on-the-fly image resizing through Timber. Don't despair! You can set custom image sizes for WordPress to use:
+
+**functions.php**
+```php
+add_image_size( 'my_custom_size', 220, 220, array( 'left', 'top' ) );
+```
+
+**single.twig**
+```twig
+<img src="{{ post.thumbnail.src('my_custom_size') }}" alt="{{ post.thumbnail.alt() }}">
+```
+
+WordPress VIP has its own caching mechanisms. So when we disable caching, we're only disabling Timber and Twig's caching — not other layers that WP VIP applies.


### PR DESCRIPTION
This pull request fixes two things.

1. Adds the *Hosts & Servers* Guide that was added in #2250 to version 2 of the docs as well.
2. Optimizes the Gutenberg guide by including the official name "Block Editor" and adding a missing `order` parameter.

## Usage Changes

None.

## Considerations

We need to remember that if we change documentation in `master`, we need to port it over to `2.x` as well, because `2.x` is the current master for the [live documentation](https://timber.github.io/docs/).