### PR TITLE
2.x Add options to better control read_more and end behavior in post excerpts

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -589,6 +589,31 @@ For this, we…
 - added a `Timber\Post::excerpt()` function that you should use instead of `Timber\Post::preview()`.
 - Changed filter names.
 
+### Read more links and end strings will not always be added
+
+We updated the logic for when read more links and end strings (`…` by default) will be added. For example, if the excerpt is generated from the post’s content, but the post’s content isn’t longer than the excerpt, then no read more link and no end string will be added.
+
+You can control this behavior with these two new parameters for excerpts:
+
+- `always_add_read_more` – Controls whether a read more link should be added even if the excerpt isn’t trimmed (when the excerpt isn’t shorter than the post’s content). The default is `false`.
+- `always_add_end` – Whether the end string should be added even if the excerpt isn’t trimmed. The default is `false`.
+
+### Filter the defaults
+
+There’s a new `timber/post/excerpt/defaults` filter that can be used to update default options for excerpts, including `always_add_read_more` and `always_add_end`.
+
+```php
+add_filter( 'timber/post/excerpt/defaults', function( $defaults ) {
+    // Only add a read more link if the post content isn’t longer than the excerpt.
+    $defaults['always_add_read_more'] = false;
+
+    // Set a default character limit.
+    $defaults['words'] = 240;
+
+    return $defaults;
+} );
+```
+
 ### `post.excerpt` takes arguments in array/hash notation
 
 The `{{ post.excerpt }}` function was added as a replacement for `{{ post.preview }}`. When using `{{ post.preview }}`, you could pass in arguments by chaining them. It’s now possible to pass in arguments as an array in PHP or in hash style in Twig. This finally cleans up how the previews of posts are handled. Here’s an example:

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -6,15 +6,24 @@ namespace Timber;
  * The PostExcerpt class lets a user modify a post preview/excerpt to their liking.
  *
  * It’s designed to be used through the `Timber\Post::excerpt()` method. The public methods of this
- * class all return the object itself, which means that this is a **chainable object**. You can
- * change the output of the excerpt by **adding more methods**.
+ * class all return the object itself, which means that this is a **chainable object**. This means
+ * that you could change the output of the excerpt by **adding more methods**. But you can also pass
+ * in your arguments to the object constructor or to `Timber\Post::excerpt()`.
  *
  * By default, the excerpt will
  *
  * - have a length of 50 words, which will be forced, even if a longer excerpt is set on the post.
  * - be stripped of all HTML tags.
  * - have an ellipsis (…) as the end of the text.
- * - have a "Read More" link appended.
+ * - have a "Read More" link appended, if there’s more to read in the post content.
+ *
+ * One thing to note: If the excerpt already contains all of the text that can also be found in the
+ * post’s content, then the read more link as well as the string to use as the end will not be
+ * added.
+ *
+ * This class will also handle cases where you use the `<!-- more -->` tag inside your post content.
+ * You can also change the text used for the read more link by adding your desired text to the
+ * `<!-- more -->` tag. Here’s an example: `<!-- more Start your journey -->`.
  *
  * You can change the defaults that are used for excerpts through the
  * [`timber/post/excerpt/defaults`](https://timber.github.io/docs/v2/hooks/filters/#timber/post/excerpts/defaults)
@@ -28,7 +37,7 @@ namespace Timber;
  * {# Use default excerpt #}
  * <p>{{ post.excerpt }}</p>
  *
- * {# Use hash notation to pass arguments #}
+ * {# Preferred method: Use hash notation to pass arguments. #}
  * <div>{{ post.excerpt({ words: 100, read_more: 'Keep reading' }) }}</div>
  *
  * {# Change the post excerpt text only #}
@@ -380,7 +389,7 @@ class PostExcerpt {
 				'timber/post/excerpt/read_more_class'
 			);
 
-				$linktext = trim( $this->read_more );
+			$linktext = trim( $this->read_more );
 
 			$link = sprintf( ' <a href="%1$s" class="%2$s">%3$s</a>',
 				$this->post->link(),

--- a/lib/PostExcerpt.php
+++ b/lib/PostExcerpt.php
@@ -92,14 +92,16 @@ class PostExcerpt {
 	 * Whether a read more link should be added even if the excerpt isn’t trimmed (when the excerpt
 	 * isn’t shorter than the post’s content).
 	 *
+	 * @since 2.0.0
 	 * @var bool
 	 */
-	protected $always_add_read_more = true;
+	protected $always_add_read_more = false;
 
 	/**
 	 * Whether the end string should be added even if the excerpt isn’t trimmed (when the excerpt
 	 * isn’t shorter than the post’s content).
 	 *
+	 * @since 2.0.0
 	 * @var bool
 	 */
 	protected $always_add_end = false;
@@ -126,14 +128,14 @@ class PostExcerpt {
 	 *     @type string   $end       String to append to the end of the excerpt. Default '&hellip;'
 	 *                               (HTML ellipsis character).
 	 *     @type bool     $force     Whether to shorten the excerpt to the length/word count
-	 *                               specified, if the editor wrote a manual excerpt longer than the
-	 *                               set length. Default `false`.
+	 *                               specified, even if an editor wrote a manual excerpt longer
+	 *                               than the set length. Default `false`.
 	 *     @type bool     $strip     Whether to strip HTML tags. Default `true`.
 	 *     @type string   $read_more String for what the "Read More" text should be. Default
 	 *                               'Read More'.
 	 *     @type bool     $always_add_read_more Whether a read more link should be added even if the
 	 *                                          excerpt isn’t trimmed (when the excerpt isn’t
-	 *                                          shorter than the post’s content). Default `true`.
+	 *                                          shorter than the post’s content). Default `false`.
 	 *     @type bool     $always_add_end       Whether the end string should be added even if the
 	 *                                          excerpt isn’t trimmed (when the excerpt isn’t
 	 *                                          shorter than the post’s content). Default `false`.
@@ -149,7 +151,7 @@ class PostExcerpt {
 			'force'                => false,
 			'strip'                => true,
 			'read_more'            => 'Read More',
-			'always_add_read_more' => true,
+			'always_add_read_more' => false,
 			'always_add_end'       => false,
 		];
 

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -286,6 +286,6 @@
 			$post = Timber::get_post( $pid );
 			$template = '{{ post.excerpt }}';
 			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertEquals('What a beautiful day for a ballgame!&hellip; <a href="http://example.org/?page_id='.$pid.'" class="read-more">Read More</a>', $str);
+			$this->assertEquals('What a beautiful day for a ballgame! <a href="http://example.org/?page_id='.$pid.'" class="read-more">Read More</a>', $str);
 		}
 	}

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -18,14 +18,16 @@
 		}
 
 		function test1886ErrorWithForce() {
-			$expected = '<p>Govenment:</p> <ul> <li>of the <strong>people</strong></li> <li>by the people</li> <li>for the people</li> </ul>';
+			$expected = '<p>Government:</p> <ul> <li>of the <strong>people</strong></li> <li>by the people</li> <li>for the people</li> </ul>';
 			$post_id = $this->factory->post->create(array('post_excerpt' => $expected, 'post_content' => $this->gettysburg));
 			$post = Timber::get_post($post_id);
-			$template = "{{ post.excerpt({ 	strip: '<ul><li>',
-											words:10,
-											force:true }) }}";
+			$template = '{{ post.excerpt({
+				strip: "<ul><li>",
+				words:10,
+				force:true })
+			}}';
 			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertEquals('Govenment: <ul> <li>of the people</li> <li>by the people</li> <li>for the</li></ul>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
+			$this->assertEquals('Government: <ul> <li>of the people</li> <li>by the people</li> <li>for the</li></ul>&hellip; <a href="http://example.org/?p='.$post_id.'" class="read-more">Read More</a>', $str);
 		}
 
 		public function testExcerptConstructorWithWords() {
@@ -240,7 +242,10 @@
 			$pid = $this->factory->post->create( array('post_content' => 'Lauren is a duck<!-- more--> Lauren is not a duck', 'post_excerpt' => '') );
 			$post = Timber::get_post( $pid );
 
-			$this->assertEquals('Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>', $post->excerpt());
+			$this->assertEquals(
+				'Lauren is a duck <a href="'.$post->link().'" class="read-more">Read More</a>',
+				(string) $post->excerpt()
+			);
 		}
 
 		function testExcerptWithCustomMoreTag() {
@@ -281,11 +286,17 @@
 			$this->assertEquals('', $str);
 		}
 
