### PR TITLE
2.x Add hint about checking for Timber’s version

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -7,7 +7,7 @@ Version 2.0 of Timber
 - Will only work as a Composer package.
 - Tries to make the naming of functions and filters more consistent.
 - Refactors how Timber Core works under the hood to improve compatibility with WordPress Core and be ready for future challenges.
-- Removes a lot of deprecated code
+- Removes a lot of deprecated code.
 
 ## New requirements
 
@@ -20,6 +20,16 @@ We upgraded Timber to work with more modern PHP and functionalities that only we
 ## No more plugin support
 
 As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/v2/getting-started/setup/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
+
+## Checking Timber’s version
+
+If you need to check what Timber version is installed, you can use `Timber::version`.
+
+```php
+if ( version_compare( Timber::$version, '2.0.0', '>=' ) ) {
+    // Timber 2.x is installed.
+}
+```
 
 ## Removed functionality
 


### PR DESCRIPTION
## Issue

When installing and trying out Timber v2, you might have to use checks for a specific Timber version if you still want to support both versions.

## Solution

Add a hint in the Upgrade Guide.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

No. just docs.