### PR TITLE
Update Timber::get_posts() deprecated instances

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -132,7 +132,6 @@ class Timber {
 	 * Get a post by post ID or query (as a query string or an array of arguments).
 	 *
 	 * @api
-	 * @deprecated since 2.0.0 Use `new Timber\Post()` instead.
 	 *
 	 * @param mixed        $query     Optional. Post ID or query (as query string or an array of
 	 *                                arguments for WP_Query). If a query is provided, only the
@@ -151,7 +150,6 @@ class Timber {
 	 * Get posts.
 	 *
 	 * @api
-	 * @deprecated since 2.0.0 Use `new Timber\PostQuery()` instead.
 	 *
 	 * @param mixed        $query
 	 * @param string|array $PostClass
@@ -256,7 +254,7 @@ class Timber {
 	 * Query post.
 	 *
 	 * @api
-	 * @deprecated since 2.0.0 Use `new Timber\Post()` instead.
+	 * @deprecated since 2.0.0 Use `Timber::get_post()` instead.
 	 *
 	 * @param mixed  $query
 	 * @param string $PostClass
@@ -271,7 +269,7 @@ class Timber {
 	 * Query posts.
 	 *
 	 * @api
-	 * @deprecated since 2.0.0 Use `new Timber\PostQuery()` instead.
+	 * @deprecated since 2.0.0 Use `Timber::get_posts()` instead.
 	 *
 	 * @param mixed  $query
 	 * @param string $PostClass

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -635,7 +635,7 @@ class Timber {
 			$post = ( new Post() )->setup();
 			$context['post'] = $post;
 		} elseif ( is_archive() || is_home() ) {
-			$context['posts'] = new PostQuery();
+			$context['posts'] = Timber::get_posts();
 		}
 
  		return $context;

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -47,7 +47,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$context = Timber::context();
 
 		$this->assertArrayNotHasKey( 'post', $context );
-		$this->assertInstanceOf( 'Timber\PostQuery', $context['posts'] );
+		$this->assertInstanceOf( 'Timber\PostArrayObject', $context['posts'] );
 		$this->assertCount( 3, $context['posts']->get_posts() );
 	}
 


### PR DESCRIPTION
A (potential) adjustment to #2311. This updates `Timber.php` to point users towards `Timber::get_posts()` instead of `Timber::query_post()` or `new Timber\PostQuery()` calls. This also handles for what comes back from `Timber::context()`