### PR TITLE
2.x Documentation optimizations

### DIFF
--- a/docs/v2/getting-started/a-post-archive.md
+++ b/docs/v2/getting-started/a-post-archive.md
@@ -73,7 +73,7 @@ There are two new things that you see here:
 
 ## Using custom queries
 
-Sometimes you’ll want to use your own queries for archive pages or to display a list of posts in other places. For that, you can use `Timber::get_posts()`. Here’s an example for a more complex query, that selects posts that have certain movie genre and actor terms assigned. The parameters you use are the same as those for [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/)
+Sometimes you’ll want to use your own queries for archive pages or to display a list of posts in other places. For that, you can use `Timber::get_posts()`. Here’s an example for a more complex query, that selects posts that have certain movie genre and actor terms assigned. The parameters you use are the same as those for [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/).
 
 ```php
 <?php

--- a/docs/v2/getting-started/introduction.md
+++ b/docs/v2/getting-started/introduction.md
@@ -43,7 +43,7 @@ To render a view, you can use `Timber::render()`.
 Timber::render( 'index.twig' );
 ```
 
-This will look for an `index.twig` file in the **views** folder of your theme and render the contents of that template.
+This will look for an **index.twig** file in the **views** folder of your theme and render the contents of that template.
 
 **index.twig**
 

--- a/docs/v2/guides/cheatsheet.md
+++ b/docs/v2/guides/cheatsheet.md
@@ -7,6 +7,7 @@ Here are some helpful conversions for functions you’re probably well familiar 
 
 ```php
 $context = Timber::context();
+
 Timber::render( 'single.twig', $context );
 ```
 

--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -91,7 +91,7 @@ add_shortcode( 'company_address', function() {
 } );
 ```
 
-In this example, we've provided all the global context variables to `shortcode/company-address.twig` via `Timber::context_global()`. Whenever you only need the global context, you should use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
+In this example, we've provided all the global context variables to **shortcode/company-address.twig** via `Timber::context_global()`. Whenever you only need the global context, you should use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
 
 Timber will not cache template contexts.
 

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -115,6 +115,7 @@ This is where we’ll start in PHP.
 
 ```php
 <?php
