### PR TITLE
Make cache extension optional and let users choose their own implemen…

### DIFF
--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -427,7 +427,18 @@ class Loader {
 				return null;
 			}));
 		}
-		$twig->addExtension($this->_get_cache_extension());
+		/**
+		 * Filters the cache extension activation
+		 *
+		 * Allows users to disable the cache extension and use their own
+		 *
+		 * @since 2.0.0
+		 * @param bool $enable_cache_extension
+		 */
+		$enable_cache_extension = apply_filters('timber/enable_cache_extension', true);
+        if ( $enable_cache_extension ) {
+            $twig->addExtension($this->_get_cache_extension());
+        }
 
 		/**
 		 * Filters …


### PR DESCRIPTION
## Issue

Whatever comes out of #2407, I think users should be able to choose their cache implementation.

## Solution

Add a filter to control Timber Cache implementation.

## Impact

None because it defaults to `true`.

## Usage Changes

Users can use that filter to manually register their own cache extension.

## Considerations

use `twig/cache-extra` 😉
