### PR TITLE
support passing extra args to Timber::context()

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -901,10 +901,13 @@ class Timber {
 	 * @api
 	 * @since 2.0.0
 	 *
+	 * @param array $extra any extra data to merge in. Overrides whatever is
+	 * already there for this call only. In other words, the underlying context
+	 * data is immutable and unaffected by passing this param.
 	 * @return array An array of context variables that is used to pass into Twig templates through
 	 *               a render or compile function.
 	 */
-	public static function context() {
+	public static function context(array $extra = []) {
 		$context = self::context_global();
 
 		if ( is_singular() ) {
@@ -913,7 +916,7 @@ class Timber {
 			$context['posts'] = Timber::get_posts();
 		}
 
- 		return $context;
+		return array_merge( $context, $extra );
 	}
 
 	/**

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -258,6 +258,30 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 		$this->assertInstanceOf( Timber\PostQuery::class, $context['posts'] );
 	}
 
+	function testContextWithExtraArgs() {
+		$pids = $this->factory->post->create_many(20);
+		$this->go_to('/');
+
+		$context = Timber::context([
+			'extra'  => 'stuff',
+			'fancy'  => [
+				'this' => 'can',
+				'be'   => 'whatever',
+			],
+		]);
+
+		$this->assertEquals( 'stuff', $context['extra'] );
+		$this->assertEquals( [
+			'this' => 'can',
+			'be'   => 'whatever',
+		],	$context['fancy'] );
+		$this->assertInstanceOf( Timber\PostQuery::class, $context['posts'] );
+
+		// Underlying context is immutable and unaffected by extra data.
+		$this->assertFalse( array_key_exists( 'extra', Timber::context() ) );
+		$this->assertFalse( array_key_exists( 'fancy', Timber::context() ) );
+	}
+
 	function testGetPostsWithClassMap() {
 		register_post_type('portfolio', array('public' => true));
 		register_post_type('alert', array('public' => true));
@@ -458,7 +482,7 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 			'post_type' => 'post',
 			'posts_per_page' => 7,
 		] );
-		
+
 		$this->assertCount(7, $posts);
 	}
 


### PR DESCRIPTION
Here's something I've had kicking around in my head for a while. :)

In [Conifer](coniferplug.in/), which we use on pretty much every WP site at SiteCrafting, we have the nice convenience of being able to pass extra data to `Conifer\Site::context()`, which delegates to `Timber::context()` and just adds this merging capability on top. It means that this code:

```php
$data = Timber::context();
$data['extra'] = 'stuff';
```

Becomes:

```php
$data = $site->context([ 'extra' => 'stuff' ]);
```

I usually err on the side of not expanding an API if you can help it, but this is extremely convenient and I've found it makes template code way more readable, especially when you have a lot of extra stuff you need to get into your view data from your template. It turns a bunch of separate, imperative operations and turns it into one data _composition_ operation, which I think is closer to how folks tend to think about view data. So I think the extra readability is worth a tiny incremental expansion to the API. :)

This process is immutable, i.e. it doesn't affect the underlying context data in any way. So subsequent calls to `::context()` without extra data will return whatever it did before.

The proposal here is to simply push this behavior down into Timber, so we can do:

```php
$data = Timber::context([ 'extra' => 'stuff' ]);
```