### PR TITLE
Fix MenuItem creation

### DIFF
--- a/lib/Factory/MenuItemFactory.php
+++ b/lib/Factory/MenuItemFactory.php
@@ -49,10 +49,9 @@ class MenuItemFactory {
 		return is_object($item) && $item instanceof WP_Post;
 	}
 
-	protected function build($item, Menu $menu) : CoreInterface {
+	protected function build($item, Menu $menu) : MenuItem {
 		$class = apply_filters('timber/menuitem/classmap', MenuItem::class, $item, $menu);
 
-		// @todo call ::build() instead of constructor
-		return new $class($item, $menu);
+		return $class::build($item, $menu);
 	}
 }

--- a/lib/MenuItem.php
+++ b/lib/MenuItem.php
@@ -3,6 +3,7 @@
 namespace Timber;
 
 use Timber\Factory\PostFactory;
+use Timber\Menu;
 
 /**
  * Class MenuItem
@@ -85,11 +86,20 @@ class MenuItem extends Core implements CoreInterface, MetaInterface {
 
 	/**
 	 * @internal
+	 * @param array|object $data The data this MenuItem is wrapping
+	 * @param \Timber\Menu $menu The `Timber\Menu` object the menu item is associated with.
+	 * @return \Timber\MenuItem a new MenuItem instance
+	 */
+	public static function build( $data, Menu $menu = null ) : self {
+		return new static($data, $menu);
+	}
+
+	/**
+	 * @internal
 	 * @param array|object $data
 	 * @param \Timber\Menu $menu The `Timber\Menu` object the menu item is associated with.
-	 * @todo make this protected and implement ::build() instead
 	 */
-	public function __construct( $data, $menu = null ) {
+	protected function __construct( $data, $menu = null ) {
 		$this->menu = $menu;
 		$data       = (object) $data;
 		$this->import($data);

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -356,7 +356,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertTrue( $menu_items[3]->current );
 		$this->assertContains( 'current-menu-item', $menu_items[3]->classes );
 	}
-  
+
 	function testMenuOptions () {
 		$menu_arr = self::_createTestMenu();
 
@@ -886,12 +886,13 @@ class TestTimberMenu extends Timber_UnitTestCase {
 	}
 
 	function testCustomMenuItemClass() {
-		$term    = self::_createTestMenu();
-		$menu_id = $term['term_id'];
+		$term       = self::_createTestMenu();
+		$menu_id    = $term['term_id'];
 		$menu_items = wp_get_nav_menu_items($menu_id);
-		$tmis = [];
+		$tmis       = [];
+
 		foreach( $menu_items as $mi ) {
-			$tmi = new CustomMenuItemClass($mi);
+			$tmi = CustomMenuItemClass::build($mi);
 			array_push($tmis, $tmi);
 		}
 		$this->assertEquals($tmis[4]->post_title, 'People');

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -428,7 +428,6 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$this->assertEquals( 'http://upstatement.com', $item->link() );
 		$this->assertEquals( 'http://upstatement.com', $item->url );
 		$this->assertTrue( $item->is_external() );
-
 	}
 
 	function testWPMLMenu() {


### PR DESCRIPTION
**Ticket**: None

## Issue

This addresses a couple issues:

1. MenuItemFactory::build() is less specific than it could be, causing PHPStan to complain.
2. MenuItem constructor is still public, allowing for direct instantiation which would forgo Class Maps.

## Impact

None.

## Usage Changes

Consistent with the rest of the Factory usage.

## Considerations

There are other Factories whose return values from `::build()` could also be more specific. These are out of scope here.

## Testing

Existing tests cover this functionality and are currently passing for me.