### PR TITLE
Get dimensions also for SVG images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ docs/output
 /Timber.php
 wordpress
 composer.lock
+.vscode

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -129,12 +129,49 @@ class Image extends Post implements CoreInterface {
 			return $this->get_dimensions_loaded($dim);
 		}
 		if ( file_exists($this->file_loc) && filesize($this->file_loc) ) {
-			list($width, $height) = getimagesize($this->file_loc);
-			$this->_dimensions = array();
-			$this->_dimensions[0] = $width;
-			$this->_dimensions[1] = $height;
+			if ( ImageHelper::is_svg( $this->file_loc ) ) {
+				$svg_size             = $this->svgs_get_dimensions( $this->file_loc );
+				$this->_dimensions    = array();
+				$this->_dimensions[0] = $svg_size->width;
+				$this->_dimensions[1] = $svg_size->height;
+			} else {
+				list($width, $height) = getimagesize($this->file_loc);
+				$this->_dimensions = array();
+				$this->_dimensions[0] = $width;
+				$this->_dimensions[1] = $height;
+			}
 			return $this->get_dimensions_loaded($dim);
 		}
+	}
+
+	/**
+	 * Retrieve dimensions from SVG file
+	 *
+	 * @internal
+	 * @param string $svg SVG Path
+	 * @return array
+	 */
+	protected function svgs_get_dimensions( $svg ) {
+		$svg    = simplexml_load_file( $svg );
+		$width  = '0';
+		$height = '0';
+
+		if ( false !== $svg ) {
+			$attributes = $svg->attributes();
+			if ( isset( $attributes->viewBox ) ) {
+				$viewbox = explode( ' ', $attributes->viewBox );
+				$width   = $viewbox[2];
+				$height  = $viewbox[3];
+			} elseif ( $attributes->width && $attributes->height ) {
+				$width  = (string) $attributes->width;
+				$height = (string) $attributes->height;
+			}
+		}
+
+		return (object) array(
+			'width'  => $width,
+			'height' => $height,
+		);
 	}
 
 	/**

--- a/tests/test-timber-theme.php
+++ b/tests/test-timber-theme.php
@@ -5,7 +5,7 @@
 		protected $backup_wp_theme_directories;
 
 		function testThemeVersion() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$theme = new TimberTheme();
 			$this->assertGreaterThan(1.2, $theme->version);
 			switch_theme('default');
@@ -72,18 +72,18 @@
 		}
 
 		function testThemeGet() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$context = Timber::context();
 			$output = Timber::compile_string('{{site.theme.get("Name")}}', $context);
-			$this->assertEquals('Twenty Seventeen', $output);
+			$this->assertEquals('Twenty Nineteen', $output);
 			switch_theme('default');
 		}
 
 		function testThemeDisplay() {
-			switch_theme('twentyseventeen');
+			switch_theme('twentynineteen');
 			$context = Timber::context();
 			$output = Timber::compile_string('{{site.theme.display("Description")}}', $context);
-			$this->assertEquals("Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.", $output);
+			$this->assertEquals("Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you&#8217;ll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it&#8217;s built to be beautiful on all screen sizes.", $output);
 			switch_theme('default');
 		}
 


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

**Ticket**: # <!-- Ignore this if not relevant -->

## Issue
<!-- Description of the problem that this code change is solving -->

Load image dimensions also for SVG files.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

Modify `Timber\Image\get_dimensions()` function and add new private function `svgs_get_dimensions()` to retrieve dimensions. from svg file.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->

Shouldn't touch performance or backward compatibility, just a new feature.

## Usage Changes

No usage changes accept that getting image.width and image.height will work for SVGs without a need to write own wrapper for it (thanks to @palmiak for helping hand!).

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->

I'm not sure how to run your test suite :( but if you'll point me the right way, I could write one.

Otherwise:
* all tests related to getting png/jpg width & height should pass
* test the same with an SVG with height and width parameters only
* test the same with an SVG with view box parameter only
