### PR TITLE
2.x Use stable release of twig/cache-extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "php": "^7.0",
     "twig/twig": "^2.10",
     "composer/installers": "~1.0",
-    "twig/cache-extension": "dev-master"
+    "twig/cache-extension": "^1.5.0"
   },
   "require-dev": {
     "johnpbloch/wordpress": ">=5.4.0",


### PR DESCRIPTION
## Issue and Solution

Up until some time ago, there wasn’t any stable release for [twig/cache-extension](https://github.com/twigphp/twig-cache-extension). But luckily, now [there are](https://github.com/twigphp/twig-cache-extension/releases). Let’s use them.

## Impact

Better control and predictability for when a new version of `twig/cache-extension` comes out.

## Usage Changes

None.

## Considerations

None.

## Testing

Should be covered by existing tests.