### PR TITLE
#2301 Keep Twig native `filter` parity

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -446,7 +446,7 @@ class Helper {
 		}
 
 		// the IteratorIterator wrapping is needed as some internal PHP classes are \Traversable but do not implement \Iterator
-		return new \CallbackFilterIterator( new \IteratorIterator($array), $arrow );
+		return new \CallbackFilterIterator( new \IteratorIterator( $list ), $arrow );
 	}
 
 	/**

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -174,7 +174,7 @@ class Helper {
 	/**
 	 * @codeCoverageIgnore
 	 * @deprecated since 1.3.0
-	 * 
+	 *
 	 * @param mixed $function_name        String or array( $class( string|object ), $function_name ).
 	 * @param array $defaults             Optional.
 	 * @param bool  $return_output_buffer Optional. Return function output instead of return value. Default false.
@@ -441,7 +441,12 @@ class Helper {
 			return self::wp_list_filter( $list, $arrow, $operator );
 		}
 
-		return array_filter( $list, $arrow, \ARRAY_FILTER_USE_BOTH );
+		if ( is_array( $list ) ) {
+			return array_filter( $list, $arrow, \ARRAY_FILTER_USE_BOTH );
+		}
+
+		// the IteratorIterator wrapping is needed as some internal PHP classes are \Traversable but do not implement \Iterator
+		return new \CallbackFilterIterator( new \IteratorIterator($array), $arrow );
 	}
 
 	/**


### PR DESCRIPTION
#2301

## Issue

The recent changes made in #2301 triggered many errors in my templates (`array_filter` running on `PostColelction` object). I use `filter` a lot and I use it against `PostCollection` which isn't an array. 


## Solution

Implement the native `twig_array_filter` method: https://github.com/twigphp/Twig/blob/1fb577363d3e3b5ce1b737b3255f2491b5f80833/src/Extension/CoreExtension.php#L1588-L1593

## Impact

It shouldn't because that method was used before that change.

## Usage Changes

None.
