### PR TITLE
fix two cases where site_url() was used instead of home_url()

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -502,7 +502,9 @@ class ImageHelper {
 		}
 		$url = untrailingslashit($url).'/'.$filename;
 		if ( !$absolute ) {
-			$url = str_replace(home_url(), '', $url);
+			$home = home_url();
+			$home = apply_filters('timber/ImageHelper/_get_file_url/home_url', $home);
+			$url = str_replace($home, '', $url);
 		}
 		return $url;
 	}

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -502,7 +502,7 @@ class ImageHelper {
 		}
 		$url = untrailingslashit($url).'/'.$filename;
 		if ( !$absolute ) {
-			$url = str_replace(site_url(), '', $url);
+			$url = str_replace(home_url(), '', $url);
 		}
 		return $url;
 	}

--- a/lib/Integrations/WPML.php
+++ b/lib/Integrations/WPML.php
@@ -8,6 +8,7 @@ class WPML {
 		add_filter('timber/URLHelper/file_system_to_url', array($this, 'file_system_to_url'), 10, 1);
 		add_filter('timber/URLHelper/get_content_subdir/home_url', array($this, 'file_system_to_url'), 10, 1);
 		add_filter('timber/URLHelper/url_to_file_system/path', array($this, 'file_system_to_url'), 10, 1);
+		add_filter('timber/ImageHelper/_get_file_url/home_url', array($this, 'file_system_to_url'), 10, 1);
 
 	}
 

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -168,7 +168,7 @@ class URLHelper {
 	 */
 	public static function file_system_to_url( $fs ) {
 		$relative_path = self::get_rel_path($fs);
-		$home = site_url('/'.$relative_path);
+		$home = home_url('/'.$relative_path);
 		$home = apply_filters('timber/URLHelper/file_system_to_url', $home);
 		return $home;
 	}

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -56,11 +56,11 @@
 
         function testFileSystemToURLWithWPML() {
             self::_setLanguage();
-            add_filter('site_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
+            add_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
             $image = TestTimberImage::copyTestImage();
             $url = Timber\URLHelper::file_system_to_url($image);
             $this->assertStringEndsWith('://example2.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-            remove_filter('site_url', array($this, 'addWPMLHomeFilterForRegExTest'));
+            remove_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'));
         }
 
         function addWPMLHomeFilterForRegExTest($url, $path) {


### PR DESCRIPTION


**Ticket**: #2356 

## Issue
site_url() returns a wrong url on bedrock based installations, since site_url() returns https://yourdomain.com/wp since the WP installation lives in this directory.

Relevant file structure of a Bedrock based project:

├── Other stuff, no relevant for this PR.
└── web                        → Web root (document root on your webserver)
    ├── app                    → **wp-content equivalent**
    │   ├── mu-plugins   → Must use plugins
    │   ├── plugins         → Plugins
    │   ├── themes         → Themes
    │   └── uploads         → Uploads
    ├── wp-config.php    → Required by WP (never edit)
    ├── index.php           → WordPress view bootstrapper
    └── wp                     → **WordPress core**

## Solution
When using home_url() this issue is resolved.

## Impact
In my initial issue I found out that changing `site_url()` to `home_url()` in  `Timber\URLHelper::file_system_to_url()` fixed a sideloading img issue. This change is inside PR. While on it I found a second instance of `site_url` in `Timber\ImageHelper::_get_file_url`. to get a relative URL we need to remove `home_url()` from the $url instead of `site_url()` since uploads in a Bedrock based installation live in `https://yourdomain.com/app/uploads/` and not in `https://yourdomain.com/wp/app/uploads/`

## Considerations
It might be a good idea to write an extra set of tests based off a Bedrock based installation because I see the combination of Bedrock + Timber a lot in my freelance work.
