### PR TITLE
2.x Clean up post preview

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -577,6 +577,18 @@ $genre->posts( [
 ] );
 ```
 
+## Post Excerpts
+
+### "Excerpt" instead of "Preview"
+
+We renamed the `Timber\PostPreview` class to `Timber\PostPreview` and also changed all instances of the term "preview" to "excerpt". The reason for this change is that the term "preview" in WordPress is mainly used for previewing a post before you save changes in the admin. For the short texts that are used in post teasers, the term "excerpt" is used. We wanted to follow the WordPress terminology here.
+
+For this, we…
+
+- renamed the `Timber\PostPreview` class to `Timber\PostExcerpt`.
+- added a `Timber\Post::excerpt()` function that you should use instead of `Timber\Post::preview()`.
+- Changed filter names.
+
 ### `post.excerpt` takes arguments in array/hash notation
 
 The `{{ post.excerpt }}` function was added as a replacement for `{{ post.preview }}`. When using `{{ post.preview }}`, you could pass in arguments by chaining them. It’s now possible to pass in arguments as an array in PHP or in hash style in Twig. This finally cleans up how the previews of posts are handled. Here’s an example:
@@ -633,6 +645,7 @@ You should update the following hooks, because they will be removed in a future 
 **Timber\PostPreview**
 
 - `timber/post/preview/read_more_class`, use `timber/post/excerpt/read_more_class` instead
+- `timber/post/get_preview/read_more_link`, use `timber/post/excerpt/read_more_link` instead
 
 **Timber\Term**
 

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -630,6 +630,10 @@ You should update the following hooks, because they will be removed in a future 
 - `timber_post_get_meta_field`, use `timber/post/meta` instead
 - `timber_post_get_meta`, use `timber/post/meta` instead
 
+**Timber\PostPreview**
+
+- `timber/post/preview/read_more_class`, use `timber/post/excerpt/read_more_class` instead
+
 **Timber\Term**
 
 - `timber/term/meta/field`, use `timber/term/meta` instead

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -912,12 +912,12 @@ $genre->posts( [
 
 ### "Excerpt" instead of "Preview"
 
-We renamed the `Timber\PostPreview` class to `Timber\PostPreview` and also changed all instances of the term "preview" to "excerpt". The reason for this change is that the term "preview" in WordPress is mainly used for previewing a post before you save changes in the admin. For the short texts that are used in post teasers, the term "excerpt" is used. We wanted to follow the WordPress terminology here.
+We renamed the `Timber\PostPreview` class to `Timber\PostExcerpt` and also changed all instances of the term "preview" to "excerpt". The reason for this change is that the term "preview" in WordPress is mainly used for previewing a post before you save changes in the admin. For the short texts that are used in post teasers, the term "excerpt" is used. We wanted to follow the WordPress terminology here.
 
 For this, we…
 
-- renamed the `Timber\PostPreview` class to `Timber\PostExcerpt`.
-- added a `Timber\Post::excerpt()` function that you should use instead of `Timber\Post::preview()`.
+- Renamed the `Timber\PostPreview` class to `Timber\PostExcerpt`.
+- Added a `Timber\Post::excerpt()` function that you should use instead of `Timber\Post::preview()`.
 - Changed filter names.
 
 ### `post.excerpt` takes arguments in array/hash notation

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -383,14 +383,14 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
-	 * Gets a preview/excerpt of your post.
+	 * Gets a excerpt of your post.
 	 *
 	 * If you have an excerpt is set on the post, the excerpt will be used. Otherwise it will try to
-	 * pull from a preview from `post_content`. If there’s a `<!-- more -->` tag in the post
+	 * pull from an excerpt from `post_content`. If there’s a `<!-- more -->` tag in the post
 	 * content, it will use that to mark where to pull through.
 	 *
 	 * @api
-	 * @see \Timber\PostPreview
+	 * @see \Timber\PostExcerpt
 	 *
 	 * @param array $options {
 	 *     An array of configuration options for generating the excerpt. Default empty.
@@ -412,43 +412,43 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 * <h2>{{ post.title }}</h2>
 	 * <div>{{ post.excerpt({ words: 100, read_more: 'Keep reading' }) }}</div>
 	 * ```
-	 * @return \Timber\PostPreview
+	 * @return \Timber\PostExcerpt
 	 */
 	public function excerpt( array $options = array() ) {
-		return new PostPreview( $this, $options );
+		return new PostExcerpt( $this, $options );
 	}
 
 	/**
-	 * Gets a preview (excerpt) of your post.
+	 * Gets an excerpt of your post.
 	 *
 	 * If you have an excerpt is set on the post, the excerpt will be used. Otherwise it will try to
-	 * pull from a preview from `post_content`. If there’s a `<!-- more -->` tag in the post
+	 * pull from an excerpt from `post_content`. If there’s a `<!-- more -->` tag in the post
 	 * content, it will use that to mark where to pull through.
 	 *
-	 * This method returns a `Timber\PostPreview` object, which is a **chainable object**. This
-	 * means that you can change the output of the preview by **adding more methods**. Refer to the
-	 * [documentation of the `Timber\PostPreview` class](https://timber.github.io/docs/reference/timber-postpreview/)
+	 * This method returns a `Timber\PostExcerpt` object, which is a **chainable object**. This
+	 * means that you can change the output of the excerpt by **adding more methods**. Refer to the
+	 * [documentation of the `Timber\PostExcerpt` class](https://timber.github.io/docs/reference/timber-postexcerpt/)
 	 * to get an overview of all the available methods.
 	 *
 	 * @api
 	 * @deprecated 2.0.0, use `{{ post.excerpt }}` instead.
-	 * @see \Timber\PostPreview
+	 * @see \Timber\PostExcerpt
 	 * @example
 	 * ```twig
-	 * {# Use default preview #}
-	 * <p>{{ post.preview }}</p>
+	 * {# Use default excerpt #}
+	 * <p>{{ post.excerpt }}</p>
 	 *
-	 * {# Change the post preview text #}
-	 * <p>{{ post.preview.read_more('Continue Reading') }}</p>
+	 * {# Change the post excerpt text #}
+	 * <p>{{ post.excerpt.read_more('Continue Reading') }}</p>
 	 *
 	 * {# Additionally restrict the length to 50 words #}
-	 * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
+	 * <p>{{ post.excerpt.length(50).read_more('Continue Reading') }}</p>
 	 * ```
-	 * @return \Timber\PostPreview
+	 * @return \Timber\PostExcerpt
 	 */
 	public function preview() {
 		Helper::deprecated('{{ post.preview }}', '{{ post.excerpt }}', '2.0.0');
-		return new PostPreview($this);
+		return new PostExcerpt($this);
 	}
 
 	/**

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -452,59 +452,6 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	}
 
 	/**
-	 * Get a preview (excerpt) of your post.
-	 *
-	 * @deprecated 1.3.1, use `{{ post.excerpt }}` instead.
-	 * @see        \Timber\Post::excerpt()
-	 *
-	 * @param int         $len      The number of words that WordPress should use to make the
-	 *                              preview.
-	 *                              (Isn’t this better than [this
-	 *                              mess](http://wordpress.org/support/topic/changing-the-default-length-of-the_excerpt-1?replies=14)?).
-	 *                              If you’ve set a post excerpt on a post, we’ll use that for the
-	 *                              preview text; otherwise the first X words of `post_content`.
-	 * @param bool        $force    What happens if your custom post excerpt is longer then the
-	 *                              length requested? By default (`$force = false`) it will use the
-	 *                              full `post_excerpt`. However, you can set this to `true` to
-	 *                              *force* your excerpt to be of the desired length.
-	 * @param string      $readmore The text you want to use for the 'readmore' link.
-	 * @param bool|string $strip    `true` for default, `false` for none, a string for a list of
-	 *                              custom attributes.
-	 * @param string      $end      The text to end the preview with. Default `...`.
-	 *
-	 * @return string The post preview.
-	 */
-	public function get_preview( $len = 50, $force = false, $readmore = 'Read More', $strip = true, $end = '&hellip;' ) {
-		Helper::deprecated('{{ post.get_preview }}', '{{ post.preview }}', '1.3.1');
-		$pp = new PostPreview($this);
-
-		/** This filter is documented in PostPreview.php */
-		add_filter('timber/post/preview/read_more_class', function(){
-			/**
-			 * Filters the CSS class used for the preview link for a post.
-			 *
-			 * This filter only applies when you use `{{ post.get_preview() }}`. When you want to
-			 * change the CSS class for all preview links in general, you can use the
-			 * `timber/post/preview/read_more_class` filter.
-			 *
-			 * @since 0.22.3
-			 * @example
-			 * ```php
-			 * // Change the CSS class for preview links
-			 * add_filter( 'timber/post/get_preview/read_more_class', function( $class ) {
-			 *     return 'post__read-more__link';
-			 * } );
-			 * ```
-			 *
-			 * @param string $class The CSS class to use for the preview link. Default `read-more`.
-			 */
-			return apply_filters('timber/post/get_preview/read_more_class', "read-more");
-		});
-
-		return $pp->length($len)->force($force)->read_more($readmore)->strip($strip)->end($end);
-	}
-
-	/**
 	 * @internal
 	 * @param int $i
 	 * @return string

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -279,18 +279,31 @@ class PostExcerpt {
 		/**
 		 * Filters the CSS class used for excerpt links.
 		 *
-		 * @since 1.0.4
+		 * @sicne 2.0.0
 		 * @example
 		 * ```php
-		 * // Change the CSS class for excerpt links
-		 * add_filter( 'timber/post/preview/read_more_class', function( $class ) {
+		 * // Change the CSS class for excerpt links.
+		 * add_filter( 'timber/post/excerpt/read_more_class', function( $class ) {
 		 *     return 'read-more__link';
 		 * } );
 		 * ```
 		 *
 		 * @param string $class The CSS class to use for the excerpt link. Default `read-more`.
 		 */
