### PR TITLE
multisite is_main_network removed

### DIFF
--- a/lib/Cache/Cleaner.php
+++ b/lib/Cache/Cleaner.php
@@ -65,7 +65,7 @@ class Cleaner {
 
 		// Delete transients from multisite, if configured as such
 
-		if ( is_multisite() && is_main_network() ) {
+		if ( is_multisite() ) {
 
 			$records .= self::delete_transients_multisite();
 		}


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
--> 

**Ticket**: # <!-- Ignore this if not relevant -->

## Issue
<!-- Description of the problem that this code change is solving -->
On WordPress whenever site on MultiSite network and try to achieve clearing cache programmatically it just clear cache only for the main site not on other sites, I configured WordPress Multisite for multilingual and regional.

And I developed a plugin for Timber-Twig Cache cleaning but whenever use this feature it only deletes cache for the main site in my case default site is EN and so the cache for FR, DE, ES remains undeleted.

## Solution
<!-- Description of the solution that these code changes are introducing to the application. -->
File: lib/cache/Cleaner.php 68
```
if ( is_multisite() && is_main_network() ) 
{
    $records .= self::delete_transients_multisite();
}
```
Change to this 
```
if ( is_multisite()  ) 
{
    $records .= self::delete_transients_multisite();
}
```
