### PR TITLE
Add patch for SVG dimensions

### DIFF
--- a/lib/Factory/PostFactory.php
+++ b/lib/Factory/PostFactory.php
@@ -98,7 +98,9 @@ class PostFactory {
 
 	protected function is_image(WP_Post $post) {
 		$src   = wp_get_attachment_url( $post->ID );
-		$check = wp_check_filetype( PathHelper::basename( $src ) );
+		$mimes = get_allowed_mime_types();
+		$mimes['svg'] = 'image/svg+xml';
+		$check = wp_check_filetype( PathHelper::basename( $src ), $mimes );
 
 		$extensions = apply_filters( 'timber/post/image_extensions', [
 			'jpg',
@@ -106,6 +108,7 @@ class PostFactory {
 			'jpe',
 			'gif',
 			'png',
+			'svg',
 			'webp',
 		] );
 

--- a/lib/Factory/PostFactory.php
+++ b/lib/Factory/PostFactory.php
@@ -98,7 +98,7 @@ class PostFactory {
 
 	protected function is_image(WP_Post $post) {
 		$src   = wp_get_attachment_url( $post->ID );
-		$mimes = get_allowed_mime_types();
+		$mimes = wp_get_mime_types();
 		$mimes['svg'] = 'image/svg+xml';
 		$check = wp_check_filetype( PathHelper::basename( $src ), $mimes );
 

--- a/lib/Factory/PostFactory.php
+++ b/lib/Factory/PostFactory.php
@@ -99,7 +99,9 @@ class PostFactory {
 	protected function is_image(WP_Post $post) {
 		$src   = wp_get_attachment_url( $post->ID );
 		$mimes = wp_get_mime_types();
+		// Add mime types that Timber recongizes as images, regardless of config
 		$mimes['svg'] = 'image/svg+xml';
+		$mimes['webp'] = 'image/webp';
 		$check = wp_check_filetype( PathHelper::basename( $src ), $mimes );
 
 		$extensions = apply_filters( 'timber/post/image_extensions', [

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -1072,12 +1072,9 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 
  	function testSVGDimensions() {
 		$pid = $this->factory->post->create();
-		$filename = self::copyTestImage( 'icon-twitter.svg' );
-		$attachment = array( 'post_title' => 'Twitter Icon', 'post_content' => '' );
-		$iid = wp_insert_attachment( $attachment, $filename, $pid );
-		$image = new TimberImage( $iid );
-		$this->assertEquals( 23, $image->width() );
-		$this->assertEquals( 20, $image->height() );
+		$image = Timber::get_image( self::get_attachment($pid, 'icon-twitter.svg') );
+ 		$this->assertEquals( 23, $image->width() );
+ 		$this->assertEquals( 20, $image->height() );
 	}
 
 }


### PR DESCRIPTION
Fixes behavior and test failures with SVG dimension loading in 2.x.

After merging in #2421, I inadvertently created a behavior conflict w how factories detect whether an image is an image (and whether an SVG counts as one). This manually moves some code from 1.x and adds a small modification to `Factory/PostFactory` to resolve this change.

### Considerations
As @gchtr notes, there could be a performance opportunity with `wp_check_filetype` to cache the results so we don't have to hit that function again and again