### PR TITLE
Create config.yml for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Support or usage question for Timber
+    url: http://stackoverflow.com/questions/tagged/timber
+    about: Is this a support or usage question? Please post to Stack Overflow using the Timber tag.


### PR DESCRIPTION
This adds an additional link to the issue template chooser that directs people to Stack Overflow for support questions.

I already added it over at the [timber/docs](https://github.com/timber/docs/issues/new/choose) repo, where it looks like this:

![](https://user-images.githubusercontent.com/2084481/100135036-5f590980-2e89-11eb-815c-80dad1d1826d.png)

Relevant documentation for the template chooser can be found here: https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser