### PR TITLE
2.x images api

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -262,6 +262,34 @@ class Timber {
 	}
 
 	/**
+	 * Alias of Timber::get_post(). As such, will honor Class Maps and will NOT
+	 * necessarily always return an Attachment object. Intended for cases where you
+	 * already know you have an attachment ID (or WP_Post of type `attachment`,
+	 * etc.), to clarify your own code.
+	 *
+	 * @api
+	 * @see Timber::get_post()
+	 * @see https://timber.github.io/docs/v2/guides/class-maps/
+	 */
+	public static function get_attachment( $query = false, $options = [] ) {
+		return static::get_post( $query, $options );
+	}
+
+	/**
+	 * Alias of Timber::get_post(). As such, will honor Class Maps and will NOT
+	 * necessarily always return an Image object. Intended for cases where you
+	 * already know you have an attachment ID (or WP_Post of type `attachment`,
+	 * etc.), to clarify your own code.
+	 *
+	 * @api
+	 * @see Timber::get_post()
+	 * @see https://timber.github.io/docs/v2/guides/class-maps/
+	 */
+	public static function get_image( $query = false, $options = [] ) {
+		return static::get_post( $query, $options );
+	}
+
+	/**
 	 * Get posts.
 	 *
 	 * @api

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -262,31 +262,43 @@ class Timber {
 	}
 
 	/**
-	 * Alias of Timber::get_post(). As such, will honor Class Maps and will NOT
-	 * necessarily always return an Attachment object. Intended for cases where you
-	 * already know you have an attachment ID (or WP_Post of type `attachment`,
-	 * etc.), to clarify your own code.
+	 * Behaves just like Timber::get_post(), except that it returns false if it
+	 * finds a Post that is not an Attachment. Honors Class Maps and falsifies return
+	 * value *after* Class Map for the found Post has been resolved.
 	 *
 	 * @api
 	 * @see Timber::get_post()
 	 * @see https://timber.github.io/docs/v2/guides/class-maps/
+	 * @param mixed $query query or post identifier
+	 * @param array $options options to ::get_post()
+	 * @return Attachment|false
 	 */
 	public static function get_attachment( $query = false, $options = [] ) {
-		return static::get_post( $query, $options );
+		$post = static::get_post( $query, $options );
+
+		// @todo make this determination at the Factory level.
+		// No need to instantiate a Post we're not going to use.
+		return ( $post instanceof Attachment ) ? $post : false;
 	}
 
 	/**
-	 * Alias of Timber::get_post(). As such, will honor Class Maps and will NOT
-	 * necessarily always return an Image object. Intended for cases where you
-	 * already know you have an attachment ID (or WP_Post of type `attachment`,
-	 * etc.), to clarify your own code.
+	 * Behaves just like Timber::get_post(), except that it returns false if it
+	 * finds a Post that is not an Image. Honors Class Maps and falsifies return
+	 * value *after* Class Map for the found Post has been resolved.
 	 *
 	 * @api
 	 * @see Timber::get_post()
 	 * @see https://timber.github.io/docs/v2/guides/class-maps/
+	 * @param mixed $query query or post identifier
+	 * @param array $options options to ::get_post()
+	 * @return Image|false
 	 */
 	public static function get_image( $query = false, $options = [] ) {
-		return static::get_post( $query, $options );
+		$post = static::get_post( $query, $options );
+
+		// @todo make this determination at the Factory level.
+		// No need to instantiate a Post we're not going to use.
+		return ( $post instanceof Image ) ? $post : false;
 	}
 
 	/**

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -52,8 +52,8 @@ class Twig {
 
 		// Posts
 		$twig->addFunction( new TwigFunction( 'get_post', [ Timber::class, 'get_post' ] ) );
-		$twig->addFunction( new TwigFunction( 'get_image', [ Timber::class, 'get_post' ] ) );
-		$twig->addFunction( new TwigFunction( 'get_attachment', [ Timber::class, 'get_post' ] ) );
+		$twig->addFunction( new TwigFunction( 'get_image', [ Timber::class, 'get_image' ] ) );
+		$twig->addFunction( new TwigFunction( 'get_attachment', [ Timber::class, 'get_attachment' ] ) );
 		$twig->addFunction( new TwigFunction( 'get_posts', [ Timber::class, 'get_posts' ] ) );
 		$twig->addFunction( new TwigFunction( 'get_attachment_by', [ Timber::class, 'get_attachment_by' ] ) );
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -52,6 +52,8 @@ class Twig {
 
 		// Posts
 		$twig->addFunction( new TwigFunction( 'get_post', [ Timber::class, 'get_post' ] ) );
+		$twig->addFunction( new TwigFunction( 'get_image', [ Timber::class, 'get_post' ] ) );
+		$twig->addFunction( new TwigFunction( 'get_attachment', [ Timber::class, 'get_post' ] ) );
 		$twig->addFunction( new TwigFunction( 'get_posts', [ Timber::class, 'get_posts' ] ) );
 		$twig->addFunction( new TwigFunction( 'get_attachment_by', [ Timber::class, 'get_attachment_by' ] ) );
 

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -39,9 +39,11 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$attachment = Timber::get_image(self::get_attachment($pid, 'dummy-pdf.pdf'));
 		$post       = Timber::get_image($pid);
 
+		// Image is good, but Timber should recognize that neither Attachment
+		// or Post are actually Image subclasses.
 		$this->assertInstanceOf(Image::class, $image);
-		$this->assertInstanceOf(Attachment::class, $attachment);
-		$this->assertInstanceOf(Post::class, $post);
+		$this->assertFalse($attachment);
+		$this->assertFalse($post);
 	}
 
 	/**
@@ -54,9 +56,11 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$attachment = Timber::get_attachment(self::get_attachment($pid, 'dummy-pdf.pdf'));
 		$post       = Timber::get_image($pid);
 
+		// Image and Attachment are *both* Attachment classes, so they're OK.
+		// A Post is not an Attachment so it should not be treated as such.
 		$this->assertInstanceOf(Image::class, $image);
 		$this->assertInstanceOf(Attachment::class, $attachment);
-		$this->assertInstanceOf(Post::class, $post);
+		$this->assertFalse($post);
 	}
 
 	/**

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -1,6 +1,9 @@
 <?php
 
+use Timber\Attachment;
+use Timber\Image;
 use Timber\Image\Operation as ImageOperation;
+use Timber\Post;
 
 /**
  * @group posts-api
@@ -25,6 +28,64 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 	/* ----------------
 	 * Tests
 	 * ---------------- */
