### PR TITLE
Fix the `thumbnail()` method return type

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -1570,7 +1570,7 @@ class Post extends Core implements CoreInterface {
 	 * ```twig
 	 * <img src="{{ post.thumbnail.src }}" />
 	 * ```
-	 * @return Timber\Image|null of your thumbnail
+	 * @return Image|null of your thumbnail
 	 */
 	public function thumbnail() {
 		$tid = get_post_thumbnail_id($this->ID);

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,8 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 
+* Fix documented return type for Timber\Image::thumbnail #2463 (thanks @titouanmathis)
+
 = 1.18.2 = 
 
 **Fixes and improvements**


### PR DESCRIPTION
## Issue
The returned value of the `Post::thumbnail()` method is considered to be `\Timber\Timber\Image` as we already are in the `Timber` namespace and `Timber\Image` is missing a leading `\`. This is making tools such as PHPStan to fail.

## Solution
The solution is to use the same type as the `Post::get_thumbnail()` method, which is directly using the `Image` class from the current namespace.

## Impact
It will improve compatibility with static analysis tools such as PHPStan.

## Testing
Nothing to update (I think).
