### PR TITLE
2.x Remove functionality deprecated in 1.x

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -625,33 +625,6 @@ class Helper {
 
 	/**
 	 * Filters a list of objects, based on a set of key => value arguments.
-	 * Uses native Twig Filter.
-	 *
-	 * @since 1.14.0
-	 * @deprecated since 1.17 (to be removed in 2.0). Use array_filter or Helper::wp_list_filter instead
-	 * @todo remove this in 2.x
-	 * @param array                 $list to filter.
-	 * @param callback|string|array $arrow function used for filtering,
-	 *                              string or array for backward compatibility.
-	 * @param string                $operator to use (AND, NOT, OR). For backward compatibility.
-	 * @return array
-	 */
-	public static function filter_array( $list, $arrow, $operator = 'AND' ) {
-		if ( ! is_callable( $arrow ) ) {
-			self::warn( 'This filter is using Twig\'s filter by default. If you want to use wp_list_filter use {{ my_array|wp_list_filter }}.' );
-			return self::wp_list_filter( $list, $arrow, $operator );
-		}
-
-		if ( is_array( $list ) ) {
-			return array_filter( $list, $arrow, \ARRAY_FILTER_USE_BOTH );
-		}
-
-		// the IteratorIterator wrapping is needed as some internal PHP classes are \Traversable but do not implement \Iterator
-		return new \CallbackFilterIterator( new \IteratorIterator( $list ), $arrow );
-	}
-
-	/**
-	 * Filters a list of objects, based on a set of key => value arguments.
 	 * Uses WordPress WP_List_Util's filter.
 	 *
 	 * @api

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -230,17 +230,6 @@ class Loader {
 	}
 
 	/**
-	 * @deprecated 1.3.5 No longer used internally
-	 * @todo remove in 2.x
-	 * @param string $name
-	 * @return bool
-	 */
-	protected function template_exists( $name ) {
-		return $this->get_loader()->exists($name);
-	}
-
-
-	/**
 	 * @return \Twig\Loader\FilesystemLoader
 	 */
 	public function get_loader() {

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -371,16 +371,4 @@ class Site extends Core implements CoreInterface {
 		}
 		$this->$key = $value;
 	}
-
-	/**
-	 * @api
-	 * @deprecated 1.0.4, use `{{ site.link }}` instead.
-	 * @see \Timber\Site::link()
-	 * @return string
-	 */
-	public function url() {
-		Helper::deprecated('{{ site.url }}', '{{ site.link }}', '1.0.4');
-		return $this->link();
-	}
-
 }

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -180,12 +180,6 @@ class Twig {
 
 		$twig->addFilter(new TwigFilter('pluck', array('Timber\Helper', 'pluck')));
 
-		/**
-		 * @deprecated since 1.13 (to be removed in 2.0). Use Twig's native filter filter instead
-		 * @todo remove this in 2.x so that filter merely passes to Twig's filter without any modification
-		 * @ticket #1594 #2120
-		 */
-		$twig->addFilter(new TwigFilter('filter', array('Timber\Helper', 'filter_array')));
 		$twig->addFilter(new TwigFilter('wp_list_filter', array('Timber\Helper', 'wp_list_filter')));
 
 		$twig->addFilter(new TwigFilter('relative', function( $link ) {

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -241,34 +241,6 @@ use Timber\PostArrayObject;
 		/**
  		 * @expectedException Twig\Error\RuntimeError
 		 */
-		function testArrayFilterKeyValueUsingPostArrayObject() {
-			$posts = [];
-			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
-			$posts[] = $this->factory->post->create(array('post_title' => 'Snoop', 'post_content' => 'Felicia Pearson'));
-			$posts[] = $this->factory->post->create(array('post_title' => 'Cheese', 'post_content' => 'Method Man'));
-			$posts = new PostArrayObject( $posts );
-			$template = '{% for post in posts | filter({post_content: "Method Man"})%}{{ post.title }}{% endfor %}';
-			$str = Timber::compile_string($template, array('posts' => $posts));
-			$this->assertEquals('Cheese', trim($str));
-		}
-
-		/**
- 		 * @expectedException Twig\Error\RuntimeError
-		 */
-		function testArrayFilterMulti() {
-			$posts = [];
-			$posts[] = $this->factory->post->create(array('post_title' => 'Stringer Bell', 'post_content' => 'Idris Elba'));
-			$posts[] = $this->factory->post->create(array('post_title' => 'Snoop', 'post_content' => 'Felicia Pearson'));
-			$posts[] = $this->factory->post->create(array('post_title' => 'Cheese', 'post_content' => 'Method Man'));
-			$posts = Timber::get_posts($posts);
-			$template = '{% for post in posts | filter({slug:"snoop", post_content:"Idris Elba"}, "OR")%}{{ post.title }} {% endfor %}';
-			$str = Timber::compile_string($template, array('posts' => $posts));
-			$this->assertEquals('Stringer Bell Snoop', trim($str));
-		}
-
-		/**
- 		 * @expectedException Twig\Error\RuntimeError
-		 */
 		function testArrayFilterWithBogusArray() {
 			$template = '{% for post in posts | filter({slug:"snoop", post_content:"Idris Elba"}, "OR")%}{{ post.title }} {% endfor %}';
 			$str = Timber::compile_string($template, array('posts' => 'foobar'));


### PR DESCRIPTION
## Issue

Functionality that was deprecated in 1.x can be removed in 2.x. And I see that not every was catched by THE PURGE in #2323.

## Solution

Search for `@todo` tags that tell us to remove 1.x functionality and actually remove it.

## Impact

Breaking Changes.

## Usage Changes

Were already covered in 1.x.

## Considerations

Any?

## Testing

Maybe we still need to update some tests. Let’s see.