### PR TITLE
Introduce Timber::get_term_by() method

### DIFF
--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -21,18 +21,30 @@ $term = Timber::get_term( get_queried_object_id() );
 
 What you get in return is a [`Timber\Term`](https://timber.github.io/docs/v2/reference/timber-term/) object, which is similar to `WP_Term`.
 
+## Get term by field
+
+If you don’t have a term ID, you can also get a term by other fields, like `slug` or `name` through `Timber::get_term_by()`.
+
+```php
+// Get a term by slug.
+$term = Timber::get_term_by( 'slug', 'news', 'category' );
+
+// Get a term by name.
+$term = Timber::get_term_by( 'name', 'News', 'category' );
+```
+
 ## Twig
 
 You can convert terms IDs to term objects in Twig using the `Term()` function.
 
 ```twig
-{% set term = Term(term_id) %}
+{% set term = get_term(term_id) %}
 ```
 
 It also works if you have an array of terms IDs that you want to convert to `Timber\Term` objects.
 
 ```twig
-{% for term in Term(term_ids) %}
+{% for term in get_term(term_ids) %}
 
 {% endfor %}
 ```

--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -154,7 +154,7 @@ And now, you probably also want to link these terms as well. You can make use of
 )|join(', ', ' and ') }}
 ```
 
-Or you can use a for-loop:
+Or you can use a for loop:
 
 ```twig
 {% for term in terms -%}

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -714,6 +714,7 @@ The following functions were **removed from the codebase**, either because they 
 - `get_menu()` – Gets a menu object for a specific menu.
 - `get_pages_menu()` – Gets a menu object built from your existing pages.
 - `get_post_by()` – Gets a post by title or slug.