+
 $post = new Timber\Post();
 
 if ( isset( $post->hero_image ) && strlen( $post->hero_image ) ) {

--- a/docs/v2/guides/cookbook-twig.md
+++ b/docs/v2/guides/cookbook-twig.md
@@ -22,10 +22,13 @@ Ready? There are a bunch of ways, but one helpful example is:
 **In your PHP file**
 
 ```php
-<?php
-$data['year'] = date('Y');
-$data['copyright'] = get_option("footer_message"); //"Copyright {{year}} by Upstatement, LLC. All Rights Reserved"
-render_twig('footer.twig', $data);
+$data = [
+    'year' => wp_date( 'Y' ),
+    // "Copyright {{year}} by Upstatement, LLC. All Rights Reserved"
+    'copyright' => get_option( 'footer_message' );
+];
+
+Timber::render( 'footer.twig', $data );
 ```
 
 **In your HTML file (let's say **footer.twig**)**

--- a/docs/v2/guides/custom-page-templates.md
+++ b/docs/v2/guides/custom-page-templates.md
@@ -9,17 +9,16 @@ There are a few ways to manage custom pages in WordPress and Timber, in order fr
 
 ## Custom Twig File
 
-If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can 
+If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can
 
 * Create a file called `page-about-us.twig` inside your `views` and go crazy.
 * Copy and paste the contents of [`page.twig`](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
 
 **How does this work?**
 
-In the `page.php` file you'll find this code:
+In the **page.php** file you'll find this code:
 
 ```php
-<?php
 Timber::render( array(
     'page-' . $post->post_name . '.twig',
     'page.twig'

--- a/docs/v2/guides/custom-page-templates.md
+++ b/docs/v2/guides/custom-page-templates.md
@@ -11,8 +11,8 @@ There are a few ways to manage custom pages in WordPress and Timber, in order fr
 
 If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can
 
-* Create a file called `page-about-us.twig` inside your `views` and go crazy.
-* Copy and paste the contents of [`page.twig`](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
+* Create a file called **page-about-us.twig** inside your `views` and go crazy.
+* Copy and paste the contents of [**page.twig**](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
 
 **How does this work?**
 
@@ -25,15 +25,15 @@ Timber::render( array(
 ), $context );
 ```
 
-This is telling PHP to first look for a Twig file named `page-{{slug}}.twig` and then fall back to `page.twig` if that doesn't exist. With the array notation, you can add as many fallbacks as you need.
+This is telling PHP to first look for a Twig file named **page-{{ slug }}.twig** and then fall back to **page.twig** if that doesn't exist. With the array notation, you can add as many fallbacks as you need.
 
 ## Custom PHP File
 
 If you need to do something special for a page in PHP, you can use the standard WordPress [template hierarchy](http://codex.wordpress.org/Template_Hierarchy) to gather and manipulate data for this page. In the example above, you would create a file
 
-`/wp-content/themes/my-theme/page-about-us.php`
+**/wp-content/themes/my-theme/page-about-us.php**
 
-and populate it with the necessary PHP. You can use the contents of the starter theme’s [`page.php`](https://github.com/timber/starter-theme/blob/master/page.php) file as a guide.
+and populate it with the necessary PHP. You can use the contents of the starter theme’s [**page.php**](https://github.com/timber/starter-theme/blob/master/page.php) file as a guide.
 
 ## Custom Page Template
 
@@ -53,5 +53,5 @@ In the WordPress admin, a new entry will be added in your page’s list of avail
 
 ![](http://codex.wordpress.org/images/thumb/a/a3/page-templates-pulldown-screenshot.png/180px-page-templates-pulldown-screenshot.png)
 
-* Name it something like `/wp-content/themes/my-theme/template-my-custom-page.php`.
+* Name it something like **/wp-content/themes/my-theme/template-my-custom-page.php**.
 * Do **NOT** name it something beginning with `page-` or [WordPress will get very confused](http://jespervanengelen.com/page-templates-in-wordpress-template-hierarchy/).

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -118,7 +118,6 @@ Then, you would use that namespace for your `BlogPost` class.
 
 namespace Theme;
 
-
 class BlogPost {
     // ...
 }
@@ -168,6 +167,7 @@ We can move this function over to the `BlogPost` class. The only difference is t
 
 ```php
 <?php
+
 class MySitePost extends \Timber\Post {
 
 /**
@@ -270,6 +270,7 @@ Of course, `Timber\Post` has no built-in concept of an issue. Imagine there’s 
 
 ```php
 <?php
+
 class MySitePost extends \Timber\Post {
 
 class MagazinePost extends \Timber\Post {
@@ -541,9 +542,9 @@ In Twig:
 
 You can also extend Twig by adding custom functionality like functions or filters.
 
-```php
-<?php
+**functions.php**
 
+```php
 add_filter( 'timber/twig', 'add_to_twig' );
 
 /**

--- a/docs/v2/guides/filters.md
+++ b/docs/v2/guides/filters.md
@@ -23,8 +23,6 @@ When you need to trim text to a desired length (in words)
 <p class="intro">Steve-O was born in London, England. His mother, Donna Gay (née Wauthier), was Canadian, and his father, Richard Glover, was American. His paternal grandfather was English and his maternal step-grandfather ...</p>
 ```
 
-* * *
-
 ## function
 
 Runs a function where you need. Really valuable for integrating plugins or existing themes
@@ -56,9 +54,8 @@ Runs a function where you need. Really valuable for integrating plugins or exist
 <div class="entry-meta">Posted on September 6, 2013</div>
 ```
 
-* * *
-
 ## relative
+
 Converts an absolute URL into a relative one, for example:
 
 ```twig
@@ -69,12 +66,9 @@ My custom link is <a href="{{ 'http://example.org/2015/08/my-blog-post' | relati
 My custom link is <a href="/2015/08/my-blog-post">here!</a>
 ```
 
-* * *
-
 ## pretags
-Converts tags like `<span>` into `&lt;span&gt;`, but only inside of `<pre>` tags. Great for code samples when you need to preserve other formatting in the non-code sample content.
 
-* * *
+Converts tags like `<span>` into `&lt;span&gt;`, but only inside of `<pre>` tags. Great for code samples when you need to preserve other formatting in the non-code sample content.
 
 ## sanitize
 
@@ -91,8 +85,6 @@ Converts Titles like this into `titles-like-this`
 ```html
 my-awesome-post
 ```
-
-* * *
 
 ## shortcodes
 
@@ -114,8 +106,6 @@ Here is my gallery <div class="gallery" id="gallery-123"><img src="...." />...</
 </section>
 ```
 
-* * *
-
 ## time_ago
 
 Displays a date in timeago format:
@@ -132,8 +122,6 @@ Displays a date in timeago format:
 <p class="entry-meta">Posted: <time>3 days ago</time></p>
 ```
 
-* * *
-
 ## truncate
 
 **Twig**
@@ -147,8 +135,6 @@ Displays a date in timeago format:
 ```html
 <p class="entry-meta">Bruce Wayne's parents were shot outside the opera ...</p>
 ```
-
-* * *
 
 ## wpautop
 
@@ -172,8 +158,6 @@ Adds paragraph breaks to new lines
 	<p>"Oh, yeah," Sinatra said, "well I've seen it, and it's a piece of crap."</p>
 </div>
 ```
-
-* * *
 
 ## list
 

--- a/docs/v2/guides/filters.md
+++ b/docs/v2/guides/filters.md
@@ -182,7 +182,6 @@ Converts an array of strings into a comma-separated list.
 **PHP**
 
 ```php
-<?php
 $context['contributors'] = array('Blake Allen','Rachel White','Maddy May');
 ```
 

--- a/docs/v2/guides/functions.md
+++ b/docs/v2/guides/functions.md
@@ -41,7 +41,7 @@ What if you need to pass arguments to a function? Easy, add them as additional a
 </div>
 ```
 
-Nice! Any gotchas? Unfortunately yes. While the above example will totally work in a single.twig file it will not in The Loop. Why? Single.twig/single.php retain the context of the current post. A function like `edit_post_link` will try to guess the ID of the post you want to edit from the current post in The Loop. the same function requires some modification in a file like `archive.twig` or `index.twig`. There, you will need to explicitly pass the post ID:
+Nice! Any gotchas? Unfortunately yes. While the above example will totally work in a single.twig file it will not in The Loop. Why? Single.twig/single.php retain the context of the current post. A function like `edit_post_link` will try to guess the ID of the post you want to edit from the current post in The Loop. the same function requires some modification in a file like **archive.twig** or **index.twig**. There, you will need to explicitly pass the post ID:
 
 ```twig
 {# index.twig #}

--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -120,8 +120,6 @@ Most of the time, you need the menu on every page. To achieve that, you can add 
 **functions.php**
 
 ```php
-<?php
-
 add_filter( 'timber/context', 'add_to_context' );
 
 /**
@@ -159,8 +157,6 @@ Here’s a small snippet that you can use to automatically set up all your regis
 **functions.php**
 
 ```php
-<?php
-
 add_filter( 'timber/context', 'add_to_context' );
 
 /**

--- a/docs/v2/guides/pagination.md
+++ b/docs/v2/guides/pagination.md
@@ -95,11 +95,9 @@ Timber::render( 'archive-event.twig', $context );
 
 ### Pagination with `pre_get_posts`
 
-Custom `query_posts` sometimes shows 404 on example.com/page/2. In that case you can also use `pre_get_posts` in your functions.php file:
+Custom `query_posts` sometimes shows 404 on example.com/page/2. In that case you can also use `pre_get_posts` in your **functions.php** file:
 
 ```php
-<?php
-
 function my_home_query( $query ) {
     if ( $query->is_main_query() && ! is_admin() ) {
         $query->set( 'post_type', [ 'movie', 'post' ] );

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -20,6 +20,7 @@ When rendering, use the `$expires` argument in [`Timber::render`](https://timber
 
 ```php
 <?php
+
 $context['posts'] = new Timber\PostQuery();
 
 Timber::render( 'index.twig', $context, 600 );
@@ -34,7 +35,6 @@ This method is very effective, but crude - the whole template is cached. So if y
 As a fourth parameter for [Timber::render()](https://timber.github.io/docs/v2/reference/timber/#render), you can set the `$cache_mode`.
 
 ```php
-<?php
 Timber::render( $filenames, $data, $expires, $cache_mode );
 ```
 
@@ -71,14 +71,12 @@ This method allows for very fine-grained control over what parts of templates ar
 In your cache, the eventual key will be:
 
 ```php
-<?php
 $annotation . '__GCS__' . $key
 ```
 
 That is in this scenario:
 
 ```php
-<?php
 'index/content__GCS__' . md5( json_encode( $context['post'] ) )
 ```
 
@@ -162,9 +160,10 @@ $context['main_stories'] = TimberHelper::transient( 'main_stories', function(){
         $tease = new Timber\Post( $tease );
     }
 
-    $main_stories = array();
-    $main_stories['posts'] = $posts;
-    $main_stories['extra_teases'] = $extra_teases;
+    $main_stories = [
+        'posts'        => $posts,
+        'extra_teases' => $extra_teases,
+    ];
 
     return $main_stories;
 }, 600 );
@@ -184,6 +183,7 @@ Timber provides some quick shortcuts to measure page timing. Here’s an example
 
 ```php
 <?php
+
 // This generates a starting time
 $start = Timber\Helper::start_timer();
 

--- a/docs/v2/guides/sidebars.md
+++ b/docs/v2/guides/sidebars.md
@@ -8,7 +8,7 @@ So you want a sidebar?
 ## Method 1: PHP file
 
 Let's say every page on the site has the same content going into its sidebar. If so, you would:
-Create a `sidebar.php` file in your theme directory (so `wp-content/themes/mytheme/sidebar.php`)
+Create a **sidebar.php** file in your theme directory (so **wp-content/themes/mytheme/sidebar.php**)
 
 **sidebar.php**
 

--- a/docs/v2/guides/sidebars.md
+++ b/docs/v2/guides/sidebars.md
@@ -10,56 +10,59 @@ So you want a sidebar?
 Let's say every page on the site has the same content going into its sidebar. If so, you would:
 Create a `sidebar.php` file in your theme directory (so `wp-content/themes/mytheme/sidebar.php`)
 
+**sidebar.php**
+
 ```php
 <?php
-/* sidebar.php */
+
 $context = array();
 $context['widget'] = my_function_to_get_widget();
 $context['ad'] = my_function_to_get_an_ad();
 Timber::render('sidebar.twig', $context);
 ```
 
-* Use that php file within your main php file (home.php, single.php, archive.php, etc):
+Use that php file within your main PHP file (home.php, single.php, archive.php, etc):
+
+**single.php**
 
 ```php
-<?php
-/* single.php */
 $context = Timber::context();
 $context['sidebar'] = Timber::get_sidebar('sidebar.php');
-Timber::render('single.twig', $context);
+
+Timber::render( 'single.twig', $context );
 ```
 
-* In the final twig file make sure you reserve a spot for your sidebar:
+In the final twig file make sure you reserve a spot for your sidebar:
+
+**single.twig**
 
 ```twig
-{# single.twig #}
 <aside class="sidebar">
 	{{sidebar}}
 </aside>
 ```
 
-* * *
-
 ## Method 2: Twig file
 
 In this example, you would populate your sidebar from your main PHP file (home.php, single.php, archive.php, etc).
 
-* Make a Twig file for what your sidebar should be:
+Make a Twig file for what your sidebar should be:
+
+**views/sidebar-related.twig**
 
 ```twig
-{# views/sidebar-related.twig #}
 <h3>Related Stories</h3>
+
 {% for post in related %}
 	<h4><a href="{{post.get_path}}">{{post.post_title}}</a></h4>
 {% endfor %}
 ```
 
-* Send data to it via your main PHP file:
+Send data to it via your main PHP file:
+
+**single.php**
 
 ```php
-<?php
-/* single.php */
-
 $post     = new Timber\Post();
 $post_cat = $post->get_terms( 'category' );
 
@@ -80,16 +83,16 @@ $context['sidebar'] = Timber::get_sidebar(
 
 Timber::render( 'single.twig', $context );
 ```
-* In the final twig file, make sure you have spot for your sidebar:
+
+In the final twig file, make sure you have spot for your sidebar:
+
+**single.twig**
 
 ```twig
-{# single.twig #}
 <aside class="sidebar">
 	{{sidebar}}
 </aside>
 ```
-
-* * *
 
 ## Method 3: Dynamic
 
@@ -97,6 +100,7 @@ This is using WordPress's built-in dynamic_sidebar tools (which, confusingly, ar
 
 ```php
 <?php
+
 $context = array();
 $context['dynamic_sidebar'] = Timber::get_widgets('dynamic_sidebar');
 Timber::render('sidebar.twig', $context);

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -106,7 +106,7 @@ add_filter( 'timber/locations', function($paths) {
 ```
 
 In the example above the namespace is called `styleguide`. You must prefix this with `@` when using it in templates (that's how Twig can differentiate namespaces from regular paths).
-Assuming you have a template called `menu.twig` within that namespace, you would call it like so:
+Assuming you have a template called **menu.twig** within that namespace, you would call it like so:
 
 ```twig
 {{ include('@styleguide/menu.twig') }}
@@ -127,4 +127,4 @@ add_filter( 'timber/locations', function($paths) {
 });
 ```
 
-You only need to do this once in your project (in `functions.php` of your theme). When you call one of the render or compile functions from a PHP file (say `single.php`), Timber will look for Twig files in these locations before it checks the child or parent theme.
+You only need to do this once in your project (in **functions.php** of your theme). When you call one of the render or compile functions from a PHP file (say **single.php**), Timber will look for Twig files in these locations before it checks the child or parent theme.

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -55,6 +55,7 @@ You can always reference **subdirectories** in your template folders relatively.
 ```php
 Timber::render( 'shared/headers/header-home.twig' );
 ```
+
 ... might correspond to a file in
 `/wp-content/themes/my-theme/views/shared/headers/header-home.twig`.
 
@@ -62,9 +63,9 @@ Timber::render( 'shared/headers/header-home.twig' );
 
 You can set your own locations for your twig files with...
 
-```php
-<?php
+**functions.php**
 
+```php
 add_filter( 'timber/locations', function($paths) {
 	$paths[] = array('/Users/lukas/Sandbox/templates');
 
@@ -74,9 +75,9 @@ add_filter( 'timber/locations', function($paths) {
 
 Use the full file path to make sure Timber knows what you're trying to draw from. You can also send an array for multiple locations:
 
-```php
-<?php
+**functions.php**
 
+```php
 add_filter( 'timber/locations', function($paths) {
 	$paths[] = array(
 		'/Users/lukas/Sandbox/templates',
@@ -92,9 +93,9 @@ add_filter( 'timber/locations', function($paths) {
 
 You can use [namespaces](https://symfony.com/doc/current/templating/namespaced_paths.html) in your locations, too. Namespaces allow you to create a shortcut to a particular location. Just define it as the value next to a path, for example:
 
-```php
-<?php
+**functions.php**
 
+```php
 add_filter( 'timber/locations', function($paths) {
 	$paths['styleguide'] = [
 		ABSPATH . '/wp-content/styleguide'
@@ -113,9 +114,9 @@ Assuming you have a template called `menu.twig` within that namespace, you would
 
 You can also register multiple paths for the same namespace. Order is important as it will look top to bottom and return the first one it encounters, for example:
 
-```php
-<?php
+**functions.php**
 
+```php
 add_filter( 'timber/locations', function($paths) {
 	$paths['styleguide'] = array(
 		ABSPATH.'/wp-content/styleguide',

--- a/docs/v2/guides/woocommerce.md
+++ b/docs/v2/guides/woocommerce.md
@@ -182,10 +182,9 @@ This should all sound familiar by now, except for one line:
 {{ fn('timber_set_product', post) }}
 ```
 
-For some reason, products in the loop don’t get the right context by default. This line will call the following function that you need to add somewhere in your `functions.php` file:
+For some reason, products in the loop don’t get the right context by default. This line will call the following function that you need to add somewhere in your **functions.php** file:
 
 ```php
-<?php
 function timber_set_product( $post ) {
     global $product;
 
@@ -207,10 +206,9 @@ One way to get around this is by building your own image calls, that means remov
 {% endif %}
 ```
 
-To remove the default image, add the following to your `functions.php` file:
+To remove the default image, add the following to your **functions.php** file:
 
 ```php
-<?php
 remove_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail' );
 ```
 

--- a/docs/v2/guides/woocommerce.md
+++ b/docs/v2/guides/woocommerce.md
@@ -59,11 +59,11 @@ if ( is_singular( 'product' ) ) {
 }
 ```
 
-You will now need the two Twig files loaded from `woocommerce.php`: `views/woo/single-product.twig` and `views/woo/archive.twig`.
+You will now need the two Twig files loaded from **woocommerce.php**: **views/woo/single-product.twig** and **views/woo/archive.twig**.
 
 ## Archives
 
-Create a Twig file according to the location asked by the above file, in this example that would be `views/woo/archive.twig`:
+Create a Twig file according to the location asked by the above file, in this example that would be **views/woo/archive.twig**:
 
 ```twig
 {% extends 'base.twig' %}
@@ -94,7 +94,7 @@ Next, we’ll take care of the single product view.
 
 ## Single Product
 
-Create a Twig file according to the location asked by the above file, in this example that would be `views/woo/single-product.twig`:
+Create a Twig file according to the location asked by the above file, in this example that would be **views/woo/single-product.twig**:
 
 ```twig
 {% extends "base.twig" %}
@@ -130,10 +130,10 @@ Create a Twig file according to the location asked by the above file, in this ex
 
 Again we are keeping things simple by using WooCommerce’s default hooks. If you need to override the output of any of those hooks, my advice would be to remove and add the relevant actions using PHP, keeping your upgrade path simple.
 
-If you wanna use the same `tease-product.twig` output as your related products, you have to remove the default related-products from theme, add the following to your `functions.php` file:
+If you wanna use the same **tease-product.twig** output as your related products, you have to remove the default related-products from theme, add the following to your **functions.php** file:
 `remove_action( 'woocommerce_after_single_product_summary', 'woocommerce_output_related_products', 20 );`
 
-Finally, we’ll need to create a teaser file for products in loops. Considering the code above that would be `views/partials/tease-product.twig`:
+Finally, we’ll need to create a teaser file for products in loops. Considering the code above that would be **views/partials/tease-product.twig**:
 
 ## Tease Product
 

--- a/docs/v2/guides/wp-integration.md
+++ b/docs/v2/guides/wp-integration.md
@@ -40,16 +40,15 @@ If you want anything from the template's context, you'll need to pass that manua
 {% do action('my_action', 'foo', post) %}
 ```
 
-```php
-<?php
+**functions.php**
 
+```php
 add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
 
 function my_function_with_args( $foo, $post ){
     echo 'I say ' . $foo . '!';
     echo 'For the post with title ' . $post->title();
 }
-
 ```
 
 ## Filters
@@ -129,8 +128,9 @@ And with the `filter` tag, it would look like this:
 Everyone loves widgets! Of course they do...
 
 ```php
-<?php
-$data['footer_widgets'] = Timber::get_widgets( 'footer_widgets' );
+$data = [
+    'footer_widgets' => Timber::get_widgets( 'footer_widgets' ),
+];
 ```
 
 ...where `footer_widgets` is the registered name of the widgets you want to get (in twentythirteen these are called `sidebar-1` and `sidebar-2`).
@@ -152,7 +152,6 @@ You can also use twig templates for your widgets! Let’s imagine we want a widg
 Inside the widget class, the widget function is used to show the widget:
 
 ```php
-<?php
 public function widget( $args, $instance ) {
     $number = rand();
 
@@ -179,7 +178,6 @@ The raw filter is needed here to embed the widget properly.
 You may also want to check if the Timber plugin was loaded before using it:
 
 ```php
-<?php
 public function widget( $args, $instance ) {
     if ( ! class_exists( 'Timber' ) ) {
         // if you want to show some error message, this is the right place
@@ -203,8 +201,9 @@ Well, if it works for widgets, why shouldn't it work for shortcodes? Of course i
 Let’s implement a `[youtube]` shortcode which embeds a youtube video.
 For the desired usage of `[youtube id=xxxx]`, we only need a few lines of code:
 
+**functions.php**
+
 ```php
-<?php
 // Should be called from within an init action hook
 add_shortcode( 'youtube', 'youtube_shortcode' );
 
@@ -255,13 +254,19 @@ It’s recommended to use the [`post_password_required()`](https://developer.wor
 **single.php**
 
 ```php
+<?php
+
 $context = Timber::context();
 $post = Timber::query_post();
 $context['post'] = $post;
+
 if ( post_password_required( $post->ID ) ) {
     Timber::render( 'single-password.twig', $context );
 } else {
-    Timber::render( array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ), $context );
+    Timber::render(
+        array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ),
+        $context
+    );
 }
 ```
 
@@ -275,8 +280,8 @@ if ( post_password_required( $post->ID ) ) {
 {% endblock %}
 ```
 
-
 #### Using a Filter
+
 With a WordPress filter, you can use a specific PHP template for all your password protected posts. Note: this is accomplished using only standard WordPress functions. This is nothing special to Timber
 
 **functions.php**
@@ -307,8 +312,6 @@ function get_password_protected_template( $template ) {
 With this filter, you can use a **password-protected.php** template file with the following contents:
 
 ```php
-<?php
-
 $context                  = Timber::context();
 $context['post']          = new Timber\Post();
 $context['password_form'] = get_the_password_form();

--- a/docs/v2/guides/wp-integration.md
+++ b/docs/v2/guides/wp-integration.md
@@ -163,7 +163,7 @@ public function widget( $args, $instance ) {
 }
 ```
 
-The corresponding template file `random-widget.twig` looks like this:
+The corresponding template file **random-widget.twig** looks like this:
 
 ```twig
 {{ args.before_widget|raw }}
@@ -173,6 +173,7 @@ The corresponding template file `random-widget.twig` looks like this:
 
 {{ args.after_widget|raw }}
 ```
+
 The raw filter is needed here to embed the widget properly.
 
 You may also want to check if the Timber plugin was loaded before using it:
@@ -219,7 +220,7 @@ function youtube_shortcode( $atts ) {
 }
 ```
 
-In `youtube-short.twig` we have the following template:
+In **youtube-short.twig** we have the following template:
 
 ```twig
 {% if id %}
@@ -227,7 +228,7 @@ In `youtube-short.twig` we have the following template:
 {% endif %}
 ```
 
-Now, when the YouTube embed code changes, we only need to edit the `youtube-short.twig` template. No need to search your PHP files for this one particular line.
+Now, when the YouTube embed code changes, we only need to edit the **youtube-short.twig** template. No need to search your PHP files for this one particular line.
 
 ### Layouts with Shortcodes
 
@@ -290,8 +291,8 @@ With a WordPress filter, you can use a specific PHP template for all your passwo
 /**
  * Use specific template for password protected posts.
  *
- * By default, this will use the `password-protected.php` template file. If you want password
- * templates specific to a post type, use `password-protected-$posttype.php`.
+ * By default, this will use the **password-protected.php** template file. If you want password
+ * templates specific to a post type, use **password-protected-$posttype.php**.
  */
 add_filter( 'template_include', 'get_password_protected_template', 99 );
 

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -48,7 +48,7 @@ And then we render that data in your Twig template.
 {% endblock %}
 ```
 
-### Unifies interacting with WordPress data 
+### Unifies interacting with WordPress data
 
 Timber makes Posts, Terms, Users, Comments and Menus more object-oriented. You can use the common WordPress objects in a way that makes sense.
 

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -95,8 +95,6 @@ You can now use all the above functions to transform your custom images in the s
 <img src="{{ post.hero_image.src | resize(500, 300) }}" />
 ```
 
-* * *
-
 ## Gallery Field
 
 ```twig
@@ -105,9 +103,8 @@ You can now use all the above functions to transform your custom images in the s
 {% endfor %}
 ```
 
-* * *
-
 ## Group Field
+
 ```twig
 {{ post.meta('group').first_field }}
 {{ post.meta('group').second_field }}
@@ -121,8 +118,6 @@ or
 {{ group.second_field }}
 ```
 
-* * *
-
 ## Relationship field
 
 The post data returned from a relationship field will not contain the Timber methods needed for easy handling inside of your Twig file. To get these, you’ll need to convert them into proper `Timber\Post` objects using `get_posts()`:
@@ -133,8 +128,6 @@ The post data returned from a relationship field will not contain the Timber met
    {# Do something with item #}
 {% endfor %}
 ```
-
-* * *
 
 ## Repeater Field
 
@@ -196,8 +189,6 @@ A common problem in working with repeaters is that you should only call the `met
 {% endfor %}
 ```
 
-* * *
-
 ## Flexible Content Field
 
 Similar to repeaters, get the field by the name of the flexible content field:
@@ -230,8 +221,6 @@ Similar to nested repeaters, you should only call the `meta` method once when yo
     {% endif %}
 {% endfor %}
 ```
-
-* * *
 
 ## Options Page
 
@@ -290,8 +279,6 @@ Now, you can use any of the option fields across the site instead of per templat
 ```twig
 <footer>{{ options.copyright_info }}</footer>
 ```
-
-* * *
 
 ## Getting ACF info
 

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -75,7 +75,6 @@ This is where we’ll start in PHP.
 **single.php**
 
 ```php
-<?php
 $post = new Timber\Post();
 
 if (isset($post->hero_image) && strlen($post->hero_image)){
@@ -269,7 +268,6 @@ ACF Pro has a built in options page, and changes the `get_fields( 'options' )` t
 To use any options fields site wide, add the `option` context to your **functions.php** file:
 
 ```php
-<?php
 add_filter( 'timber/context', 'global_timber_context' );
 
 /**

--- a/docs/v2/upgrade-guides/1.0.md
+++ b/docs/v2/upgrade-guides/1.0.md
@@ -41,10 +41,10 @@ _Note: because we're not monsters, the [Upstatement/routes] repo will continue t
 
 If you haven't already, you'll need to load Composer's autoload file into your theme via:
 
+**functions.php**
+
 ```php
-<?php
-/* functions.php */
-require_once('vendor/autoload.php');
+require_once( 'vendor/autoload.php' );
 ```
 
 ### 3. Update your Routes
@@ -54,7 +54,6 @@ Now just update the PHP for your old routes to the new ones. It'll be basically 
 **Before**
 
 ```php
-<?php
 Timber::add_route('myfoo/bar', 'my_callback_function');
 Timber::add_route('my-events/:event', function($params) {
     $query = new WP_Query('post_type=event');
@@ -65,7 +64,6 @@ Timber::add_route('my-events/:event', function($params) {
 **After**
 
 ```php
-<?php
 Routes::map('myfoo/bar', 'my_callback_function');
 Routes::map('my-events/:event', function($params) {
     $query = new WP_Query('post_type=event');


### PR DESCRIPTION
## Issue

Documentation formatting.

## Solution

- Removes a couple of horizontal rules (`* * *`) we don’t need.
- Optimizes where we add `<?php` in front of PHP code examples. In general: when it’s a whole template file, there should be an opening tag, otherwise, the surrounding text should suggest what language it is, e.g. when it’s introduced with a filename (single.php, functions.php, etc).
- Uses more consistent file name formatting by using bold formatting instead of code formatting.
- Fixes a couple of newline inconsistencies.
- Fixes a couple of incorrect array declarations, when an array was declared by assigning a key.

## Impact

More consistency. A little less clutter.

## Usage Changes

None.

## Considerations

None.

## Testing

None, documentation only.