### PR TITLE
Update PHPStan configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "wpackagist-plugin/advanced-custom-fields": "5.*",
     "wpackagist-plugin/co-authors-plus": "3.2.*|3.4.*",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-    "szepeviktor/phpstan-wordpress": "^0.6.0",
+    "szepeviktor/phpstan-wordpress": "^0.7.0",
     "php-stubs/wp-cli-stubs": "^2.2.0"
   },
   "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,15 @@
 includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-    level: max
+    #level: max
+    level: 5
     paths:
-        - %currentWorkingDirectory%/lib/
-    autoload_files:
-        - %currentWorkingDirectory%/tests/phpstan/bootstrap.php
+        - lib/
+    scanFiles:
         # Plugin stubs
-        - %currentWorkingDirectory%/vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
+        - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
+    bootstrapFiles:
+        - tests/phpstan/bootstrap.php
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters invoked with [3456] parameters, 2 required\.$#'


### PR DESCRIPTION
The thing is there are critical errors in the 2.x branch.

e.g.

#2433 and

```
 ------ -------------------------------------------------------------------------------------
  Line   Integrations/CoAuthorsPlusUser.php
 ------ -------------------------------------------------------------------------------------
  49     Access to an undefined property Timber\Integrations\CoAuthorsPlusUser::$user_email.
 ------ -------------------------------------------------------------------------------------

 ------ -----------------------------------------------------------------
  Line   Menu.php
 ------ -----------------------------------------------------------------
  115    Constructor of class Timber\Menu has an unused parameter $slug.
 ------ -----------------------------------------------------------------
```