### PR TITLE
2.x Documentation fixes

### DIFF
--- a/docs/v1/guides/acf-cookbook.md
+++ b/docs/v1/guides/acf-cookbook.md
@@ -24,7 +24,7 @@ You can retrieve an image from a custom field, then use it in a Twig template. T
 ### The quick way (for most situations)
 
 ```twig
-<img src="{{ get_image(post.meta('hero_image')).src }}" />
+<img src="{{ Image(post.meta('hero_image')).src }}" />
 ```
 
 ### The long way (for some special situations)
@@ -57,7 +57,7 @@ You can now use all the above functions to transform your custom images in the s
 
 ```twig
 {% for image in post.meta('gallery') %}
-    <img src="{{ get_image(image) }}" />
+    <img src="{{ Image(image) }}" />
 {% endfor %}
 ```
 
@@ -81,7 +81,7 @@ or
 The post data returned from a relationship field will not contain the Timber methods needed for easy handling inside of your Twig file. To get these, you'll need to convert them into a proper Timber `Post` object like so:
 
 ```twig
-{% for item in Post(post.relationship_field) %} 
+{% for item in Post(post.relationship_field) %}
    {{ item.title }}
    {# Do something with item #}
 {% endfor %}
@@ -101,7 +101,7 @@ You can access repeater fields within twig files:
 		<div class="item">
 			<h4>{{ item.name }}</h4>
 			<h6>{{ item.info }}</h6>
-			<img src="{{ get_image(item.picture).src }}" />
+			<img src="{{ Image(item.picture).src }}" />
 		</div>
 	{% endfor %}
 </div>
@@ -157,8 +157,8 @@ Similar to repeaters, get the field by the name of the flexible content field:
 ```twig
 {% for media_item in post.meta('media_set') %}
 	{% if media_item.acf_fc_layout == 'image_set' %}
-		<img src="{{ get_image(media_item.image).src }}" />
-		<p class="caption">{{ get_image(media_item.image).caption }}</p>
+		<img src="{{ Image(media_item.image).src }}" />
+		<p class="caption">{{ Image(media_item.image).caption }}</p>
 		<aside class="notes">{{ media_item.notes }}</aside>
 	{% elseif media_item.acf_fc_layout == 'video_set' %}
 		<iframe width="560" height="315" src="http://www.youtube.com/embed/{{ media_item.youtube_id }}" frameborder="0" allowfullscreen></iframe>

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -384,7 +384,7 @@ Version 2.0 introduces the concept of template contexts for Timber. This means t
 In short:
 
 - If you use `$context['post'] = Timber::get_post()` or `$context['posts'] = Timber::get_posts()` in your template files, you can probably omit these, because the context will do this for you. You might also benefit from better compatibility with third party plugins, because for singular templates, Timber will handle certain globals and hooks when setting up `post`.
-- If you decide to still use `$context['post'] = …` in your template file, then you should to set up your post through `$context['post']->setup()`. The `setup()` function improves compatibility with third-party plugins..
+- If you decide to still use `$context['post'] = …` in your template file, then you should to set up your post through `$context['post']->setup()`. The `setup()` function improves compatibility with third-party plugins.
 - It’s now possible to [overwrite the default arguments](https://timber.github.io/docs/v2/guides/context/#change-arguments-for-default-query) that are passed to the default query for `posts`.
 - When you need the global context in partials, then use `Timber::context_global()` to only load the global context.
 
@@ -910,7 +910,7 @@ $genre->posts( [
 
 ## Post Excerpts
 
-### "Excerpt" instead of "Preview"
+### Excerpt instead of Preview
 
 We renamed the `Timber\PostPreview` class to `Timber\PostExcerpt` and also changed all instances of the term "preview" to "excerpt". The reason for this change is that the term "preview" in WordPress is mainly used for previewing a post before you save changes in the admin. For the short texts that are used in post teasers, the term "excerpt" is used. We wanted to follow the WordPress terminology here.
 


### PR DESCRIPTION
## Issue

Some documentation issues.

## Solution

- Fix an issue with anchor links while building the docs when a Markdown heading contains "".
- Fix instances of where I used the new `get_image()` function in documentation for Timber v1, where it should still be `Image()`.

## Usage Changes

None.

## Considerations

Current documentation at https://timber.github.io/docs/ is already built from this branch.

## Testing

None.