### PR TITLE
Fix bug when using switch_to_blog() in combination with Timber images

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -240,10 +240,18 @@ class Image extends Post implements CoreInterface {
 		return $url;
 	}
 
+	/**
+	 * Gets cached version of wp_upload_dir().
+	 *
+	 * Because wp_upload_dir() returns a different result for each site in a multisite, we shouldn’t
+	 * return the cached version when we switched to a different site in a multisite environment.
+	 *
+	 * @todo Deprecate this function in the future and use wp_upload_dir() directly.
+	 */
 	public static function wp_upload_dir() {
 		static $wp_upload_dir = false;
 
-		if ( !$wp_upload_dir ) {
+		if ( ! $wp_upload_dir || ( is_multisite() && ms_is_switched() ) ) {
 			$wp_upload_dir = wp_upload_dir();
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 
-* Fixed a bug when using `switch_to_blog()` in combination with Timber images
+* Fixed a bug when using `switch_to_blog()` in combination with Timber images #1312 #2478 (thanks @gchtr)
 
 = 1.18.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,9 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 
-= 1.18.2 = 
+* Fixed a bug when using `switch_to_blog()` in combination with Timber images
+
+= 1.18.2 =
 
 **Fixes and improvements**
 

--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -31,7 +31,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		$this->assertEquals('http://example.org/bark', $sites[2]->url);
 		$this->assertEquals('http://example.org/bar', $sites[1]->url);
 		$this->assertEquals("example.org", $sites[2]->domain);
-		
+
 	}
 
 	function testPostGettingAcrossSites() {
@@ -48,7 +48,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		foreach($site_ids as $site_id) {
 			switch_to_blog($site_id);
 			$this->factory->post->create(array('post_title' => array_pop($post_titles)));
-			
+
 		}
 
 		$timber_posts = array();
@@ -57,7 +57,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		foreach ($sites as $site) {
 		    switch_to_blog($site->blog_id);
 		    //error_log(print_r($site, true));
-		    // fetch all the posts 
+		    // fetch all the posts
 		    $timber_query = Timber::get_posts(array('post_type' => 'post'));
 		    foreach ($timber_query as $post) {
 		        $timber_posts[] = $post;
@@ -70,12 +70,12 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		    restore_current_blog();
 		    // display all posts
 		}
-		
+
 		$this->assertEquals(6, count($timber_posts));
 		$this->assertEquals(6, count($wp_posts));
 
 		// ensure tha the current site's post count is distinct from our test condition
-		$current_site_all_posts = get_posts(array('post_type' => 'post')); 
+		$current_site_all_posts = get_posts(array('post_type' => 'post'));
 		$this->assertEquals(2, count($current_site_all_posts));
 	}
 
@@ -95,7 +95,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		foreach($site_ids as $site_id) {
 			switch_to_blog($site_id);
 			$this->factory->post->create(['post_title' => 'Zebras are good on site ID = '.$site_id]);
-			
+
 		}
 		$this->go_to('/');
 		$timber_posts = array();
@@ -103,7 +103,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		$sites = Timber::get_sites();
 		foreach ($sites as $site) {
 		    switch_to_blog($site->blog_id);
-		    // fetch all the posts 
+		    // fetch all the posts
 		    $timber_query = Timber::get_posts();
 		    foreach ($timber_query as $post) {
 		        $timber_posts[] = $post;
@@ -116,7 +116,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		    restore_current_blog();
 		    // display all posts
 		}
-		// testing that in multisite we get back posts in a loop 
+		// testing that in multisite we get back posts in a loop
 		$this->assertGreaterThan(0, count($timber_posts));
 		$this->assertGreaterThan(0, count($wp_posts));
 
@@ -124,7 +124,6 @@ class TestTimberMultisite extends Timber_UnitTestCase {
           "WordPress's get_posts() and Timber::get_posts() behave differently here. This could be resolved in the future with investigations on defaults with no arguments and they should be handled"
         );
 	}
-
 
 	function testPostSearchAcrossSites() {
 		if ( !is_multisite() ) {
@@ -140,7 +139,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		foreach($site_ids as $site_id) {
 			switch_to_blog($site_id);
 			$this->factory->post->create(array('post_title' => array_pop($post_titles)));
-			
+
 		}
 
 		$timber_posts = array();
@@ -148,7 +147,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		$sites = Timber::get_sites();
 		foreach ($sites as $site) {
 		    switch_to_blog($site->blog_id);
-		    // fetch all the posts 
+		    // fetch all the posts
 		    $timber_query = Timber::get_posts(['s' => 'zebra']);
 		    foreach ($timber_query as $post) {
 		        $timber_posts[] = $post;
@@ -161,13 +160,41 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		    restore_current_blog();
 		    // display all posts
 		}
-		
+
 		$this->assertEquals(3, count($timber_posts));
 		$this->assertEquals(3, count($wp_posts));
 
 		// ensure tha the current site's post count is distinct from our test condition
-		$current_site_all_posts = get_posts(); 
+		$current_site_all_posts = get_posts();
 		$this->assertEquals(5, count($current_site_all_posts));
+	}
+
+	/**
+	 * Tests whether images accessed with switch_to_blog() get the correct url.
+	 *
+	 * @ticket https://github.com/timber/timber/issues/1312
+	 */
+	function test_switch_to_blog_with_timber_images() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( "You can't get sites except on Multisite" );
+
+			return;
+		}
+
+		// Load image and cache for Timber\Image::wp_upload_dir() in site 1.
+		new Timber\Image( TestTimberImage::get_image_attachment() );
+
+		// Create site 2 and switch to it.
+		self::createSubDirectorySite( '/site-2/', 'Site 2' );
+
+		// Create and load image in site 2.
+		$site_2_upload_dir  = wp_upload_dir();
+		$image_2            = new Timber\Image( TestTimberImage::get_image_attachment() );
+		$image_2_upload_dir = $image_2::wp_upload_dir();
+
+		restore_current_blog();
+
+		$this->assertEquals( $site_2_upload_dir['baseurl'], $image_2_upload_dir['baseurl'] );
 	}
 
 	public static function createSubDomainSite($domain = 'test.example.org', $title = 'Multisite Test' ) {
@@ -180,7 +207,7 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 	public static function createSubDirectorySite($dir = '/mysite/', $title = 'Multisite Subdir Test' ) {
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 		$blog_id = wpmu_create_blog('example.org', $dir, $title, 1);
-		switch_to_blog($blog_id);
+			switch_to_blog($blog_id);
 		return $blog_id;
 	}
 


### PR DESCRIPTION
**Ticket**: #1312 

## Issue

`Timber/Image::wp_upload_dir()` caches the result of `wp_upload_dir()`. This causes problems when `switch_to_blog()` is used.

## Solution

Add a check whether we are in a multisite and whether we are in a switched site context. In that case, never return a cached result.

## Impact

None.

## Usage Changes

None.

## Considerations

We could think about whether the result should be cached at all or if we always should use a plain `wp_upload_dir()` call, because of all the side effects that might be involved.

To miminize performance impacts, we could think about passing the second `$create_dir` parameter as `false`, which would skip the checks whether the correct folder already exists. Of course we would have to check whether the check is already made by other functions earlier.

To actually remove the `Timber/Image::wp_upload_dir()` function, we would have to deprecate it first, because it’s public.

And sorry, I missed all the whitespace changes, because I set the settings in [Fork](https://git-fork.com/) to ignore whitespace in commits 😐.

## Testing

Yes.