### PR TITLE
Package twig/cache-extension is abandoned,Use twig/cache-extra instead ?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "twig/twig": "^1.41|^2.10",
     "upstatement/routes": "0.8",
     "composer/installers": "~1.0",
-    "twig/cache-extension": "^1.5"
+    "twig/cache-extra": "^3"
   },
   "require-dev": {
     "johnpbloch/wordpress": "*",


### PR DESCRIPTION
## Issue
When installing Timber I got 
`Package twig/cache-extension is abandoned, you should avoid using it. Use twig/cache-extra instead.`

## Solution
Use `twig/cache-extra` instead as suggested 


## Impact
Not sure
