### PR TITLE
Add webp to recognized image extensions

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -497,7 +497,7 @@ class Image extends Post implements CoreInterface {
 	 */
 	protected function is_image() {
 		$src = wp_get_attachment_url($this->ID);
-		$image_exts = array( 'jpg', 'jpeg', 'jpe', 'gif', 'png' );
+		$image_exts = array( 'gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp' );
 		$check = wp_check_filetype(PathHelper::basename($src), null);
 		return in_array($check['ext'], $image_exts);
 	}


### PR DESCRIPTION
## Issue
`webp` isn't in the list of recognized image extensions. So `webp` images will fail `Image::is_image()` check

## Solution
Add it!

## Impact
Should resolve unseen issues of it upper-level functions failing.

## Usage Changes
None

## Considerations
We've been unable to test against Webp previously on Travis. This would be a good time to figure that out (I've been able to test locally successfully, it seems to be because of how the Travis PHP build is configured)

## Testing
We've been unable to test against Webp previously on Travis. This would be a good time to figure that out (I've been able to test locally successfully, it seems to be because of how the Travis PHP build is configured)
