### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ twig-cache/*
 vendor
 build
 /cache
+!/lib/Cache
 *.swp
 *~
 wp-content


### PR DESCRIPTION
Do not ignore `/lib/Cache` on case-insensitive filesystems (MacOS)


**Ticket**: #342

## Issue
On case-insensitive file systems, the current `/cache` line in .gitignore, results in `/lib/Cache` being ignored, which shouldn't happen.

## Solution
Add an extra line to un-ignore `/lib/Cache`

## Impact
Some contributors might have modified files in `/lib/Cache` which will pop up as merge conflicts, changed files or otherwise create mild confusion.
