### PR TITLE
fix #2216: delete sideloaded image tmp files

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -378,14 +378,15 @@ class ImageHelper {
 		$file_array = array();
 		$file_array['name'] = PathHelper::basename($matches[0]);
 		$file_array['tmp_name'] = $tmp;
-		// If error storing temporarily, unlink
+		// If error storing temporarily, do not use
 		if ( is_wp_error($tmp) ) {
-			@unlink($file_array['tmp_name']);
 			$file_array['tmp_name'] = '';
 		}
 		// do the validation and storage stuff
 		$locinfo = PathHelper::pathinfo($loc);
 		$file = wp_upload_bits($locinfo['basename'], null, file_get_contents($file_array['tmp_name']));
+		// delete tmp file
+		@unlink($file_array['tmp_name']);
 		return $file['url'];
 	}
 


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

**Ticket**: #2216

## Issue

After having sideloaded an external image, the temporary file created by download_url is not deleted.

## Solution

This deletes the temporary file after it has been uploaded to wordpress.

## Impact

No impact, bug fix.

## Usage Changes

None

## Considerations

None

## Testing

No unit tests added.