-		$read_more_class = apply_filters('timber/post/preview/read_more_class', "read-more");
+		$read_more_class = apply_filters( 'timber/post/excerpt/read_more_class', 'read-more' );
+
+		/**
+		 * Filters the CSS class used for excerpt links.
+		 *
+		 * @deprecated 2.0.0
+		 * @since 1.0.4
+		 */
+		$read_more_class = apply_filters_deprecated(
+			'timber/post/preview/read_more_class',
+			[ $read_more_class ],
+			'2.0.0',
+			'timber/post/excerpt/read_more_class'
+		);
 
 		if ( $this->read_more && !empty($readmore_matches) && !empty( $readmore_matches[1]) ) {
 			$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -276,40 +276,80 @@ class PostExcerpt {
 			}
 		}
 
-		/**
-		 * Filters the CSS class used for excerpt links.
-		 *
-		 * @sicne 2.0.0
-		 * @example
-		 * ```php
-		 * // Change the CSS class for excerpt links.
-		 * add_filter( 'timber/post/excerpt/read_more_class', function( $class ) {
-		 *     return 'read-more__link';
-		 * } );
-		 * ```
-		 *
-		 * @param string $class The CSS class to use for the excerpt link. Default `read-more`.
-		 */
-		$read_more_class = apply_filters( 'timber/post/excerpt/read_more_class', 'read-more' );
+		// Maybe add read more link.
+		if ( $this->read_more ) {
+			/**
+			 * Filters the CSS class used for excerpt links.
+			 *
+			 * @since 2.0.0
+			 * @example
+			 * ```php
+			 * // Change the CSS class for excerpt links.
+			 * add_filter( 'timber/post/excerpt/read_more_class', function( $class ) {
+			 *     return 'read-more__link';
+			 * } );
+			 * ```
+			 *
+			 * @param string $class The CSS class to use for the excerpt link. Default `read-more`.
+			 */
+			$read_more_class = apply_filters( 'timber/post/excerpt/read_more_class', 'read-more' );
 
-		/**
-		 * Filters the CSS class used for excerpt links.
-		 *
-		 * @deprecated 2.0.0
-		 * @since 1.0.4
-		 */
-		$read_more_class = apply_filters_deprecated(
-			'timber/post/preview/read_more_class',
-			[ $read_more_class ],
-			'2.0.0',
-			'timber/post/excerpt/read_more_class'
-		);
+			/**
+			 * Filters the CSS class used for excerpt links.
+			 *
+			 * @deprecated 2.0.0
+			 * @since 1.0.4
+			 */
+			$read_more_class = apply_filters_deprecated(
+				'timber/post/preview/read_more_class',
+				[ $read_more_class ],
+				'2.0.0',
+				'timber/post/excerpt/read_more_class'
+			);
 
-		if ( $this->read_more && !empty($readmore_matches) && !empty( $readmore_matches[1]) ) {
-			$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
-		} elseif ( $this->read_more ) {
-			$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($this->read_more).'</a>';
+			if ( !empty($readmore_matches) && !empty( $readmore_matches[1]) ) {
+				$linktext = trim( $readmore_matches[1] );
+			} else {
+				$linktext = trim( $this->read_more );
+			}
+
+			$link = sprintf( ' <a href="%1$s" class="%2$s">%3$s</a>',
+				$this->post->link(),
+				$read_more_class,
+				$linktext
+			);
+
+			/**
+			 * Filters the link used for a read more text in an excerpt.
+			 *
+			 * @since 2.0.0
+			 * @param string $link The HTML link.
+			 * @param \Timber\Post $post Post instance.
+			 */
+			$link = apply_filters(
+				'timber/post/excerpt/read_more_link',
+				$link,
+				$this->post,
+				$linktext,
+				$read_more_class
+			);
+
+			/**
+			 * Filters the link used for a read more text in an excerpt.
+			 *
+			 * @deprecated 2.0.0
+			 * @since 1.1.3
+			 */
+			$link = apply_filters_deprecated(
+				'timber/post/get_preview/read_more_link',
+				[ $link ],
+				'2.0.0',
+				'timber/post/excerpt/read_more_link'
+			);
+
+			$text .= $link;
 		}
+
 		if ( !$this->strip && $last_p_tag && (strpos($text, '<p>') > -1 || strpos($text, '<p ')) ) {
 			$text .= '</p>';
 		}

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -3,13 +3,13 @@
 namespace Timber;
 
 /**
- * The PostPreview class lets a user modify a post preview/excerpt to their liking.
+ * The PostExcerpt class lets a user modify a post preview/excerpt to their liking.
  *
- * It’s designed to be used through the `Timber\Post::preview()` method. The public methods of this
+ * It’s designed to be used through the `Timber\Post::excerpt()` method. The public methods of this
  * class all return the object itself, which means that this is a **chainable object**. You can
- * change the output of the preview by **adding more methods**.
+ * change the output of the excerpt by **adding more methods**.
  *
- * By default, the preview will
+ * By default, the excerpt will
  *
  * - have a length of 50 words, which will be forced, even if a longer excerpt is set on the post.
  * - be stripped of all HTML tags.
@@ -18,23 +18,23 @@ namespace Timber;
  *
  * @api
  * @since 1.0.4
- * @see \Timber\Post::preview()
+ * @see \Timber\Post::excerpt()
  * @example
  * ```twig
- * {# Use default preview #}
- * <p>{{ post.preview }}</p>
+ * {# Use default excerpt #}
+ * <p>{{ post.excerpt }}</p>
  *
  * {# Use hash notation to pass arguments #}
  * <div>{{ post.excerpt({ words: 100, read_more: 'Keep reading' }) }}</div>
  *
- * {# Change the post preview text only #}
- * <p>{{ post.preview.read_more('Continue Reading') }}</p>
+ * {# Change the post excerpt text only #}
+ * <p>{{ post.excerpt.read_more('Continue Reading') }}</p>
  *
  * {# Additionally restrict the length to 50 words #}
- * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
+ * <p>{{ post.excerpt.length(50).read_more('Continue Reading') }}</p>
  * ```
  */
-class PostPreview {
+class PostExcerpt {
 	/**
 	 * Post.
 	 *
@@ -43,7 +43,7 @@ class PostPreview {
 	protected $post;
 
 	/**
-	 * Preview end.
+	 * Excerpt end.
 	 *
 	 * @var string
 	 */
@@ -92,11 +92,11 @@ class PostPreview {
 	protected $destroy_tags = array('script', 'style');
 
 	/**
-	 * PostPreview constructor.
+	 * PostExcerpt constructor.
 	 *
 	 * @api
 	 *
-	 * @param \Timber\Post $post The post to pull the preview from.
+	 * @param \Timber\Post $post The post to pull the excerpt from.
 	 * @param array        $options {
 	 *     An array of configuration options for generating the excerpt. Default empty.
 	 *
@@ -136,7 +136,7 @@ class PostPreview {
 	}
 
 	/**
-	 * Returns the resulting preview.
+	 * Returns the resulting excerpt.
 	 *
 	 * @api
 	 * @return string
@@ -146,15 +146,15 @@ class PostPreview {
 	}
 
 	/**
-	 * Restricts the length of the preview to a certain amount of words.
+	 * Restricts the length of the excerpt to a certain amount of words.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
-	 * <p>{{ post.preview.length(50) }}</p>
+	 * <p>{{ post.excerpt.length(50) }}</p>
 	 * ```
-	 * @param int $length The maximum amount of words (not letters) for the preview. Default `50`.
-	 * @return \Timber\PostPreview
+	 * @param int $length The maximum amount of words (not letters) for the excerpt. Default `50`.
+	 * @return \Timber\PostExcerpt
 	 */
 	public function length( $length = 50 ) {
 		$this->length = $length;
@@ -162,16 +162,16 @@ class PostPreview {
 	}
 
 	/**
-	 * Restricts the length of the preview to a certain amount of characters.
+	 * Restricts the length of the excerpt to a certain amount of characters.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
-	 * <p>{{ post.preview.chars(180) }}</p>
+	 * <p>{{ post.excerpt.chars(180) }}</p>
 	 * ```
-	 * @param int|bool $char_length The maximum amount of characters for the preview. Default
+	 * @param int|bool $char_length The maximum amount of characters for the excerpt. Default
 	 *                              `false`.
-	 * @return \Timber\PostPreview
+	 * @return \Timber\PostExcerpt
 	 */
 	public function chars( $char_length = false ) {
 		$this->char_length = $char_length;
@@ -179,15 +179,15 @@ class PostPreview {
 	}
 
 	/**
-	 * Defines the text to end the preview with.
+	 * Defines the text to end the excerpt with.
 	 *
 	 * @api
 	 * @example
 	 * ```twig
-	 * <p>{{ post.preview.end('… and much more!') }}</p>
+	 * <p>{{ post.excerpt.end('… and much more!') }}</p>
 	 * ```
-	 * @param string $end The text for the end of the preview. Default `…`.
-	 * @return \Timber\PostPreview
+	 * @param string $end The text for the end of the excerpt. Default `…`.
+	 * @return \Timber\PostExcerpt
 	 */
 	public function end( $end = '&hellip;' ) {
 		$this->end = $end;
@@ -195,7 +195,7 @@ class PostPreview {
 	}
 
 	/**
-	 * Forces preview lengths.
+	 * Forces excerpt lengths.
 	 *
 	 * What happens if your custom post excerpt is longer than the length requested? By default, it
 	 * will use the full `post_excerpt`. However, you can set this to `true` to *force* your excerpt
@@ -204,12 +204,12 @@ class PostPreview {
 	 * @api
 	 * @example
 	 * ```twig
-	 * <p>{{ post.preview.length(20).force }}</p>
+	 * <p>{{ post.excerpt.length(20).force }}</p>
 	 * ```
-	 * @param bool $force Whether the length of the preview should be forced to the requested
+	 * @param bool $force Whether the length of the excerpt should be forced to the requested
 	 *                    length, even if an editor wrote a manual excerpt that is longer than the
 	 *                    set length. Default `true`.
-	 * @return \Timber\PostPreview
+	 * @return \Timber\PostExcerpt
 	 */
 	public function force( $force = true ) {
 		$this->force = $force;
@@ -223,12 +223,12 @@ class PostPreview {
 	 *
 	 * @api
 	 * ```twig
-	 * <p>{{ post.preview.read_more('Learn more') }}</p>
+	 * <p>{{ post.excerpt.read_more('Learn more') }}</p>
 	 * ```
 	 *
 	 * @param string $text Text for the link. Default 'Read More'.
 	 *
-	 * @return \Timber\PostPreview
+	 * @return \Timber\PostExcerpt
 	 */
 	public function read_more( $text = 'Read More' ) {
 		$this->read_more = $text;
@@ -236,17 +236,17 @@ class PostPreview {
 	}
 
 	/**
-	 * Defines how HTML tags should be stripped from the preview.
+	 * Defines how HTML tags should be stripped from the excerpt.
 	 *
 	 * @api
 	 * ```twig
 	 * {# Strips all HTML tags, except for bold or emphasized text #}
-	 * <p>{{ post.preview.length('50').strip('<strong><em>') }}</p>
+	 * <p>{{ post.excerpt.length('50').strip('<strong><em>') }}</p>
 	 * ```
-	 * @param bool|string $strip Whether or how HTML tags in the preview should be stripped. Use
+	 * @param bool|string $strip Whether or how HTML tags in the excerpt should be stripped. Use
 	 *                           `true` to strip all tags, `false` for no stripping, or a string for
 	 *                           a list of allowed tags (e.g. '<p><a>'). Default `true`.
-	 * @return \Timber\PostPreview
+	 * @return \Timber\PostExcerpt
 	 */
 	public function strip( $strip = true ) {
 		$this->strip = $strip;
@@ -277,18 +277,18 @@ class PostPreview {
 		}
 
 		/**
-		 * Filters the CSS class used for preview links.
+		 * Filters the CSS class used for excerpt links.
 		 *
 		 * @since 1.0.4
 		 * @example
 		 * ```php
-		 * // Change the CSS class for preview links
+		 * // Change the CSS class for excerpt links
 		 * add_filter( 'timber/post/preview/read_more_class', function( $class ) {
 		 *     return 'read-more__link';
 		 * } );
 		 * ```
 		 *
-		 * @param string $class The CSS class to use for the preview link. Default `read-more`.
+		 * @param string $class The CSS class to use for the excerpt link. Default `read-more`.
 		 */
 		$read_more_class = apply_filters('timber/post/preview/read_more_class', "read-more");
 

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -357,11 +357,7 @@ class PostExcerpt {
 	}
 
 	protected function run() {
-		$force = $this->force;
-		$len = $this->length;
-		$chars = $this->char_length;
-		$strip = $this->strip;
-		$allowable_tags = ( $strip && is_string($strip)) ? $strip : false;
+		$allowable_tags = ( $this->strip && is_string($this->strip)) ? $this->strip : false;
 		$readmore_matches = array();
 		$text = '';
 		$trimmed = false;
@@ -372,12 +368,12 @@ class PostExcerpt {
 			if ( $this->force ) {
 
 				if ( $allowable_tags ) {
-					$text = TextHelper::trim_words($text, $len, false, strtr($allowable_tags, '<>', '  '));
+					$text = TextHelper::trim_words($text, $this->length, false, strtr($allowable_tags, '<>', '  '));
 				} else {
-					$text = TextHelper::trim_words($text, $len, false);
+					$text = TextHelper::trim_words($text, $this->length, false);
 				}
-				if ( $chars !== false ) {
-					$text = TextHelper::trim_characters($text, $chars, false);
+				if ( $this->char_length !== false ) {
+					$text = TextHelper::trim_characters($text, $this->char_length, false);
 				}
 				$trimmed = true;
 			}
@@ -385,14 +381,14 @@ class PostExcerpt {
 		if ( !strlen($text) && preg_match('/<!--\s?more(.*?)?-->/', $this->post->post_content, $readmore_matches) ) {
 			$pieces = explode($readmore_matches[0], $this->post->post_content);
 			$text = $pieces[0];
-			if ( $force ) {
+			if ( $this->force ) {
 				if ( $allowable_tags ) {
-					$text = TextHelper::trim_words($text, $len, false, strtr($allowable_tags, '<>', '  '));
+					$text = TextHelper::trim_words($text, $this->length, false, strtr($allowable_tags, '<>', '  '));
 				} else {
-					$text = TextHelper::trim_words($text, $len, false);
+					$text = TextHelper::trim_words($text, $this->length, false);
 				}
-				if ( $chars !== false ) {
-					$text = TextHelper::trim_characters($text, $chars, false);
+				if ( $this->char_length !== false ) {
+					$text = TextHelper::trim_characters($text, $this->char_length, false);
 				}
 				$trimmed = true;
 			}
@@ -402,19 +398,19 @@ class PostExcerpt {
 			$text = $this->post->content();
 			$text = TextHelper::remove_tags($text, $this->destroy_tags);
 			if ( $allowable_tags ) {
-				$text = TextHelper::trim_words($text, $len, false, strtr($allowable_tags, '<>', '  '));
+				$text = TextHelper::trim_words($text, $this->length, false, strtr($allowable_tags, '<>', '  '));
 			} else {
-				$text = TextHelper::trim_words($text, $len, false);
+				$text = TextHelper::trim_words($text, $this->length, false);
 			}
-			if ( $chars !== false ) {
-				$text = TextHelper::trim_characters($text, $chars, false);
+			if ( $this->char_length !== false ) {
+				$text = TextHelper::trim_characters($text, $this->char_length, false);
 			}
 			$trimmed = true;
 		}
 		if ( !strlen(trim($text)) ) {
 			return trim($text);
 		}
-		if ( $strip ) {
+		if ( $this->strip ) {
 			$text = trim(strip_tags($text, $allowable_tags));
 		}
 		if ( strlen($text) ) {

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -378,7 +378,9 @@ class PostExcerpt {
 				$trimmed = true;
 			}
 		}
-		if ( !strlen($text) && preg_match('/<!--\s?more(.*?)?-->/', $this->post->post_content, $readmore_matches) ) {
+
+		// Check for <!-- more --> tag in post content.
+		if ( empty( $text ) && preg_match('/<!--\s?more(.*?)?-->/', $this->post->post_content, $readmore_matches) ) {
 			$pieces = explode($readmore_matches[0], $this->post->post_content);
 			$text = $pieces[0];
 			if ( $this->force ) {
@@ -394,7 +396,9 @@ class PostExcerpt {
 			}
 			$text = do_shortcode($text);
 		}
-		if ( !strlen($text) ) {
+
+		// Build an excerpt text from the post’s content.
+		if ( empty( $text ) ) {
 			$text = $this->post->content();
 			$text = TextHelper::remove_tags($text, $this->destroy_tags);
 			if ( $allowable_tags ) {
@@ -407,13 +411,13 @@ class PostExcerpt {
 			}
 			$trimmed = true;
 		}
-		if ( !strlen(trim($text)) ) {
+		if ( empty( trim( $text ) ) ) {
 			return trim($text);
 		}
 		if ( $this->strip ) {
 			$text = trim(strip_tags($text, $allowable_tags));
 		}
-		if ( strlen($text) ) {
+		if ( ! empty( $text ) ) {
 			return $this->assemble($text, $readmore_matches, $trimmed);
 		}
 

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -222,11 +222,13 @@ class PostPreview {
 	 * ```twig
 	 * <p>{{ post.preview.read_more('Learn more') }}</p>
 	 * ```
-	 * @param string $readmore Text for the link. Default 'Read More'.
+	 *
+	 * @param string $text Text for the link. Default 'Read More'.
+	 *
 	 * @return \Timber\PostPreview
 	 */
-	public function read_more( $readmore = 'Read More' ) {
 		$this->readmore = $readmore;
+	public function read_more( $text = 'Read More' ) {
 		return $this;
 	}
 

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -72,7 +72,7 @@ class PostPreview {
 	 *
 	 * @var string
 	 */
-	protected $readmore = 'Read More';
+	protected $read_more = 'Read More';
 
 	/**
 	 * HTML tag stripping behavior.
@@ -129,7 +129,7 @@ class PostPreview {
 		$this->end         = $options['end'];
 		$this->force       = $options['force'];
 		$this->strip       = $options['strip'];
-		$this->readmore    = $options['read_more'];
+		$this->read_more   = $options['read_more'];
 	}
 
 	/**
@@ -227,8 +227,8 @@ class PostPreview {
 	 *
 	 * @return \Timber\PostPreview
 	 */
-		$this->readmore = $readmore;
 	public function read_more( $text = 'Read More' ) {
+		$this->read_more = $text;
 		return $this;
 	}
 
@@ -289,10 +289,10 @@ class PostPreview {
 		 */
 		$read_more_class = apply_filters('timber/post/preview/read_more_class', "read-more");
 
-		if ( $this->readmore && !empty($readmore_matches) && !empty($readmore_matches[1]) ) {
+		if ( $this->read_more && !empty($readmore_matches) && !empty( $readmore_matches[1]) ) {
 			$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($readmore_matches[1]).'</a>';
-		} elseif ( $this->readmore ) {
-			$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($this->readmore).'</a>';
+		} elseif ( $this->read_more ) {
+			$text .= ' <a href="'.$this->post->link().'" class="'.$read_more_class.'">'.trim($this->read_more).'</a>';
 		}
 		if ( !$this->strip && $last_p_tag && (strpos($text, '<p>') > -1 || strpos($text, '<p ')) ) {
 			$text .= '</p>';

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -16,6 +16,9 @@ namespace Timber;
  * - have an ellipsis (…) as the end of the text.
  * - have a "Read More" link appended.
  *
+ * @api
+ * @since 1.0.4
+ * @see \Timber\Post::preview()
  * @example
  * ```twig
  * {# Use default preview #}
@@ -27,8 +30,6 @@ namespace Timber;
  * {# Additionally restrict the length to 50 words #}
  * <p>{{ post.preview.length(50).read_more('Continue Reading') }}</p>
  * ```
- * @since 1.0.4
- * @see \Timber\Post::preview()
  */
 class PostPreview {
 	/**
@@ -120,7 +121,7 @@ class PostPreview {
 			'force'     => false,
 			'strip'     => true,
 			'read_more' => 'Read More',
-		));
+		) );
 
 		// Set excerpt properties
 		$this->length      = $options['words'];

--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -24,7 +24,10 @@ namespace Timber;
  * {# Use default preview #}
  * <p>{{ post.preview }}</p>
  *
- * {# Change the post preview text #}
+ * {# Use hash notation to pass arguments #}
+ * <div>{{ post.excerpt({ words: 100, read_more: 'Keep reading' }) }}</div>
+ *
+ * {# Change the post preview text only #}
  * <p>{{ post.preview.read_more('Continue Reading') }}</p>
  *
  * {# Additionally restrict the length to 50 words #}

--- a/tests/test-timber-filters.php
+++ b/tests/test-timber-filters.php
@@ -33,16 +33,4 @@ class TestTimberFilters extends Timber_UnitTestCase {
 	function filter_timber_output( $output, $data, $file ) {
 		return $file . $data['number'];
 	}
-
-	function testReadMoreLinkFilter() {
-		$link = "Foobar";
-		add_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ), 10, 1 );
-		$this->assertEquals( 'Foobar', apply_filters( 'timber/post/get_preview/read_more_link', $link ) );
-		remove_filter( 'timber/post/get_preview/read_more_link', array( $this, 'filter_timber_post_get_preview_read_more_link' ) );
-	}
-
-	function filter_timber_post_get_preview_read_more_link( $link ) {
-		return $link;
-	}
-
 }

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -3,7 +3,7 @@
 	/**
 	 * @group posts-api
 	 */
-	class TestTimberPostPreviewObject extends Timber_UnitTestCase {
+	class TestTimberPostExcerptObject extends Timber_UnitTestCase {
 
 		protected $gettysburg = 'Four score and seven years ago our fathers brought forth on this continent a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal.';
 
@@ -22,7 +22,7 @@
 			$post_id = $this->factory->post->create(array('post_excerpt' => $expected, 'post_content' => $this->gettysburg));
 			$post = Timber::get_post($post_id);
 			$template = "{{ post.excerpt({ 	strip: '<ul><li>',
-											words:10, 
+											words:10,
 											force:true }) }}";
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Govenment: <ul> <li>of the people</li> <li>by the people</li> <li>for the</li></ul>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
@@ -139,7 +139,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewWithStyleTags() {
+		function testExcerptWithStyleTags() {
 			global $wpdb;
 			$style = '<style>body { background-color: red; }</style><b>Yo.</b> ';
 			$id = $wpdb->insert(
@@ -162,7 +162,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewTags() {
+		function testExcerptTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 			$post = Timber::get_post($post_id);
 			$template = '{{post.preview.length(3).read_more(false).strip(false)}}';
@@ -173,7 +173,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithCharAndWordLengthWordsWin() {
+		function testPostExcerptObjectWithCharAndWordLengthWordsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(2).chars(20) }}';
 			$post = Timber::get_post($pid);
@@ -184,7 +184,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithCharAndWordLengthCharsWin() {
+		function testPostExcerptObjectWithCharAndWordLengthCharsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(20).chars(20) }}';
 			$post = Timber::get_post($pid);
@@ -195,7 +195,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithCharLength() {
+		function testPostExcerptObjectWithCharLength() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
 			$template = '{{ post.preview.chars(20) }}';
 			$post = Timber::get_post($pid);
@@ -206,7 +206,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithLength() {
+		function testPostExcerptObjectWithLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
 			$template = '{{ post.preview.length(4) }}';
 			$post = Timber::get_post($pid);
@@ -217,7 +217,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithForcedLength() {
+		function testPostExcerptObjectWithForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.force.length(3) }}';
 			$post = Timber::get_post($pid);
@@ -228,7 +228,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObject() {
+		function testPostExcerptObject() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview }}';
 			$post = Timber::get_post($pid);
@@ -239,7 +239,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectStrip() {
+		function testPostExcerptObjectStrip() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
 			$template = '{{ post.preview.strip(false) }}';
 			$post = Timber::get_post($pid);
@@ -250,7 +250,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithReadMore() {
+		function testPostExcerptObjectWithReadMore() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.read_more("Keep Reading") }}';
 			$post = Timber::get_post($pid);
@@ -261,7 +261,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPostPreviewObjectWithEverything() {
+		function testPostExcerptObjectWithEverything() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
 			$template = '{{ post.preview.length(6).force.end("-->").read_more("Keep Reading") }}';
 			$post = Timber::get_post($pid);
@@ -272,7 +272,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewWithMoreTagAndForcedLength() {
+		function testExcerptWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
 
@@ -282,7 +282,7 @@
 		/**
 			* @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewWithCustomMoreTag() {
+		function testExcerptWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
@@ -291,7 +291,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewWithSpaceInMoreTag() {
+		function testExcerptWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
 			$template = '{{post.preview.length(3).force}}';
@@ -302,7 +302,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewWithStripAndClosingPTag() {
+		function testExcerptWithStripAndClosingPTag() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
 			$post = Timber::get_post( $pid );
 			$template = '{{post.preview.strip(false)}}';
@@ -313,7 +313,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testPreviewWithStripAndClosingPTagForced() {
+		function testExcerptWithStripAndClosingPTagForced() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
 			$post = Timber::get_post( $pid );
 			$template = '{{post.preview.strip(false).force(4)}}';
@@ -324,7 +324,7 @@
 		/**
 		 * @expectedDeprecated {{ post.preview }}
 		 */
-		function testEmptyPreview() {
+		function testEmptyExcerpt() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '', 'post_content' => '') );
 			$post = Timber::get_post( $pid );
 			$template = '{{ post.preview }}';
@@ -332,14 +332,11 @@
 			$this->assertEquals('', $str);
 		}
 
-		function testPagePreviewOnSearch() {
+		function testPageExcerptOnSearch() {
 			$pid = $this->factory->post->create(array('post_type' => 'page', 'post_content' => 'What a beautiful day for a ballgame!', 'post_excerpt' => ''));
 			$post = Timber::get_post( $pid );
 			$template = '{{ post.excerpt }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('What a beautiful day for a ballgame!&hellip; <a href="http://example.org/?page_id='.$pid.'" class="read-more">Read More</a>', $str);
 		}
-
-
-
 	}

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -136,9 +136,6 @@
 			$this->assertEquals($expected, ''.$excerpt);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptWithStyleTags() {
 			global $wpdb;
 			$style = '<style>body { background-color: red; }</style><b>Yo.</b> ';
@@ -154,124 +151,91 @@
 			);
 			$post_id = $wpdb->insert_id;
 			$post = Timber::get_post($post_id);
-			$template = '{{ post.preview.length(9).read_more(false).strip(true) }}';
+			$template = '{{ post.excerpt.length(9).read_more(false).strip(true) }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Yo. Four score and seven years ago our fathers&hellip;', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 			$post = Timber::get_post($post_id);
-			$template = '{{post.preview.length(3).read_more(false).strip(false)}}';
+			$template = '{{post.excerpt.length(3).read_more(false).strip(false)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertNotContains('</p>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithCharAndWordLengthWordsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
-			$template = '{{ post.preview.length(2).chars(20) }}';
+			$template = '{{ post.excerpt.length(2).chars(20) }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithCharAndWordLengthCharsWin() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
-			$template = '{{ post.preview.length(20).chars(20) }}';
+			$template = '{{ post.excerpt.length(20).chars(20) }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score and seven&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithCharLength() {
 			$pid = $this->factory->post->create( array('post_content' => $this->gettysburg, 'post_excerpt' => '') );
-			$template = '{{ post.preview.chars(20) }}';
+			$template = '{{ post.excerpt.chars(20) }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Four score and seven&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck she a big ole duck!', 'post_excerpt' => '') );
-			$template = '{{ post.preview.length(4) }}';
+			$template = '{{ post.excerpt.length(4) }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Lauren is a duck&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
-			$template = '{{ post.preview.force.length(3) }}';
+			$template = '{{ post.excerpt.force.length(3) }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger&hellip; <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObject() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
-			$template = '{{ post.preview }}';
+			$template = '{{ post.excerpt }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectStrip() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since.') );
-			$template = '{{ post.preview.strip(false) }}';
+			$template = '{{ post.excerpt.strip(false) }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been <a href="http://google.com">turning over</a> in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithReadMore() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
-			$template = '{{ post.preview.read_more("Keep Reading") }}';
+			$template = '{{ post.excerpt.read_more("Keep Reading") }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since. <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testPostExcerptObjectWithEverything() {
 			$pid = $this->factory->post->create( array('post_content' => 'Great Gatsby', 'post_excerpt' => 'In my younger and more vulnerable years my father gave me some advice that I’ve been turning over in my mind ever since.') );
-			$template = '{{ post.preview.length(6).force.end("-->").read_more("Keep Reading") }}';
+			$template = '{{ post.excerpt.length(6).force.end("-->").read_more("Keep Reading") }}';
 			$post = Timber::get_post($pid);
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('In my younger and more vulnerable--> <a href="http://example.org/?p='.$pid.'" class="read-more">Keep Reading</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptWithMoreTagAndForcedLength() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
@@ -279,55 +243,40 @@
 			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
 		}
 
-		/**
-			* @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
 			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptWithSpaceInMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
-			$template = '{{post.preview.length(3).force}}';
+			$template = '{{post.excerpt.length(3).force}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptWithStripAndClosingPTag() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
 			$post = Timber::get_post( $pid );
-			$template = '{{post.preview.strip(false)}}';
+			$template = '{{post.excerpt.strip(false)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('<p>Lauren is a duck, but a great duck let me tell you why <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a></p>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testExcerptWithStripAndClosingPTagForced() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '<p>Lauren is a duck, but a great duck let me tell you why</p>') );
 			$post = Timber::get_post( $pid );
-			$template = '{{post.preview.strip(false).force(4)}}';
+			$template = '{{post.excerpt.strip(false).force(4)}}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('<p>Lauren is a duck, but a great duck let me tell you why&hellip;  <a href="http://example.org/?p='.$pid.'" class="read-more">Read More</a></p>', $str);
 		}
 
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
 		function testEmptyExcerpt() {
 			$pid = $this->factory->post->create( array('post_excerpt' => '', 'post_content' => '') );
 			$post = Timber::get_post( $pid );
-			$template = '{{ post.preview }}';
+			$template = '{{ post.excerpt }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertEquals('', $str);
 		}

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -240,13 +240,13 @@
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
 
-			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
+			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->excerpt());
 		}
 
 		function testExcerptWithCustomMoreTag() {
 			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
-			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->preview());
+			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->excerpt());
 		}
 
 		function testExcerptWithSpaceInMoreTag() {

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -159,7 +159,7 @@
 		function testExcerptTags() {
 			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 			$post = Timber::get_post($post_id);
-			$template = '{{post.excerpt.length(3).read_more(false).strip(false)}}';
+			$template = '{{ post.excerpt.length(3).read_more(false).strip(false) }}';
 			$str = Timber::compile_string($template, array('post' => $post));
 			$this->assertNotContains('</p>', $str);
 		}

--- a/tests/test-timber-post-excerpt.php
+++ b/tests/test-timber-post-excerpt.php
@@ -30,6 +30,39 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase {
 		$this->assertContains('and-foo', (string) $text);
 	}
 
+	function testReadMoreLinkFilter() {
+		$post_id = $this->factory->post->create( [
+			'post_excerpt' => 'Let this be the excerpt!',
+		] );
+
+		$post    = Timber::get_post( $post_id );
+		$excerpt = $post->excerpt();
+
+		$this->add_filter_temporarily( 'timber/post/excerpt/read_more_link', function( $link ) {
+			return ' Foobar';
+		} );
+
+		$this->assertEquals( 'Let this be the excerpt! Foobar', (string) $excerpt );
+	}
+
+	/**
+	 * @expectedDeprecated timber/post/get_preview/read_more_link
+	 */
+	function testReadMoreLinkFilterDeprecated() {
+		$post_id = $this->factory->post->create( [
+			'post_excerpt' => 'Let this be the excerpt!',
+		] );
+
+		$post    = Timber::get_post( $post_id );
+		$excerpt = $post->excerpt();
+
+		$this->add_filter_temporarily( 'timber/post/get_preview/read_more_link', function( $link ) {
+			return ' Foobar';
+		} );
+
+		$this->assertEquals( 'Let this be the excerpt! Foobar', (string) $excerpt );
+	}
+
 	function testExcerptTags() {
 		$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 		$post = Timber::get_post($post_id);

--- a/tests/test-timber-post-excerpt.php
+++ b/tests/test-timber-post-excerpt.php
@@ -19,7 +19,7 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase {
 	}
 
 	function testReadMoreClassFilter() {
-		$this->add_filter_temporarily('timber/post/preview/read_more_class', function($class) {
+		$this->add_filter_temporarily('timber/post/excerpt/read_more_class', function($class) {
 			return $class . ' and-foo';
 		});
 		$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));

--- a/tests/test-timber-post-excerpt.php
+++ b/tests/test-timber-post-excerpt.php
@@ -1,21 +1,21 @@
 <?php
 
-use Timber\PostPreview;
+use Timber\PostExcerpt;
 
 /**
  * @group called-post-constructor
  */
-class TestTimberPostPreview extends Timber_UnitTestCase {
+class TestTimberPostExcerpt extends Timber_UnitTestCase {
 	function testDoubleEllipsis(){
 		$post_id = $this->factory->post->create();
 		$post = Timber::get_post($post_id);
 		$post->post_excerpt = 'this is super dooper trooper long words';
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words' => 3,
 			'force' => true,
 		] );
 
-		$this->assertEquals(1, substr_count((string) $preview, '&hellip;'));
+		$this->assertEquals(1, substr_count((string) $excerpt, '&hellip;'));
 	}
 
 	function testReadMoreClassFilter() {
@@ -24,16 +24,16 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		});
 		$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 		$post = Timber::get_post($post_id);
-		$text = new PostPreview( $post, [
+		$text = new PostExcerpt( $post, [
 			'words' => 10,
 		] );
 		$this->assertContains('and-foo', (string) $text);
 	}
 
-	function testPreviewTags() {
+	function testExcerptTags() {
 		$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
 		$post = Timber::get_post($post_id);
-		$text = new PostPreview( $post, [
+		$text = new PostExcerpt( $post, [
 			'words'    => 20,
 			'force'    => false,
 			'read_more' => '',
@@ -42,7 +42,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$this->assertNotContains('</p>', (string) $text);
 	}
 
-	function testGetPreview() {
+	function testGetExcerpt() {
 		global $wp_rewrite;
 		$struc = false;
 		$wp_rewrite->permalink_structure = $struc;
@@ -57,33 +57,33 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 
 		// excerpt set, force is false, no read more
 		$post->post_excerpt = 'this is excerpt longer than three words';
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words'    => 3,
 			'force'    => false,
 			'read_more' => '',
 		] );
-		$this->assertEquals( (string) $preview, $post->post_excerpt);
+		$this->assertEquals( (string) $excerpt, $post->post_excerpt);
 
 		// custom read more set
 		$post->post_excerpt = '';
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words'    => 3,
 			'force'    => false,
 			'read_more' => 'Custom more',
 		] );
-		$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', (string) $preview);
+		$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', (string) $excerpt);
 
 		// content with <!--more--> tag, force false
 		$post->post_content = 'this is super dooper<!--more--> trooper long words';
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words'    => 2,
 			'force'    => false,
 			'read_more' => '',
 		] );
-		$this->assertEquals('this is super dooper', (string) $preview);
+		$this->assertEquals('this is super dooper', (string) $excerpt);
 	}
 
-	function testShortcodesInPreviewFromContent() {
+	function testShortcodesInExcerptFromContent() {
 		add_shortcode('mythang', function($text) {
 			return 'mythangy';
 		});
@@ -92,7 +92,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$this->assertEquals( 'jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->excerpt() );
 	}
 
-	function testShortcodesInPreviewFromContentWithMoreTag() {
+	function testShortcodesInExcerptFromContentWithMoreTag() {
 		add_shortcode('duck', function($text) {
 			return 'Quack!';
 		});
@@ -101,24 +101,24 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->excerpt());
 	}
 
-	function testPreviewWithSpaceInMoreTag() {
+	function testExcerptWithSpaceInMoreTag() {
 		$pid = $this->factory->post->create( [
 			'post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck',
 			'post_excerpt' => ''
 		] );
 		$post = Timber::get_post( $pid );
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words' => 3,
 			'force' => true,
 		] );
 
 		$this->assertEquals(
 			'Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>',
-			(string) $preview
+			(string) $excerpt
 		);
 	}
 
-	function testPreviewWithMoreTagAndForcedLength() {
+	function testExcerptWithMoreTagAndForcedLength() {
 		$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
 		$post = Timber::get_post( $pid );
 		$this->assertEquals(
@@ -127,7 +127,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		);
 	}
 
-	function testPreviewWithCustomMoreTag() {
+	function testExcerptWithCustomMoreTag() {
 		$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
 		$post = Timber::get_post( $pid );
 		$this->assertEquals(
@@ -136,13 +136,13 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		);
 	}
 
-	function testPreviewWithCustomEnd() {
+	function testExcerptWithCustomEnd() {
 		$pid = $this->factory->post->create( [
 			'post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck',
 			'post_excerpt' => ''
 		] );
 		$post = Timber::get_post( $pid );
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words'    => 3,
 			'force'    => true,
 			'read_more' => 'Read More',
@@ -151,17 +151,17 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		] );
 		$this->assertEquals(
 			'Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>',
-			$preview
+			$excerpt
 		);
 	}
 
-	function testPreviewWithCustomStripTags() {
+	function testExcerptWithCustomStripTags() {
 		$pid = $this->factory->post->create( [
 			'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
 		] );
 		$post = Timber::get_post($pid);
 		$post->post_excerpt = '';
-		$preview = new PostPreview( $post, [
+		$excerpt = new PostExcerpt( $post, [
 			'words'    => 6,
 			'force'    => true,
 			'read_more' => 'Read More',
@@ -169,7 +169,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		] );
 		$this->assertEquals(
 			'<span>Even in the world of make-believe</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>',
-			(string) $preview
+			(string) $excerpt
 		);
 	}
 }

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -1,149 +1,175 @@
 <?php
 
+use Timber\PostPreview;
+
 /**
  * @group called-post-constructor
  */
-	class TestTimberPostPreview extends Timber_UnitTestCase {
+class TestTimberPostPreview extends Timber_UnitTestCase {
+	function testDoubleEllipsis(){
+		$post_id = $this->factory->post->create();
+		$post = Timber::get_post($post_id);
+		$post->post_excerpt = 'this is super dooper trooper long words';
+		$preview = new PostPreview( $post, [
+			'words' => 3,
+			'force' => true,
+		] );
 
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testDoubleEllipsis(){
-			$post_id = $this->factory->post->create();
-			$post = Timber::get_post($post_id);
-			$post->post_excerpt = 'this is super dooper trooper long words';
-			$prev = $post->get_preview(3, true);
-			$this->assertEquals(1, substr_count($prev, '&hellip;'));
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testReadMoreClassFilter() {
-			add_filter('timber/post/get_preview/read_more_class', function($class) {
-				return $class . ' and-foo';
-			});
-			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = Timber::get_post($post_id);
-			$text = $post->get_preview(10);
-			$this->assertContains('and-foo', (string) $text);
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testPreviewTags() {
-			$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
-			$post = Timber::get_post($post_id);
-			$text = $post->get_preview(20, false, '', false);
-			$this->assertNotContains('</p>', (string) $text);
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testGetPreview() {
-			global $wp_rewrite;
-			$struc = false;
-			$wp_rewrite->permalink_structure = $struc;
-			update_option('permalink_structure', $struc);
-			$post_id = $this->factory->post->create(array('post_content' => 'this is super dooper trooper long words'));
-			$post = Timber::get_post($post_id);
-
-			// no excerpt
-			$post->post_excerpt = '';
-			$preview = $post->get_preview(3);
-			$str = Timber::compile_string('{{post.get_preview(3)}}', array('post' => $post));
-			$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $str);
-
-			// excerpt set, force is false, no read more
-			$post->post_excerpt = 'this is excerpt longer than three words';
-			$preview = $post->get_preview(3, false, '');
-			$this->assertEquals($preview, $post->post_excerpt);
-
-			// custom read more set
-			$post->post_excerpt = '';
-			$preview = $post->get_preview(3, false, 'Custom more');
-			$preview = (string) $preview;
-			$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', $preview);
-
-			// content with <!--more--> tag, force false
-			$post->post_content = 'this is super dooper<!--more--> trooper long words';
-			$preview = $post->get_preview(2, false, '');
-			$this->assertEquals('this is super dooper', $preview);
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
-		function testShortcodesInPreviewFromContent() {
-			add_shortcode('mythang', function($text) {
-				return 'mythangy';
-			});
-			$pid = $this->factory->post->create( array('post_content' => 'jared [mythang]', 'post_excerpt' => '') );
-			$post = Timber::get_post( $pid );
-			$this->assertEquals('jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.preview }}
-		 */
-		function testShortcodesInPreviewFromContentWithMoreTag() {
-			add_shortcode('duck', function($text) {
-				return 'Quack!';
-			});
-			$pid = $this->factory->post->create( array('post_content' => 'jared [duck] <!--more--> joojoo', 'post_excerpt' => '') );
-			$post = Timber::get_post( $pid );
-			$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->preview());
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testPreviewWithSpaceInMoreTag() {
-			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = Timber::get_post( $pid );
-			$this->assertEquals('Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true));
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testPreviewWithMoreTagAndForcedLength() {
-			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = Timber::get_post( $pid );
-			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview());
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testPreviewWithCustomMoreTag() {
-			$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
-			$post = Timber::get_post( $pid );
-			$this->assertEquals('Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>', $post->get_preview());
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testPreviewWithCustomEnd() {
-			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck', 'post_excerpt' => '') );
-			$post = Timber::get_post( $pid );
-			$this->assertEquals('Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>', $post->get_preview(3, true, 'Read More', true, ' ???'));
-		}
-
-		/**
-		 * @expectedDeprecated {{ post.get_preview }}
-		 */
-		function testPreviewWithCustomStripTags() {
-			$pid = $this->factory->post->create(array(
-				'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
-			));
-			$post = Timber::get_post($pid);
-			$post->post_excerpt = '';
-			$preview = $post->get_preview(6, true, 'Read More', '<span>');
-			$this->assertEquals('<span>Even in the world of make-believe</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', (string) $preview);
-		}
-
+		$this->assertEquals(1, substr_count((string) $preview, '&hellip;'));
 	}
+
+	function testReadMoreClassFilter() {
+		$this->add_filter_temporarily('timber/post/preview/read_more_class', function($class) {
+			return $class . ' and-foo';
+		});
+		$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
+		$post = Timber::get_post($post_id);
+		$text = new PostPreview( $post, [
+			'words' => 10,
+		] );
+		$this->assertContains('and-foo', (string) $text);
+	}
+
+	function testPreviewTags() {
+		$post_id = $this->factory->post->create(array('post_excerpt' => 'It turned out that just about anyone in authority — cops, judges, city leaders — was in on the game.'));
+		$post = Timber::get_post($post_id);
+		$text = new PostPreview( $post, [
+			'words'    => 20,
+			'force'    => false,
+			'readmore' => '',
+			'strip'    => false,
+		] );
+		$this->assertNotContains('</p>', (string) $text);
+	}
+
+	function testGetPreview() {
+		global $wp_rewrite;
+		$struc = false;
+		$wp_rewrite->permalink_structure = $struc;
+		update_option('permalink_structure', $struc);
+		$post_id = $this->factory->post->create(array('post_content' => 'this is super dooper trooper long words'));
+		$post = Timber::get_post($post_id);
+
+		// no excerpt
+		$post->post_excerpt = '';
+		$str = Timber::compile_string('{{ post.excerpt({ words: 3 }) }}', [ 'post' => $post ] );
+		$this->assertRegExp( '/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $str );
+
+		// excerpt set, force is false, no read more
+		$post->post_excerpt = 'this is excerpt longer than three words';
+		$preview = new PostPreview( $post, [
+			'words'    => 3,
+			'force'    => false,
+			'readmore' => '',
+		] );
+		$this->assertEquals( (string) $preview, $post->post_excerpt);
+
+		// custom read more set
+		$post->post_excerpt = '';
+		$preview = new PostPreview( $post, [
+			'words'    => 3,
+			'force'    => false,
+			'readmore' => 'Custom more',
+		] );
+		$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', (string) $preview);
+
+		// content with <!--more--> tag, force false
+		$post->post_content = 'this is super dooper<!--more--> trooper long words';
+		$preview = new PostPreview( $post, [
+			'words'    => 2,
+			'force'    => false,
+			'readmore' => '',
+		] );
+		$this->assertEquals('this is super dooper', (string) $preview);
+	}
+
+	function testShortcodesInPreviewFromContent() {
+		add_shortcode('mythang', function($text) {
+			return 'mythangy';
+		});
+		$pid = $this->factory->post->create( [ 'post_content' => 'jared [mythang]', 'post_excerpt' => '' ] );
+		$post = Timber::get_post( $pid );
+		$this->assertEquals( 'jared mythangy&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>', $post->excerpt() );
+	}
+
+	function testShortcodesInPreviewFromContentWithMoreTag() {
+		add_shortcode('duck', function($text) {
+			return 'Quack!';
+		});
+		$pid = $this->factory->post->create( array('post_content' => 'jared [duck] <!--more--> joojoo', 'post_excerpt' => '') );
+		$post = Timber::get_post( $pid );
+		$this->assertEquals('jared Quack! <a href="'.$post->link().'" class="read-more">Read More</a>', $post->excerpt());
+	}
+
+	function testPreviewWithSpaceInMoreTag() {
+		$pid = $this->factory->post->create( [
+			'post_content' => 'Lauren is a duck, but a great duck let me tell you why <!--more--> Lauren is not a duck',
+			'post_excerpt' => ''
+		] );
+		$post = Timber::get_post( $pid );
+		$preview = new PostPreview( $post, [
+			'words' => 3,
+			'force' => true,
+		] );
+
+		$this->assertEquals(
+			'Lauren is a&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>',
+			(string) $preview
+		);
+	}
+
+	function testPreviewWithMoreTagAndForcedLength() {
+		$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
+		$post = Timber::get_post( $pid );
+		$this->assertEquals(
+			'Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>',
+			$post->excerpt()
+		);
+	}
+
+	function testPreviewWithCustomMoreTag() {
+		$pid = $this->factory->post->create( array('post_content' => 'Eric is a polar bear <!-- more But what is Elaina? --> Lauren is not a duck', 'post_excerpt' => '') );
+		$post = Timber::get_post( $pid );
+		$this->assertEquals(
+			'Eric is a polar bear <a href="'.$post->link().'" class="read-more">But what is Elaina?</a>',
+			$post->excerpt()
+		);
+	}
+
+	function testPreviewWithCustomEnd() {
+		$pid = $this->factory->post->create( [
+			'post_content' => 'Lauren is a duck, but a great duck let me tell you why Lauren is a duck',
+			'post_excerpt' => ''
+		] );
+		$post = Timber::get_post( $pid );
+		$preview = new PostPreview( $post, [
+			'words'    => 3,
+			'force'    => true,
+			'readmore' => 'Read More',
+			'strip'    => true,
+			'end'      => ' ???',
+		] );
+		$this->assertEquals(
+			'Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>',
+			(string) $preview
+		);
+	}
+
+	function testPreviewWithCustomStripTags() {
+		$pid = $this->factory->post->create( [
+			'post_content' => '<span>Even in the <a href="">world</a> of make-believe there have to be rules. The parts have to be consistent and belong together</span>'
+		] );
+		$post = Timber::get_post($pid);
+		$post->post_excerpt = '';
+		$preview = new PostPreview( $post, [
+			'words'    => 6,
+			'force'    => true,
+			'readmore' => 'Read More',
+			'strip'    => '<span>',
+		] );
+		$this->assertEquals(
+			'<span>Even in the world of make-believe</span>&hellip; <a href="'.$post->link().'" class="read-more">Read More</a>',
+			(string) $preview
+		);
+	}
+}

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -36,7 +36,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$text = new PostPreview( $post, [
 			'words'    => 20,
 			'force'    => false,
-			'readmore' => '',
+			'read_more' => '',
 			'strip'    => false,
 		] );
 		$this->assertNotContains('</p>', (string) $text);
@@ -145,7 +145,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$preview = new PostPreview( $post, [
 			'words'    => 3,
 			'force'    => true,
-			'readmore' => 'Read More',
+			'read_more' => 'Read More',
 			'strip'    => true,
 			'end'      => ' ???',
 		] );
@@ -164,7 +164,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$preview = new PostPreview( $post, [
 			'words'    => 6,
 			'force'    => true,
-			'readmore' => 'Read More',
+			'read_more' => 'Read More',
 			'strip'    => '<span>',
 		] );
 		$this->assertEquals(

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -60,7 +60,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$preview = new PostPreview( $post, [
 			'words'    => 3,
 			'force'    => false,
-			'readmore' => '',
+			'read_more' => '',
 		] );
 		$this->assertEquals( (string) $preview, $post->post_excerpt);
 
@@ -69,7 +69,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$preview = new PostPreview( $post, [
 			'words'    => 3,
 			'force'    => false,
-			'readmore' => 'Custom more',
+			'read_more' => 'Custom more',
 		] );
 		$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', (string) $preview);
 
@@ -78,7 +78,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		$preview = new PostPreview( $post, [
 			'words'    => 2,
 			'force'    => false,
-			'readmore' => '',
+			'read_more' => '',
 		] );
 		$this->assertEquals('this is super dooper', (string) $preview);
 	}

--- a/tests/test-timber-post-preview.php
+++ b/tests/test-timber-post-preview.php
@@ -151,7 +151,7 @@ class TestTimberPostPreview extends Timber_UnitTestCase {
 		] );
 		$this->assertEquals(
 			'Lauren is a ??? <a href="'.$post->link().'" class="read-more">Read More</a>',
-			(string) $preview
+			$preview
 		);
 	}
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -264,7 +264,7 @@ class TestTimberPost extends Timber_UnitTestCase {
 		$this->assertEquals($title, trim(strip_tags($post->title())));
 	}
 
-	function testCustomFieldPreviewRevision(){
+	function testCustomFieldExcerptRevision(){
 		global $current_user;
 		global $wp_query;
 
@@ -300,7 +300,7 @@ class TestTimberPost extends Timber_UnitTestCase {
 		$this->assertEquals( $assertCustomFieldVal, $str_getfield );
 	}
 
-	function testCustomFieldPreviewNotRevision() {
+	function testCustomFieldExcerptNotRevision() {
 		global $current_user;
 		global $wp_query;
 		$original_content = 'The custom field content';

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -345,7 +345,7 @@ class TestTimberMainClass extends Timber_UnitTestCase {
 	/* Previews */
 
 
-	function testGetPostPreview(){
+	function testGetPostExcerpt(){
 		$editor_user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $editor_user_id );
 


### PR DESCRIPTION
## Issue

Functions that were deprecated in 1.x can be removed in 2.x. `Post::get_preview()` is one of these candidates.

## Solution

- Delete the method and update tests.
- Add an `@api` tag to the `PostPreview` class so that it appears in the documentation, because currently, it’s missing.

## Impact

Breaking change.

## Usage Changes

`Post::preview()` or `new PostPreview()` should be used.

## Considerations

When using `$preview = new PostPreview()` in PHP, you’ll have to do `(string) $preview` for it to be converted to string (so that `__toString()` kicks in), because `PostPreview::run()` is protected. I don’t like this API very much. Are there better solutions?

- `$preview->to_string()`?
- `$preview->get()`?
- others?

## Testing

There’s a failing test because when we use an empty string as the value for the `readmore` option, a Readmore link will still be added. I’m not sure whether this behavior was introduced only lately, because the tests tell us that an empty string should probably be evaluated as `false`, resulting in no link being added. @jarednova I would be glad if you could have a look.

Oh, and maybe ignore whitespace when looking at the changes, because I fixed a wrong indentation in the tests, too.