### PR TITLE
replace : asm89/twig-cache-extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "twig/twig": "^1.41|^2.10",
     "upstatement/routes": "0.5",
     "composer/installers": "~1.0",
-    "asm89/twig-cache-extension": "~1.0"
+    "twig/cache-extension": "^1.5"
   },
   "require-dev": {
     "johnpbloch/wordpress": "*",

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -51,7 +51,7 @@ The following cache modes are available:
 
 ## Cache _Parts_ of the Twig File and Data
 
-This method implements the [Twig Cache Extension](https://github.com/asm89/twig-cache-extension). It adds the cache tag, for use in templates. Best shown by example:
+This method implements the [Twig Cache Extension](https://github.com/twigphp/twig-cache-extension). It adds the cache tag, for use in templates. Best shown by example:
 
 ```twig
 {% cache 'index/content' posts %}

--- a/lib/Cache/KeyGenerator.php
+++ b/lib/Cache/KeyGenerator.php
@@ -2,7 +2,7 @@
 
 namespace Timber\Cache;
 
-use Asm89\Twig\CacheExtension\CacheStrategy\KeyGeneratorInterface;
+use Twig\CacheExtension\CacheStrategy\KeyGeneratorInterface;
 
 class KeyGenerator implements KeyGeneratorInterface {
 

--- a/lib/Cache/WPObjectCacheAdapter.php
+++ b/lib/Cache/WPObjectCacheAdapter.php
@@ -1,6 +1,6 @@
 <?php namespace Timber\Cache;
 
-use Asm89\Twig\CacheExtension\CacheProviderInterface;
+use Twig\CacheExtension\CacheProviderInterface;
 use Timber\Loader;
 
 class WPObjectCacheAdapter implements CacheProviderInterface {

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -272,15 +272,15 @@ class Loader {
 	}
 
 	/**
-	 * @return \Asm89\Twig\CacheExtension\Extension
+	 * @return \Twig\CacheExtension\Extension
 	 */
 	private function _get_cache_extension() {
 
 		$key_generator   = new \Timber\Cache\KeyGenerator();
 		$cache_provider  = new \Timber\Cache\WPObjectCacheAdapter($this);
 		$cache_lifetime  = apply_filters('timber/cache/extension/lifetime', 0);
-		$cache_strategy  = new \Asm89\Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy($cache_provider, $key_generator, $cache_lifetime);
-		$cache_extension = new \Asm89\Twig\CacheExtension\Extension($cache_strategy);
+		$cache_strategy  = new \Twig\CacheExtension\CacheStrategy\GenerationalCacheStrategy($cache_provider, $key_generator, $cache_lifetime);
+		$cache_extension = new \Twig\CacheExtension\Extension($cache_strategy);
 
 		return $cache_extension;
 	}


### PR DESCRIPTION
resolves notice : 

> Package asm89/twig-cache-extension is abandoned, you should avoid using it. Use twig/cache-extension instead.

fixes : https://github.com/timber/timber/issues/2347

