### PR TITLE
Handle search, tax queries in ::context()

### DIFF
--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -99,7 +99,7 @@ Timber will not cache template contexts.
 
 When WordPress decides [which PHP template file](https://wphierarchy.com/) it will display, it has already run database queries to fetch posts for archive templates or to set up the `$post` global for singular templates.
 
-When you call `Timber::context()`, Timber will automatically populate your context with a `post` or `posts` variable, depending on which type of template file you’re in.
+When you call `Timber::context()`, Timber will automatically populate your context with different variables like `post`, `posts`, `term`, `terms` or `author`, depending on which type of template file you’re in.
 
 ### Singular templates
 
@@ -150,9 +150,21 @@ $context['post'] = Timber::get_post()->setup();
 
 ### Archive templates
 
-The `posts` variable will be available in archive templates (when [ `is_archive()`](https://developer.wordpress.org/reference/functions/is_archive/) returns `true`), like your posts index page, category or tag archives, date-based or author archives. It will contain a `Timber\PostCollection` object with the posts that WordPress already fetched for your archive page.
+The `posts` variable will be available in archive templates (when [ `is_archive()`](https://developer.wordpress.org/reference/functions/is_archive/) returns `true`). In addition to that, it will also contain `post` or `term` variables for different archive types. Here’s a small overview.
+
+| Archive | Condition | Context variables |
+|---|---|---|
+| Home | `is_home()` | `post`<br>`posts` |
+| Taxonomy Archive | `is_category()`<br>`is_tag()`<br>`is_tax()` | `term`<br>`posts` |
+| Author Archive | `is_author()` | `author`<br>`posts` |
+| Search Archive | `is_search()` | `posts`<br>`search_query` |
+| All other archives | `is_archive()` | `posts` |
+
+The `posts` variable will contain a `Timber\PostCollection` object with the posts that WordPress already fetched for your archive page.
 
 #### Use the default query
+
+**archive.php**
 
 ```php
 $context = Timber::context();
@@ -163,6 +175,8 @@ Timber::render( 'archive.twig', $context );
 #### Write your own query
 
 When you don’t need the default query, you can pass in your own arguments to `Timber::get_posts()`.
+
+**archive.php**
 
 ```php
 $context          = Timber::context();

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -379,7 +379,9 @@ The context variables `{{ wp_head }}` and `{{ wp_footer }}` were removed definit
 
 ### Template context
 
-Version 2.0 introduces the concept of template contexts for Timber. This means that Timber will automatically set `post` in your context for singular templates and `posts` for archive templates. Through the context, compatibility for third party plugins will be improved as well. Refer to the new [Context Guide](https://timber.github.io/docs/v2/guides/context/) to learn more.
+Version 2.0 introduces the concept of template contexts for Timber. This means that Timber will automatically set different variables like `post` in your context for singular templates and `posts` and maybe `term` or `author` for archive templates. Check out [the section in the Context Guide](https://timber.github.io/docs/v2/guides/context/#template-contexts) for an overview.
+
+Through the context, compatibility for third party plugins will be improved as well. Refer to the new [Context Guide](https://timber.github.io/docs/v2/guides/context/) to learn more.
 
 In short:
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -923,6 +923,9 @@ class Timber {
 		} elseif ( is_search() ) {
 			$context['posts']        = Timber::get_posts();
 			$context['search_query'] = get_search_query();
+		} elseif ( is_author() ) {
+			$context['author'] = Timber::get_user(get_query_var('author'));
+			$context['posts']  = Timber::get_posts();
 		} elseif ( is_archive() ) {
 			$context['posts'] = Timber::get_posts();
 		}

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -912,7 +912,10 @@ class Timber {
 
 		if ( is_singular() ) {
 			$context['post'] = Timber::get_post()->setup();
-		} elseif ( is_archive() || is_home() ) {
+		} elseif ( is_category() || is_tag() || is_tax() ) {
+			$context['term']  = Timber::get_term();
+			$context['posts'] = Timber::get_posts();
+		} elseif ( is_archive() || is_home() || is_search() ) {
 			$context['posts'] = Timber::get_posts();
 		}
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -913,13 +913,17 @@ class Timber {
 		if ( is_singular() ) {
 			// NOTE: this also handles the is_front_page() case.
 			$context['post'] = Timber::get_post()->setup();
+		} elseif ( is_home() ) {
+			// show_on_front = page
+			$context['post']  = Timber::get_post()->setup();
+			$context['posts'] = Timber::get_posts();
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$context['term']  = Timber::get_term();
 			$context['posts'] = Timber::get_posts();
 		} elseif ( is_search() ) {
 			$context['posts']        = Timber::get_posts();
 			$context['search_query'] = get_search_query();
-		} elseif ( is_archive() || is_home() ) {
+		} elseif ( is_archive() ) {
 			$context['posts'] = Timber::get_posts();
 		}
 

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -911,6 +911,7 @@ class Timber {
 		$context = self::context_global();
 
 		if ( is_singular() ) {
+			// NOTE: this also handles the is_front_page() case.
 			$context['post'] = Timber::get_post()->setup();
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$context['term']  = Timber::get_term();

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -915,7 +915,10 @@ class Timber {
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$context['term']  = Timber::get_term();
 			$context['posts'] = Timber::get_posts();
-		} elseif ( is_archive() || is_home() || is_search() ) {
+		} elseif ( is_search() ) {
+			$context['posts']        = Timber::get_posts();
+			$context['search_query'] = get_search_query();
+		} elseif ( is_archive() || is_home() ) {
 			$context['posts'] = Timber::get_posts();
 		}
 

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -69,6 +69,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertArrayNotHasKey( 'post', $context );
 		$this->assertInstanceOf( PostQuery::class, $context['posts'] );
 		$this->assertCount( 3, $context['posts'] );
+		$this->assertEquals( 'stuff', $context['search_query'] );
 	}
 
 	function testPostsContextCategory() {

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -4,6 +4,7 @@ use Timber\Post;
 use Timber\PostQuery;
 use Timber\Term;
 use Timber\Timber;
+use Timber\User;
 
 /**
  * @group posts-api
@@ -91,6 +92,26 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertInstanceOf( PostQuery::class, $context['posts'] );
 		$this->assertCount( 3, $context['posts'] );
 		$this->assertEquals( 'stuff', $context['search_query'] );
+	}
+
+	function testPostsContextAuthor() {
+		$uid = $this->factory->user->create([
+			'user_login' => 'bob',
+		]);
+		$this->factory->post->create_many( 3, [
+			'post_content' => 'here are some things',
+			'post_author'  => $uid,
+			'post_status'  => 'publish',
+	  ]	);
+		query_posts('author=' . $uid);
+
+		$context = Timber::context();
+
+		$this->assertArrayNotHasKey( 'post', $context );
+		$this->assertInstanceOf( PostQuery::class, $context['posts'] );
+		$this->assertCount( 3, $context['posts'] );
+		$this->assertInstanceOf( User::class, $context['author'] );
+		$this->assertEquals( $uid, $context['author']->id );
 	}
 
 	function testPostsContextCategory() {

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -43,14 +43,20 @@ class TestTimberContext extends Timber_UnitTestCase {
 
 	function testPostsContextHomePosts() {
 		update_option( 'show_on_front', 'posts' );
+		$id = $this->factory->post->create([
+			'post_title' => 'Blog',
+			'post_type'  => 'page',
+		]);
+		update_option( 'page_for_posts', $id );
 		$this->factory->post->create_many( 3 );
 		$this->go_to( '/' );
 
 		$context = Timber::context();
 
-		$this->assertArrayNotHasKey( 'post', $context );
 		$this->assertInstanceOf( PostQuery::class, $context['posts'] );
 		$this->assertCount( 3, $context['posts'] );
+		$this->assertInstanceOf( Post::class, $context['post'] );
+		$this->assertEquals( $context['post']->id, $context['posts'][0]->id );
 	}
 
 	function testPostsContextHomePage() {

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -41,7 +41,7 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertEquals('http://example.org', $context['http_host']);
 	}
 
-	function testPostsContextSimple() {
+	function testPostsContextHomePosts() {
 		update_option( 'show_on_front', 'posts' );
 		$this->factory->post->create_many( 3 );
 		$this->go_to( '/' );
@@ -51,6 +51,21 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertArrayNotHasKey( 'post', $context );
 		$this->assertInstanceOf( PostQuery::class, $context['posts'] );
 		$this->assertCount( 3, $context['posts'] );
+	}
+
+	function testPostsContextHomePage() {
+		update_option( 'show_on_front', 'page' );
+		$id = $this->factory->post->create([
+			'post_type' => 'page',
+		]);
+		update_option( 'page_on_front', $id );
+		$this->go_to( '/' );
+
+		$context = Timber::context();
+
+		$this->assertArrayNotHasKey( 'posts', $context );
+		$this->assertInstanceOf( Post::class, $context['post'] );
+		$this->assertEquals( $id, $context['post']->id );
 	}
 
 	function testPostsContextSearch() {


### PR DESCRIPTION
## Issue

Default `Timber::context()` behavior has some nice handling for singular/archive templates, but I'd expect it would handle other common scenarios, such as search and term pages as well.

## Solution

Handle `is_category()`, `is_tag()`, `is_tax()`, and `is_search()`.

## Impact

`$context['posts']` is now set in all cases listed above. For term archives, `$context['term']` also gets set.

## Usage Changes

No API changes; fewer instances where you need to set `posts`/`term` explicitly.

## Considerations

Are there more scenarios we want to cover?

## Testing

Yes.