### PR TITLE
Pass more variables to the `timber/loader/loader` filter

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -147,7 +147,7 @@ class Loader {
 			$rootPath = null;
 		}
 		$fs = new \Twig\Loader\FilesystemLoader($paths, $rootPath);
-		$fs = apply_filters('timber/loader/loader', $fs);
+		$fs = apply_filters('timber/loader/loader', $fs, $paths, $rootPath);
 		return $fs;
 	}
 


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

## Issue
<!-- Description of the problem that this code change is solving -->
In the process of trying to override the `\Twig\Loader\FilesystemLoader` passed over on the WordPress filter `timber/loader/loader` it is required to pass over `$paths`, and `$rootPath` as arguments to the Loader class as seeing here: 

https://github.com/timber/timber/blob/master/lib/Loader.php#L149

```php
$fs = new \Twig\Loader\FilesystemLoader($paths, $rootPath);
```

The problem lies in the fact that the provided filter doesn't pass over the needed variables to accomplish this:

https://github.com/timber/timber/blob/master/lib/Loader.php#L150

```php
$fs = apply_filters('timber/loader/loader', $fs);
```


## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

This can be resolved by simply passing over the required variables like in this PR:

```php
$fs = apply_filters('timber/loader/loader', $fs, $paths, $rootPath);
```

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
There should not be any impact to current users.

```php
add_filter( 'timber/loader/loader', 'custom_loader_override', 10, 3 );
```

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.

Alternatively, you’re very welcome to directly edit the readme.txt file with:
- A quick summary, including your Github handle.
- A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
- New usage instructions, possibly with a short code example.
-->

Current users using this filter would keep getting the `$fs` variable by default by simply using the `add_filter()` function:

```php
add_filter( 'timber/loader/loader', 'custom_loader_override' );
```

New users that require these additional variables could request it in the `add_filter()` function like this:

```php
add_filter( 'timber/loader/loader', 'custom_loader_override', 10, 3 );
```


## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
This is indeed only useful for advanced users, but it opens up possibilities to extend for custom templates paths to be used such as the ones from [Fractal Twig Adapter](https://fractal.build/).

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
There won't be need for additional tests.
