### PR TITLE
2.x Improve documentation for terms

### DIFF
--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -1,7 +1,9 @@
 ---
-title: "Term"
+title: "Terms"
 order: "120"
 ---
+
+## Get a term
 
 To get a term object in Timber, you use `Timber::get_term()` and pass the WordPress term ID as an argument.
 
@@ -23,16 +25,16 @@ What you get in return is a [`Timber\Term`](https://timber.github.io/docs/v2/ref
 
 ## Twig
 
-You can convert terms IDs to term objects in Twig using the `Term()` function.
+You can convert terms IDs to term objects in Twig using the `get_term()` function.
 
 ```twig
-{% set term = Term(term_id) %}
+{% set term = get_term(term_id) %}
 ```
 
-It also works if you have an array of terms IDs that you want to convert to `Timber\Term` objects.
+If you have an array of terms IDs that you want to convert to `Timber\Term` objects, you can use `get_terms()`.
 
 ```twig
-{% for term in Term(term_ids) %}
+{% for term in get_terms(term_ids) %}
 
 {% endfor %}
 ```
@@ -81,7 +83,7 @@ If you want to get a collection of terms, you can use `Timber::get_terms()`.
 
 ```php
 $terms = Timber::get_terms( [
-    'query' => $query,
+    'hide_empty' => false,
 ] );
 ```
 
@@ -90,16 +92,14 @@ You can use this function in a similar way to how you use [`WP_Term_Query`](http
 ```php
 // Using the WP_Term_Query argument format.
 $term_query = new Timber::get_terms( [
-    'query' => [
-        'taxonomy' => 'book_genre',
-        'count'    => true,
-    ],
- ] );
+    'taxonomy' => 'book_genre',
+    'count'    => true,
+] );
 ```
 
-Be aware that you need to pass an array to `Timber::get_terms()` with a `query` parameter. This array can have additional arguments that you can check out in the documentation for [`Timber::get_terms()`](https://timber.github.io/docs/v2/reference/timber/#get-terms).
+Also check out the documentation for [`Timber::get_terms()`](https://timber.github.io/docs/v2/reference/timber/#get-terms).
 
-What you get as a return value is not a pure array of posts, but a `Timber\TermCollection` object, which is an `ArrayObject` that is very similar to an array as you know it. To loop over the terms collection in PHP, you first need to convert it to an array with `$terms->get_terms()`.
+What you get as a return value is not a pure array of term, but a `Timber\TermCollection` object, which is an `ArrayObject` that is very similar to an array as you know it. To loop over the terms collection in PHP, you first need to convert it to an array with `$terms->get_terms()`.
 
 ```php
 foreach ( $terms_query->get_terms() as $term ) {
@@ -115,7 +115,7 @@ In Twig, you can directly loop over it.
 {% endfor %}
 ```
 
-When you query for certain post types, Timber will use the [Term Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map) to check which class it should use to instantiate your posts.
+When you query for terms, Timber will use the [Term Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map) to check which class it should use to instantiate your terms.
 
 ### Listing terms in Twig
 

--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -91,37 +91,35 @@ In the same way that you [can’t instantiate post objects directly](https://tim
 
 ## Querying Terms
 
-If you want to get a collection of terms, you can use `Timber::get_terms()`.
+If you want to get an array of terms, you can use `Timber::get_terms()`.
 
 ```php
-$terms = Timber::get_terms( [
-    'hide_empty' => false,
-] );
+$terms = Timber::get_terms();
 ```
 
-You can use this function in a similar way to how you use [`WP_Term_Query`](https://developer.wordpress.org/reference/classes/wp_term_query/). If you don’t pass in any argument, Timber will use the global query.
+If you don’t pass in any argument, Timber will use [`get_taxonomies()`](https://developer.wordpress.org/reference/functions/get_taxonomies/) to get a list of terms from all taxonomies.
+
+You can pass the same arguments to this function that you know from using [`WP_Term_Query`](https://developer.wordpress.org/reference/classes/wp_term_query/).
 
 ```php
 // Using the WP_Term_Query argument format.
-$term_query = Timber::get_terms( [
-    'query' => [
-        'taxonomy' => 'book_genre',
-        'count'    => true,
-    ],
+$terms = Timber::get_terms( [
+    'taxonomy' => 'book_genre',
+    'count'    => true,
  ] );
 ```
 
-Also check out the documentation for [`Timber::get_terms()`](https://timber.github.io/docs/v2/reference/timber/#get-terms).
+Also check out the documentation for [`Timber::get_terms()`](https://timber.github.io/docs/v2/reference/timber-timber/#get_terms).
 
-What you get as a return value is not a pure array of term, but a `Timber\TermCollection` object, which is an `ArrayObject` that is very similar to an array as you know it. To loop over the terms collection in PHP, you first need to convert it to an array with `$terms->get_terms()`.
+You get array of terms as a return value that you can loop over.
 
 ```php
-foreach ( $terms_query->get_terms() as $term ) {
+foreach ( $terms as $term ) {
     echo $term->title();
 }
 ```
 
-In Twig, you can directly loop over it.
+In Twig, you can do the same.
 
 ```twig
 {% for term in terms %}

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -108,16 +108,17 @@ By using the Factory Pattern, we refactored a lot of code and by moving logic in
 - `Timber\TermGetter`
 - `Timber\QueryIterator`
 
+## Posts
 
-### Posts
+Before version 2.0, when you wanted to get a collection of posts, the standard way was to use `Timber::get_posts()`, and `Timber::get_post()` to get a single post. But you could also use `new Timber\Post()` or `new Timber\PostQuery()`.
 
-Before version 2.0, when you wanted to get a collection of posts, the standard way was to use `Timber::get_posts()`, and `Timber::get_post()` to get a single post. But you could also use `new Timber\Post()` or `new Timber\PostQuery()`. We deprecated the possibility to instantiate objects directly. Instead, you should only use `Timber::get_post()` and `Timber::get_posts()`.
+We deprecated the possibility to instantiate objects directly. Instead, you should only use `Timber::get_post()` and `Timber::get_posts()`.
 
 Make sure you also read the new [Posts Guide](https://timber.github.io/docs/v2/guides/posts).
 
-#### Timber::get_post()
+### Timber::get_post()
 
-##### Use `Timber::get_post()` instead of `new Timber\Post()`
+#### Use `Timber::get_post()` instead of `new Timber\Post()`
 
 It’s not possible anymore to directly instantiate a post with `new Timber\Post()`. Instead, you always need to use `Timber::get_post()` and pass in the ID of the post.
 
@@ -135,7 +136,7 @@ $post = Timber::get_post();
 $post = Timber::get_post( 56 );
 ```
 
-##### Updated function signature for `Timber::get_post()`
+#### Updated function signature for `Timber::get_post()`
 
 We updated the function parameters for `Timber::get_post()`.
 
@@ -153,9 +154,9 @@ function get_post( mixed $query = false, array $options = [] );
 
 We deprecated the `$PostClass` parameter. If you want to control the class your post should be instantiated with, use a [Class Map filter](TODO). Instead, we now have an `$options` array.
 
-#### Timber::get_posts()
+### Timber::get_posts()
 
-##### Use `Timber::get_posts()` instead of `new Timber\PostQuery()`
+#### Use `Timber::get_posts()` instead of `new Timber\PostQuery()`
 
 **Old**
 
@@ -185,7 +186,7 @@ foreach ( $latest_books->to_array() as $book ) {
 }
 ```
 
-##### Use an array instead of query strings in `Timber::get_posts()`
+#### Use an array instead of query strings in `Timber::get_posts()`
 
 It will no longer be possible to pass in arguments to `Timber::get_posts()` as a query string. Instead, you will have to use the array notation.
 
@@ -203,7 +204,7 @@ Timber::get_posts( [
 ] );
 ```
 
-##### Updated function signature for `Timber::get_posts()`
+#### Updated function signature for `Timber::get_posts()`
 
 We updated the function parameters for `Timber::get_posts()`.
 
@@ -221,7 +222,7 @@ function get_posts( array $query, array $options = [] );
 
 The function still accepts the `$query` parameters as the first argument. Most of your queries will still work.
 
-The following two parameters were deprecated:
+The following two parameters were removed:
 
 - **`$PostClass`** – You can’t directly pass the class to instantiate the object with anymore. Instead, you will have to use a [Class Map filter](TODO).
 - **`$return_collection`** – You can’t tell the function whether it should return a `Timber\PostCollection` or an array of posts. It will always return a `Timber\PostCollection`. But you can always convert to collection to posts when you use `to_array()`:
@@ -258,7 +259,7 @@ $latest_books_array      = Timber::get_posts( $args )->to_array();
 
 The new `$options` parameter can be used to pass in options for the query. Check out the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/reference/timber/#get-posts) to see all options.
 
-#### Post queries in Twig
+### Post queries in Twig
 
 You can run post queries in Twig. Pass the parameters in an argument hash (in Twig, [key-value arrays are called hashes](https://mijingo.com/blog/key-value-arrays-in-twig), and you use curly braces `{}` instead of brackets `[]` for them).
 
@@ -275,21 +276,77 @@ You can run post queries in Twig. Pass the parameters in an argument hash (in Tw
 
 We still recommend you to run queries and prepare posts in PHP and not in Twig. But sometimes this is not possible when you don’t have access to the relevant PHP files, but only to Twig.
 
-#### Post Collections
+### Post Collections
 
 We added some documentation about how to work with [Post Collections](https://timber.github.io/docs/v2/guides/posts#post-collections), which are returned when you use `Timber::get_posts()`.
 
 Make sure you also read about [the Laziness of posts](https://timber.github.io/docs/v2/guides/posts#laziness-and-caching).
 
-#### Post Serialization
+### Post Serialization
 
 When converting post data to JSON, for example to use post data in JavaScript, then we talk about [Serialization](https://timber.github.io/docs/v2/guides/posts#serialization). We added some documentation for that.
 
 ---
 
-### Terms
+## Terms
+
+Similar to posts, when you wanted to get a Timber term object before version 2.0, you could either use `Timber::get_term()` or `new Timber\Term()`. Now, instantiating `Timber\Term` directly doesn’t work anymore. You will always have to use `Timber::get_term()`.
+
+Make sure you also read the new [Terms Guide](https://timber.github.io/docs/v2/guides/terms).
 
 @TODO
+
+### Timber::get_term()
+
+#### Use `Timber::get_term()` instead of `new Timber\Term()`
+
+It’s not possible anymore to directly instantiate a term with `new Timber\Term()`. Instead, you always need to use `Timber::get_term()` and pass in the ID of the term.
+
+```php
+// Pass in a term ID (or a WP_Term object) to get a particular term.
+$term = Timber::get_term( 17 );
+```
+
+#### Updated function signature for `Timber::get_term()`
+
+We updated the function parameters for `Timber::get_term()`.
+
+**Old**
+
+```php
+function get_term( $term, $taxonomy = 'post_tag', $TermClass = 'Timber\Term' );
+```
+
+**New**
+
+```php
+function get_term( $term = null );
+```
+
+- We removed the `$taxonomy` parameter. Timber needs the ID of a term or a `WP_Term` object. It can figure out the taxonomy itself.
+- We removed the `$TermClass` parameter. If you want to control the class your term should be instantiated with, use a [Term Class Map filter](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map).
+
+### Timber::get_terms()
+
+#### Updated function signature for `Timber::get_terms()`
+
+We updated the function parameters for `Timber::get_terms()`.
+
+**Old**
+
+```php
+function get_terms( $args = null, $maybe_args = array(), $TermClass = 'Timber\Term' );
+```
+
+**New**
+
+```php
+function get_terms( $args = null, array $options = [] );
+```
+
+- The function still accepts an `$args` parameter where you pass in the same arguments that you would pass to [`WP_Term_Query()`](https://developer.wordpress.org/reference/classes/WP_Term_Query/__construct/). Most of your calls to `Timber::get_terms()` should still work the same.
+- The `$options` parameter is not used yet, but it might be used in the future.
+- We removed the `$TermClass` parameter. If you want to control the class your term should be instantiated with, use a [Term Class Map filter](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map).
 
 #### Updated default query parameters for `Timber::get_terms()`
 
@@ -304,14 +361,13 @@ $terms = Timber::get_terms( [
 ] );
 ```
 
-
-### Comments
+## Comments
 
 @TODO
 
 ---
 
-### Menus
+## Menus
 
 Before version 2.0, when you wanted to get a menu, the standard way was to use `new Timber\Menu()`. We deprecated the possibility to instantiate objects directly. Instead, you should only use `Timber::get_menu()`.
 
@@ -327,7 +383,7 @@ $menu = new Timber\Menu( 'primary' );
 $menu = Timber::get_menu( 'primary' );
 ```
 
-#### A parameter is always required
+### A parameter is always required
 
 Before 2.0, you could pass in nothing to the constructor of `Timber\Menu` to get the first menu Timber found. We removed the possibility to pass in nothing when getting a menu because it led to confusing cases.
 
@@ -347,7 +403,7 @@ Always pass a parameter.
 $menu = Timber::get_menu( 'primary' );
 ```
 
-#### The Pages Menu
+### The Pages Menu
 
 Previously, if you didn’t provide a parameter to `Timber\Menu()` and didn’t have any menus registered, Timber would build **a menu from your existing pages**. To achieve this same functionality, you must now use the new `Timber::get_pages_menu()` function.
 
@@ -367,7 +423,7 @@ If `Timber::get_menu()` can’t find a menu with the parameters you used, it wil
 
 ---
 
-### Users
+## Users
 
 @TODO
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -562,38 +562,43 @@ class Timber {
 	================================ */
 
 	/**
-	 * Get terms.
+	 * Gets terms.
+	 *
 	 * @api
-	 * @param string|array $args a string or array identifying the taxonomy or
-	 * `WP_Term_Query` args. Numeric strings are treated as term IDs; non-numeric
-	 * strings are treated as taxonomy names. Numeric arrays are treated as a
-	 * list a of term identifiers; associative arrays are treated as args to
-	 * `WP_Term_Query::__construct()` and accepts any valid parameters to that
-	 * constructor.
-	 * @param array        $options optional; none are currently supported.
-	 * @return Iterable
 	 * @see https://developer.wordpress.org/reference/classes/wp_term_query/__construct/
 	 * @example
 	 * ```php
 	 * // Get all tags.
-	 * $tags = Timber::get_terms('post_tag');
+	 * $tags = Timber::get_terms( 'post_tag' );
 	 * // Note that this is equivalent to:
 	 * $tags = Timber::get_terms( 'tag' );
 	 * $tags = Timber::get_terms( 'tags' );
 	 *
 	 * // Get all categories.
-	 * $cats = Timber::get_terms('category');
+	 * $cats = Timber::get_terms( 'category' );
 	 *
 	 * // Get all terms in a custom taxonomy.
 	 * $cats = Timber::get_terms('my_taxonomy');
 	 *
 	 * // Perform a custom Term query.
-	 * $cats = Timber::get_terms([
+	 * $cats = Timber::get_terms( [
 	 *   'taxonomy' => 'my_taxonomy',
 	 *   'orderby'  => 'slug',
 	 *   'order'    => 'DESC',
-	 * ]);
+	 * ] );
 	 * ```
+	 *
+	 * @param string|array $args    A string or array identifying the taxonomy or
+	 *                              `WP_Term_Query` args. Numeric strings are treated as term IDs;
+	 *                              non-numeric strings are treated as taxonomy names. Numeric
+	 *                              arrays are treated as a list a of term identifiers; associative
+	 *                              arrays are treated as args for `WP_Term_Query::__construct()`
+	 *                              and accept any valid parameters to that constructor.
+	 *                              Default `null`, which will get terms from all queryable
+	 *                              taxonomies.
+	 * @param array        $options Optional. None are currently supported. Default empty array.
+	 *
+	 * @return Iterable
 	 */
 	public static function get_terms( $args = null, array $options = [] ) : Iterable {
 		// default to all queryable taxonomies
@@ -614,7 +619,7 @@ class Timber {
 	 * @example
 	 * ```php
 	 * // Get a Term.
-	 * $tag = Timber::get_term(123);
+	 * $tag = Timber::get_term( 123 );
 	 * ```
 	 */
 	public static function get_term( $term = null ) {


### PR DESCRIPTION
**Ticket**: #1617

## Issue

There were still some todos for terms, and also some issues.

## Solution

- Add changes for terms to the Upgrade Guide.
- Fix some issues that we forgot or changed in the meantime.

## Impact

None.

## Usage Changes

None.

## Considerations

1. In the documentation for [Querying Terms](https://timber.github.io/docs/v2/guides/terms/#querying-terms), I once wrote that there will be `TermCollections` that work similar to `PostCollections`. I guess I’ll have to remove that part, because we don’t have term collections yet?
2. In the same section, I wrote "If you don’t pass in any argument, Timber will use the global query.". Currently, that’s not what we do. Instead, we get terms from all all queryable taxonomies. So, we could probably do something similar to what we already do in https://github.com/timber/timber/blob/41f0d6f61c4121095c6dc810050fc93f85245e68/lib/Timber.php#L350-L354, or we could change the documentation.
3. And I’m thinking: should we set up a default term object in [`Timber::context()`](https://github.com/timber/timber/blob/2.x/lib/Timber.php#L910) as well, if a term is returned by `get_queried_object()`?

## Testing

Only docs, no tests.