### PR TITLE
Bump upstatement/routes package to 0.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": ">=5.3.0|7.*",
     "twig/twig": "^1.41|^2.10",
-    "upstatement/routes": "0.5",
+    "upstatement/routes": "0.8",
     "composer/installers": "~1.0",
     "twig/cache-extension": "^1.5"
   },


### PR DESCRIPTION
## Issue
The version of upstatement/routes (0.5) used by Timber is mishandling URLs when using it with a multilingual plugin like WPML, as shown on this issue from the lib repository: [https://github.com/Upstatement/routes/issues/12](https://github.com/Upstatement/routes/issues/12)

## Solution
Bump upstatement/routes to latest version (0.8).
The 0.6 release was motivated by this exact issue: [Fix issue with WPML](https://github.com/Upstatement/routes/releases/tag/0.6) Since then no breaking changes have been introduced.

## Impact
No expected impact. Not much has changed other than this bug fix and some dependencies updates.
[Comparing 0.5...0.8 · Upstatement/routes](https://github.com/Upstatement/routes/compare/0.5...0.8)