+- `get_term_by()` – Gets a post by title or slug.
 - `get_user()` – Gets a single user.
 - `get_users()` – Gets one or more users as an array.
 - `get_user_by()` – Gets a user by field.

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -648,16 +648,17 @@ class Timber {
 	 * $term = Timber::get_term_by( 'slug', 'security' );
 	 *
 	 * // Get a term by name.
-	 * $user = Timber::get_term_by( 'name', 'Security' );
+	 * $term = Timber::get_term_by( 'name', 'Security' );
 	 *
 	 * // Get a term by slug from a specific taxonomy.
-	 * $user = Timber::get_term_by( 'slug', 'security', 'category' );
+	 * $term = Timber::get_term_by( 'slug', 'security', 'category' );
 	 * ```
 	 *
-	 * @param string     $field The name of the field to retrieve the user with. One of: `id`,
-	 *                          `ID`, `slug`, `name` or `term_taxonomy_id`.
-	 * @param int|string $value The value to search for by `$field`.
-	 * @param string     $taxonomy The taxonomy you want to retrieve from. Empty string will search from all.
+	 * @param string     $field    The name of the field to retrieve the term with. One of: `id`,
+	 *                             `ID`, `slug`, `name` or `term_taxonomy_id`.
+	 * @param int|string $value    The value to search for by `$field`.
+	 * @param string     $taxonomy The taxonomy you want to retrieve from. Empty string will search 
+	 *                             from all.
 	 *
 	 * @return \Timber\Term|null
 	 */

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -633,6 +633,44 @@ class Timber {
 		return $factory->from($term);
 	}
 
+	/**
+	 * Gets a term by field.
+	 *
+	 * This function works like
+	 * [`get_term_by()`](https://developer.wordpress.org/reference/functions/get_term_by/), but
+	 * returns a `Timber\Term` object.
+	 *
+	 * @api
+	 * @since 2.0.0
+	 * @example
+	 * ```php
+	 * // Get a term by slug.
+	 * $term = Timber::get_term_by( 'slug', 'security' );
+	 *
+	 * // Get a term by name.
+	 * $user = Timber::get_term_by( 'name', 'Security' );
+	 *
+	 * // Get a term by slug from a specific taxonomy.
+	 * $user = Timber::get_term_by( 'slug', 'security', 'category' );
+	 * ```
+	 *
+	 * @param string     $field The name of the field to retrieve the user with. One of: `id`,
+	 *                          `ID`, `slug`, `name` or `term_taxonomy_id`.
+	 * @param int|string $value The value to search for by `$field`.
+	 * @param string     $taxonomy The taxonomy you want to retrieve from. Empty string will search from all.
+	 *
+	 * @return \Timber\Term|null
+	 */
+	public static function get_term_by( string $field, $value, string $taxonomy = '' ) {
+		$wp_term = get_term_by($field, $value, $taxonomy);
+
+		if ($wp_term === false) {
+			return false;
+		}
+
+		return static::get_term($wp_term);
+	}
+
 	/* User Retrieval
 	================================ */
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -618,6 +618,7 @@ class Timber {
 	 * ```
 	 */
 	public static function get_term( $term = null ) {
+		
 		if (null === $term) {
 			// get the fallback term_id from the current query
 			global $wp_query;
@@ -630,7 +631,11 @@ class Timber {
 
 		$factory = new TermFactory();
 
-		return $factory->from($term);
+		$terms = $factory->from($term);
+		if ( is_array($terms) ) {
+			$terms = $terms[0];
+		}
+		return $terms;
 	}
 
 	/**
@@ -663,9 +668,14 @@ class Timber {
 	 * @return \Timber\Term|null
 	 */
 	public static function get_term_by( string $field, $value, string $taxonomy = '' ) {
+
 		$wp_term = get_term_by($field, $value, $taxonomy);
 
-		if ($wp_term === false) {
+		if ( $wp_term === false ) {
+			if ( empty($taxonomy) && $field != 'term_taxonomy_id' ) {
+				$search = [$field => $value, $taxonomy => 'any', 'hide_empty' => false];
+				return static::get_term($search);
+			}
 			return false;
 		}
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -99,18 +99,20 @@ class Twig {
 			}
 		) );
 
+		$termFactory = new TermFactory();
+
 		$twig->addFunction( new TwigFunction(
 			'Term',
-			function( $term_id ) {
+			function( $term_id ) use ( $termFactory ) {
 				Helper::deprecated( '{{ Term() }}', '{{ get_term() }} or {{ get_terms() }}', '2.0.0' );
-				return Timber::get_term( $term_id );
+				return $termFactory->from( $term_id );
 			}
 		) );
 		$twig->addFunction( new TwigFunction(
 			'TimberTerm',
-			function( $term_id ) {
+			function( $term_id ) use ( $termFactory ) {
 				Helper::deprecated( '{{ TimberTerm() }}', '{{ get_term() }} or {{ get_terms() }}', '2.0.0' );
-				return Timber::get_term( $term_id );
+				return $termFactory->from( $term_id );
 			}
 		) );
 

--- a/tests/test-term-factory.php
+++ b/tests/test-term-factory.php
@@ -272,4 +272,21 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(MyTerm::class, $res[0]);
 		$this->assertInstanceOf(MyTerm::class, $res[1]);
 	}
+
+	public function testTermBy() {
+		$post_tag_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'post_tag'));
+		$category_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'category'));
+
+		$post_id     = $this->factory->post->create();
+		wp_set_object_terms($post_id, $post_tag_id, 'post_tag', true);
+		wp_set_object_terms($post_id, $category_id, 'category', true);
+
+		$term_post_tag  = Timber::get_term_by('slug', 'security', 'post_tag');
+		$this->assertEquals('post_tag', $term_post_tag->taxonomy);
+		$this->assertEquals('Security', $term_post_tag->title());
+
+		$term_category = Timber::get_term_by('name', 'Security', 'category');
+		$this->assertEquals('category', $term_category->taxonomy);
+		$this->assertEquals('Security', $term_category->title());
+	}
 }

--- a/tests/test-term-factory.php
+++ b/tests/test-term-factory.php
@@ -278,8 +278,6 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$category_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'category'));
 
 		$post_id     = $this->factory->post->create();
