### PR TITLE
How to split into chunks flexible content fields

### DIFF
--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -186,7 +186,7 @@ Assuming block Twig files are inside a `blocks` folder:
 {% endfor %}
 ```
 
-> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
+The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
 
 ```twig
 <p>Photo by: {{ block.credit }}</p>   

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -186,12 +186,10 @@ Assuming block Twig files are inside a `blocks` folder:
 {% endfor %}
 ```
 
-> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name
-
-And for example for a Flexible Content Field named `text` containing a `text` field, inside a `blocks/text.twig` file:
+> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
 
 ```twig
-<p>{{ block.text }}</p>   
+<p>Photo by: {{ block.credit }}</p>   
 ```
 
 ### Troubleshooting Repeaters

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -171,6 +171,29 @@ When you run `meta` on an outer ACF field, everything inside is ready to be trav
 {% endfor %}
 ```
 
+### Split into small chunks flexible content fields
+
+We can break flexible content fields into small blocks thanks to `acf_fc_layout` value. This way we have more flexibility and reusability. It could be a way to build a landing page for instance.
+
+Assuming blocks are inside a `blocks` folder:
+
+```twig
+{% for block in post.meta( 'blocks' ) %}
+    {% 
+        include "blocks/#{ block.acf_fc_layout | sanitize ) }.twig"
+        with { block: block }
+    %}
+{% endfor %}
+```
+
+> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), slugify the block name
+
+And for example for a flexible content named `text` containing a `text` field, inside a `blocks/text.twig` file:
+
+```twig
+<p>{{ block.text }}</p>   
+```
+
 ### Troubleshooting Repeaters
 
 A common problem in working with repeaters is that you should only call the `meta` method **once** on an item. In other words if you have a field inside a field (for example, a relationship inside a repeater or a repeater inside a repeater, **do not** call `meta` on the inner field). More:

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -171,11 +171,11 @@ When you run `meta` on an outer ACF field, everything inside is ready to be trav
 {% endfor %}
 ```
 
-### Split into small chunks flexible content fields
+### Split Flexible Content Fields into includes / chunks
 
-We can break flexible content fields into small blocks thanks to `acf_fc_layout` value. This way we have more flexibility and reusability. It could be a way to build a landing page for instance.
+We can break Flexible Content Fields into small blocks with include files utilizing the `acf_fc_layout` value. This way you have more flexibility and reusability for included sections. For instance, this is a great way to build a landing pages that re-use the same blocks in different configurations.
 
-Assuming blocks are inside a `blocks` folder:
+Assuming block Twig files are inside a `blocks` folder:
 
 ```twig
 {% for block in post.meta( 'blocks' ) %}
@@ -186,9 +186,9 @@ Assuming blocks are inside a `blocks` folder:
 {% endfor %}
 ```
 
-> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), slugify the block name
+> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name
 
-And for example for a flexible content named `text` containing a `text` field, inside a `blocks/text.twig` file:
+And for example for a Flexible Content Field named `text` containing a `text` field, inside a `blocks/text.twig` file:
 
 ```twig
 <p>{{ block.text }}</p>   


### PR DESCRIPTION
Add an example on how to split into small chunks flexible content fields thanks to `acf_fc_layout` value, it could be a way to build a landing page for instance.

It may be related to this issue [#90](https://github.com/timber/starter-theme/issues/90)

What do you think about it?