+		/**
+		 * @ticket #2045
+		 */
 		function testPageExcerptOnSearch() {
 			$pid = $this->factory->post->create(array('post_type' => 'page', 'post_content' => 'What a beautiful day for a ballgame!', 'post_excerpt' => ''));
 			$post = Timber::get_post( $pid );
 			$template = '{{ post.excerpt }}';
 			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertEquals('What a beautiful day for a ballgame! <a href="http://example.org/?page_id='.$pid.'" class="read-more">Read More</a>', $str);
+			$this->assertEquals(
+				'What a beautiful day for a ballgame!',
+				$str
+			);
 		}
 	}


### PR DESCRIPTION
**Ticket**: #2365, #1345

## Issue

When using Timber’s excerpt functionality, the read more link is always added – even if the post’s content isn’t longer than the excerpt.

## Solution

First, there are two new options for post excerpts that can both be passed to the `Post::excerpt()` function as well as when using `new PostExcerpt()`:

- `always_add_read_more` – Controls whether a read more link should be added even if the excerpt isn’t trimmed (when the excerpt isn’t shorter than the post’s content). The default is `true` in order to not break backwards compatibility.
- `always_add_end` – Whether the end string should be added even if the excerpt isn’t trimmed. The default is `false`, because to me, that was a bug before.

More thoughts about why I chose these defaults can be found in https://github.com/timber/timber/issues/1345#issuecomment-726316686. We can still discuss this further in here.

And then, there’s a new `timber/post/excerpt/defaults` filter that can be used to update default options, including `always_add_read_more` and `always_add_end`.

It can also be used to change the defaults for other things.

```php
add_filter( 'timber/post/excerpt/defaults', function( $defaults ) {
    // Only add a read more link if the post content isn’t longer than the excerpt.
    $defaults['always_add_read_more'] = false;

    // Set a default character limit.
    $defaults['words'] = 240;

    return $defaults;
} );
```

I chose `always_add_*` instead of `always_show_*` (discussion in https://github.com/timber/timber/issues/1345#issuecomment-726794645), because the "showing" is very close to echoing. But a post excerpt is always "returned". So I think "add" would be cleaner when the meaning should be that a string is "assembled and returned".

## Impact

More versatility for post excerpts through the two new options and the new `timber/post/excerpt/defaults` filter.

## Usage Changes

- When the excerpt isn’t trimmed, then the end string is not added by default.

## Considerations

- The new options cannot be updated through chaining. Is that bad?
- When the `end` string is added, a read more links is always added to, no matter that the `always_add_read_more` option is set to. Does that make sense?

## Testing

Yes, I added tests. But do they cover all cases we need to cover?

## Todo

- [x] Update Upgrade Guide.