### PR TITLE
📝 Add to menus.md: Code samples using > 1 menu

### DIFF
--- a/docs/guides/menus.md
+++ b/docs/guides/menus.md
@@ -88,6 +88,19 @@ $context = Timber::context();
 Timber::render( 'index.twig', $context );
 ```
 
+When adding multiple menus to the global `$context`, declare unique names for each menu in the `add_to_context` function.
+
+**functions.php**
+
+```php
+public function add_to_context( $context ) {
+    $context['primary_menu']  = new Timber\Menu('Primary Navigation');
+    $context['footer_menu'] = new Timber\Menu('Footer Navigation');
+    // ...
+    return $context;
+}
+```
+
 ## Displaying the menu items
 
 In your Twig file, you can loop over the menu items like normal arrays. You’re in complete control of the markup.
@@ -112,6 +125,23 @@ In your Twig file, you can loop over the menu items like normal arrays. You’re
             </li>
         {% endfor %}
     </ul>
+</nav>
+```
+
+When using multiple menus, use the unique name in your Twig markup. Notice `primary_menu.items` instead of `menu.items`.
+
+**index.twig**
+
+```twig
+<nav>
+  <ul class="nav-main">
+      {% for item in primary_menu.items %}
+          <li class="nav-main-item {{ item.classes|join(' ') }}">
+              <a class="nav-main-link" href="{{ item.link }}">{{ item.title }}</a>
+              <!-- ... -->
+          </li>
+      {% endfor %}
+  </ul>
 </nav>
 ```
 


### PR DESCRIPTION
**Add 2 code samples, which show how to use the global $context for more than one menu.**
1. Declare plural menus in `functions.php`.
2. Use one menu of several in Twig markup.

## Issue

The `docs/menus.md` did not have an example, in which more than one menu was declared in the global `$context`. As such, I created two menus, but with the latter overriding the former at `$context['menu']`. This led to the behavior that only one menu was available in the markup.

## Solution

Write a Markdown file with examples showing how to declare more than one menu. Use the example menu in Twig markup.

## Impact

This Pull Request does not affect the PHP codebase. It is an addition of 30 lines to `/docs/menus.md`.

## Usage Changes

I do not think there are usage changes. Please correct me if I am wrong.

## Considerations

The `menus.md` file will look more fleshed out as a result of this addition.

## Testing

The syntax highlighting mimics the same syntax highlighting as the other examples, using `php` and `twig`, respectively.