### PR TITLE
Fix typo

### DIFF
--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -312,7 +312,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * Or when you only want to add a target attribute if it is really needed:
 	 *
 	 * ```twig
-	 * <a href="{{ item.link }}" {{ item.is_external ? 'target="_blank"' }}">
+	 * <a href="{{ item.link }}" {{ item.is_external ? 'target="_blank"' }}>
 	 * ```
 	 *
 	 * In combination with `is_target_blank()`:

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -318,7 +318,7 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 	 * In combination with `is_target_blank()`:
 	 *
 	 * ```twig
-	 * <a href="{{ item.link }}" {{ item.is_external or item.is_target_blank ? 'target="_blank"' }}">
+	 * <a href="{{ item.link }}" {{ item.is_external or item.is_target_blank ? 'target="_blank"' }}>
 	 * ```
 	 *
 	 * @return bool Whether the link is external or not.


### PR DESCRIPTION
Remove unnecessary quotes in line 321: 

```php
	 * <a href="{{ item.link }}" {{ item.is_external or item.is_target_blank ? 'target="_blank"' }}">
```