### PR TITLE
#2386 Remove dormant Term::from() methods

### DIFF
--- a/lib/Term.php
+++ b/lib/Term.php
@@ -89,6 +89,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	}
 
 	/**
+	 *
 	 * @deprecated 2.0.0, use TermFactory::from instead.
 	 *
 	 * @param $tid
@@ -97,7 +98,12 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	 * @return static
 	 */
 	public static function from( $tid, $taxonomy ) {
-		//Helper::deprecated('Term::from', 'Timber\Factory\TermFactory::from', '2.0.0');
+		Helper::deprecated(
+			"Term::from()", 
+			"Timber\Factory\TermFactory->from()",
+			'2.0.0'
+		);
+
 		$termFactory = new TermFactory();
 		return $termFactory->from($tid, $taxonomy);
 	}

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -87,7 +87,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	}
 
 	/**
-	 * @api
+	 * @deprecated 2.0.0, use TermFactory::from instead.
 	 *
 	 * @param $tid
 	 * @param $taxonomy
@@ -95,6 +95,7 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	 * @return static
 	 */
 	public static function from( $tid, $taxonomy ) {
+		Helper::deprecated('Term::from', 'TermFactory::from', '2.0.0');
 		if ( is_array($tid) ) {
 			return array_map( function($term) use ($taxonomy) {
 				return new static($term, $taxonomy);
@@ -187,7 +188,6 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	===================== */
 
 	/**
-	 * @api
 	 * @deprecated 2.0.0, use `{{ term.edit_link }}` instead.
 	 * @return string
 	 */
@@ -198,7 +198,6 @@ class Term extends Core implements CoreInterface, MetaInterface {
 
 	/**
 	 * Gets a term meta value.
-	 * @api
 	 * @deprecated 2.0.0, use `{{ term.meta('field_name') }}` instead.
 	 *
 	 * @param string $field_name The field name for which you want to get the value.

--- a/lib/Term.php
+++ b/lib/Term.php
@@ -5,6 +5,8 @@ namespace Timber;
 use WP_Query;
 use WP_Term;
 
+use Timber\Factory\TermFactory;
+
 /**
  * Class Term
  *
@@ -95,13 +97,9 @@ class Term extends Core implements CoreInterface, MetaInterface {
 	 * @return static
 	 */
 	public static function from( $tid, $taxonomy ) {
-		Helper::deprecated('Term::from', 'TermFactory::from', '2.0.0');
-		if ( is_array($tid) ) {
-			return array_map( function($term) use ($taxonomy) {
-				return new static($term, $taxonomy);
-			}, $tid);
-		}
-		return new static($tid, $taxonomy);
+		//Helper::deprecated('Term::from', 'Timber\Factory\TermFactory::from', '2.0.0');
+		$termFactory = new TermFactory();
+		return $termFactory->from($tid, $taxonomy);
 	}
 
 

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -1,62 +1,69 @@
 <?php
 
-	/**
-	* @group terms-api
-	*/
-	class TestTimberTermFactories extends Timber_UnitTestCase {
+/**
+ * @group terms-api
+ */
+class TestTimberTermFactories extends Timber_UnitTestCase {
 
-		function setUp() {
-			$this->truncate('term_relationships');
-			$this->truncate('term_taxonomy');
-			$this->truncate('terms');
-			$this->truncate('termmeta');
-		}
-
-		function testGetTerm() {
-			$term_id = $this->factory->term->create(['name' => 'Thingo', 'taxonomy' => 'post_tag']);
-			$term = Timber::get_term($term_id);
-			$this->assertEquals('Thingo', $term->name);
-		}
-
-		function testGetMultiTerm() {
-			register_taxonomy('cars', 'post');
-			$term_ids[] = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
-			$term_ids[] = $this->factory->term->create(['name' => 'Honda', 'taxonomy' => 'cars']);
-			$term_ids[] = $this->factory->term->create(['name' => 'Chevy', 'taxonomy' => 'cars']);
-			$post_id = $this->factory->post->create();
-			wp_set_object_terms( $post_id, $term_ids, 'cars' );
-
-			$term_get = Timber::get_terms(['taxonomy' => 'cars']);
-			$this->assertEquals('Chevy', $term_get[0]->title());
-
-			$terms_from = Timber\Term::from(get_terms(['taxonomy' => 'cars']), 'cars');
-			$this->assertEquals('Chevy', $terms_from[0]->title());
-		}
-
-		function testTermFrom() {
-			register_taxonomy('baseball', array('post'));
-			register_taxonomy('hockey', array('post'));
-			$term_id = $this->factory->term->create(array('name' => 'Rangers', 'taxonomy' => 'baseball'));
-			$term_id = $this->factory->term->create(array('name' => 'Cardinals', 'taxonomy' => 'baseball'));
-			$term_id = $this->factory->term->create(array('name' => 'Rangers', 'taxonomy' => 'hockey'));
-			$baseball_teams = Timber\Term::from(get_terms(array('taxonomy' => 'baseball', 'hide_empty' => false)), 'baseball');
-			$this->assertEquals(2, count($baseball_teams));
-			$this->assertEquals('Cardinals', $baseball_teams[0]->name);
-		}
-
-		/**
-		 * @expectedDeprecated Term::from
-		 */
-		function testGetSingleTermFrom() {
-			register_taxonomy('cars', 'post');
-			$term_id = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
-			$post_id = $this->factory->post->create();
-			wp_set_object_terms( $post_id, $term_id, 'cars' );
-
-			$term_get = Timber::get_term(['taxonomy' => 'cars']);
-			$this->assertEquals($term_id, $term_get[0]->ID);
-
-			$term_from = Timber\Term::from(get_terms(['taxonomy' => 'cars', 'hide_empty' => false]), 'cars');
-			$this->assertEquals($term_id, $term_from[0]->ID);
-		}
+	function setUp() {
+		$this->truncate('term_relationships');
+		$this->truncate('term_taxonomy');
+		$this->truncate('terms');
+		$this->truncate('termmeta');
+		parent::setUp();
 	}
+
+	function testGetTerm() {
+		$term_id = $this->factory->term->create(['name' => 'Thingo', 'taxonomy' => 'post_tag']);
+		$term = Timber::get_term($term_id);
+		$this->assertEquals('Thingo', $term->name);
+	}
+
+	/**
+	 * @expectedDeprecated Term::from()
+	 */
+	function testGetMultiTerm() {
+		register_taxonomy('cars', 'post');
+		$term_ids[] = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
+		$term_ids[] = $this->factory->term->create(['name' => 'Honda', 'taxonomy' => 'cars']);
+		$term_ids[] = $this->factory->term->create(['name' => 'Chevy', 'taxonomy' => 'cars']);
+		$post_id = $this->factory->post->create();
+		wp_set_object_terms( $post_id, $term_ids, 'cars' );
+
+		$term_get = Timber::get_terms(['taxonomy' => 'cars']);
+		$this->assertEquals('Chevy', $term_get[0]->title());
+
+		$terms_from = Timber\Term::from(get_terms(['taxonomy' => 'cars']), 'cars');
+		$this->assertEquals('Chevy', $terms_from[0]->title());
+	}
+
+	/**
+	 * @expectedDeprecated Term::from()
+	 */
+	function testTermFrom() {
+		register_taxonomy('baseball', array('post'));
+		register_taxonomy('hockey', array('post'));
+		$term_id = $this->factory->term->create(array('name' => 'Rangers', 'taxonomy' => 'baseball'));
+		$term_id = $this->factory->term->create(array('name' => 'Cardinals', 'taxonomy' => 'baseball'));
+		$term_id = $this->factory->term->create(array('name' => 'Rangers', 'taxonomy' => 'hockey'));
+		$baseball_teams = Timber\Term::from(get_terms(array('taxonomy' => 'baseball', 'hide_empty' => false)), 'baseball');
+		$this->assertEquals(2, count($baseball_teams));
+		$this->assertEquals('Cardinals', $baseball_teams[0]->name);
+	}
+
+	/**
+	 * @expectedDeprecated Term::from()
+	 */
+	function testGetSingleTermFrom() {
+		register_taxonomy('cars', 'post');
+		$term_id = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
+		$post_id = $this->factory->post->create();
+		wp_set_object_terms( $post_id, $term_id, 'cars' );
+
+		$term_from = Timber\Term::from(get_terms(['taxonomy' => 'cars', 'hide_empty' => false]), 'cars');
+		$this->assertEquals($term_id, $term_from[0]->ID);
+
+		$term_get = Timber::get_term(['taxonomy' => 'cars']);
+		$this->assertEquals($term_id, $term_get[0]->ID);
+	}
+}

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -39,12 +39,11 @@
 			$term_id = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
 			$post_id = $this->factory->post->create();
 			wp_set_object_terms( $post_id, $term_id, 'cars' );
-			// passes ....
-			$term_get = Timber::get_term(['taxonomy' => 'cars']);
-			$this->assertEquals($term_id, $term_get->ID);
 
-			// fails ...
+			$term_get = Timber::get_term(['taxonomy' => 'cars']);
+			$this->assertEquals($term_id, $term_get[0]->ID);
+
 			$term_from = Timber\Term::from($term_id, 'cars');
-			$this->assertEquals($term_id, $term_from->ID);
+			$this->assertEquals($term_id, $term_from[0]->ID);
 		}
 	}

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -18,19 +18,33 @@
 			$this->assertEquals('Thingo', $term->name);
 		}
 
-		// function testGetMultiTerm() {
-		// 	register_taxonomy('cars', 'post');
-		// 	$term_ids[] = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
-		// 	$term_ids[] = $this->factory->term->create(['name' => 'Honda', 'taxonomy' => 'cars']);
-		// 	$terms = Timber\Term::from($term_ids, 'cars');
-		// 	$this->assertEquals($term_ids[0], $terms[0]->ID);
-		// }
+		function testGetMultiTerm() {
+			register_taxonomy('cars', 'post');
+			$term_ids[] = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
+			$term_ids[] = $this->factory->term->create(['name' => 'Honda', 'taxonomy' => 'cars']);
+			$term_ids[] = $this->factory->term->create(['name' => 'Chevy', 'taxonomy' => 'cars']);
+			$post_id = $this->factory->post->create();
+			wp_set_object_terms( $post_id, $term_ids, 'cars' );
 
-		// function testGetSingleTermFrom() {
-		// 	register_taxonomy('cars', 'post');
-		// 	$term_id = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
-		// 	$term = Timber\Term::from($term_id, 'cars');
-		// 	error_log(print_r($term, true));
-		// 	$this->assertEquals($term_id, $term->ID);
-		// }
+			$term_get = Timber::get_terms(['taxonomy' => 'cars']);
+			$this->assertEquals('Chevy', $term_get[0]->title());
+
+			$terms_from = Timber\Term::from($term_ids, 'cars');
+			$this->assertEquals('Chevy', $terms_from[0]->title());
+			//$this->assertEquals($term_ids[0], $terms[0]->ID);
+		}
+
+		function testGetSingleTermFrom() {
+			register_taxonomy('cars', 'post');
+			$term_id = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
+			$post_id = $this->factory->post->create();
+			wp_set_object_terms( $post_id, $term_id, 'cars' );
+			// passes ....
+			$term_get = Timber::get_term(['taxonomy' => 'cars']);
+			$this->assertEquals($term_id, $term_get->ID);
+
+			// fails ...
+			$term_from = Timber\Term::from($term_id, 'cars');
+			$this->assertEquals($term_id, $term_from->ID);
+		}
 	}

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -29,11 +29,24 @@
 			$term_get = Timber::get_terms(['taxonomy' => 'cars']);
 			$this->assertEquals('Chevy', $term_get[0]->title());
 
-			$terms_from = Timber\Term::from($term_ids, 'cars');
+			$terms_from = Timber\Term::from(get_terms(['taxonomy' => 'cars']), 'cars');
 			$this->assertEquals('Chevy', $terms_from[0]->title());
-			//$this->assertEquals($term_ids[0], $terms[0]->ID);
 		}
 
+		function testTermFrom() {
+			register_taxonomy('baseball', array('post'));
+			register_taxonomy('hockey', array('post'));
+			$term_id = $this->factory->term->create(array('name' => 'Rangers', 'taxonomy' => 'baseball'));
+			$term_id = $this->factory->term->create(array('name' => 'Cardinals', 'taxonomy' => 'baseball'));
+			$term_id = $this->factory->term->create(array('name' => 'Rangers', 'taxonomy' => 'hockey'));
+			$baseball_teams = Timber\Term::from(get_terms(array('taxonomy' => 'baseball', 'hide_empty' => false)), 'baseball');
+			$this->assertEquals(2, count($baseball_teams));
+			$this->assertEquals('Cardinals', $baseball_teams[0]->name);
+		}
+
+		/**
+		 * @expectedDeprecated Term::from
+		 */
 		function testGetSingleTermFrom() {
 			register_taxonomy('cars', 'post');
 			$term_id = $this->factory->term->create(['name' => 'Toyota', 'taxonomy' => 'cars']);
@@ -43,7 +56,7 @@
 			$term_get = Timber::get_term(['taxonomy' => 'cars']);
 			$this->assertEquals($term_id, $term_get[0]->ID);
 
-			$term_from = Timber\Term::from($term_id, 'cars');
+			$term_from = Timber\Term::from(get_terms(['taxonomy' => 'cars', 'hide_empty' => false]), 'cars');
 			$this->assertEquals($term_id, $term_from[0]->ID);
 		}
 	}


### PR DESCRIPTION
**Ticket**: #2386 

## Issue
There's a dormant `Term::from()` method hiding out. Sort of a primordial implementation of Factories. Of course, we now have real Factories so it can go.


## Solution
Since it was public and `@api` I've deprecated the function

## Impact
I'm guessing it's a narrow number of users who were using this. The deprecation notices/warnings should help them find their way

## Testing
Re-enabled the tests that were connected. Since it's deprecated, I'll make it test the new Factories equivalents 
