### PR TITLE
#2368 – Update context format in documentation

### DIFF
--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -27,7 +27,9 @@ Timber::render( 'single.twig', $data );
 <p>{{ message }}</p>
 ```
 
-Of course, you don’t have to figure out all the variables you need for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`.
+## The `Timber::context()` function
+
+You don’t have to figure out all the variables you need in a template for yourself. Timber will provide you with a set of useful variables when you call `Timber::context()`.
 
 **single.php**
 
@@ -38,6 +40,28 @@ Timber::render( 'single.twig', $context );
 ```
 
 Follow this guide to get an overview of what’s in the context, or use `var_dump( $context );` in PHP or `{{ dump() }}` in Twig to display the contents of the context in your browser.
+
+### Setting variables in the context
+
+After you’ve called `Timber::context()`, you can add additional variables or overwrite existing variables in your context.
+
+```php
+$context = Timber::get_context();
+
+$context['today'] = wp_date( 'Ymd' );
+
+Timber::render( 'single.twig', $context );
+```
+
+Another way to do this is to pass your custom data to the `Timber::context()` function itself:
+
+```php
+$context = Timber::get_context(
+    'today' => wp_date( 'Ymd' ),
+);
+
+Timber::render( 'single.twig', $context );
+```
 
 ## Global context
 
@@ -81,7 +105,7 @@ Having a cached global context can be useful if you need the context in other pl
 
 ```php
 /**
- * Shortcode for address inside a WYSIWG field
+ * Shortcode for address inside a WYSIWG field.
  */
 add_shortcode( 'company_address', function() {
     return Timber::compile(
@@ -134,16 +158,25 @@ If you want to use [your own post class](https://timber.github.io/docs/v2/guides
 If you want to overwrite the existing `post` variable in the context, you can do that.
 
 ```php
-$context = Timber::context();
-
 // Getting another post.
 $post = Timber::get_post( 12 );
 $post->setup();
 
-$context['post'] = $post;
+// Get context with your post.
+$context = Timber::context( [
+    'post' => $post,
+] );
+```
 
-// Or very short
-$context['post'] = Timber::get_post()->setup();
+Or even shorter:
+
+```php
+// Getting another post.
+$post = Timber::get_post( 12 );
+
+$context = Timber::context( [
+    'post' => $post->setup(),
+] )
 ```
 
 **Be aware!** Whenever you set up **a post in a singular template** (instead of relying on `Timber::context()` to do it for you), **you need to set up your post through `$post->setup()`**. The `setup()` function improves compatibility with third-party plugins.
@@ -165,12 +198,13 @@ Timber::render( 'archive.twig', $context );
 When you don’t need the default query, you can pass in your own arguments to `Timber::get_posts()`.
 
 ```php
-$context          = Timber::context();
-$context['posts'] = Timber::get_posts( [
-    'post_type'      => 'book',
-    'posts_per_page' => -1,
-    'post_status'    => 'publish',
-] );
+$context = Timber::context(
+    'posts' => Timber::get_posts( [
+        'post_type'      => 'book',
+        'posts_per_page' => -1,
+        'post_status'    => 'publish',
+    ] ),
+);
 ```
 
 #### Change arguments for default query
@@ -180,12 +214,16 @@ Sometimes you don’t want to use the default query, but build on the default qu
 **archive.php**
 
 ```php
-$context          = Timber::context();
-$context['posts'] = Timber::get_posts( [
-    'author__in' => [ 1, 6, 14 ],
-], [
-    'merge_default' => true,
-] );
+$context = Timber::context(
+    'posts' => Timber::get_posts(
+        [
+            'author__in' => [ 1, 6, 14 ],
+        ],
+        [
+            'merge_default' => true,
+        ]
+    ),
+);
 
 Timber::render( 'archive.twig', $context );
 ```

--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -56,9 +56,9 @@ Timber::render( 'single.twig', $context );
 Another way to do this is to pass your custom data to the `Timber::context()` function itself:
 
 ```php
-$context = Timber::get_context(
-    'today' => wp_date( 'Ymd' ),
-);
+$context = Timber::get_context( [
+    'today' => wp_date( 'Ymd' )
+] );
 
 Timber::render( 'single.twig', $context );
 ```

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -121,8 +121,10 @@ if ( isset( $post->hero_image ) && strlen( $post->hero_image ) ) {
     $post->hero_image = new Timber\Image( $post->hero_image );
 }
 
-$data = Timber::context();
-$data['post'] = $post;
+$data = Timber::context( [
+    'post' => $post
+] );
+
 Timber::render( 'single.twig', $data );
 ```
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -52,16 +52,14 @@ Next, you you have to create your `render_callback()` function:
  * @param   bool   $is_preview True during AJAX preview.
  */
 function my_acf_block_render_callback( $block, $content = '', $is_preview = false ) {
-    $context = Timber::context();
-
-    // Store block values.
-    $context['block'] = $block;
-
-    // Store field values.
-    $context['fields'] = get_fields();
-
-    // Store $is_preview value.
-    $context['is_preview'] = $is_preview;
+    $context = Timber::context( [
+        // Store block values.
+        'block'      => $block,
+        // Store field values.
+        'fields'     => get_fields(),
+        // Store $is_preview value.
+        'is_preview' => $is_preview,
+    ] );
 
     // Render the block.
     Timber::render( 'block/example-block.twig', $context );

--- a/docs/v2/guides/pagination.md
+++ b/docs/v2/guides/pagination.md
@@ -82,12 +82,12 @@ if ( ! isset( $paged ) || ! $paged ) {
     $paged = 1;
 }
 
-$context = Timber::context();
-
-$context['posts'] = Timber::get_posts( [
-    'post_type'      => 'event',
-    'posts_per_page' => 5,
-    'paged'          => $paged
+$context = Timber::context( [
+    'posts' => Timber::get_posts( [
+        'post_type'      => 'event',
+        'posts_per_page' => 5,
+        'paged'          => $paged
+    ] ),
 ] );
 
 Timber::render( 'archive-event.twig', $context );

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -187,8 +187,9 @@ Timber provides some quick shortcuts to measure page timing. Here’s an example
 // This generates a starting time
 $start = Timber\Helper::start_timer();
 
-$context = Timber::context();
-$context['whatever'] = get_my_foo();
+$context = Timber::context( [
+    'whatever' => get_my_foo(),
+] );
 
 Timber::render( 'single.twig', $context, 600 );
 

--- a/docs/v2/guides/sidebars.md
+++ b/docs/v2/guides/sidebars.md
@@ -24,9 +24,11 @@ Timber::render('sidebar.twig', $context);
 ```php
 <?php
 /* single.php */
-$context = Timber::context();
-$context['sidebar'] = Timber::get_sidebar('sidebar.php');
-Timber::render('single.twig', $context);
+$context = Timber::context( [
+    'sidebar' => Timber::get_sidebar( 'sidebar.php' ),
+] );
+
+Timber::render( 'single.twig', $context );
 ```
 
 * In the final twig file make sure you reserve a spot for your sidebar:
@@ -69,14 +71,13 @@ $sidebar_context = array(
 	'related' => new Timber\PostQuery( 'cat=' . $post_cat ),
 );
 
-$context = Timber::context( array(
-	'post' => $post,
-) );
-
-$context['sidebar'] = Timber::get_sidebar(
-	'sidebar-related.twig',
-	$sidebar_context
-);
+$context = Timber::context( [
+    'post'    => $post,
+    'sidebar' => Timber::get_sidebar(
+        'sidebar-related.twig',
+        $sidebar_context
+    ),
+] );
 
 Timber::render( 'single.twig', $context );
 ```
@@ -97,13 +98,16 @@ This is using WordPress's built-in dynamic_sidebar tools (which, confusingly, ar
 
 ```php
 <?php
-$context = array();
-$context['dynamic_sidebar'] = Timber::get_widgets('dynamic_sidebar');
+
+$context = [
+    'dynamic_sidebar' => Timber::get_widgets( 'dynamic_sidebar' ),
+];
+
 Timber::render('sidebar.twig', $context);
 ```
 
 ```twig
 <aside class="my-sidebar">
-{{dynamic_sidebar}}
+    {{dynamic_sidebar}}
 </aside>
 ```

--- a/docs/v2/guides/sidebars.md
+++ b/docs/v2/guides/sidebars.md
@@ -41,7 +41,7 @@ In the final twig file make sure you reserve a spot for your sidebar:
 
 ```twig
 <aside class="sidebar">
-	{{sidebar}}
+	{{ sidebar }}
 </aside>
 ```
 
@@ -57,7 +57,7 @@ Make a Twig file for what your sidebar should be:
 <h3>Related Stories</h3>
 
 {% for post in related %}
-	<h4><a href="{{post.get_path}}">{{post.post_title}}</a></h4>
+	<h4><a href="{{ post.get_path }}">{{ post.post_title }}</a></h4>
 {% endfor %}
 ```
 
@@ -94,7 +94,7 @@ In the final twig file, make sure you have spot for your sidebar:
 
 ```twig
 <aside class="sidebar">
-	{{sidebar}}
+	{{ sidebar }}
 </aside>
 ```
 
@@ -113,6 +113,6 @@ Timber::render('sidebar.twig', $context);
 
 ```twig
 <aside class="my-sidebar">
-    {{dynamic_sidebar}}
+    {{ dynamic_sidebar }}
 </aside>
 ```

--- a/docs/v2/guides/wp-integration.md
+++ b/docs/v2/guides/wp-integration.md
@@ -257,11 +257,7 @@ It’s recommended to use the [`post_password_required()`](https://developer.wor
 ```php
 <?php
 
-$post = Timber::get_post();
-
-$context = Timber::context( [
-    'post' => $post,
-] );
+$context = Timber::context();
 
 if ( post_password_required( $post->ID ) ) {
     Timber::render( 'single-password.twig', $context );

--- a/docs/v2/guides/wp-integration.md
+++ b/docs/v2/guides/wp-integration.md
@@ -255,9 +255,12 @@ It’s recommended to use the [`post_password_required()`](https://developer.wor
 **single.php**
 
 ```php
-$context = Timber::context();
 $post = Timber::query_post();
-$context['post'] = $post;
+
+$context = Timber::context( [
+    'post' => $post,
+] );
+
 if ( post_password_required( $post->ID ) ) {
     Timber::render( 'single-password.twig', $context );
 } else {
@@ -309,9 +312,10 @@ With this filter, you can use a **password-protected.php** template file with th
 ```php
 <?php
 
-$context                  = Timber::context();
-$context['post']          = new Timber\Post();
-$context['password_form'] = get_the_password_form();
+$context = Timber::context( [
+    'post'          => new Timber\Post(),
+    'password_form' => get_the_password_form(),
+] );
 
 Timber::render( 'password-protected.twig', $context );
 ```

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -82,8 +82,9 @@ if (isset($post->hero_image) && strlen($post->hero_image)){
     $post->hero_image = new Timber\Image($post->hero_image);
 }
 
-$context = Timber::context();
-$context['post'] = $post;
+$context = Timber::context( [
+    'post' => $post,
+] );
 
 Timber::render('single.twig', $context);
 ```

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -388,6 +388,42 @@ In short:
 - It’s now possible to [overwrite the default arguments](https://timber.github.io/docs/v2/guides/context/#change-arguments-for-default-query) that are passed to the default query for `posts`.
 - When you need the global context in partials, then use `Timber::context_global()` to only load the global context.
 
+### Passing variables directly to context
+
+It’s now possible to pass data directly to `Timber::context()`.
+
+Here’s an example: Instead of setting a `posts` variable in `$context` after you’ve called `Timber::context()`, you can pass an associative array with a `posts` key and the same value to the `Timber::context()` function:
+
+**Still correct**
+
+```php
+$context = Timber::context();
+
+$context['posts'] = new Timber::get_posts( [
+    'query' => [
+        'post_type'      => 'book',
+        'posts_per_page' => -1,
+        'post_status'    => 'publish',
+    ],
+] );
+
+Timber::render( 'archive.twig', $context );
+```
+
+**Another way to do it**
+
+```php
+$context = Timber::context( [
+	'posts' => new Timber::get_posts( [
+        'post_type'      => 'book',
+        'posts_per_page' => -1,
+        'post_status'    => 'publish',
+	],
+] );
+
+Timber::render( 'archive.twig', $context );
+```
+
 ## Twig
 
 ### Updated function names

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -17,11 +17,13 @@ class Helper {
 	 * @api
 	 * @example
 	 * ```php
-	 * $context = Timber::context();
-	 * $context['favorites'] = Timber\Helper::transient('user-' .$uid. '-favorites', function() use ($uid) {
-	 *  	//some expensive query here that's doing something you want to store to a transient
-	 *  	return $favorites;
-	 * }, 600);
+	 * $context = Timber::context( [
+	 *     'favorites' => Timber\Helper::transient( 'user-' . $uid . '-favorites' , function() use ( $uid ) {
+	 *  	    // Some expensive query here that’s doing something you want to store to a transient.
+	 *  	    return $favorites;
+	 *     }, 600 ),
+	 * ] );
+	 *
 	 * Timber::render('single.twig', $context);
 	 * ```
 	 *
@@ -30,6 +32,7 @@ class Helper {
 	 * @param integer  	$transient_time (optional) Expiration of transients in seconds
 	 * @param integer 	$lock_timeout   (optional) How long (in seconds) to lock the transient to prevent race conditions
 	 * @param boolean 	$force          (optional) Force callback to be executed when transient is locked
+	 *
 	 * @return mixed
 	 */
 	public static function transient( $slug, $callback, $transient_time = 0, $lock_timeout = 5, $force = false ) {
@@ -212,8 +215,10 @@ class Helper {
 	 *     echo '<form action="form.php"><input type="text" /><input type="submit /></form>';
 	 * }
 	 *
-	 * $context = Timber::context();
-	 * $context['my_form'] = Timber\Helper::ob_function('the_form');
+	 * $context = Timber::context( [
+	 *     'form' => Timber\Helper::ob_function( 'the_form' ),
+	 * ] );
+	 *
 	 * Timber::render('single-form.twig', $context);
 	 * ```
 	 * ```twig

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -10,12 +10,14 @@ namespace Timber;
  * @api
  * @example
  * ```php
- * $context         = Timber::context();
+ * $context = Timber::context();
  *
  * // Lets say you have an alternate large 'cover image' for your post
  * // stored in a custom field which returns an image ID.
  * $cover_image_id = $context['post']->cover_image;
+ *
  * $context['cover_image'] = Timber::get_post($cover_image_id);
+ *
  * Timber::render('single.twig', $context);
  * ```
  *

--- a/lib/Site.php
+++ b/lib/Site.php
@@ -11,9 +11,12 @@ namespace Timber;
  * @api
  * @example
  * ```php
- * $context = Timber::context();
  * $other_site_id = 2;
- * $context['other_site'] = new Timber\Site($other_site_id);
+ *
+ * $context = Timber::context( [
+ *     'other_site' => new Timber\Site( $other_site_id ),
+ * ] );
+ *
  * Timber::render('index.twig', $context);
  * ```
  * ```twig

--- a/lib/Theme.php
+++ b/lib/Theme.php
@@ -14,6 +14,7 @@ namespace Timber;
  * ```php
  * <?php
  * $context = Timber::context();
+ *
  * Timber::render('index.twig', $context);
  * ?>
  * ```
@@ -165,8 +166,8 @@ class Theme extends Core {
 
 	/**
 	 * Gets a raw, unformatted theme header.
-	 * 
-	 * @api 
+	 *
+	 * @api
 	 * @see \WP_Theme::get()
 	 * @example
 	 * ```twig

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -31,8 +31,9 @@ use Timber\URLHelper;
  *     'category_name' => 'sports',
  * ] );
  *
- * $context = Timber::context();
- * $context['posts'] = $posts;
+ * $context = Timber::context( [
+ *     'posts' => $posts,
+ * ] );
  *
  * Timber::render( 'index.twig', $context );
  * ```


### PR DESCRIPTION
**Ticket**: #2368

## Issue

Now that we can pass an array directly to `Timber::context()`, it’s probably worth updating the documentation to the new format in a couple of cases.

## Solution

Update documentation.

## Impact

I think it’s actually more readable in a couple of places.

## Usage Changes

None.

## Considerations

I doesn’t make sense to change the format everywhere, especially if there is advanced logic involved.

## Testing

None.

## Todo

- [x] Update Context Guide.
- [x] Update Upgrade Guide.