### PR TITLE
upgrade Loader to use renamed Twig\TwigFunction

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -7,6 +7,7 @@ use Twig\CacheExtension;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
 
 class Loader {
 
@@ -433,7 +434,7 @@ class Loader {
 		if ( WP_DEBUG ) {
 			$twig->addExtension(new \Twig\Extension\DebugExtension());
 		} else {
-			$twig->addFunction(new Twig_Function('dump', function() {
+			$twig->addFunction(new TwigFunction('dump', function() {
 				return null;
 			}));
 		}


### PR DESCRIPTION
If `WP_DEBUG` is disabled, a Fatal Error will be thrown: "Class 'Timber\Twig_Function' not found". This just fixes the name so we're using the right class.

## Issue

I'm just starting to integrate our budding 2.x alpha on a real project, and this is the first thing I ran into. Looks like a code path that's probably not covered by the tests, but I don't have time to figure out how to test using different constants. But the fix is about as simple as it gets.

## Solution

`use` the correct `Twig\TwigFunction` class within Loader.

## Impact

The thing will work now! :smile: 

## Usage Changes

None

## Considerations

How can we test this reliably? Is it worth it?

## Testing
None for now.
