### PR TITLE
2.x Document post serialization

### DIFF
--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -360,6 +360,11 @@ console.log(post);
 }
 ```
 
+Now you might think: Why do I have to add all the data manually. Could we not just add all the data from all the methods of a post? Well, technically we could. But all that data would end up in your HTML output, which might not be a good idea:
+
+- There could be sensible data that you don’t want to have publicly available in your HTML.
+- All the data you add to the HTML will make your page size bigger. For performance reasons, it makes sense to only load the data you need.
+
 ## Performance
 
 ### Consider using the `pre_get_posts` action

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -306,7 +306,7 @@ Because `link` is a method of your post object, you wouldn’t have access to it
 console.log(post.link); // undefined
 ```
 
-Luckily, support for serialization is baked into Timber queries when you implements PHP’s [JsonSerializable](https://www.php.net/manual/en/class.jsonserializable.php) interface.
+Luckily, support for serialization is baked into Timber queries when you implement PHP’s [JsonSerializable](https://www.php.net/manual/en/class.jsonserializable.php) interface.
 
 Say you create a `Book` class that [extends](/docs/v2/guides/extending-timber/) `Timber\Post`. You define a `jsonSerialize()` method for that class. This method returns an array with all the data you want to use in JavaScript.
 

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -287,7 +287,7 @@ Of course, the other main difference is that instead of returning plain `WP_Post
 
 When you want to work with post data in JavaScript, you will want to convert it to JSON first.
 
-Under normal circumstances, this would be a problem. Timber posts are instantiated lazily. This means that most methods will only calculate and return a value the first time you call them. Take the `Timber\Post::link()` method for example. You use it to get the permalink for a post.
+Under normal circumstances, this wouldn't be a problem. However, Timber posts are instantiated lazily. This means that most methods will only calculate and return a value the first time you call them. Take the `Timber\Post::link()` method for example. You use it to get the permalink for a post.
 
 ```php
 $permalink = $post->link();
@@ -331,13 +331,13 @@ class Book extends Post implements JsonSerializable {
             'title'     => $this->title(),
             'link'      => $this->link(),
             'thumbnail' => $this->thumbnail()->src( 'thumbnail' ),
-			'price'     => $this->meta( 'price' ),
+            'price'     => $this->meta( 'price' ),
 		];
 	}
 }
 ```
 
-After you defined with [Class Maps](/docs/v2/guides/class-maps/#the-post-class-map) that all `book` posts should be instantiated with your `Book` class, you can directly convert your posts query to JSON:
+Once you define with [Class Maps](/docs/v2/guides/class-maps/#the-post-class-map) that all `book` post types should be instantiated with your `Book` class, you can directly convert your posts query to JSON:
 
 ```php
 $posts = Timber::get_posts( [
@@ -360,9 +360,9 @@ console.log(post);
 }
 ```
 
-Now you might think: Why do I have to add all the data manually. Could we not just add all the data from all the methods of a post? Well, technically we could. But all that data would end up in your HTML output, which might not be a good idea:
+Now you might think: Why do I have to add all the data manually? Could we not just add all the data from all the methods of a post? Well, technically we could. But all that data would end up in your HTML output, which might not be a good idea:
 
-- There could be sensible data that you don’t want to have publicly available in your HTML.
+- There could be sensitive data that you don’t want to have publicly available in your HTML.
 - All the data you add to the HTML will make your page size bigger. For performance reasons, it makes sense to only load the data you need.
 
 ## Performance

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -283,6 +283,83 @@ If you’re used to using `get_posts()` instead of `WP_Query`, you will have to 
 
 Of course, the other main difference is that instead of returning plain `WP_Post` objects, `Timber::get_posts()` returns instances of `Timber\Post`.
 
+## Serialization
+
+When you want to work with post data in JavaScript, you will want to convert it to JSON first.
+
+Under normal circumstances, this would be a problem. Timber posts are instantiated lazily. This means that most methods will only calculate and return a value the first time you call them. Take the `Timber\Post::link()` method for example. You use it to get the permalink for a post.
+
+```php
+$permalink = $post->link();
+```
+
+Now let’s say you need to access that link in JavaScript, so you would convert your post data to JSON:
+
+```php
+$post = Timber::get_post( 84 );
+$json = wp_json_encode( $post );
+```
+
+Because `link` is a method of your post object, you wouldn’t have access to it in JavaScript, because when you JSON-encode a post, you will only get its properties.
+
+```js
+console.log(post.link); // undefined
+```
+
+Luckily, support for serialization is baked into Timber queries when you implements PHP’s [JsonSerializable](https://www.php.net/manual/en/class.jsonserializable.php) interface.
+
+Say you create a `Book` class that [extends](/docs/v2/guides/extending-timber/) `Timber\Post`. You define a `jsonSerialize()` method for that class. This method returns an array with all the data you want to use in JavaScript.
+
+```php
+<?php
+
+use Timber\Post;
+
+/**
+ * Class Book
+ *
+ * Implements custom JSON serialization.
+ */
+class Book extends Post implements JsonSerializable {
+    /**
+     * Defines data that is used when post is converted to JSON.
+     *
+     * @return array
+     */
+	public function jsonSerialize() {
+		return [
+            'title'     => $this->title(),
+            'link'      => $this->link(),
+            'thumbnail' => $this->thumbnail()->src( 'thumbnail' ),
+			'price'     => $this->meta( 'price' ),
+		];
+	}
+}
+```
+
+After you defined with [Class Maps](/docs/v2/guides/class-maps/#the-post-class-map) that all `book` posts should be instantiated with your `Book` class, you can directly convert your posts query to JSON:
+
+```php
+$posts = Timber::get_posts( [
+    'post_type' => 'book',
+] );
+
+$posts_json = wp_json_encode( $posts_json );
+```
+
+Now, when you access your posts in JavaScript, you will have all the data you defined in your `Book::jsonSerialize()` method as object properties of your post.
+
+```js
+console.log(post);
+
+{
+    title: 'The magic serialization of posts',
+    link: 'https://example.org/book/the-magic-serialization-of-posts',
+    thumbnail: 'https://example.org/wp-content/uploads/the-magic-serializaton-of-posts-150x150.jpg',
+    price: 100
+}
+```
+
 ## Performance
 
 ### Consider using the `pre_get_posts` action


### PR DESCRIPTION
**Ticket**: #2311

## Issue

As one of the final documentation issues in #2073, we should document JSON serialization of posts that was added in #2311.

## Solution

Take a stab at adding an example with a book post.

## Impact

Even more insights about posts and advanced Timber coding.

## Usage Changes

None.

## Considerations

@acobster I hope I got everything right!

Also, in https://github.com/timber/timber/pull/2311#issuecomment-677820224 you had an idea to implement `jsonSerialize()` in `Timber\Post`.

> > Yeah, in addition to providing some sensible default behavior in `Timber\Post` (I just wanted to avoid touching Post too much in this PR, and just focus on collections). Child implementations can easily call `parent::jsonSerialize()` to get the data to use as a basis, so we should capture that in the docs.
> 
> Right, good idea! We should definitely also have an example that explains that removing data would make sense, too, because you don’t want to fill the HTML of a page with data that has to be downloaded but that you will never need.

I’m still not sure about that, but I think it might be hard to figure out which data is added by default, because this depends sooo much on the use case. Maybe not defining a default isn’t all that bad after all?

## Testing

Nope.