### PR TITLE
Fix a very annoying test

### DIFF
--- a/tests/test-timber-twig-date-function.php
+++ b/tests/test-timber-twig-date-function.php
@@ -9,13 +9,14 @@ class TestTimberTwigDateFunction extends Timber_UnitTestCase {
 	/**
 	 * This test also checks whether date() returns a Datetime object.
 	 *
-	 * NOTE: this may randomly fail. There's not really a way around this
-	 * because of how PHP deals with time.
+	 * NOTE: we do the rounding because otherwise this can randomly fail when some fraction of ~.5 
+	 * seconds has elapsed between when compile_string is called and the date().getTimestamp()
+	 * method is executed.
 	 */
-	function testDateNow() {
+	function testDateNowRounded() {
 		$result = Timber\Timber::compile_string(
-			"{{ date().getTimestamp() == date ? 'OK' : 'KO' }}",
-			[ 'date' => time() ]
+			"{{ (date().getTimestamp()/10)|round == date ? 'OK' : 'KO' }}",
+			[ 'date' => round(time()/10) ]
 		);
 
 		$this->assertEquals( 'OK', $result );


### PR DESCRIPTION
## Issue
There's a routine test around date comparisons that fails ~2% of the time due to some fraction of a second elapsing between two calls to the unix epoch timestamp.

## Solution
Round things by 10 to reduce/eliminate this scenario.

## Impact
No more randomly failing tests (at least for this one, hopefully)

## Usage Changes
None

## Testing
Updated/renamed one test and the docblock info
