### PR TITLE
Make number_format support WordPress locale

### DIFF
--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -249,7 +249,7 @@ class Twig {
 	/**
 	 * Overwrite Twig defaults.
 	 *
-	 * Makes Twig compatible with how WordPress handles dates, timezones and perhaps other items in
+	 * Makes Twig compatible with how WordPress handles dates, timezones, numbers and perhaps other items in
 	 * the future
 	 *
 	 * @since 2.0.0
@@ -262,6 +262,12 @@ class Twig {
 	public function set_defaults( Environment $twig ) {
 		$twig->getExtension( CoreExtension::class )->setDateFormat( get_option( 'date_format' ), '%d days' );
 		$twig->getExtension( CoreExtension::class )->setTimezone( wp_timezone_string() );
+
+		/** @see https://developer.wordpress.org/reference/functions/number_format_i18n/ */
+		global $wp_locale;
+		if ( isset( $wp_locale ) ) {
+			$twig->getExtension( CoreExtension::class )->setNumberFormat( 0, $wp_locale->number_format['decimal_point'], $wp_locale->number_format['thousands_sep'] );
+		}
 
 		return $twig;
 	}

--- a/tests/test-timber-twig-number-format-filter-default.php
+++ b/tests/test-timber-twig-number-format-filter-default.php
@@ -14,6 +14,12 @@ class TestTimberTwigNumberFormatFilterDefault extends Timber_UnitTestCase {
 		parent::setUp();
 	}
 
+	function tearDown() {
+		// Reset locale
+		$GLOBALS['wp_locale'] = new WP_Locale();
+		parent::tearDown();
+	}
+
 	function get_context() {
 		return [
 			'number1'     => 20,

--- a/tests/test-timber-twig-number-format-filter-default.php
+++ b/tests/test-timber-twig-number-format-filter-default.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Replicates Twig tests from twig/twig/tests/Fixtures/filters/number_format*.test
+ *
+ * @group Timber\Number
+ */
+class TestTimberTwigNumberFormatFilterDefault extends Timber_UnitTestCase {
+	function setUp() {
+		// Simulate fr_FR locale
+		global $wp_locale;
+		$wp_locale->number_format['decimal_point'] = ',';
+		$wp_locale->number_format['thousands_sep'] = ' ';
+		parent::setUp();
+	}
+
+	function get_context() {
+		return [
+			'number1'     => 20,
+			'number2'     => 20.25,
+			'number3'     => 1020.25,
+		];
+	}
+
+	function testNumberFormat1() {
+		$result = Timber\Timber::compile_string(
+			"{{ number1|number_format }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20', $result );
+	}
+
+	function testNumberFormat2() {
+		$result = Timber\Timber::compile_string(
+			"{{ number2|number_format }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20', $result );
+	}
+
+	function testNumberFormat3() {
+		$result = Timber\Timber::compile_string(
+			"{{ number2|number_format(2) }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20,25', $result );
+	}
+
+	function testNumberFormat5() {
+		$result = Timber\Timber::compile_string(
+			"{{ number3|number_format }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '1 020', $result );
+	}
+
+	function testNumberFormat6() {
+		$result = Timber\Timber::compile_string(
+			"{{ number3|number_format(2) }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '1 020,25', $result );
+	}
+
+}

--- a/tests/test-timber-twig-number-format-filter.php
+++ b/tests/test-timber-twig-number-format-filter.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Replicates Twig tests from twig/twig/tests/Fixtures/filters/number_format*.test
+ *
+ * @group Timber\Number
+ */
+class TestTimberTwigNumberFormatFilter extends Timber_UnitTestCase {
+
+	function get_context() {
+		return [
+			'number1'     => 20,
+			'number2'     => 20.25,
+			'number3'     => 1020.25,
+		];
+	}
+
+	function testNumberFormat1() {
+		$result = Timber\Timber::compile_string(
+			"{{ number1|number_format }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20', $result );
+	}
+
+	function testNumberFormat2() {
+		$result = Timber\Timber::compile_string(
+			"{{ number2|number_format }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20', $result );
+	}
+
+	function testNumberFormat3() {
+		$result = Timber\Timber::compile_string(
+			"{{ number2|number_format(2) }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20.25', $result );
+	}
+
+	function testNumberFormat4() {
+		$result = Timber\Timber::compile_string(
+			"{{ number2|number_format(2, ',') }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '20,25', $result );
+	}
+
+	function testNumberFormat5() {
+		$result = Timber\Timber::compile_string(
+			"{{ number3|number_format(2, ',') }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '1,020,25', $result );
+	}
+
+	function testNumberFormat6() {
+		$result = Timber\Timber::compile_string(
+			"{{ number3|number_format(2, ',', '.') }}",
+			$this->get_context()
+		);
+
+		$this->assertEquals( '1.020,25', $result );
+	}
+
+}


### PR DESCRIPTION
Hello Timber team!

## Issue

You took care of `date` filter but `number_format` seemed forgotten.

## Solution

Grabs WordPress locale settings (`decimal_point`, `thousands_sep`) and set [Twig number format](https://twig.symfony.com/doc/2.x/filters/number_format.html).

## Impact

No locale was set before this. So Twig applied the default PHP locale. If someone set custom `number_format` on the filter level, it will still work as exptected.

## Usage Changes

Not that I'm aware of. This setting didn't exists before and is automatic now because it depends on `$wp_locale`. 

## Considerations

Use PHP Locale would be great.

## Testing

Yes, taken from Twig's tests and adapted.
