### PR TITLE
#2382 Optimizations for "How to split into chunks flexible content fields"

### DIFF
--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -226,7 +226,8 @@ Similar to nested repeaters, you should only call the `meta` method once when yo
 
 We can break Flexible Content Fields into small blocks with include files utilizing the `acf_fc_layout` value. This way you have more flexibility and reusability for included sections. For instance, this is a great way to build landing pages that re-use the same blocks in different configurations.
 
-Assuming your block Twig files are inside a **blocks** folder:
+You could use a **blocks** subdirectory where you put all your Twig template files for your blocks. For example:
+**wp-content/themes/example-theme/views/blocks**.
 
 ```twig
 {% for block in post.meta( 'blocks' ) %}
@@ -236,10 +237,22 @@ Assuming your block Twig files are inside a **blocks** folder:
 {% endfor %}
 ```
 
-The [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize) filter will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the **blocks/photo.twig** file:
+The [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize) filter will slugify the block name.
+
+Consider this example for a Flexible Content Field named `Photo` with a text field named `credit`. You would create a **blocks/photo.twig** file which is automatically included:
 
 ```twig
 <p>Photo by: {{ block.credit }}</p>
+```
+
+To prevent errors with include files that can’t be found, you can optionally use the `ignore_missing` parameter for `include()`:
+
+```twig
+{% for block in post.meta( 'blocks' ) %}
+    {{ include("blocks/#{ block.acf_fc_layout|sanitize ) }.twig", {
+        block: block
+    }, ignore_missing = true) }}
+{% endfor %}
 ```
 
 ## Options Page

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -186,7 +186,7 @@ Assuming block Twig files are inside a `blocks` folder:
 {% endfor %}
 ```
 
-> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
+The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
 
 ```twig
 <p>Photo by: {{ block.credit }}</p>   

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -96,8 +96,6 @@ You can now use all the above functions to transform your custom images in the s
 <img src="{{ post.hero_image.src | resize(500, 300) }}" />
 ```
 
-* * *
-
 ## Gallery Field
 
 ```twig
@@ -105,8 +103,6 @@ You can now use all the above functions to transform your custom images in the s
     <img src="{{ get_image(image) }}" />
 {% endfor %}
 ```
-
-* * *
 
 ## Group Field
 ```twig
@@ -122,8 +118,6 @@ or
 {{ group.second_field }}
 ```
 
-* * *
-
 ## Relationship field
 
 The post data returned from a relationship field will not contain the Timber methods needed for easy handling inside of your Twig file. To get these, you’ll need to convert them into proper `Timber\Post` objects using `get_posts()`:
@@ -134,8 +128,6 @@ The post data returned from a relationship field will not contain the Timber met
    {# Do something with item #}
 {% endfor %}
 ```
-
-* * *
 
 ## Repeater Field
 
@@ -218,8 +210,6 @@ A common problem in working with repeaters is that you should only call the `met
 {% endfor %}
 ```
 
-* * *
-
 ## Flexible Content Field
 
 Similar to repeaters, get the field by the name of the flexible content field:
@@ -253,7 +243,6 @@ Similar to nested repeaters, you should only call the `meta` method once when yo
 {% endfor %}
 ```
 
-* * *
 
 ## Options Page
 
@@ -313,8 +302,6 @@ Now, you can use any of the option fields across the site instead of per templat
 ```twig
 <footer>{{ options.copyright_info }}</footer>
 ```
-
-* * *
 
 ## Getting ACF info
 

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -186,12 +186,10 @@ Assuming block Twig files are inside a `blocks` folder:
 {% endfor %}
 ```
 
-> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name
-
-And for example for a Flexible Content Field named `text` containing a `text` field, inside a `blocks/text.twig` file:
+> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
 
 ```twig
-<p>{{ block.text }}</p>   
+<p>Photo by: {{ block.credit }}</p>   
 ```
 
 ### Troubleshooting Repeaters

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -171,6 +171,29 @@ When you run `meta` on an outer ACF field, everything inside is ready to be trav
 {% endfor %}
 ```
 
+### Split into small chunks flexible content fields
+
+We can break flexible content fields into small blocks thanks to `acf_fc_layout` value. This way we have more flexibility and reusability. It could be a way to build a landing page for instance.
+
+Assuming blocks are inside a `blocks` folder:
+
+```twig
+{% for block in post.meta( 'blocks' ) %}
+    {% 
+        include "blocks/#{ block.acf_fc_layout | sanitize ) }.twig"
+        with { block: block }
+    %}
+{% endfor %}
+```
+
+> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), slugify the block name
+
+And for example for a flexible content named `text` containing a `text` field, inside a `blocks/text.twig` file:
+
+```twig
+<p>{{ block.text }}</p>   
+```
+
 ### Troubleshooting Repeaters
 
 A common problem in working with repeaters is that you should only call the `meta` method **once** on an item. In other words if you have a field inside a field (for example, a relationship inside a repeater or a repeater inside a repeater, **do not** call `meta` on the inner field). More:

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -163,27 +163,6 @@ When you run `meta` on an outer ACF field, everything inside is ready to be trav
 {% endfor %}
 ```
 