+
+	/**
+	 * @group attachment-aliases
+	 */
+	function testGetImageAlias() {
+		$pid = $this->factory->post->create();
+
+		$image      = Timber::get_image(self::get_attachment($pid, 'arch.jpg'));
+		$attachment = Timber::get_image(self::get_attachment($pid, 'dummy-pdf.pdf'));
+		$post       = Timber::get_image($pid);
+
+		$this->assertInstanceOf(Image::class, $image);
+		$this->assertInstanceOf(Attachment::class, $attachment);
+		$this->assertInstanceOf(Post::class, $post);
+	}
+
+	/**
+	 * @group attachment-aliases
+	 */
+	function testGetAttachmentAlias() {
+		$pid = $this->factory->post->create();
+
+		$image      = Timber::get_attachment(self::get_attachment($pid, 'arch.jpg'));
+		$attachment = Timber::get_attachment(self::get_attachment($pid, 'dummy-pdf.pdf'));
+		$post       = Timber::get_image($pid);
+
+		$this->assertInstanceOf(Image::class, $image);
+		$this->assertInstanceOf(Attachment::class, $attachment);
+		$this->assertInstanceOf(Post::class, $post);
+	}
+
+	/**
+	 * @group attachment-aliases
+	 */
+	function testGetImageTwigAlias() {
+		$pid = $this->factory->post->create();
+
+		$iid = self::get_attachment($pid, 'arch.jpg');
+		$src = Timber::get_post($iid)->src();
+
+		$this->assertEquals($src, Timber::compile_string('{{ get_image(iid).src }}', [
+			'iid' => $iid,
+		]));
+	}
+
+	/**
+	 * @group attachment-aliases
+	 */
+	function testGetAttachmentTwigAlias() {
+		$pid = $this->factory->post->create();
+
+		$iid = self::get_attachment($pid, 'arch.jpg');
+		$src = Timber::get_post($iid)->src();
+
+		$this->assertEquals($src, Timber::compile_string('{{ get_attachment(iid).src }}', [
+			'iid' => $iid,
+		]));
+	}
 
 	function testTimberImageSrc() {
 		$iid = self::get_attachment();


### PR DESCRIPTION
**Ticket**: #2333

## Issue

Discussed in detail in the linked issue and in #2316 .

## Solution

Aliases and docs for `::get_image()` and `::get_attachment()` and corresponding Twig functions.

## Impact

A slightly bigger but less confusing API.

## Usage Changes

MOAR METHODS

## Considerations

We threw out the idea of adding `::get_images()` and `::get_attachments()` (plural) for consistency. I don't see as strong a reason to have these in there, and they're potentially even more confusing because of the potential for getting back a mixed bag of concrete classes.

## Testing

Yes, test all the things!