### PR TITLE
Replace Gitter refs with GitHub Discssions

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,6 +4,6 @@ Please post your question to Stack Overflow (http://stackoverflow.com/questions/
 
 ## Other places
 
-You can use [Gitter](https://gitter.im/timber/timber) for user-to-user support and help.
+You can use [GitHub Discussions](https://github.com/timber/timber/discussions) to open up questions and engage in discussions with the contributors and other users.
 
 Please don't post to the [WordPress.org support forum](https://wordpress.org/support/plugin/timber-library/). You might see a response, but it will just redirect you to either GitHub (for bugs/issues) or StackOverflow (for usage/support questions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Here are ways to get involved:
 5. Tweet and [blog](http://www.oomphinc.com/blog/2013-10/php-templating-wordpress/#post-content) about the advantages (and criticisms) of the project and Twig.
 6. Browse ["help wanted"](https://github.com/timber/timber/labels/help%20wanted) and ["good first issue"](https://github.com/timber/timber/labels/good%20first%20issue) labels for areas of WordPress/PHP/code you know well to consider, build or document.
 7. Answer questions on [Stack Overflow posted under the «Timber» tag](https://stackoverflow.com/questions/tagged/timber). You can also [subscribe to a tag](https://stackoverflow.blog/2010/12/20/subscribe-to-tags-via-emai/) via email to get notified when someone needs help.
-8. Answer questions in the support channel on [Gitter](https://gitter.im/timber/timber).
+8. Answer questions and join in on [GitHub Discussions](https://github.com/timber/timber/discussions).
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ By
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/timber/timber.svg?style=flat-square)](https://scrutinizer-ci.com/g/timber/timber/?branch=master)
 [![Latest Stable Version](https://img.shields.io/packagist/v/timber/timber.svg?style=flat-square)](https://packagist.org/packages/timber/timber)
 [![WordPress Download Count](https://img.shields.io/wordpress/plugin/dt/timber-library.svg?style=flat-square)](https://wordpress.org/plugins/timber-library/)
-[![Join the chat at https://gitter.im/timber/timber](https://img.shields.io/gitter/room/timber/timber.svg?style=flat-square)](https://gitter.im/timber/timber?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![WordPress Rating](https://img.shields.io/wordpress/plugin/r/timber-library.svg?style=flat-square)](https://wordpress.org/support/plugin/timber-library/reviews/)
 
 


### PR DESCRIPTION
## Issue
Gitter is mostly tumbleweeds. Even if it weren't, we don't have the ability to provide the "live" support that Gitter's interface suggests.

## Solution
Remove the refs (and replace with GitHub Discussions an a few spots)

## Considerations
We should also probably post a message and/or turn off the Gitter instance.

## Testing
None needed
