### PR TITLE
Fix a test failing with 2.x + Multisite

### DIFF
--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -195,6 +195,12 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		restore_current_blog();
 
 		$this->assertStringStartsWith($site_2_upload_dir['baseurl'], $image_2_src);
+
+		// test resizing
+		$template = '{{ image|resize(300, 300) }}?template=true';
+		$img_resized_src = Timber::compile_string($template, ['image' => $image_2_src]);
+		$this->assertStringStartsWith($site_2_upload_dir['baseurl'], $img_resized_src);
+
 	}
 
 	public static function createSubDomainSite($domain = 'test.example.org', $title = 'Multisite Test' ) {

--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -182,19 +182,19 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		}
 
 		// Load image and cache for Timber\Image::wp_upload_dir() in site 1.
-		new Timber\Image( TestTimberImage::get_image_attachment() );
+		$image_1 = Timber::get_image( TestTimberImage::get_attachment() );
 
 		// Create site 2 and switch to it.
 		self::createSubDirectorySite( '/site-2/', 'Site 2' );
 
 		// Create and load image in site 2.
 		$site_2_upload_dir  = wp_upload_dir();
-		$image_2            = new Timber\Image( TestTimberImage::get_image_attachment() );
-		$image_2_upload_dir = $image_2::wp_upload_dir();
+		$image_2            = Timber::get_image( TestTimberImage::get_attachment() );
 
+		$image_2_src = (string) $image_2->src();
 		restore_current_blog();
 
-		$this->assertEquals( $site_2_upload_dir['baseurl'], $image_2_upload_dir['baseurl'] );
+		$this->assertStringStartsWith($site_2_upload_dir['baseurl'], $image_2_src);
 	}
 
 	public static function createSubDomainSite($domain = 'test.example.org', $title = 'Multisite Test' ) {


### PR DESCRIPTION
**Ticket**: #1617

## Issue
A new test with #2478 causes issues in 2.x because Image::wp_upload_dir() is removed.

## Solution
Test against the generated URL rather than what's stored in this (no longer existent) variable

## Impact
Just a change to a test, no functional code. I don't think the test covers anything "real" at this point since that var isn't being cached; but didn't want to toss the test just in case.

## Usage Changes
None

## Considerations
As I type this, I realize I should confirm against resizing too

