### PR TITLE
Update Helper.php / twig_array_filter

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -427,6 +427,8 @@ class Helper {
 	 * Uses native Twig Filter.
 	 *
 	 * @since 1.14.0
+	 * @deprecated since 1.17 (to be removed in 2.0). Use array_filter or Helper::wp_list_filter instead
+	 * @todo remove this in 2.x
 	 * @param array                 $list to filter.
 	 * @param callback|string|array $arrow function used for filtering,
 	 *                              string or array for backward compatibility.

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -439,7 +439,7 @@ class Helper {
 			return self::wp_list_filter( $list, $arrow, $operator );
 		}
 
-		return twig_array_filter( $list, $arrow );
+		return array_filter( $list, $arrow, \ARRAY_FILTER_USE_BOTH );
 	}
 
 	/**

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -203,7 +203,7 @@ class Twig {
 
 		/**
 		 * @deprecated since 1.13 (to be removed in 2.0). Use Twig's native filter filter instead
-     *  @todo remove this in 2.x so that filter merely passes to Twig's filter without any modification
+		 * @todo remove this in 2.x so that filter merely passes to Twig's filter without any modification
 		 * @ticket #1594 #2120
 		 */
 		$twig->addFilter(new Twig_Filter('filter', array('Timber\Helper', 'filter_array')));


### PR DESCRIPTION
**Ticket**: #2301

## Issue
As pointed out by @gchtr:

This issue was raised in https://wordpress.org/support/topic/args-passed-to-twig_array_filter-must-be-an-instance-of-twigenvironment/.

In this commit, they changed the parameters from
```php
function twig_array_filter($array, $arrow) {}
```
to
```php
function twig_array_filter(Environment $env, $array, $arrow) {}
```
Yes, they prepended a parameter. This now conflicts with the patch we introduced in Timber 1.14.0, in #2124 to be exact. The tricky thing would be to get the Twig environment in there. Or maybe we need to take a completely different approach.


## Solution
Simply replace the call to the native PHP `array_filter` function. I copied the third parameter of the `\ARRAY_FILTER_USE_BOTH` constant as well to match what Twig is doing internally.

## Impact
Fixes a fatal error when that function is called right now. 

## Usage Changes
None.

## Considerations
This is short-circuiting certain Twig checks around sandboxing, etc. Was anyone using them? Out of tens of thousands of Timber sites, maybe _somebody_, but I doubt a mass.

## Testing
Existing tests that were failing now pass
