### PR TITLE
2.x Fix bug when page_on_front is not set in some cases

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -624,7 +624,7 @@ class Timber {
 	 * ```
 	 */
 	public static function get_term( $term = null ) {
-		
+
 		if (null === $term) {
 			// get the fallback term_id from the current query
 			global $wp_query;
@@ -668,7 +668,7 @@ class Timber {
 	 * @param string     $field    The name of the field to retrieve the term with. One of: `id`,
 	 *                             `ID`, `slug`, `name` or `term_taxonomy_id`.
 	 * @param int|string $value    The value to search for by `$field`.
-	 * @param string     $taxonomy The taxonomy you want to retrieve from. Empty string will search 
+	 * @param string     $taxonomy The taxonomy you want to retrieve from. Empty string will search
 	 *                             from all.
 	 *
 	 * @return \Timber\Term|null
@@ -969,8 +969,14 @@ class Timber {
 			// NOTE: this also handles the is_front_page() case.
 			$context['post'] = Timber::get_post()->setup();
 		} elseif ( is_home() ) {
-			// show_on_front = page
-			$context['post']  = Timber::get_post()->setup();
+			$post = Timber::get_post();
+
+			// When no page_on_front is set, there’s no post we can set up.
+			if ( $post ) {
+				$post->setup();
+			}
+
+			$context['post']  = $post;
 			$context['posts'] = Timber::get_posts();
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$context['term']  = Timber::get_term();

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -60,9 +60,13 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertEquals( $context['post']->id, $context['posts'][0]->id );
 	}
 
+	/**
+	 * @ticket https://github.com/timber/timber/issues/2470
+	 */
 	function testPostsContextWithPostOnFrontAndNoPageForPosts() {
 		update_option( 'show_on_front', 'posts' );
 		update_option( 'page_for_posts', 0 );
+		update_option( 'page_on_front', 0 );
 
 		$this->go_to( '/' );
 

--- a/tests/test-timber-context.php
+++ b/tests/test-timber-context.php
@@ -60,6 +60,17 @@ class TestTimberContext extends Timber_UnitTestCase {
 		$this->assertEquals( $context['post']->id, $context['posts'][0]->id );
 	}
 
+	function testPostsContextWithPostOnFrontAndNoPageForPosts() {
+		update_option( 'show_on_front', 'posts' );
+		update_option( 'page_for_posts', 0 );
+
+		$this->go_to( '/' );
+
+		$context = Timber::context();
+
+		$this->assertNotContains( 'post', $context );
+	}
+
 	function testPostsContextHomePage() {
 		update_option( 'show_on_front', 'page' );
 		$id = $this->factory->post->create([


### PR DESCRIPTION
**Ticket**: #2470

## Issue

When no `page_on_front` is set, Timber tries to run `setup()` on a post that doesn’t exist, which leads to errors.

## Solution

Check for a post before running setup.

## Impact

Fixes a bug.

## Usage Changes

None.

## Considerations

I thought about whether I should add different checks there, like using `get_option('page_on_front')` or using [@nlemoine’s suggestion](https://github.com/timber/timber/issues/2470#issuecomment-911970671). But then I thought: why think about all the various cases we could run into if Timber already provides an easy way to check whether there’s a post – by using `Timber::get_post()` itself.

## Testing

Yes.