-		wp_set_object_terms($post_id, $post_tag_id, 'post_tag', true);
-		wp_set_object_terms($post_id, $category_id, 'category', true);
 
 		$term_post_tag  = Timber::get_term_by('slug', 'security', 'post_tag');
 		$this->assertEquals('post_tag', $term_post_tag->taxonomy);

--- a/tests/test-term-factory.php
+++ b/tests/test-term-factory.php
@@ -277,8 +277,6 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$post_tag_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'post_tag'));
 		$category_id = $this->factory->term->create(array('name' => 'Security', 'taxonomy' => 'category'));
 
-		$post_id     = $this->factory->post->create();
-
 		$term_post_tag  = Timber::get_term_by('slug', 'security', 'post_tag');
 		$this->assertEquals('post_tag', $term_post_tag->taxonomy);
 		$this->assertEquals('Security', $term_post_tag->title());
@@ -286,5 +284,14 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$term_category = Timber::get_term_by('name', 'Security', 'category');
 		$this->assertEquals('category', $term_category->taxonomy);
 		$this->assertEquals('Security', $term_category->title());
+	}
+
+	public function testTermByNoTaxonomy() {
+		$category_id = $this->factory->term->create(array('name' => 'Breaking News', 'taxonomy' => 'category'));
+		$terms = Timber::get_terms(['name' => 'Breaking News', 'hide_empty' => false]);
+		
+		$term_category = Timber::get_term_by('name', 'Breaking News');
+		$this->assertEquals('category', $term_category->taxonomy);
+		$this->assertEquals('Breaking News', $term_category->title());
 	}
 }

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -64,6 +64,6 @@ class TestTimberTermFactories extends Timber_UnitTestCase {
 		$this->assertEquals($term_id, $term_from[0]->ID);
 
 		$term_get = Timber::get_term(['taxonomy' => 'cars']);
-		$this->assertEquals($term_id, $term_get[0]->ID);
+		$this->assertEquals($term_id, $term_get->ID);
 	}
 }

--- a/tests/test-timber-theme.php
+++ b/tests/test-timber-theme.php
@@ -5,18 +5,18 @@
 		protected $backup_wp_theme_directories;
 
 		function testThemeVersion() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$theme = new Timber\Theme();
 			$this->assertGreaterThan(1.2, $theme->version);
 			switch_theme('default');
 		}
 
 		function testThemeParentWithNoParent() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$context = Timber::context();
 			$theme = $context['site']->theme;
 			$output = Timber::compile_string('{{ site.theme.parent.slug }}', $context);
-			$this->assertEquals('twentyseventeen', $output );
+			$this->assertEquals('twentynineteen', $output );
 		}
 
 		function testThemeMods(){
@@ -80,18 +80,18 @@
 		}
 
 		function testThemeGet() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$context = Timber::context();
 			$output = Timber::compile_string('{{site.theme.get("Name")}}', $context);
-			$this->assertEquals('Twenty Seventeen', $output);
+			$this->assertEquals('Twenty Nineteen', $output);
 			switch_theme('default');
 		}
 
 		function testThemeDisplay() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$context = Timber::context();
 			$output = Timber::compile_string('{{site.theme.display("Description")}}', $context);
-			$this->assertEquals("Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.", $output);
+			$this->assertEquals("Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you&#8217;ll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it&#8217;s built to be beautiful on all screen sizes.", $output);
 			switch_theme('default');
 		}
 


### PR DESCRIPTION
**Ticket**: #2359 

## Issue
There's `Timber::get_post_by`, `Timber::get_user_by` ... — let's wrap it up with `get_term_by`


## Solution
Copy the pattern from other get_x_by and apply it!

## Impact
More poly-morphizing

## Usage Changes
- [x] Need to add docs example


## Considerations
@acobster suggested in the write-up that we can improve upon WP functionality by better processing the `taxonomy` value. I agree. Even when writing the tests I was thrown off by its requirement even when there's only one term with a certain name.
- [x] Handle for what happens when a taxonomy isn't supplied

## Testing
Wrote a new test `testTermBy`
