### PR TITLE
URLHelper::get_params() return value

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -1136,6 +1136,10 @@ add_filter( 'timber/twig/environment/options', function( $options ) {
 
 Read more about this in the [Escaping Guide](@todo).
 
+## URLHelper
+
+The `URLHelper::get_params()` method now returns `false` if passed an index that does not exist, whereas before it returned `null` in that case. This is for better consistency with other core API methods and will only affect code that is doing `===` or equivalent checks on return values from this method.
+
 ## Documentation
 
 We added a couple of new guides that you may want to read through in addition to this Upgrade Guide:

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -1138,7 +1138,7 @@ Read more about this in the [Escaping Guide](@todo).
 
 ## URLHelper
 
-The `URLHelper::get_params()` method now returns `false` if passed an index that does not exist, whereas before it returned `null` in that case. This is for better consistency with other core API methods and will only affect code that is doing `===` or equivalent checks on return values from this method.
+The `URLHelper::get_params()` method now returns `false` if passed an index that does not exist, whereas before it returned `null` in that case. This is for better consistency with other core API methods and only affects code using `===` or equivalent checks on return values from this method.
 
 ## Documentation
 

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -506,7 +506,7 @@ class URLHelper {
 
 	/**
 	 * Returns the url path parameters, or a single parameter if given an index.
-	 * Normalizes REQUEST_URI to lower-case. Returns null if given a
+	 * Normalizes REQUEST_URI to lower-case. Returns false if given a
 	 * non-existent index.
 	 *
 	 * @example
@@ -530,7 +530,7 @@ class URLHelper {
 	 *
 	 * @api
 	 * @param boolean|int $i the position of the parameter to grab.
-	 * @return array|string|null
+	 * @return array|string|false
 	 */
 	public static function get_params( $i = false ) {
 		$uri    = trim(strtolower($_SERVER['REQUEST_URI']));
@@ -545,7 +545,7 @@ class URLHelper {
 			$i = count($params) + $i;
 		}
 
-		return $params[$i] ?? null;
+		return $params[$i] ?? false;
 	}
 
 }

--- a/lib/URLHelper.php
+++ b/lib/URLHelper.php
@@ -504,35 +504,47 @@ class URLHelper {
 	}
 
 	/**
-	 * Returns the url parameters
+	 * Returns the url path parameters, or a single parameter if given an index.
+	 * Normalizes REQUEST_URI to lower-case. Returns false if given a
+	 * non-existent index.
 	 *
-	 * For example, for URL `http://example.org/blog/post/news/2014/whatever` this will return
-	 * `array('blog', 'post', 'news', '2014', 'whatever');` OR if sent an integer like:
-	 * `Timber\URLHelper::get_params(2);` this will return `news`.
+	 * @example
+	 * ```php
+	 * // Given a $_SERVER["REQUEST_URI"] of:
+	 * // http://example.org/blog/post/news/2014/whatever
+	 *
+	 * $params = URLHelper::get_params();
+	 * // => ["blog", "post", "news", "2014", "whatever"]
+	 *
+	 * $third = URLHelper::get_params(2);
+	 * // => "news"
+	 *
+	 * // get_params() supports negative indices:
+	 * $last = URLHelper::get_params(-1);
+	 * // => "whatever"
+	 *
+	 * $nada = URLHelper::get_params(99);
+	 * // => false
+	 * ```
 	 *
 	 * @api
-	 *
-	 * @param int $i the position of the parameter to grab.
-	 *
-	 * @return array|string
+	 * @param boolean|int $i the position of the parameter to grab.
+	 * @return array|string|null
 	 */
 	public static function get_params( $i = false ) {
-		$args    = explode('/', trim(strtolower($_SERVER['REQUEST_URI'])));
-		$newargs = array();
-		foreach ( $args as $arg ) {
-			if ( strlen($arg) ) {
-				$newargs[] = $arg;
-			}
-		}
+		$uri    = trim(strtolower($_SERVER['REQUEST_URI']));
+		$params = array_values(array_filter(explode('/', $uri)));
+
 		if ( false === $i ) {
-			return $newargs;
+			return $params;
 		}
+
+		// Support negative indices.
 		if ( $i < 0 ) {
-			$i = count($newargs) + $i;
+			$i = count($params) + $i;
 		}
-		if ( isset($newargs[ $i ]) ) {
-			return $newargs[ $i ];
-		}
+
+		return $params[$i] ?? null;
 	}
 
 }

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -5,207 +5,207 @@ class TestTimberURLHelper extends Timber_UnitTestCase {
 	private $mockUploadDir = false;
 
 	function setUp() {
-			$_SERVER['SERVER_PORT'] = 80;
+		$_SERVER['SERVER_PORT'] = 80;
 	}
 
 	function testHTTPSCurrentURL() {
-			$this->go_to('/');
-			$_SERVER['HTTPS'] = 'on';
-			$_SERVER['SERVER_PORT'] = 443;
-			$url = Timber\URLHelper::get_current_url();
-			$this->assertEquals('https://example.org/', trailingslashit($url));
-			$_SERVER['HTTPS'] = 'off';
-			unset($_SERVER['HTTPS']);
+		$this->go_to('/');
+		$_SERVER['HTTPS'] = 'on';
+		$_SERVER['SERVER_PORT'] = 443;
+		$url = Timber\URLHelper::get_current_url();
+		$this->assertEquals('https://example.org/', trailingslashit($url));
+		$_SERVER['HTTPS'] = 'off';
+		unset($_SERVER['HTTPS']);
 	}
 
 	function testSwapProtocolHTTPtoHTTPS() {
-			$url = 'http://nytimes.com/news/reports/2017';
-			$url = Timber\URLHelper::swap_protocol($url);
-			$this->assertStringStartsWith('https://', $url);
+		$url = 'http://nytimes.com/news/reports/2017';
+		$url = Timber\URLHelper::swap_protocol($url);
+		$this->assertStringStartsWith('https://', $url);
 	}
 
 	function testSwapProtocolHTTPStoHTTP() {
-			$url = 'https://nytimes.com/news/reports/2017';
-			$url = Timber\URLHelper::swap_protocol($url);
-			$this->assertStringStartsWith('http://', $url);
+		$url = 'https://nytimes.com/news/reports/2017';
+		$url = Timber\URLHelper::swap_protocol($url);
+		$this->assertStringStartsWith('http://', $url);
 	}
 
 	function testStartsWith() {
-			$haystack = 'http://nytimes.com/news/reports/2017';
-			$starts_with = 'http://nytimes.com/news';
-			$nope = 'http://bostonglobe.com';
-			$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
-			$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
+		$haystack = 'http://nytimes.com/news/reports/2017';
+		$starts_with = 'http://nytimes.com/news';
+		$nope = 'http://bostonglobe.com';
+		$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
+		$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
 	}
 
 	function testStartsWithHTTPs() {
-			$haystack = 'http://nytimes.com/news/reports/2017';
-			$starts_with = 'https://nytimes.com/news';
-			$nope = 'http://bostonglobe.com';
-			$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
-			$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
+		$haystack = 'http://nytimes.com/news/reports/2017';
+		$starts_with = 'https://nytimes.com/news';
+		$nope = 'http://bostonglobe.com';
+		$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
+		$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
 	}
 
 	function testStartsWithHTTPsFlip() {
-			$haystack = 'https://nytimes.com/news/reports/2017';
-			$starts_with = 'http://nytimes.com/news';
-			$nope = 'http://bostonglobe.com';
-			$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
-			$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
+		$haystack = 'https://nytimes.com/news/reports/2017';
+		$starts_with = 'http://nytimes.com/news';
+		$nope = 'http://bostonglobe.com';
+		$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
+		$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
 	}
 
 	function testFileSystemToURLWithWPML() {
-			self::_setLanguage();
-			add_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
-			$image = TestTimberImage::copyTestAttachment();
+		self::_setLanguage();
+		add_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
+		$image = TestTimberImage::copyTestAttachment();
 
-			$url = Timber\URLHelper::file_system_to_url($image);
-			$this->assertStringEndsWith('://example2.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-			remove_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'));
+		$url = Timber\URLHelper::file_system_to_url($image);
+		$this->assertStringEndsWith('://example2.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+		remove_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'));
 	}
 
 	function addWPMLHomeFilterForRegExTest($url, $path) {
-			return 'http://example2.org/en'.$path;
+		return 'http://example2.org/en'.$path;
 	}
 
 	function testFileSystemToURL() {
-			$image = TestTimberImage::copyTestAttachment();
-			$url = Timber\URLHelper::file_system_to_url($image);
-			$this->assertStringEndsWith('://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+		$image = TestTimberImage::copyTestAttachment();
+		$url = Timber\URLHelper::file_system_to_url($image);
+		$this->assertStringEndsWith('://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
 	}
 
 	function addWPMLHomeFilter($url, $path) {
-			return 'http://example.org/en'.$path;
+		return 'http://example.org/en'.$path;
 	}
 
 	function _setLanguage() {
-			if ( !defined('ICL_LANGUAGE_CODE') ) {
-					define('ICL_LANGUAGE_CODE', 'en');
-			}
+		if ( !defined('ICL_LANGUAGE_CODE') ) {
+			define('ICL_LANGUAGE_CODE', 'en');
+		}
 	}
 
 	function _setupWPMLDirectory() {
-			self::_setLanguage();
-			add_filter('home_url', array($this, 'addWPMLHomeFilter'), 10, 2);
+		self::_setLanguage();
+		add_filter('home_url', array($this, 'addWPMLHomeFilter'), 10, 2);
 	}
 
 	function testFileSystemToURLWithWPMLPrefix() {
-			self::_setupWPMLDirectory();
-			$image = TestTimberImage::copyTestAttachment();
-			$url = Timber\URLHelper::file_system_to_url($image);
-			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-			remove_filter('home_url', array($this, 'addWPMLHomeFilter'));
+		self::_setupWPMLDirectory();
+		$image = TestTimberImage::copyTestAttachment();
+		$url = Timber\URLHelper::file_system_to_url($image);
+		$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+		remove_filter('home_url', array($this, 'addWPMLHomeFilter'));
 	}
 
 	function testContentSubDirectory() {
-			$subdir = Timber\URLHelper::get_content_subdir();
-			$this->assertEquals('/wp-content', $subdir);
+		$subdir = Timber\URLHelper::get_content_subdir();
+		$this->assertEquals('/wp-content', $subdir);
 	}
 
 	function testURLToFileSystem() {
-			$url = 'http://example.org/wp-content/uploads/2012/06/mypic.jpg';
-			$file = Timber\URLHelper::url_to_file_system($url);
-			$this->assertStringStartsWith(ABSPATH, $file);
-			$this->assertStringEndsWith('/2012/06/mypic.jpg', $file);
-			$this->assertNotContains($file, 'http://example.org');
-			$this->assertNotContains($file, '//');
+		$url = 'http://example.org/wp-content/uploads/2012/06/mypic.jpg';
+		$file = Timber\URLHelper::url_to_file_system($url);
+		$this->assertStringStartsWith(ABSPATH, $file);
+		$this->assertStringEndsWith('/2012/06/mypic.jpg', $file);
+		$this->assertNotContains($file, 'http://example.org');
+		$this->assertNotContains($file, '//');
 	}
 
 	function testGetHost() {
-			$http_host = $_SERVER['HTTP_HOST'];
-			$server_name = $_SERVER['SERVER_NAME'];
-			$_SERVER['HTTP_HOST'] = '';
-			$_SERVER['SERVER_NAME'] = 'example.org';
-			$host = Timber\URLHelper::get_host();
-			$this->assertEquals('example.org', $host);
-			$_SERVER['HTTP_HOST'] = $http_host;
-			$_SERVER['SERVER_NAME'] = $server_name;
+		$http_host = $_SERVER['HTTP_HOST'];
+		$server_name = $_SERVER['SERVER_NAME'];
+		$_SERVER['HTTP_HOST'] = '';
+		$_SERVER['SERVER_NAME'] = 'example.org';
+		$host = Timber\URLHelper::get_host();
+		$this->assertEquals('example.org', $host);
+		$_SERVER['HTTP_HOST'] = $http_host;
+		$_SERVER['SERVER_NAME'] = $server_name;
 	}
 
 	function testGetHostEmpty() {
-			$http_host = $_SERVER['HTTP_HOST'];
-			$server_name = $_SERVER['SERVER_NAME'];
-			$_SERVER['HTTP_HOST'] = '';
-			$_SERVER['SERVER_NAME'] = '';
-			$host = Timber\URLHelper::get_host();
-			$this->assertEquals('', $host);
-			$_SERVER['HTTP_HOST'] = $http_host;
-			$_SERVER['SERVER_NAME'] = $server_name;
+		$http_host = $_SERVER['HTTP_HOST'];
+		$server_name = $_SERVER['SERVER_NAME'];
+		$_SERVER['HTTP_HOST'] = '';
+		$_SERVER['SERVER_NAME'] = '';
+		$host = Timber\URLHelper::get_host();
+		$this->assertEquals('', $host);
+		$_SERVER['HTTP_HOST'] = $http_host;
+		$_SERVER['SERVER_NAME'] = $server_name;
 	}
 
 	function testPrepend() {
-			$joined = Timber\URLHelper::prepend_to_url('example.com', '/thing/foo');
-			$this->assertEquals('example.com/thing/foo', $joined);
+		$joined = Timber\URLHelper::prepend_to_url('example.com', '/thing/foo');
+		$this->assertEquals('example.com/thing/foo', $joined);
 	}
 
 	function testPrependWithPort() {
-			$joined = Timber\URLHelper::prepend_to_url('http://example.com:8080/thing/', '/jiggly');
-			$this->assertEquals('http://example.com:8080/jiggly/thing/', $joined);
+		$joined = Timber\URLHelper::prepend_to_url('http://example.com:8080/thing/', '/jiggly');
+		$this->assertEquals('http://example.com:8080/jiggly/thing/', $joined);
 	}
 
 	function testPrependWithFragment() {
-			$joined = Timber\URLHelper::prepend_to_url('http://example.com/thing/#foo', '/jiggly');
-			$this->assertEquals('http://example.com/jiggly/thing/#foo', $joined);
+		$joined = Timber\URLHelper::prepend_to_url('http://example.com/thing/#foo', '/jiggly');
+		$this->assertEquals('http://example.com/jiggly/thing/#foo', $joined);
 	}
 
 	function testPrependWithQuery() {
-			$joined = Timber\URLHelper::prepend_to_url('http://example.com/?s=foo&jolly=good', '/search');
-			$this->assertEquals('http://example.com/search/?s=foo&jolly=good', $joined);
+		$joined = Timber\URLHelper::prepend_to_url('http://example.com/?s=foo&jolly=good', '/search');
+		$this->assertEquals('http://example.com/search/?s=foo&jolly=good', $joined);
 	}
 
 	function testUserTrailingSlashIt() {
-			global $wp_rewrite;
-			$wp_rewrite->use_trailing_slashes = true;
-			$link = '2016/04/my-silly-story';
-			$url = Timber\URLHelper::user_trailingslashit($link);
-			$this->assertEquals($link.'/', $url);
-			$wp_rewrite->use_trailing_slashes = false;
+		global $wp_rewrite;
+		$wp_rewrite->use_trailing_slashes = true;
+		$link = '2016/04/my-silly-story';
+		$url = Timber\URLHelper::user_trailingslashit($link);
+		$this->assertEquals($link.'/', $url);
+		$wp_rewrite->use_trailing_slashes = false;
 	}
 
 	function testDoubleSlashesWithHTTP() {
-			$url = 'http://nytimes.com/news//world/thing.html';
-			$expected_url = 'http://nytimes.com/news/world/thing.html';
-			$url = Timber\URLHelper::remove_double_slashes($url);
-			$this->assertEquals($expected_url, $url);
+		$url = 'http://nytimes.com/news//world/thing.html';
+		$expected_url = 'http://nytimes.com/news/world/thing.html';
+		$url = Timber\URLHelper::remove_double_slashes($url);
+		$this->assertEquals($expected_url, $url);
 	}
 
 	function testDoubleSlashesWithHTTPS() {
-			$url = 'https://nytimes.com/news//world/thing.html';
-			$expected_url = 'https://nytimes.com/news/world/thing.html';
-			$url = Timber\URLHelper::remove_double_slashes($url);
-			$this->assertEquals($expected_url, $url);
+		$url = 'https://nytimes.com/news//world/thing.html';
+		$expected_url = 'https://nytimes.com/news/world/thing.html';
+		$url = Timber\URLHelper::remove_double_slashes($url);
+		$this->assertEquals($expected_url, $url);
 	}
 
 	function testDoubleSlashesWithS3() {
-			$url = 's3://bucket/folder//thing.html';
-			$expected_url = 's3://bucket/folder/thing.html';
-			$url = Timber\URLHelper::remove_double_slashes($url);
-			$this->assertEquals($expected_url, $url);
+		$url = 's3://bucket/folder//thing.html';
+		$expected_url = 's3://bucket/folder/thing.html';
+		$url = Timber\URLHelper::remove_double_slashes($url);
+		$this->assertEquals($expected_url, $url);
 	}
 
-function testDoubleSlashesWithGS() {
-			$url = 'gs://bucket/folder//thing.html';
-			$expected_url = 'gs://bucket/folder/thing.html';
-			$url = Timber\URLHelper::remove_double_slashes($url);
-			$this->assertEquals($expected_url, $url);
+	function testDoubleSlashesWithGS() {
+		$url = 'gs://bucket/folder//thing.html';
+		$expected_url = 'gs://bucket/folder/thing.html';
+		$url = Timber\URLHelper::remove_double_slashes($url);
+		$this->assertEquals($expected_url, $url);
 	}
 
 	function testUserTrailingSlashItFailure() {
-			$link = 'http:///example.com';
-			$url = Timber\URLHelper::user_trailingslashit($link);
-			$this->assertEquals($link, $url);
+		$link = 'http:///example.com';
+		$url = Timber\URLHelper::user_trailingslashit($link);
+		$this->assertEquals($link, $url);
 	}
 
 	function testUnPreSlashIt() {
-			$str = '/wp-content/themes/undefeated/style.css';
-			$str = Timber\URLHelper::unpreslashit($str);
-			$this->assertEquals('wp-content/themes/undefeated/style.css', $str);
+		$str = '/wp-content/themes/undefeated/style.css';
+		$str = Timber\URLHelper::unpreslashit($str);
+		$this->assertEquals('wp-content/themes/undefeated/style.css', $str);
 	}
 
 	function testPreSlashIt() {
-			$before = 'thing/foo';
-			$after = Timber\URLHelper::preslashit($before);
-			$this->assertEquals('/'.$before, $after);
+		$before = 'thing/foo';
+		$after = Timber\URLHelper::preslashit($before);
+		$this->assertEquals('/'.$before, $after);
 	}
 
 	function testPreSlashItNadda() {
@@ -225,151 +225,150 @@ function testDoubleSlashesWithGS() {
 	}
 
 	function testCurrentURLWithServerPort() {
-			$old_port = $_SERVER['SERVER_PORT'];
-			$_SERVER['SERVER_PORT'] = 3000;
-			if (!isset($_SERVER['SERVER_NAME'])){
-					$_SERVER['SERVER_NAME'] = 'example.org';
-			}
-			$this->go_to('/');
-			$url = Timber\URLHelper::get_current_url();
-			$this->assertEquals('http://example.org:3000/', $url);
-			$_SERVER['SERVER_PORT'] = $old_port;
+		$old_port = $_SERVER['SERVER_PORT'];
+		$_SERVER['SERVER_PORT'] = 3000;
+		if (!isset($_SERVER['SERVER_NAME'])){
+		$_SERVER['SERVER_NAME'] = 'example.org';
+		}
+		$this->go_to('/');
+		$url = Timber\URLHelper::get_current_url();
+		$this->assertEquals('http://example.org:3000/', $url);
+		$_SERVER['SERVER_PORT'] = $old_port;
 	}
 
 	function testCurrentURL() {
-			$_SERVER['SERVER_PORT'] = 80;
-			$_SERVER['SERVER_NAME'] = 'example.org';
-			$this->go_to('/');
-			$url = Timber\URLHelper::get_current_url();
-			$this->assertEquals('http://example.org/', $url);
+		$_SERVER['SERVER_PORT'] = 80;
+		$_SERVER['SERVER_NAME'] = 'example.org';
+		$this->go_to('/');
+		$url = Timber\URLHelper::get_current_url();
+		$this->assertEquals('http://example.org/', $url);
 	}
 
 	function testCurrentURLIsSecure(){
-			if (!isset($_SERVER['SERVER_PORT'])){
-					$_SERVER['SERVER_PORT'] = 443;
-			}
-			if (!isset($_SERVER['SERVER_NAME'])){
-					$_SERVER['SERVER_NAME'] = 'example.org';
-			}
-			$_SERVER['HTTPS'] = 'on';
-			$this->go_to('/');
-			$url = Timber\URLHelper::get_current_url();
-			$this->assertEquals('https://example.org/', $url);
+		if (!isset($_SERVER['SERVER_PORT'])){
+			$_SERVER['SERVER_PORT'] = 443;
+		}
+		if (!isset($_SERVER['SERVER_NAME'])){
+			$_SERVER['SERVER_NAME'] = 'example.org';
+		}
+		$_SERVER['HTTPS'] = 'on';
+		$this->go_to('/');
+		$url = Timber\URLHelper::get_current_url();
+		$this->assertEquals('https://example.org/', $url);
 	}
 
 	function testUrlSchemeIsSecure() {
-			$_SERVER['HTTPS'] = 'on';
-			$scheme = Timber\URLHelper::get_scheme();
-			$this->assertEquals('https', $scheme);
+		$_SERVER['HTTPS'] = 'on';
+		$scheme = Timber\URLHelper::get_scheme();
+		$this->assertEquals('https', $scheme);
 	}
 
 	function testUrlSchemeIsNotSecure() {
-			$_SERVER['HTTPS'] = 'off';
-			$scheme = Timber\URLHelper::get_scheme();
-			$this->assertEquals('http', $scheme);
+		$_SERVER['HTTPS'] = 'off';
+		$scheme = Timber\URLHelper::get_scheme();
+		$this->assertEquals('http', $scheme);
 	}
 
 	function testIsURL(){
-			$url = 'http://example.org';
-			$not_url = '/blog/2014/05/whatever';
-			$this->assertTrue(Timber\URLHelper::is_url($url));
-			$this->assertFalse(Timber\URLHelper::is_url($not_url));
+		$url = 'http://example.org';
+		$not_url = '/blog/2014/05/whatever';
+		$this->assertTrue(Timber\URLHelper::is_url($url));
+		$this->assertFalse(Timber\URLHelper::is_url($not_url));
 		$this->assertFalse(Timber\URLHelper::is_url(8000));
 	}
 
 	function testIsExternal(){
-			$local = 'http://example.org';
-			$subdomain = 'http://cdn.example.org';
-			$external = 'http://upstatement.com';
-			$protocol_relative = '//upstatement.com';
+		$local = 'http://example.org';
+		$subdomain = 'http://cdn.example.org';
+		$external = 'http://upstatement.com';
+		$protocol_relative = '//upstatement.com';
 
-			$this->assertFalse(Timber\URLHelper::is_external($local));
-			$this->assertFalse(Timber\URLHelper::is_external($subdomain));
-			$this->assertTrue(Timber\URLHelper::is_external($external));
-$this->assertTrue(Timber\URLHelper::is_external($protocol_relative));
+		$this->assertFalse(Timber\URLHelper::is_external($local));
+		$this->assertFalse(Timber\URLHelper::is_external($subdomain));
+		$this->assertTrue(Timber\URLHelper::is_external($external));
+		$this->assertTrue(Timber\URLHelper::is_external($protocol_relative));
 	}
 
-function testIsExternalContent() {
-$internal = 'http://example.org/wp-content/uploads/my-image.png';
-$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
-$internal_in_uploads = 'http://example.org/uploads/uploads/my-image.png';
-$external = 'http://upstatement.com/my-image.png';
+	function testIsExternalContent() {
+		$internal = 'http://example.org/wp-content/uploads/my-image.png';
+		$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
+		$internal_in_uploads = 'http://example.org/uploads/uploads/my-image.png';
+		$external = 'http://upstatement.com/my-image.png';
 
-$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
-$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
-$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
-$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
-}
+		$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
+		$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
+		$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
+		$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
+	}
 
-function testIsExternalContentMovingFolders() {
-$internal = 'http://example.org/wp-content/uploads/my-image.png';
-$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
-$internal_in_uploads = 'http://example.org/uploads/my-image.png';
-$external = 'http://upstatement.com/my-image.png';
+	function testIsExternalContentMovingFolders() {
+		$internal = 'http://example.org/wp-content/uploads/my-image.png';
+		$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
+		$internal_in_uploads = 'http://example.org/uploads/my-image.png';
+		$external = 'http://upstatement.com/my-image.png';
 
-add_filter( 'upload_dir', array( &$this, 'mockUploadDir' ) );
-add_filter( 'content_url', array( &$this, 'mockContentUrl' ) );
+		add_filter( 'upload_dir', array( &$this, 'mockUploadDir' ) );
+		add_filter( 'content_url', array( &$this, 'mockContentUrl' ) );
 
-$this->mockUploadDir = true;
+		$this->mockUploadDir = true;
 
-$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
-$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
-$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
-$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
+		$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
+		$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
+		$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
+		$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
 
-$this->mockUploadDir = false;
-}
+		$this->mockUploadDir = false;
+	}
 
-function mockContentUrl($url) {
-return ( $this->mockUploadDir ) ? site_url( 'wp' ) : $url;
-}
+	function mockContentUrl($url) {
+		return ( $this->mockUploadDir ) ? site_url( 'wp' ) : $url;
+	}
 
-function mockUploadDir($path) {
-if ( $this->mockUploadDir ) {
+	function mockUploadDir($path) {
+		if ( $this->mockUploadDir ) {
+			$path['url'] = str_replace( $path['baseurl'], site_url().'/uploads', $path['url'] );
+			$path['baseurl'] = site_url().'/uploads';
 
-	$path['url'] = str_replace( $path['baseurl'], site_url().'/uploads', $path['url'] );
-	$path['baseurl'] = site_url().'/uploads';
+			$path['path'] = str_replace( $path['basedir'], ABSPATH.'uploads', $path['path'] );
+			$path['basedir'] = ABSPATH . 'uploads';
 
-	$path['path'] = str_replace( $path['basedir'], ABSPATH.'uploads', $path['path'] );
-	$path['basedir'] = ABSPATH . 'uploads';
+			$path['relative'] = '/uploads';
+		}
 
-	$path['relative'] = '/uploads';
-}
-
-return $path;
-}
+		return $path;
+	}
 
 	function testGetRelURL(){
-			$local = 'http://example.org/directory';
-			$subdomain = 'http://cdn.example.org/directory';
-			$external = 'http://upstatement.com';
-			$rel_url = '/directory/';
-			$this->assertEquals('/directory', Timber\URLHelper::get_rel_url($local));
-			$this->assertEquals($subdomain, Timber\URLHelper::get_rel_url($subdomain));
-			$this->assertEquals($external, Timber\URLHelper::get_rel_url($external));
-			$this->assertEquals($rel_url, Timber\URLHelper::get_rel_url($rel_url));
+		$local = 'http://example.org/directory';
+		$subdomain = 'http://cdn.example.org/directory';
+		$external = 'http://upstatement.com';
+		$rel_url = '/directory/';
+		$this->assertEquals('/directory', Timber\URLHelper::get_rel_url($local));
+		$this->assertEquals($subdomain, Timber\URLHelper::get_rel_url($subdomain));
+		$this->assertEquals($external, Timber\URLHelper::get_rel_url($external));
+		$this->assertEquals($rel_url, Timber\URLHelper::get_rel_url($rel_url));
 	}
 
 	function testRemoveTrailingSlash(){
-			$url_with_trailing_slash = 'http://example.org/directory/';
-			$root_url = "/";
-			$this->assertEquals('http://example.org/directory', Timber\URLHelper::remove_trailing_slash($url_with_trailing_slash));
-			$this->assertEquals('/', Timber\URLHelper::remove_trailing_slash($root_url));
+		$url_with_trailing_slash = 'http://example.org/directory/';
+		$root_url = "/";
+		$this->assertEquals('http://example.org/directory', Timber\URLHelper::remove_trailing_slash($url_with_trailing_slash));
+		$this->assertEquals('/', Timber\URLHelper::remove_trailing_slash($root_url));
 	}
 
 	function testGetParams(){
-			$_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
-			$params = Timber\URLHelper::get_params();
-			$this->assertEquals(7, count($params));
-			$whatever = Timber\URLHelper::get_params(-1);
-			$blog = Timber\URLHelper::get_params(2);
-			$this->assertEquals('whatever', $whatever);
-			$this->assertEquals('blog', $blog);
+		$_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
+		$params = Timber\URLHelper::get_params();
+		$this->assertEquals(7, count($params));
+		$whatever = Timber\URLHelper::get_params(-1);
+		$blog = Timber\URLHelper::get_params(2);
+		$this->assertEquals('whatever', $whatever);
+		$this->assertEquals('blog', $blog);
 	}
 
 	function testGetParamsNada(){
-			$_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
-			$params = Timber\URLHelper::get_params(93);
-			$this->assertFalse($params);
+		$_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
+		$params = Timber\URLHelper::get_params(93);
+		$this->assertFalse($params);
 	}
 }

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -182,7 +182,7 @@
             $url = Timber\URLHelper::remove_double_slashes($url);
             $this->assertEquals($expected_url, $url);
         }
-		
+
 	function testDoubleSlashesWithGS() {
             $url = 'gs://bucket/folder//thing.html';
             $expected_url = 'gs://bucket/folder/thing.html';
@@ -367,11 +367,9 @@
             $this->assertEquals('blog', $blog);
         }
 
-        function testGetParamsNadda(){
+        function testGetParamsNada(){
             $_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
             $params = Timber\URLHelper::get_params(93);
-            $this->assertNull($params);
+            $this->assertFalse($params);
         }
-
-
     }

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -1,375 +1,375 @@
 <?php
 
-	class TestTimberURLHelper extends Timber_UnitTestCase {
+class TestTimberURLHelper extends Timber_UnitTestCase {
 
-		private $mockUploadDir = false;
+	private $mockUploadDir = false;
 
-        function setUp() {
-            $_SERVER['SERVER_PORT'] = 80;
-        }
+	function setUp() {
+			$_SERVER['SERVER_PORT'] = 80;
+	}
 
-        function testHTTPSCurrentURL() {
-            $this->go_to('/');
-            $_SERVER['HTTPS'] = 'on';
-            $_SERVER['SERVER_PORT'] = 443;
-            $url = Timber\URLHelper::get_current_url();
-            $this->assertEquals('https://example.org/', trailingslashit($url));
-            $_SERVER['HTTPS'] = 'off';
-            unset($_SERVER['HTTPS']);
-        }
+	function testHTTPSCurrentURL() {
+			$this->go_to('/');
+			$_SERVER['HTTPS'] = 'on';
+			$_SERVER['SERVER_PORT'] = 443;
+			$url = Timber\URLHelper::get_current_url();
+			$this->assertEquals('https://example.org/', trailingslashit($url));
+			$_SERVER['HTTPS'] = 'off';
+			unset($_SERVER['HTTPS']);
+	}
 
-        function testSwapProtocolHTTPtoHTTPS() {
-            $url = 'http://nytimes.com/news/reports/2017';
-            $url = Timber\URLHelper::swap_protocol($url);
-            $this->assertStringStartsWith('https://', $url);
-        }
+	function testSwapProtocolHTTPtoHTTPS() {
+			$url = 'http://nytimes.com/news/reports/2017';
+			$url = Timber\URLHelper::swap_protocol($url);
+			$this->assertStringStartsWith('https://', $url);
+	}
 
-        function testSwapProtocolHTTPStoHTTP() {
-            $url = 'https://nytimes.com/news/reports/2017';
-            $url = Timber\URLHelper::swap_protocol($url);
-            $this->assertStringStartsWith('http://', $url);
-        }
+	function testSwapProtocolHTTPStoHTTP() {
+			$url = 'https://nytimes.com/news/reports/2017';
+			$url = Timber\URLHelper::swap_protocol($url);
+			$this->assertStringStartsWith('http://', $url);
+	}
 
-        function testStartsWith() {
-            $haystack = 'http://nytimes.com/news/reports/2017';
-            $starts_with = 'http://nytimes.com/news';
-            $nope = 'http://bostonglobe.com';
-            $this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
-            $this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
-        }
+	function testStartsWith() {
+			$haystack = 'http://nytimes.com/news/reports/2017';
+			$starts_with = 'http://nytimes.com/news';
+			$nope = 'http://bostonglobe.com';
+			$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
+			$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
+	}
 
-        function testStartsWithHTTPs() {
-            $haystack = 'http://nytimes.com/news/reports/2017';
-            $starts_with = 'https://nytimes.com/news';
-            $nope = 'http://bostonglobe.com';
-            $this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
-            $this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
-        }
+	function testStartsWithHTTPs() {
+			$haystack = 'http://nytimes.com/news/reports/2017';
+			$starts_with = 'https://nytimes.com/news';
+			$nope = 'http://bostonglobe.com';
+			$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
+			$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
+	}
 
-        function testStartsWithHTTPsFlip() {
-            $haystack = 'https://nytimes.com/news/reports/2017';
-            $starts_with = 'http://nytimes.com/news';
-            $nope = 'http://bostonglobe.com';
-            $this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
-            $this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
-        }
+	function testStartsWithHTTPsFlip() {
+			$haystack = 'https://nytimes.com/news/reports/2017';
+			$starts_with = 'http://nytimes.com/news';
+			$nope = 'http://bostonglobe.com';
+			$this->assertTrue(Timber\URLHelper::starts_with($haystack, $starts_with));
+			$this->assertFalse(Timber\URLHelper::starts_with($haystack, $nope));
+	}
 
-        function testFileSystemToURLWithWPML() {
-            self::_setLanguage();
-            add_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
-            $image = TestTimberImage::copyTestAttachment();
+	function testFileSystemToURLWithWPML() {
+			self::_setLanguage();
+			add_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'), 10, 2);
+			$image = TestTimberImage::copyTestAttachment();
 
-            $url = Timber\URLHelper::file_system_to_url($image);
-            $this->assertStringEndsWith('://example2.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-            remove_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'));
-        }
+			$url = Timber\URLHelper::file_system_to_url($image);
+			$this->assertStringEndsWith('://example2.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+			remove_filter('home_url', array($this, 'addWPMLHomeFilterForRegExTest'));
+	}
 
-        function addWPMLHomeFilterForRegExTest($url, $path) {
-            return 'http://example2.org/en'.$path;
-        }
+	function addWPMLHomeFilterForRegExTest($url, $path) {
+			return 'http://example2.org/en'.$path;
+	}
 
-        function testFileSystemToURL() {
-            $image = TestTimberImage::copyTestAttachment();
-            $url = Timber\URLHelper::file_system_to_url($image);
-            $this->assertStringEndsWith('://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-        }
+	function testFileSystemToURL() {
+			$image = TestTimberImage::copyTestAttachment();
+			$url = Timber\URLHelper::file_system_to_url($image);
+			$this->assertStringEndsWith('://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+	}
 
-        function addWPMLHomeFilter($url, $path) {
-            return 'http://example.org/en'.$path;
-        }
+	function addWPMLHomeFilter($url, $path) {
+			return 'http://example.org/en'.$path;
+	}
 
-        function _setLanguage() {
-            if ( !defined('ICL_LANGUAGE_CODE') ) {
-                define('ICL_LANGUAGE_CODE', 'en');
-            }
-        }
-
-        function _setupWPMLDirectory() {
-            self::_setLanguage();
-            add_filter('home_url', array($this, 'addWPMLHomeFilter'), 10, 2);
-        }
-
-        function testFileSystemToURLWithWPMLPrefix() {
-            self::_setupWPMLDirectory();
-            $image = TestTimberImage::copyTestAttachment();
-            $url = Timber\URLHelper::file_system_to_url($image);
-            $this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
-            remove_filter('home_url', array($this, 'addWPMLHomeFilter'));
-        }
-
-        function testContentSubDirectory() {
-            $subdir = Timber\URLHelper::get_content_subdir();
-            $this->assertEquals('/wp-content', $subdir);
-        }
-
-        function testURLToFileSystem() {
-            $url = 'http://example.org/wp-content/uploads/2012/06/mypic.jpg';
-            $file = Timber\URLHelper::url_to_file_system($url);
-            $this->assertStringStartsWith(ABSPATH, $file);
-            $this->assertStringEndsWith('/2012/06/mypic.jpg', $file);
-            $this->assertNotContains($file, 'http://example.org');
-            $this->assertNotContains($file, '//');
-        }
-
-        function testGetHost() {
-            $http_host = $_SERVER['HTTP_HOST'];
-            $server_name = $_SERVER['SERVER_NAME'];
-            $_SERVER['HTTP_HOST'] = '';
-            $_SERVER['SERVER_NAME'] = 'example.org';
-            $host = Timber\URLHelper::get_host();
-            $this->assertEquals('example.org', $host);
-            $_SERVER['HTTP_HOST'] = $http_host;
-            $_SERVER['SERVER_NAME'] = $server_name;
-        }
-
-        function testGetHostEmpty() {
-            $http_host = $_SERVER['HTTP_HOST'];
-            $server_name = $_SERVER['SERVER_NAME'];
-            $_SERVER['HTTP_HOST'] = '';
-            $_SERVER['SERVER_NAME'] = '';
-            $host = Timber\URLHelper::get_host();
-            $this->assertEquals('', $host);
-            $_SERVER['HTTP_HOST'] = $http_host;
-            $_SERVER['SERVER_NAME'] = $server_name;
-        }
-
-        function testPrepend() {
-            $joined = Timber\URLHelper::prepend_to_url('example.com', '/thing/foo');
-            $this->assertEquals('example.com/thing/foo', $joined);
-        }
-
-        function testPrependWithPort() {
-            $joined = Timber\URLHelper::prepend_to_url('http://example.com:8080/thing/', '/jiggly');
-            $this->assertEquals('http://example.com:8080/jiggly/thing/', $joined);
-        }
-
-        function testPrependWithFragment() {
-            $joined = Timber\URLHelper::prepend_to_url('http://example.com/thing/#foo', '/jiggly');
-            $this->assertEquals('http://example.com/jiggly/thing/#foo', $joined);
-        }
-
-        function testPrependWithQuery() {
-            $joined = Timber\URLHelper::prepend_to_url('http://example.com/?s=foo&jolly=good', '/search');
-            $this->assertEquals('http://example.com/search/?s=foo&jolly=good', $joined);
-        }
-
-        function testUserTrailingSlashIt() {
-            global $wp_rewrite;
-            $wp_rewrite->use_trailing_slashes = true;
-            $link = '2016/04/my-silly-story';
-            $url = Timber\URLHelper::user_trailingslashit($link);
-            $this->assertEquals($link.'/', $url);
-            $wp_rewrite->use_trailing_slashes = false;
-        }
-
-        function testDoubleSlashesWithHTTP() {
-            $url = 'http://nytimes.com/news//world/thing.html';
-            $expected_url = 'http://nytimes.com/news/world/thing.html';
-            $url = Timber\URLHelper::remove_double_slashes($url);
-            $this->assertEquals($expected_url, $url);
-        }
-
-        function testDoubleSlashesWithHTTPS() {
-            $url = 'https://nytimes.com/news//world/thing.html';
-            $expected_url = 'https://nytimes.com/news/world/thing.html';
-            $url = Timber\URLHelper::remove_double_slashes($url);
-            $this->assertEquals($expected_url, $url);
-        }
-
-        function testDoubleSlashesWithS3() {
-            $url = 's3://bucket/folder//thing.html';
-            $expected_url = 's3://bucket/folder/thing.html';
-            $url = Timber\URLHelper::remove_double_slashes($url);
-            $this->assertEquals($expected_url, $url);
-        }
-
-	function testDoubleSlashesWithGS() {
-            $url = 'gs://bucket/folder//thing.html';
-            $expected_url = 'gs://bucket/folder/thing.html';
-            $url = Timber\URLHelper::remove_double_slashes($url);
-            $this->assertEquals($expected_url, $url);
-        }
-
-        function testUserTrailingSlashItFailure() {
-            $link = 'http:///example.com';
-            $url = Timber\URLHelper::user_trailingslashit($link);
-            $this->assertEquals($link, $url);
-        }
-
-        function testUnPreSlashIt() {
-            $str = '/wp-content/themes/undefeated/style.css';
-            $str = Timber\URLHelper::unpreslashit($str);
-            $this->assertEquals('wp-content/themes/undefeated/style.css', $str);
-        }
-
-        function testPreSlashIt() {
-            $before = 'thing/foo';
-            $after = Timber\URLHelper::preslashit($before);
-            $this->assertEquals('/'.$before, $after);
-        }
-
-        function testPreSlashItNadda() {
-            $before = '/thing/foo';
-            $after = Timber\URLHelper::preslashit($before);
-            $this->assertEquals($before, $after);
-        }
-
-        function testPathBase() {
-            $struc = '/%year%/%monthnum%/%postname%/';
-            $this->setPermalinkStructure( $struc );
-        	$this->assertEquals('/', Timber\URLHelper::get_path_base());
-        }
-
-        function testIsLocal() {
-        	$this->assertFalse(Timber\URLHelper::is_local('http://wordpress.org'));
-        }
-
-        function testCurrentURLWithServerPort() {
-            $old_port = $_SERVER['SERVER_PORT'];
-            $_SERVER['SERVER_PORT'] = 3000;
-            if (!isset($_SERVER['SERVER_NAME'])){
-                $_SERVER['SERVER_NAME'] = 'example.org';
-            }
-            $this->go_to('/');
-            $url = Timber\URLHelper::get_current_url();
-            $this->assertEquals('http://example.org:3000/', $url);
-            $_SERVER['SERVER_PORT'] = $old_port;
-        }
-
-        function testCurrentURL() {
-            $_SERVER['SERVER_PORT'] = 80;
-            $_SERVER['SERVER_NAME'] = 'example.org';
-            $this->go_to('/');
-            $url = Timber\URLHelper::get_current_url();
-            $this->assertEquals('http://example.org/', $url);
-        }
-
-        function testCurrentURLIsSecure(){
-            if (!isset($_SERVER['SERVER_PORT'])){
-                $_SERVER['SERVER_PORT'] = 443;
-            }
-            if (!isset($_SERVER['SERVER_NAME'])){
-                $_SERVER['SERVER_NAME'] = 'example.org';
-            }
-            $_SERVER['HTTPS'] = 'on';
-            $this->go_to('/');
-            $url = Timber\URLHelper::get_current_url();
-            $this->assertEquals('https://example.org/', $url);
-        }
-
-        function testUrlSchemeIsSecure() {
-            $_SERVER['HTTPS'] = 'on';
-            $scheme = Timber\URLHelper::get_scheme();
-            $this->assertEquals('https', $scheme);
-        }
-
-        function testUrlSchemeIsNotSecure() {
-            $_SERVER['HTTPS'] = 'off';
-            $scheme = Timber\URLHelper::get_scheme();
-            $this->assertEquals('http', $scheme);
-        }
-
-        function testIsURL(){
-            $url = 'http://example.org';
-            $not_url = '/blog/2014/05/whatever';
-            $this->assertTrue(Timber\URLHelper::is_url($url));
-            $this->assertFalse(Timber\URLHelper::is_url($not_url));
-      		$this->assertFalse(Timber\URLHelper::is_url(8000));
-        }
-
-        function testIsExternal(){
-            $local = 'http://example.org';
-            $subdomain = 'http://cdn.example.org';
-            $external = 'http://upstatement.com';
-            $protocol_relative = '//upstatement.com';
-
-            $this->assertFalse(Timber\URLHelper::is_external($local));
-            $this->assertFalse(Timber\URLHelper::is_external($subdomain));
-            $this->assertTrue(Timber\URLHelper::is_external($external));
-			$this->assertTrue(Timber\URLHelper::is_external($protocol_relative));
-        }
-
-		function testIsExternalContent() {
-			$internal = 'http://example.org/wp-content/uploads/my-image.png';
-			$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
-			$internal_in_uploads = 'http://example.org/uploads/uploads/my-image.png';
-			$external = 'http://upstatement.com/my-image.png';
-
-			$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
-			$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
-			$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
-			$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
-		}
-
-		function testIsExternalContentMovingFolders() {
-			$internal = 'http://example.org/wp-content/uploads/my-image.png';
-			$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
-			$internal_in_uploads = 'http://example.org/uploads/my-image.png';
-			$external = 'http://upstatement.com/my-image.png';
-
-			add_filter( 'upload_dir', array( &$this, 'mockUploadDir' ) );
-			add_filter( 'content_url', array( &$this, 'mockContentUrl' ) );
-
-			$this->mockUploadDir = true;
-
-			$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
-			$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
-			$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
-			$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
-
-			$this->mockUploadDir = false;
-		}
-
-		function mockContentUrl($url) {
-			return ( $this->mockUploadDir ) ? site_url( 'wp' ) : $url;
-		}
-
-		function mockUploadDir($path) {
-			if ( $this->mockUploadDir ) {
-
-				$path['url'] = str_replace( $path['baseurl'], site_url().'/uploads', $path['url'] );
-				$path['baseurl'] = site_url().'/uploads';
-
-				$path['path'] = str_replace( $path['basedir'], ABSPATH.'uploads', $path['path'] );
-				$path['basedir'] = ABSPATH . 'uploads';
-
-				$path['relative'] = '/uploads';
+	function _setLanguage() {
+			if ( !defined('ICL_LANGUAGE_CODE') ) {
+					define('ICL_LANGUAGE_CODE', 'en');
 			}
+	}
 
-			return $path;
-		}
+	function _setupWPMLDirectory() {
+			self::_setLanguage();
+			add_filter('home_url', array($this, 'addWPMLHomeFilter'), 10, 2);
+	}
 
-        function testGetRelURL(){
-            $local = 'http://example.org/directory';
-            $subdomain = 'http://cdn.example.org/directory';
-            $external = 'http://upstatement.com';
-            $rel_url = '/directory/';
-            $this->assertEquals('/directory', Timber\URLHelper::get_rel_url($local));
-            $this->assertEquals($subdomain, Timber\URLHelper::get_rel_url($subdomain));
-            $this->assertEquals($external, Timber\URLHelper::get_rel_url($external));
-            $this->assertEquals($rel_url, Timber\URLHelper::get_rel_url($rel_url));
-        }
+	function testFileSystemToURLWithWPMLPrefix() {
+			self::_setupWPMLDirectory();
+			$image = TestTimberImage::copyTestAttachment();
+			$url = Timber\URLHelper::file_system_to_url($image);
+			$this->assertEquals('http://example.org/wp-content/uploads/'.date('Y/m').'/arch.jpg', $url);
+			remove_filter('home_url', array($this, 'addWPMLHomeFilter'));
+	}
 
-        function testRemoveTrailingSlash(){
-            $url_with_trailing_slash = 'http://example.org/directory/';
-            $root_url = "/";
-            $this->assertEquals('http://example.org/directory', Timber\URLHelper::remove_trailing_slash($url_with_trailing_slash));
-            $this->assertEquals('/', Timber\URLHelper::remove_trailing_slash($root_url));
-        }
+	function testContentSubDirectory() {
+			$subdir = Timber\URLHelper::get_content_subdir();
+			$this->assertEquals('/wp-content', $subdir);
+	}
 
-        function testGetParams(){
-            $_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
-            $params = Timber\URLHelper::get_params();
-            $this->assertEquals(7, count($params));
-            $whatever = Timber\URLHelper::get_params(-1);
-            $blog = Timber\URLHelper::get_params(2);
-            $this->assertEquals('whatever', $whatever);
-            $this->assertEquals('blog', $blog);
-        }
+	function testURLToFileSystem() {
+			$url = 'http://example.org/wp-content/uploads/2012/06/mypic.jpg';
+			$file = Timber\URLHelper::url_to_file_system($url);
+			$this->assertStringStartsWith(ABSPATH, $file);
+			$this->assertStringEndsWith('/2012/06/mypic.jpg', $file);
+			$this->assertNotContains($file, 'http://example.org');
+			$this->assertNotContains($file, '//');
+	}
 
-        function testGetParamsNada(){
-            $_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
-            $params = Timber\URLHelper::get_params(93);
-            $this->assertFalse($params);
-        }
-    }
+	function testGetHost() {
+			$http_host = $_SERVER['HTTP_HOST'];
+			$server_name = $_SERVER['SERVER_NAME'];
+			$_SERVER['HTTP_HOST'] = '';
+			$_SERVER['SERVER_NAME'] = 'example.org';
+			$host = Timber\URLHelper::get_host();
+			$this->assertEquals('example.org', $host);
+			$_SERVER['HTTP_HOST'] = $http_host;
+			$_SERVER['SERVER_NAME'] = $server_name;
+	}
+
+	function testGetHostEmpty() {
+			$http_host = $_SERVER['HTTP_HOST'];
+			$server_name = $_SERVER['SERVER_NAME'];
+			$_SERVER['HTTP_HOST'] = '';
+			$_SERVER['SERVER_NAME'] = '';
+			$host = Timber\URLHelper::get_host();
+			$this->assertEquals('', $host);
+			$_SERVER['HTTP_HOST'] = $http_host;
+			$_SERVER['SERVER_NAME'] = $server_name;
+	}
+
+	function testPrepend() {
+			$joined = Timber\URLHelper::prepend_to_url('example.com', '/thing/foo');
+			$this->assertEquals('example.com/thing/foo', $joined);
+	}
+
+	function testPrependWithPort() {
+			$joined = Timber\URLHelper::prepend_to_url('http://example.com:8080/thing/', '/jiggly');
+			$this->assertEquals('http://example.com:8080/jiggly/thing/', $joined);
+	}
+
+	function testPrependWithFragment() {
+			$joined = Timber\URLHelper::prepend_to_url('http://example.com/thing/#foo', '/jiggly');
+			$this->assertEquals('http://example.com/jiggly/thing/#foo', $joined);
+	}
+
+	function testPrependWithQuery() {
+			$joined = Timber\URLHelper::prepend_to_url('http://example.com/?s=foo&jolly=good', '/search');
+			$this->assertEquals('http://example.com/search/?s=foo&jolly=good', $joined);
+	}
+
+	function testUserTrailingSlashIt() {
+			global $wp_rewrite;
+			$wp_rewrite->use_trailing_slashes = true;
+			$link = '2016/04/my-silly-story';
+			$url = Timber\URLHelper::user_trailingslashit($link);
+			$this->assertEquals($link.'/', $url);
+			$wp_rewrite->use_trailing_slashes = false;
+	}
+
+	function testDoubleSlashesWithHTTP() {
+			$url = 'http://nytimes.com/news//world/thing.html';
+			$expected_url = 'http://nytimes.com/news/world/thing.html';
+			$url = Timber\URLHelper::remove_double_slashes($url);
+			$this->assertEquals($expected_url, $url);
+	}
+
+	function testDoubleSlashesWithHTTPS() {
+			$url = 'https://nytimes.com/news//world/thing.html';
+			$expected_url = 'https://nytimes.com/news/world/thing.html';
+			$url = Timber\URLHelper::remove_double_slashes($url);
+			$this->assertEquals($expected_url, $url);
+	}
+
+	function testDoubleSlashesWithS3() {
+			$url = 's3://bucket/folder//thing.html';
+			$expected_url = 's3://bucket/folder/thing.html';
+			$url = Timber\URLHelper::remove_double_slashes($url);
+			$this->assertEquals($expected_url, $url);
+	}
+
+function testDoubleSlashesWithGS() {
+			$url = 'gs://bucket/folder//thing.html';
+			$expected_url = 'gs://bucket/folder/thing.html';
+			$url = Timber\URLHelper::remove_double_slashes($url);
+			$this->assertEquals($expected_url, $url);
+	}
+
+	function testUserTrailingSlashItFailure() {
+			$link = 'http:///example.com';
+			$url = Timber\URLHelper::user_trailingslashit($link);
+			$this->assertEquals($link, $url);
+	}
+
+	function testUnPreSlashIt() {
+			$str = '/wp-content/themes/undefeated/style.css';
+			$str = Timber\URLHelper::unpreslashit($str);
+			$this->assertEquals('wp-content/themes/undefeated/style.css', $str);
+	}
+
+	function testPreSlashIt() {
+			$before = 'thing/foo';
+			$after = Timber\URLHelper::preslashit($before);
+			$this->assertEquals('/'.$before, $after);
+	}
+
+	function testPreSlashItNadda() {
+			$before = '/thing/foo';
+			$after = Timber\URLHelper::preslashit($before);
+			$this->assertEquals($before, $after);
+	}
+
+	function testPathBase() {
+			$struc = '/%year%/%monthnum%/%postname%/';
+			$this->setPermalinkStructure( $struc );
+		$this->assertEquals('/', Timber\URLHelper::get_path_base());
+	}
+
+	function testIsLocal() {
+		$this->assertFalse(Timber\URLHelper::is_local('http://wordpress.org'));
+	}
+
+	function testCurrentURLWithServerPort() {
+			$old_port = $_SERVER['SERVER_PORT'];
+			$_SERVER['SERVER_PORT'] = 3000;
+			if (!isset($_SERVER['SERVER_NAME'])){
+					$_SERVER['SERVER_NAME'] = 'example.org';
+			}
+			$this->go_to('/');
+			$url = Timber\URLHelper::get_current_url();
+			$this->assertEquals('http://example.org:3000/', $url);
+			$_SERVER['SERVER_PORT'] = $old_port;
+	}
+
+	function testCurrentURL() {
+			$_SERVER['SERVER_PORT'] = 80;
+			$_SERVER['SERVER_NAME'] = 'example.org';
+			$this->go_to('/');
+			$url = Timber\URLHelper::get_current_url();
+			$this->assertEquals('http://example.org/', $url);
+	}
+
+	function testCurrentURLIsSecure(){
+			if (!isset($_SERVER['SERVER_PORT'])){
+					$_SERVER['SERVER_PORT'] = 443;
+			}
+			if (!isset($_SERVER['SERVER_NAME'])){
+					$_SERVER['SERVER_NAME'] = 'example.org';
+			}
+			$_SERVER['HTTPS'] = 'on';
+			$this->go_to('/');
+			$url = Timber\URLHelper::get_current_url();
+			$this->assertEquals('https://example.org/', $url);
+	}
+
+	function testUrlSchemeIsSecure() {
+			$_SERVER['HTTPS'] = 'on';
+			$scheme = Timber\URLHelper::get_scheme();
+			$this->assertEquals('https', $scheme);
+	}
+
+	function testUrlSchemeIsNotSecure() {
+			$_SERVER['HTTPS'] = 'off';
+			$scheme = Timber\URLHelper::get_scheme();
+			$this->assertEquals('http', $scheme);
+	}
+
+	function testIsURL(){
+			$url = 'http://example.org';
+			$not_url = '/blog/2014/05/whatever';
+			$this->assertTrue(Timber\URLHelper::is_url($url));
+			$this->assertFalse(Timber\URLHelper::is_url($not_url));
+		$this->assertFalse(Timber\URLHelper::is_url(8000));
+	}
+
+	function testIsExternal(){
+			$local = 'http://example.org';
+			$subdomain = 'http://cdn.example.org';
+			$external = 'http://upstatement.com';
+			$protocol_relative = '//upstatement.com';
+
+			$this->assertFalse(Timber\URLHelper::is_external($local));
+			$this->assertFalse(Timber\URLHelper::is_external($subdomain));
+			$this->assertTrue(Timber\URLHelper::is_external($external));
+$this->assertTrue(Timber\URLHelper::is_external($protocol_relative));
+	}
+
+function testIsExternalContent() {
+$internal = 'http://example.org/wp-content/uploads/my-image.png';
+$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
+$internal_in_uploads = 'http://example.org/uploads/uploads/my-image.png';
+$external = 'http://upstatement.com/my-image.png';
+
+$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
+$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
+$this->assertTrue( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
+$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
+}
+
+function testIsExternalContentMovingFolders() {
+$internal = 'http://example.org/wp-content/uploads/my-image.png';
+$internal_in_abspath = 'http://example.org/wp/uploads/my-image.png';
+$internal_in_uploads = 'http://example.org/uploads/my-image.png';
+$external = 'http://upstatement.com/my-image.png';
+
+add_filter( 'upload_dir', array( &$this, 'mockUploadDir' ) );
+add_filter( 'content_url', array( &$this, 'mockContentUrl' ) );
+
+$this->mockUploadDir = true;
+
+$this->assertFalse( Timber\URLHelper::is_external_content( $internal ) );
+$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_uploads ) );
+$this->assertFalse( Timber\URLHelper::is_external_content( $internal_in_abspath ) );
+$this->assertTrue( Timber\URLHelper::is_external_content( $external ) );
+
+$this->mockUploadDir = false;
+}
+
+function mockContentUrl($url) {
+return ( $this->mockUploadDir ) ? site_url( 'wp' ) : $url;
+}
+
+function mockUploadDir($path) {
+if ( $this->mockUploadDir ) {
+
+	$path['url'] = str_replace( $path['baseurl'], site_url().'/uploads', $path['url'] );
+	$path['baseurl'] = site_url().'/uploads';
+
+	$path['path'] = str_replace( $path['basedir'], ABSPATH.'uploads', $path['path'] );
+	$path['basedir'] = ABSPATH . 'uploads';
+
+	$path['relative'] = '/uploads';
+}
+
+return $path;
+}
+
+	function testGetRelURL(){
+			$local = 'http://example.org/directory';
+			$subdomain = 'http://cdn.example.org/directory';
+			$external = 'http://upstatement.com';
+			$rel_url = '/directory/';
+			$this->assertEquals('/directory', Timber\URLHelper::get_rel_url($local));
+			$this->assertEquals($subdomain, Timber\URLHelper::get_rel_url($subdomain));
+			$this->assertEquals($external, Timber\URLHelper::get_rel_url($external));
+			$this->assertEquals($rel_url, Timber\URLHelper::get_rel_url($rel_url));
+	}
+
+	function testRemoveTrailingSlash(){
+			$url_with_trailing_slash = 'http://example.org/directory/';
+			$root_url = "/";
+			$this->assertEquals('http://example.org/directory', Timber\URLHelper::remove_trailing_slash($url_with_trailing_slash));
+			$this->assertEquals('/', Timber\URLHelper::remove_trailing_slash($root_url));
+	}
+
+	function testGetParams(){
+			$_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
+			$params = Timber\URLHelper::get_params();
+			$this->assertEquals(7, count($params));
+			$whatever = Timber\URLHelper::get_params(-1);
+			$blog = Timber\URLHelper::get_params(2);
+			$this->assertEquals('whatever', $whatever);
+			$this->assertEquals('blog', $blog);
+	}
+
+	function testGetParamsNada(){
+			$_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
+			$params = Timber\URLHelper::get_params(93);
+			$this->assertFalse($params);
+	}
+}


### PR DESCRIPTION
PHPStan considers implicit null returns a bug:

```
 ------ ---------------------------------------------------------------------------------------------------                                                                                                        
  Line   URLHelper.php                                                                                                                                                                                             
 ------ ---------------------------------------------------------------------------------------------------                                                                                                        
  533    Method Timber\URLHelper::get_params() should return array|string but return statement is missing.                                                                                                         
 ------ --------------------------------------------------------------------------------------------------- 
```

The fix is to always explicitly return, as well as declare the right `@return` type. I did some cleanup for conciseness, too.

No usage changes or other considerations I'm aware of. Tests still pass.