### PR TITLE
Adding double quotes check when using Read More block from Gutenberg

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1233,15 +1233,15 @@ class Post extends Core implements CoreInterface {
 	}
 
 	/**
-	 * Handles for an circumstance with the Block editor where a "more" block has an option to 
-	 * "Hide the excerpt on the full content page" which hides everything prior to the inserted 
+	 * Handles for an circumstance with the Block editor where a "more" block has an option to
+	 * "Hide the excerpt on the full content page" which hides everything prior to the inserted
 	 * "more" block
 	 * @ticket #2218
 	 * @param string $content
 	 * @return string
 	 */
 	protected function content_handle_no_teaser_block( $content ) {
-		if ( strpos($content, 'noTeaser:true') !== false ) {
+		if ( strpos($content, 'noTeaser:true') !== false || strpos($content, '"noTeaser":true') !== false ) {
 			$arr = explode('<!--noteaser-->', $content);
 			return $arr[1];
 		}


### PR DESCRIPTION
**Ticket**: https://github.com/timber/timber/issues/2337

## Issue
Using `{{post.content}}` in a Post that contains a "Read More" block from Gutenberg with the option to hide the excerpt enabled sometimes does NOT hide the excerpt on full content page.


## Solution
Added an additional check for `'"noTeaser":true'` tag to cover the possibility that it contains double quotes.


## Impact
This should be 100% backwards-compatible, as it only adds a `strpos(...)` check with a `||` operator. The change will only correct the bug for instances of WordPress that use double quotes to surround `noTeaser` tag part.


## Usage Changes
None.


## Considerations
While repeating chunks of code (in this case `strpos(...)`) is not ideal, I tend to think that this is less error-prone in this case since dealing with quotes in a variable content can often lead to unexpected behaviour.

We could, however, first remove possible double quotes from the needle (`'"noTeaser":true'`), then use `strpos(...)` on it. I just wanted to keep things simple.