### PR TITLE
Bugfix/wp cli

### DIFF
--- a/lib/Integrations.php
+++ b/lib/Integrations.php
@@ -19,10 +19,6 @@ class Integrations {
 
 	public function init() {
 		add_action('init', array($this, 'maybe_init_integrations'));
-
-		if ( class_exists('WP_CLI_Command') ) {
-			\WP_CLI::add_command('timber', 'Timber\Integrations\Timber_WP_CLI_Command');
-		}
 	}
 
 	public function maybe_init_integrations() {


### PR DESCRIPTION
WP-CLI is currently broken because `Timber_WP_CLI_Command` was removed in 354f0a9c but `Timber\Integrations` is still trying to add it as a command. This simply removes the registration code too.