-### Split Flexible Content Fields into includes / chunks
-
-We can break Flexible Content Fields into small blocks with include files utilizing the `acf_fc_layout` value. This way you have more flexibility and reusability for included sections. For instance, this is a great way to build a landing pages that re-use the same blocks in different configurations.
-
-Assuming block Twig files are inside a `blocks` folder:
-
-```twig
-{% for block in post.meta( 'blocks' ) %}
-    {% 
-        include "blocks/#{ block.acf_fc_layout | sanitize ) }.twig"
-        with { block: block }
-    %}
-{% endfor %}
-```
-
-The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the `blocks/photo.twig` file:
-
-```twig
-<p>Photo by: {{ block.credit }}</p>   
-```
-
 ### Troubleshooting Repeaters
 
 A common problem in working with repeaters is that you should only call the `meta` method **once** on an item. In other words if you have a field inside a field (for example, a relationship inside a repeater or a repeater inside a repeater, **do not** call `meta` on the inner field). More:
@@ -243,6 +222,25 @@ Similar to nested repeaters, you should only call the `meta` method once when yo
 {% endfor %}
 ```
 
+### Split Flexible Content Fields into includes / chunks
+
+We can break Flexible Content Fields into small blocks with include files utilizing the `acf_fc_layout` value. This way you have more flexibility and reusability for included sections. For instance, this is a great way to build landing pages that re-use the same blocks in different configurations.
+
+Assuming your block Twig files are inside a **blocks** folder:
+
+```twig
+{% for block in post.meta( 'blocks' ) %}
+    {{ include("blocks/#{ block.acf_fc_layout|sanitize ) }.twig", {
+        block: block
+    }) }}
+{% endfor %}
+```
+
+The [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize) filter will slugify the block name. Consider this example for a Flexible Content Field named `credit` containing a `text` field, inside the **blocks/photo.twig** file:
+
+```twig
+<p>Photo by: {{ block.credit }}</p>
+```
 
 ## Options Page
 

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -171,11 +171,11 @@ When you run `meta` on an outer ACF field, everything inside is ready to be trav
 {% endfor %}
 ```
 
-### Split into small chunks flexible content fields
+### Split Flexible Content Fields into includes / chunks
 
-We can break flexible content fields into small blocks thanks to `acf_fc_layout` value. This way we have more flexibility and reusability. It could be a way to build a landing page for instance.
+We can break Flexible Content Fields into small blocks with include files utilizing the `acf_fc_layout` value. This way you have more flexibility and reusability for included sections. For instance, this is a great way to build a landing pages that re-use the same blocks in different configurations.
 
-Assuming blocks are inside a `blocks` folder:
+Assuming block Twig files are inside a `blocks` folder:
 
 ```twig
 {% for block in post.meta( 'blocks' ) %}
@@ -186,9 +186,9 @@ Assuming blocks are inside a `blocks` folder:
 {% endfor %}
 ```
 
-> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), slugify the block name
+> The filter [sanitize](https://timber.github.io/docs/v2/guides/filters/#sanitize), will slugify the block name
 
-And for example for a flexible content named `text` containing a `text` field, inside a `blocks/text.twig` file:
+And for example for a Flexible Content Field named `text` containing a `text` field, inside a `blocks/text.twig` file:
 
 ```twig
 <p>{{ block.text }}</p>   


### PR DESCRIPTION
**Ticket**: #2382

I added some optimizations for #2368 

- Moved new content from section about Reapeater Fields to Flexible Content Field section.
- Used `include()` function instead of `include` statement, as this is recommended by Twig, see https://twig.symfony.com/doc/3.x/tags/include.html.
- Added some syntax optimizations.