### PR TITLE
Multisite Timber::get_sites() returns same locale for all sites (#1908)

### DIFF
--- a/lib/Site.php
+++ b/lib/Site.php
@@ -175,7 +175,7 @@ class Site extends Core implements CoreInterface {
 		$this->rss = get_bloginfo('rss_url');
 		$this->rss2 = get_bloginfo('rss2_url');
 		$this->atom = get_bloginfo('atom_url');
-		$this->language = get_bloginfo('language');
+		$this->language = get_locale();
 		$this->charset = get_bloginfo('charset');
 		$this->pingback = $this->pingback_url = get_bloginfo('pingback_url');
 	}


### PR DESCRIPTION
**Ticket**: #1908 

## Issue
In a multisite environment `Timber::get_sites()` returns the same locale for all sites in backend (and frontend also, if user is logged in). This also happens while using `new Timber\Site()`.
When using `get_bloginfo( 'language' )`, then `determine_locale()` is used, which considers the language set in the user profile. This could lead to all the sites returning the same language when a user overwrites it in their profile on all sites. 

## Solution
Using `get_locale()` is way more predictable, because it always uses the language setting used for a site.

## Impact
No problems expected.

## Usage Changes
Use `Timber::get_sites()` and new Timber\Site() as before.