### PR TITLE
Remove unused method Post::check_post_id()

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -455,8 +455,8 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 	 */
 	protected function get_info( WP_Post $post ) {
 		$post->status = $post->post_status;
-		$post->id = $post->ID;
-		$post->slug = $post->post_name;
+		$post->id     = $post->ID;
+		$post->slug   = $post->post_name;
 
 		return $post;
 	}

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -365,24 +365,6 @@ class Post extends Core implements CoreInterface, MetaInterface, DatedInterface,
 
 
 	/**
-	 * Helps you find the post id regardless of whether you send a string or whatever.
-	 *
-	 * @internal
-	 * @param integer $pid number to check against.
-	 * @return integer ID number of a post
-	 */
-	protected static function check_post_id( $pid ) {
-		if ( is_numeric($pid) && 0 === $pid ) {
-			$pid = get_the_ID();
-			return $pid;
-		}
-		if ( ! is_numeric($pid) && is_string($pid) ) {
-			$pid = PostGetter::get_post_id_by_name($pid);
-		}
-		return $pid;
-	}
-
-	/**
 	 * Gets a excerpt of your post.
 	 *
 	 * If you have an excerpt is set on the post, the excerpt will be used. Otherwise it will try to


### PR DESCRIPTION
**Ticket**: #2433

## Issue

This method was supposed to be removed in THE PURGE.

## Solution

🔪 

## Impact

💀 

## Usage Changes

None.

## Considerations

Are there more? I did a quick sweep of the `Post` class and didn't find any (other than some minor formatting I tweaked here).

## Testing

No tests needed since this is dead code. This should actually increase coverage.