### PR TITLE
2.x – Rename "Getting Started Theme" to "Learn Timber Theme"

### DIFF
--- a/docs/v2/getting-started/introduction.md
+++ b/docs/v2/getting-started/introduction.md
@@ -10,7 +10,7 @@ Let’s get familiar with some of the concepts of Timber and Twig.
 If you want to start from scratch, you can use the following command. Run it from the **wp-content/themes** folder of your WordPress installation.
 
 ```bash
-composer create-project timber/getting-started-theme getting-started-theme
+composer create-project timber/learn-timber-theme learn-timber-theme
 ```
 
 And now …


### PR DESCRIPTION
**Ticket**: https://github.com/timber/learn-timber-theme/issues/1

## Issue

"Learn Timber Theme" is a clearer name than "Getting Started Theme"

## Solution

Let’s rename it.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

I tested the `composer create-project` command. It works.