### PR TITLE
Handle for duplicate term names in difft taxes

### DIFF
--- a/lib/Term.php
+++ b/lib/Term.php
@@ -164,6 +164,19 @@ class Term extends Core implements CoreInterface {
 		}
 		$tid = self::get_tid($tid);
 
+		if ( is_array($tid) ) {
+			//there's more than one matching $term_id, let's figure out which is correct
+			if ( isset($this->taxonomy) && strlen($this->taxonomy) ) {
+				foreach( $tid as $term_id ) {
+					$maybe_term = get_term($term_id, $this->taxonomy);
+					if ( $maybe_term ) {
+						return $maybe_term;
+					}
+				}
+			}
+			$tid = $tid[0];
+		}
+
 		if ( isset($this->taxonomy) && strlen($this->taxonomy) ) {
 			return get_term($tid, $this->taxonomy);
 		} else {
@@ -181,7 +194,7 @@ class Term extends Core implements CoreInterface {
 	/**
 	 * @internal
 	 * @param int $tid
-	 * @return int
+	 * @return int|array
 	 */
 	protected function get_tid( $tid ) {
 		global $wpdb;
@@ -192,15 +205,16 @@ class Term extends Core implements CoreInterface {
 			$tid = $tid->term_id;
 		}
 		if ( is_numeric($tid) ) {
-			$query = $wpdb->prepare("SELECT * FROM $wpdb->terms WHERE term_id = %d", $tid);
+			$query = $wpdb->prepare("SELECT term_id FROM $wpdb->terms WHERE term_id = %d", $tid);
 		} else {
-			$query = $wpdb->prepare("SELECT * FROM $wpdb->terms WHERE slug = %s", $tid);
+			$query = $wpdb->prepare("SELECT term_id FROM $wpdb->terms WHERE slug = %s", $tid);
 		}
-		$result = $wpdb->get_row($query);
-		if ( isset($result->term_id) ) {
-			$result->ID = $result->term_id;
-			$result->id = $result->term_id;
-			return $result->ID;
+		$result = $wpdb->get_col($query);
+		if ( $result ) {
+			if ( count($result) == 1) {
+				return $result[0];
+			}
+			return $result;
 		}
 		return 0;
 	}

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -13,6 +13,25 @@
 			$this->assertEquals('Cardinals', $baseball_teams[0]->name());
 		}
 
+		/**
+		 * @ticket #2362
+		 */
+		function testMultiTermsWithSameSlug() {
+			$post_tag_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'post_tag'));
+			$category_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'category'));
+			$post_id     = $this->factory->post->create();
+			wp_set_object_terms($post_id, $post_tag_id, 'post_tag', true);
+			wp_set_object_terms($post_id, $category_id, 'category', true);
+
+			$term_default  = new Timber\Term('security');
+			$this->assertEquals('post_tag', $term_default->taxonomy);
+			$this->assertEquals('Security', $term_default->title());
+
+			$term_category = new Timber\Term('security', 'category');
+			$this->assertEquals('category', $term_category->taxonomy);
+			$this->assertEquals('Security', $term_category->title());
+		}
+
 		function testConstructorWithClass() {
 			register_taxonomy('arts', array('post'));
 


### PR DESCRIPTION
**Ticket**: #2362 

## Issue
When there are two identically named terms in two different taxonomies (which WordPress allows), attempting to fetch the newest one from a specific taxonomy will return false.

## Solution
Modify the `Term::get_tid` method. When >1 term_id is discovered, test it against possible taxonomies in `Term::get_term`.

## Impact
This will apply only to 1.x as 2.x handles this situation much more gracefully via Factories. The `Term::get_tid` method is protected, so modifying its return type is unlikely to cause issues. Theoretically, there could be an issue only if a user has extended the `Term` class specifically and is directly interacting with the method.

## Usage Changes
None. Should now work as anticipated.

## Considerations
This is a patch. The true "fix" is how 2.x handles this. I'd spend more time optimizing if this were going to be an enduring part of the code base. This definitely qualifies as a "bug" which is why I wanted to resolve for 1.x

## Testing
New test written to uncover and solve the issue described in #2362 