### PR TITLE
2.x Improve routing docs

### DIFF
--- a/docs/v2/guides/routing.md
+++ b/docs/v2/guides/routing.md
@@ -3,7 +3,18 @@ title: "Routing"
 order: "2000"
 ---
 
-Timber 1.x allowed for custom routes. However, in 2.x and above this should be handled by a third-party plugin or library like:
+Timber 1.x shipped with the [Upstatement/routes](https://github.com/Upstatement/routes) package for custom routes (see [Routing Guide](https://timber.github.io/docs/guides/routing/) for Timber v1). However, Timber 2.x and above ships **without a default routing library**.
+
+If you still want to use Routing as it were before, you can install the package yourself:
+
+```bash
+composer require upstatement/routes
+```
+
+
+ this should be handled by a third-party plugin or library like:
+
+Here’s a selection of routing
 
 - [Upstatement/routes](https://github.com/Upstatement/routes)
 - [Rareloop/router](https://github.com/Rareloop/router)

--- a/docs/v2/guides/routing.md
+++ b/docs/v2/guides/routing.md
@@ -11,10 +11,7 @@ If you still want to use Routing as it were before, you can install the package 
 composer require upstatement/routes
 ```
 
-
- this should be handled by a third-party plugin or library like:
-
-Here’s a selection of routing
+Here’s a selection of routing options that you can use in conjunction with Timber:
 
 - [Upstatement/routes](https://github.com/Upstatement/routes)
 - [Rareloop/router](https://github.com/Rareloop/router)

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -25,7 +25,7 @@ As of version 2.0, you can’t install Timber as a plugin. You need to install i
 
 ### Removed Routes
 
-The routing feature was removed in Timber 2.0. Routing in Timber is an edge case. Many of its use cases can usually be solved via existing WordPress functionality. And we wanted to make it easier for developers to use other routing libraries. 
+The routing feature had been deprecated in Timber 1.x and was fully removed in Timber 2.0. Routing in Timber is outside its primary mission. Many of its use cases can usually be solved via existing WordPress functionality. We wanted to make it easier for developers to use other routing libraries. 
 
 In case you still need routing as it were before, you can install the library that Timber used before:
 

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -25,7 +25,15 @@ As of version 2.0, you can’t install Timber as a plugin. You need to install i
 
 ### Removed Routes
 
-The Routing feature was removed in Timber 2.0. Routing in Timber is an edge case. Many of its use cases can usually be solved via existing WordPress functionality. In case you still need Routing, you can use one of the available libraries and hook it into your code. Follow the [Routing Guide](https://timber.github.io/docs/guides/routing/) for more information.
+The routing feature was removed in Timber 2.0. Routing in Timber is an edge case. Many of its use cases can usually be solved via existing WordPress functionality. And we wanted to make it easier for developers to use other routing libraries. 
+
+In case you still need routing as it were before, you can install the library that Timber used before:
+
+```bash
+composer require upstatement/routes
+```
+
+Or you can use one of the available libraries and hook it into your code. Follow the [Routing Guide](https://timber.github.io/docs/v2/guides/routing/) for more information.
 
 ### Removed support for Co-Authors Plus
 


### PR DESCRIPTION
**Ticket**: #2446, https://github.com/Upstatement/routes/issues/29

## Issue

It might not have been clear enough that we can still use the routing Timber always had with Timber v2.


## Solution

Improve documentation.

## Impact

– 

## Usage Changes

None.

## Considerations

None?

## Testing

Nope, just docs.