### PR TITLE
Use Timber full path

### DIFF
--- a/lib/Integrations/ACF.php
+++ b/lib/Integrations/ACF.php
@@ -7,7 +7,7 @@
 
 namespace Timber\Integrations;
 
-use Timber;
+use Timber\Timber;
 
 /**
  * Class used to handle integration with Advanced Custom Fields


### PR DESCRIPTION
## Issue

Just a tiny fix, internally, use Timber fully qualified namespace.
