### PR TITLE
Update integration tests:

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4']
-        wp: ['5.3.6', 'latest']
+        wp: ['5.3', '5.8'] # Always use branches not tags (e.g. 5.3 not 5.3.6), new test suite is only available in branches
         multisite: ['0', '1']
         dependency-version: [prefer-stable] # prefer-lowest
         webp: [false]
@@ -41,15 +41,21 @@ jobs:
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
+          # PHP 8.0
+          - php: '8.0'
+            wp: 'trunk'
+            dependency-version: 'prefer-stable'
+            multisite: '0'
+            experimental: true
           # PHP with Imagick
           - php: '7.4'
-            wp: 'latest'
+            wp: '5.8'
             dependency-version: 'prefer-stable'
             multisite: '0'
             extensions: 'imagick'
           # Coverage
           - php: '7.4'
-            wp: 'latest'
+            wp: '5.8'
             dependency-version: 'prefer-stable'
             multisite: '0'
             coverage: true
@@ -99,6 +105,10 @@ jobs:
       - name: Install composer dependencies
         run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --no-interaction
 
+      - name: Downgrade PHPUnit to ^7.5 when WP < 5.9
+        if: ${{ matrix.wp < '5.9' }}
+        run: composer req phpunit/phpunit:^7.5 -W --dev
+
       - name: Install tests
         run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true
 
@@ -129,4 +139,4 @@ jobs:
 
       - name: Run webp tests
         if: ${{ matrix.webp }}
-        run: vendor/phpunit/phpunit/phpunit -c phpunit.xml --verbose ./tests/test-timber-image-towebp.php
+        run: vendor/phpunit/phpunit/phpunit -c phpunit.xml --verbose --filter 'TestTimberImageToWEBP'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,17 @@ jobs:
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
-          # PHP 8.0
-          - php: '8.0'
+          # PHP 8.1
+          - php: '8.1'
             wp: 'trunk'
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
+          # PHP 8.0
+          - php: '8.0'
+            wp: '5.8'
+            dependency-version: 'prefer-stable'
+            multisite: '0'
           # PHP with Imagick
           - php: '7.4'
             wp: '5.8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             experimental: true
           # PHP 8.0
           - php: '8.0'
-            wp: '5.8'
+            wp: 'trunk'
             dependency-version: 'prefer-stable'
             multisite: '0'
           # PHP with Imagick

--- a/composer.json
+++ b/composer.json
@@ -28,20 +28,19 @@
     "docs": "https://timber.github.io/docs/"
   },
   "require": {
-    "php": "^7.4",
+    "php": "^7.4|^8.0",
     "twig/twig": "^2.12|^3.0",
     "composer/installers": "^1.9",
     "twig/cache-extension": "^1.5.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5 || ^7.5",
     "squizlabs/php_codesniffer": "^3.0",
     "wp-coding-standards/wpcs": "^2.0",
     "wpackagist-plugin/advanced-custom-fields": "^5.0",
     "wpackagist-plugin/co-authors-plus": "^3.3",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "php-stubs/wp-cli-stubs": "^2.2.0",
-    "yoast/phpunit-polyfills": "^1.0"
+    "yoast/phpunit-polyfills": "^1.0.1"
   },
   "suggest": {
     "php-coveralls/php-coveralls": "^2.0 for code coverage"

--- a/lib/AccessesPostsLazily.php
+++ b/lib/AccessesPostsLazily.php
@@ -84,7 +84,7 @@ trait AccessesPostsLazily {
 	/**
 	 * @internal
 	 */
-	public function getArrayCopy() {
+	public function getArrayCopy() : array {
 		// Force eager instantiation of Timber\Posts before returning them all in an array.
 		$this->realize();
 		return parent::getArrayCopy();
@@ -113,6 +113,7 @@ trait AccessesPostsLazily {
 	 *
 	 * @internal
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset) {
 		$post = parent::offsetGet($offset);
 		if ($post instanceof WP_Post) {

--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -236,7 +236,7 @@ class Attachment extends Post implements CoreInterface {
 	 * @return string The URL of the attachment.
 	 */
 	public function link() {
-		if ( strlen( $this->abs_url ) ) {
+		if ( $this->abs_url ) {
 			return $this->abs_url;
 		}
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -238,9 +238,7 @@ class Helper {
 	public static function ob_function( $function, $args = array(null) ) {
 		ob_start();
 		call_user_func_array($function, $args);
-		$data = ob_get_contents();
-		ob_end_clean();
-		return $data;
+		return ob_get_clean();
 	}
 
 	/**

--- a/lib/Image/Operation/Letterbox.php
+++ b/lib/Image/Operation/Letterbox.php
@@ -117,7 +117,7 @@ class Letterbox extends ImageOperation {
 				}
 			}
 			$image = $func($save_filename);
-			imagecopy($bg, $image, $x, $y, 0, 0, $owt, $oht);
+			imagecopy($bg, $image, round($x), round($y), 0, 0, round($owt), round($oht));
 			if ( $save_func === 'imagegif' ) {
 				return $save_func($bg, $save_filename);
 			}

--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -75,7 +75,7 @@ class Resize extends ImageOperation {
 		$image = $image->coalesceImages();
 		$crop  = $this->get_target_sizes($editor);
 		foreach ( $image as $frame ) {
-			$frame->cropImage($crop['src_w'], $crop['src_h'], $crop['x'], $crop['y']);
+			$frame->cropImage($crop['src_w'], $crop['src_h'], round($crop['x']), round($crop['y']));
 			$frame->thumbnailImage($w, $h);
 			$frame->setImagePage($w, $h, 0, 0);
 		}
@@ -102,7 +102,8 @@ class Resize extends ImageOperation {
 			//the user wants to resize based on constant height
 			$w = round($h * $src_ratio);
 		}
-		if ( !$crop ) {
+
+		if ( !$crop || $crop === 'default' ) {
 			return array(
 				'x' => 0, 'y' => 0,
 				'src_w' => $src_w, 'src_h' => $src_h,

--- a/lib/PostArrayObject.php
+++ b/lib/PostArrayObject.php
@@ -38,7 +38,7 @@ class PostArrayObject extends \ArrayObject implements PostCollectionInterface, J
 	 * @see https://bugs.php.net/bug.php?id=69264
 	 * @internal
 	 */
-	public function __debugInfo() {
+	public function __debugInfo() : array {
 		return [
 			'info' => sprintf( '
 ********************************************************************************
@@ -65,6 +65,7 @@ class PostArrayObject extends \ArrayObject implements PostCollectionInterface, J
 	 *
 	 * @internal
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->getArrayCopy();
 	}

--- a/lib/PostQuery.php
+++ b/lib/PostQuery.php
@@ -139,7 +139,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
 	 * @see https://bugs.php.net/bug.php?id=69264
 	 * @internal
 	 */
-	public function __debugInfo() {
+	public function __debugInfo() : array {
 		return [
 			'info' => sprintf( '
 ********************************************************************************
@@ -169,6 +169,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
 	 *
 	 * @internal
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->getArrayCopy();
 	}

--- a/lib/PostsIterator.php
+++ b/lib/PostsIterator.php
@@ -16,6 +16,7 @@ class PostsIterator extends \ArrayIterator {
 	 *
 	 * @return mixed
 	 */
+	#[\ReturnTypeWillChange]
 	public function current() {
 		static $factory;
 		$factory = $factory ?? new PostFactory();
@@ -47,7 +48,7 @@ class PostsIterator extends \ArrayIterator {
 	 *
 	 * @since 2.0.0
 	 */
-	public function next() {
+	public function next() : void {
 		/**
 		 * The `loop_end` action is not the only thing we do to improve compatibility. There’s
 		 * more going on in the Timber\Post::teardown() function. The compabitibility improvements

--- a/phpunit-nocover.xml
+++ b/phpunit-nocover.xml
@@ -2,10 +2,11 @@
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
+	convertDeprecationsToExceptions="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	>
+>
 	<testsuites>
 		<testsuite name="all">
 			<directory prefix="test-" suffix=".php">tests/</directory>

--- a/tests/TimberAttachment_UnitTestCase.php
+++ b/tests/TimberAttachment_UnitTestCase.php
@@ -8,13 +8,13 @@
 			$this->_files[] = $file;
 		}
 
-		function setUp(){
-			parent::setUp();
+		function set_up(){
+			parent::set_up();
 			$this->_files = array();
 		}
 
-		function tearDown() {
-			parent::tearDown();
+		function tear_down() {
+			parent::tear_down();
 			if (isset($this->_files) && is_array($this->_files)) {
 				foreach($this->_files as $file) {
 					if (file_exists($file)) {

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -30,9 +30,9 @@
 			flush_rewrite_rules( true );
 		}
 
-		function tearDown() {
+		function tear_down() {
 			self::resetPermalinks();
-			parent::tearDown();
+			parent::tear_down();
 			Timber::$context_cache = array();
 
 			// remove any hooks added during this test run
@@ -206,7 +206,7 @@
 
 		/**
 		 * Exactly the same as add_filter, but automatically calls remove_filter with the same
-		 * arguments during tearDown().
+		 * arguments during tear_down().
 		 */
 		protected function add_filter_temporarily(string $filter, callable $callback, int $pri = 10, int $count = 1) {
 			add_filter($filter, $callback, $pri, $count);
@@ -214,10 +214,10 @@
 				remove_filter($filter, $callback, $pri, $count);
 			};
 		}
-    
+
     /**
 		 * Exactly the same as add_action, but automatically calls remove_action with the same
-		 * arguments during tearDown().
+		 * arguments during tear_down().
 		 */
 		protected function add_action_temporarily(string $action, callable $callback, int $pri = 10, int $count = 1) {
 			add_action($action, $callback, $pri, $count);
@@ -289,6 +289,6 @@
 				'item_ids' => $item_ids,
 			];
 		}
-		
+
 
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,14 +1,17 @@
 <?php
 
-if ( PHP_MAJOR_VERSION >= 8 ) {
-	echo "The scaffolded tests cannot currently be run on PHP 8.0+. See https://github.com/wp-cli/scaffold-command/issues/285" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	exit( 1 );
-}
+require_once __DIR__ . '/../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {
 	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
 }
 
 if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {

--- a/tests/test-comment-factory.php
+++ b/tests/test-comment-factory.php
@@ -74,10 +74,9 @@ class TestCommentFactory extends Timber_UnitTestCase {
 		remove_filter( 'timber/comment/classmap', $my_class_map );
 	}
 
-	/**
-	 * @expectedException InvalidArgumentException
-	 */
 	public function testInvalidCommentClassThrowsError() {
+
+		$this->expectException(\InvalidArgumentException::class);
 
 		$post_comment_id = $this->factory->comment->create([
 			'comment_post_ID' => $this->factory->post->create(),

--- a/tests/test-menu-factory.php
+++ b/tests/test-menu-factory.php
@@ -105,10 +105,8 @@ class TestMenuFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(Menu::class, $factory->from($term));
 	}
 
-	/**
-     * @expectedException InvalidArgumentException
-     */
 	public function testFromTimberMenuObjectGarbageInGarbageOut() {
+		$this->expectException(InvalidArgumentException::class);
 		$factory = new MenuFactory();
 		$this->assertFalse($factory->from(new stdClass()));
 	}

--- a/tests/test-menu-factory.php
+++ b/tests/test-menu-factory.php
@@ -84,8 +84,9 @@ class TestMenuFactory extends Timber_UnitTestCase {
 
 		// Set up our new custom menu location.
 		register_nav_menu('custom', 'Custom nav location');
-		$locations = get_theme_mod('nav_menu_locations');
-		$locations['custom'] = $id;
+		$locations = [
+			'custom' => $id,
+		];
 		set_theme_mod('nav_menu_locations', $locations);
 
 		$factory = new MenuFactory();

--- a/tests/test-term-factory.php
+++ b/tests/test-term-factory.php
@@ -12,9 +12,9 @@ class HellaWhackTerm extends Term {}
  * @group terms-api
  */
 class TestTermFactory extends Timber_UnitTestCase {
-	public function tearDown() {
+	public function tear_down() {
 		unregister_taxonomy_for_object_type('make', 'post');
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	public function testGetTerm() {
@@ -289,7 +289,7 @@ class TestTermFactory extends Timber_UnitTestCase {
 	public function testTermByNoTaxonomy() {
 		$category_id = $this->factory->term->create(array('name' => 'Breaking News', 'taxonomy' => 'category'));
 		$terms = Timber::get_terms(['name' => 'Breaking News', 'hide_empty' => false]);
-		
+
 		$term_category = Timber::get_term_by('name', 'Breaking News');
 		$this->assertEquals('category', $term_category->taxonomy);
 		$this->assertEquals('Breaking News', $term_category->title());

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -188,7 +188,7 @@
         	if (is_dir($cache_dir)){
         		Timber\Loader::rrmdir($cache_dir);
         	}
-        	$this->assertFileNotExists($cache_dir);
+        	$this->assertFileDoesNotExist($cache_dir);
         	Timber::$twig_cache = true;
         	$pid = $this->factory->post->create();
 					$post = Timber::get_post($pid);
@@ -198,7 +198,7 @@
         	$loader = new Timber\Loader();
         	$loader->clear_cache_twig();
         	Timber::$twig_cache = false;
-        	$this->assertFileNotExists($cache_dir);
+        	$this->assertFileDoesNotExist($cache_dir);
         }
 
         /**
@@ -209,7 +209,7 @@
         	if (is_dir($cache_dir)){
         		Timber\Loader::rrmdir($cache_dir);
         	}
-        	$this->assertFileNotExists($cache_dir);
+        	$this->assertFileDoesNotExist($cache_dir);
         	Timber::$cache = true;
         	$pid = $this->factory->post->create();
 					$post = Timber::get_post($pid);
@@ -220,7 +220,7 @@
         	$loader->clear_cache_twig();
         	Timber::$cache = false;
         	Timber::$twig_cache = false;
-        	$this->assertFileNotExists($cache_dir);
+        	$this->assertFileDoesNotExist($cache_dir);
         }
 
         function testTwigCache(){
@@ -230,7 +230,7 @@
 		        Timber\Loader::rrmdir( $cache_dir );
 	        }
 
-	        $this->assertFileNotExists( $cache_dir );
+	        $this->assertFileDoesNotExist( $cache_dir );
 
 	        $cache_enabler = function( $options ) {
 				$options['cache'] = true;
@@ -249,7 +249,7 @@
 
 	        $loader = new Timber\Loader();
 	        $loader->clear_cache_twig();
-	        $this->assertFileNotExists( $cache_dir );
+	        $this->assertFileDoesNotExist( $cache_dir );
 
 	        remove_filter( 'timber/twig/environment/options', $cache_enabler );
         }
@@ -293,13 +293,13 @@
             $this->assertTrue($works);
         }
 
-        function tearDown() {
+        function tear_down() {
             global $_wp_using_ext_object_cache;
             $_wp_using_ext_object_cache = false;
             global $wpdb;
             $query = "DELETE FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
             $wpdb->query($query);
-            parent::tearDown();
+            parent::tear_down();
         }
 
         function testTimberLoaderCacheTransients() {

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -42,7 +42,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase {
 		return $this->markTestSkipped('@todo Twig\Error\RuntimeError: An exception has been thrown during the rendering of a template ("readfile(/srv/www/wordpress-trunk/public_html/src/wp-includes/js/wp-emoji-loader.js): failed to open stream: No such file or directory")');
 		$context = Timber::context();
 		$str = Timber::compile_string('{{ function("wp_head") }}', $context);
-		$this->assertRegexp('/<title>Test Blog/', trim($str));
+		$this->assertMatchesRegularExpression('/<title>Test Blog/', trim($str));
 	}
 
 	function testFunctionInTemplate() {

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -146,10 +146,8 @@ use Timber\PostArrayObject;
 			$this->assertFalse(\Timber\Helper::get_object_index_by_property('butts', 'skill', 'cooking'));
 		}
 
-		/**
-     	 * @expectedException InvalidArgumentException
-     	 */
 		function testGetObjectByPropertyButNo() {
+			$this->expectException(InvalidArgumentException::class);
 			$obj1 = new stdClass();
 			$obj1->name = 'mark';
 			$obj1->skill = 'acro yoga';
@@ -160,7 +158,7 @@ use Timber\PostArrayObject;
 			$start = Timber\Helper::start_timer();
 			sleep(1);
 			$end = Timber\Helper::stop_timer($start);
-			$this->assertContains(' seconds.', $end);
+			$this->assertStringContainsString(' seconds.', $end);
 			$time = str_replace(' seconds.', '', $end);
 			$this->assertGreaterThan(1, $time);
 		}
@@ -240,10 +238,9 @@ use Timber\PostArrayObject;
 
 		/**
 		 * Test for when we're filtering something that's not an array.
-		 *
- 		 * @expectedException Twig\Error\RuntimeError
 		 */
 		function testArrayFilterWithBogusArray() {
+			$this->expectException(Twig\Error\RuntimeError::class);
 			$template = '{% for post in posts | filter({slug:"snoop", post_content:"Idris Elba"}, "OR")%}{{ post.title }} {% endfor %}';
 			$str = Timber::compile_string($template, array('posts' => 'foobar'));
 			$this->assertEquals('', $str);

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -230,6 +230,15 @@ use Timber\PostArrayObject;
 			$this->assertEquals('Felicia Pearson', trim($str));
 		}
 
+		function testIsArrayAssoc() {
+			$arr = [14, 21, 'thing'];
+			$this->assertFalse(Timber\Helper::is_array_assoc($arr));
+
+			$assoc_array = ['thing' => 'yeah', 'foo' => 'bar'];
+			$this->assertTrue(Timber\Helper::is_array_assoc($assoc_array));
+
+		}
+
 		function testTwigFilterFilter() {
 			$template = "{% set sizes = [34, 36, 38, 40, 42] %}{{ sizes|filter(v => v > 38)|join(', ') }}";
 			$str = Timber::compile_string($template);

--- a/tests/test-timber-image-letterbox.php
+++ b/tests/test-timber-image-letterbox.php
@@ -5,8 +5,8 @@ class TestTimberImageLetterbox extends TimberAttachment_UnitTestCase {
 	/**
 	 * @requires extension gd
 	 */
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 		if ( ! extension_loaded( 'gd' ) ) {
 			self::markTestSkipped( 'Letterbox image operation tests requires GD extension' );
 		}

--- a/tests/test-timber-image-multisite.php
+++ b/tests/test-timber-image-multisite.php
@@ -2,7 +2,7 @@
 
 	class TestTimberImageMultisite extends Timber_UnitTestCase {
 
-		function tearDown() {
+		function tear_down() {
 			if (is_multisite()) {
 				switch_to_blog(1);
 			}

--- a/tests/test-timber-image-resize.php
+++ b/tests/test-timber-image-resize.php
@@ -5,8 +5,8 @@
  */
 class TestTimberImageResize extends Timber_UnitTestCase {
 
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 		if ( ! extension_loaded( 'gd' ) ) {
 			self::markTestSkipped( 'Image resizing tests requires GD extension' );
 		}

--- a/tests/test-timber-image-tojpg.php
+++ b/tests/test-timber-image-tojpg.php
@@ -2,8 +2,8 @@
 
 	class TestTimberImageToJPG extends Timber_UnitTestCase {
 
-		function setUp() {
-			parent::setUp();
+		function set_up() {
+			parent::set_up();
 			if ( ! extension_loaded( 'gd' ) ) {
 				self::markTestSkipped( 'JPEG conversion tests requires GD extension' );
 			}

--- a/tests/test-timber-image-towebp.php
+++ b/tests/test-timber-image-towebp.php
@@ -2,8 +2,8 @@
 
 	class TestTimberImageToWEBP extends Timber_UnitTestCase {
 
-		function setUp() {
-			parent::setUp();
+		function set_up() {
+			parent::set_up();
 			if ( ! function_exists( 'imagewebp' ) ) {
 				self::markTestSkipped( 'WEBP conversion tests requires imagewebp function' );
 			}

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -545,7 +545,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		Timber\ImageHelper::delete_generated_files( $file );
 		//The child of the regular arch image should be like
 		//poof-be-gone
-		$this->assertFileNotExists( $arch_regular );
+		$this->assertFileDoesNotExist( $arch_regular );
 		//...but the night image remains!
 		$this->assertFileExists( $arch_2night );
 
@@ -570,8 +570,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		//Now delete the "parent" image
 		Timber\ImageHelper::delete_generated_files( $file );
 		//Have the children been deleted as well?
-		$this->assertFileNotExists( $resized_520_file );
-		$this->assertFileNotExists( $resized_500_file );
+		$this->assertFileDoesNotExist( $resized_520_file );
+		$this->assertFileDoesNotExist( $resized_500_file );
 	}
 
 	function testImageDeletionByURL() {
@@ -602,8 +602,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		//Now delete the "parent" image
 		Timber\ImageHelper::delete_generated_files( $data['test_image'] );
 		//Have the children been deleted as well?
-		$this->assertFileNotExists( $resized_520_file );
-		$this->assertFileNotExists( $resized_500_file );
+		$this->assertFileDoesNotExist( $resized_520_file );
+		$this->assertFileDoesNotExist( $resized_500_file );
 	}
 
 	function testImageDeletionByDeletingAttachment() {
@@ -634,8 +634,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		//Now delete the "parent" image
 		wp_delete_attachment( $attach_id );
 		//Have the children been deleted as well?
-		$this->assertFileNotExists( $resized_520_file );
-		$this->assertFileNotExists( $resized_500_file );
+		$this->assertFileDoesNotExist( $resized_520_file );
+		$this->assertFileDoesNotExist( $resized_500_file );
 	}
 
 	function testImageDeletionByAttachmentLocation() {
@@ -667,8 +667,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		$post = Timber::get_post( $attach_id );
 		Timber\ImageHelper::delete_generated_files( $post->file_loc );
 		//Have the children been deleted as well?
-		$this->assertFileNotExists( $resized_520_file );
-		$this->assertFileNotExists( $resized_500_file );
+		$this->assertFileDoesNotExist( $resized_520_file );
+		$this->assertFileDoesNotExist( $resized_500_file );
 	}
 
 	/**
@@ -689,7 +689,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		//Now delete the "parent" image
 		Timber\ImageHelper::delete_generated_files( $file );
 		//Have the children been deleted as well?
-		$this->assertFileNotExists( $letterboxed_file );
+		$this->assertFileDoesNotExist( $letterboxed_file );
 	}
 
 	function _makeThemeImageDirectory() {
@@ -705,7 +705,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		}
 	}
 
-	function tearDown() {
+	function tear_down() {
 		$theme_url = get_theme_root_uri().'/'.get_stylesheet();
 		$img_dir = get_stylesheet_directory_uri().'/images';
 		if ( file_exists($img_dir) ) {
@@ -718,7 +718,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 				unlink($file);
 			}
 		}
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	function testThemeImageResize() {
@@ -1007,10 +1007,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase {
 		return $data;
 	}
 
-	/**
-		 * @expectedException Twig\Error\RuntimeError
-		 */
 	function testAnimagedGifResizeWithoutImagick() {
+		$this->expectException(\Twig\Error\RuntimeError::class);
 		define('TEST_NO_IMAGICK', true);
 		$image = self::copyTestAttachment('robocop.gif');
 		$data = array('crop' => 'default');

--- a/tests/test-timber-integrations-coauthors.php
+++ b/tests/test-timber-integrations-coauthors.php
@@ -20,11 +20,11 @@ use Timber\Integration\CoAuthorsPlusIntegration;
 			parent::expectedDeprecated();
 		}
 
-		function setUp() {
+		function set_up() {
 			if ( !class_exists('CoAuthors_Plus') ) {
 				return $this->markTestSkipped('CoAuthors_Plus plugin not loaded');
 			}
-			parent::setUp();
+			parent::set_up();
 		}
 
 		/* ----------------

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -65,7 +65,7 @@
 		function testTwigPathFilter() {
 			$php_unit = $this;
 			add_filter('timber/loader/paths', function($paths) use ($php_unit) {
-				$paths = call_user_func_array('array_merge', $paths);
+				$paths = call_user_func_array('array_merge', array_values($paths));
 				$count = count($paths);
 				$php_unit->assertEquals(3, count($paths));
 				$pos = array_search('/', $paths);

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -362,10 +362,10 @@ class TestTimberMenu extends Timber_UnitTestCase {
 
 		// With no options set.
 		$menu = Timber::get_menu($menu_arr['term_id']);
-		$this->assertInternalType("int", $menu->depth);
+		$this->assertIsInt($menu->depth);
 		$this->assertEquals( 0, $menu->depth );
-		$this->assertInternalType("array", $menu->raw_options);
-		$this->assertInternalType('array', $menu->options);
+		$this->assertIsArray($menu->raw_options);
+		$this->assertIsArray($menu->options);
 		$this->assertEquals(array( 'depth' => 0 ), $menu->options);
 
 		// With Valid options set.
@@ -373,11 +373,11 @@ class TestTimberMenu extends Timber_UnitTestCase {
 			'depth' => 1,
 		);
 		$menu = Timber::get_menu('Menu One', $arguments);
-		$this->assertInternalType("int", $menu->depth);
+		$this->assertIsInt($menu->depth);
 		$this->assertEquals( 1, $menu->depth );
-		$this->assertInternalType("array", $menu->raw_options);
+		$this->assertIsArray($menu->raw_options);
 		$this->assertEquals( $arguments, $menu->raw_options );
-		$this->assertInternalType('array', $menu->options);
+		$this->assertIsArray($menu->options);
 		$this->assertEquals(array( 'depth' => 1 ), $menu->options);
 
 		// With invalid option set.
@@ -385,7 +385,7 @@ class TestTimberMenu extends Timber_UnitTestCase {
 			'depth' => 'boogie',
 		);
 		$menu = Timber::get_menu('Menu One', $arguments);
-		$this->assertInternalType("int", $menu->depth);
+		$this->assertIsInt($menu->depth);
 		$this->assertEquals( 0, $menu->depth );
 	}
 
@@ -480,10 +480,10 @@ class TestTimberMenu extends Timber_UnitTestCase {
 		$context['menu'] = Timber::get_menu();
 		$str = Timber::compile( 'assets/menu-classes.twig', $context );
 		$str = trim( $str );
-		$this->assertContains( 'current_page_item', $str );
-		$this->assertContains( 'current-menu-item', $str );
-		$this->assertContains( 'menu-item-object-page', $str );
-		$this->assertNotContains( 'foobar', $str );
+		$this->assertStringContainsString( 'current_page_item', $str );
+		$this->assertStringContainsString( 'current-menu-item', $str );
+		$this->assertStringContainsString( 'menu-item-object-page', $str );
+		$this->assertStringNotContainsString( 'foobar', $str );
   }
 
 	function testCustomArchivePage() {

--- a/tests/test-timber-meta-deprecated.php
+++ b/tests/test-timber-meta-deprecated.php
@@ -16,8 +16,8 @@ use Timber\Integration\AcfIntegration;
  * @group called-post-constructor
  */
 class TestTimberMetaDeprecated extends Timber_UnitTestCase {
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		remove_filter( 'timber/post/pre_meta', array( AcfIntegration::class, 'post_get_meta_field' ) );
 		remove_filter( 'timber/post/meta_object_field', array( AcfIntegration::class, 'post_meta_object' ) );

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -20,8 +20,8 @@ class TestTimberMeta extends Timber_UnitTestCase {
 	protected $is_get_term_meta_hit;
 	protected $is_get_comment_meta_hit;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		require_once 'php/MetaPost.php';
 		require_once 'php/MetaTerm.php';
@@ -528,10 +528,9 @@ class TestTimberMeta extends Timber_UnitTestCase {
 	/**
 	 * Tests when you try to directly access a custom field value that is also the name of an
 	 * existing public method on the object that has at least one required parameter.
-	 *
-	 * @expectedException \ArgumentCountError
 	 */
 	function testPostMetaDirectAccessMethodWithRequiredParametersConflict() {
+		$this->expectException(\ArgumentCountError::class);
 		$post_id = $this->factory->post->create();
 
 		update_post_meta( $post_id, 'public_method_with_args', 'I am a meta value' );
@@ -549,10 +548,9 @@ class TestTimberMeta extends Timber_UnitTestCase {
 	/**
 	 * Tests when you try to directly access a custom field value that is also the name of an
 	 * existing method on the object that has at least one required parameter.
-	 *
-	 * @expectedException \ArgumentCountError
 	 */
 	function testTermMetaDirectAccessMethodWithRequiredParametersConflict() {
+		$this->expectException(\ArgumentCountError::class);
 		$term_id = $this->factory->term->create();
 
 		update_term_meta( $term_id, 'public_method_with_args', 'I am a meta value' );
@@ -574,10 +572,10 @@ class TestTimberMeta extends Timber_UnitTestCase {
 	/**
 	 * Tests when you try to directly access a custom field value that is also the name of an
 	 * existing method on the object that has at least one required parameter.
-	 *
-	 * @expectedException \ArgumentCountError
 	 */
 	function testUserMetaDirectAccessMethodWithRequiredParametersConflict() {
+		$this->expectException(\ArgumentCountError::class);
+
 		$user_id = $this->factory->user->create();
 
 		update_user_meta( $user_id, 'public_method_with_args', 'I am a meta value' );
@@ -598,10 +596,9 @@ class TestTimberMeta extends Timber_UnitTestCase {
 	/**
 	 * Tests when you try to directly access a custom field value that is also the name of an
 	 * existing method on the object that has at least one required parameter.
-	 *
-	 * @expectedException \ArgumentCountError
 	 */
 	function testCommentMetaDirectAccessMethodWithRequiredParametersConflict() {
+		$this->expectException(\ArgumentCountError::class);
 
 		$post_id    = $this->factory->post->create();
 		$comment_id = $this->factory->comment->create(array('comment_post_ID' => $post_id));

--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -2,9 +2,9 @@
 
 class TestTimberMultisite extends Timber_UnitTestCase {
 
-	function setUp() {
+	function set_up() {
 		self::clear();
-		parent::setUp();
+		parent::set_up();
 	}
 
 	function testGetSubDomainSites() {
@@ -227,9 +227,9 @@ class TestTimberMultisite extends Timber_UnitTestCase {
 		$blog_ids = $wpdb->get_col("SELECT blog_id FROM $wpdb->blogs ORDER BY blog_id ASC");
 	}
 
-	function tearDown() {
+	function tear_down() {
 		self::clear();
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 }

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -9,15 +9,15 @@ use Timber\PostQuery;
  */
 class TestTimberPagination extends Timber_UnitTestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->setPermalinkStructure('/%postname%/');
 		register_post_type( 'portfolio' );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 
 		unregister_post_type('portfolio');
 	}
@@ -459,7 +459,7 @@ class TestTimberPagination extends Timber_UnitTestCase {
 	  $pagination = $data['posts']->pagination();
 	  $this->assertEquals('http://example.org/my_cpt/page/3/', $pagination->pages[2]['link']);
 	}
-	
+
 	/**
 	 * @ticket #2302
 	 */

--- a/tests/test-timber-post-array-object.php
+++ b/tests/test-timber-post-array-object.php
@@ -15,11 +15,11 @@ require_once 'php/SerializablePost.php';
  */
 class TestTimberPostArrayObject extends Timber_UnitTestCase {
 
-	function setUp() {
+	function set_up() {
 		global $wpdb;
 		$wpdb->query("TRUNCATE TABLE $wpdb->posts");
 		$wpdb->query("ALTER TABLE $wpdb->posts AUTO_INCREMENT = 1");
-		parent::setUp();
+		parent::set_up();
   }
 
   function testEmpty() {
@@ -161,7 +161,7 @@ class TestTimberPostArrayObject extends Timber_UnitTestCase {
 
 		// @todo once the Posts API uses Factories, simplify this to Timber::get_posts([...])
 		$wp_query = new WP_Query('post_type=post');
-    
+
     $collection = new PostArrayObject($wp_query->posts);
 
 		$this->assertEquals('Post 0', $collection[0]->title());
@@ -195,9 +195,9 @@ class TestTimberPostArrayObject extends Timber_UnitTestCase {
     $wp_query = new WP_Query([
       'post_type' => ['post', 'page', 'custom']
     ]);
-    
+
 		$collection = new PostArrayObject($wp_query->posts);
-		
+
 		// Test that iteration realizes the correct class.
 		$expected = [
 			CollectionTestCustom::class,

--- a/tests/test-timber-post-collection.php
+++ b/tests/test-timber-post-collection.php
@@ -16,11 +16,11 @@ require_once 'php/SerializablePost.php';
  */
 class TestTimberPostQuery extends Timber_UnitTestCase {
 
-	function setUp() {
+	function set_up() {
 		global $wpdb;
 		$wpdb->query("TRUNCATE TABLE $wpdb->posts");
 		$wpdb->query("ALTER TABLE $wpdb->posts AUTO_INCREMENT = 1");
-		parent::setUp();
+		parent::set_up();
 	}
 
 	function testBasicCollection() {

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -163,7 +163,7 @@
 			$post = Timber::get_post($post_id);
 			$template = '{{ post.excerpt.length(3).read_more(false).strip(false) }}';
 			$str = Timber::compile_string($template, array('post' => $post));
-			$this->assertNotContains('</p>', $str);
+			$this->assertStringNotContainsString('</p>', $str);
 		}
 
 		function testPostExcerptObjectWithCharAndWordLengthWordsWin() {

--- a/tests/test-timber-post-excerpt.php
+++ b/tests/test-timber-post-excerpt.php
@@ -30,7 +30,7 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase {
 			'always_add_read_more' => true,
 		] );
 
-		$this->assertContains('and-foo', (string) $text);
+		$this->assertStringContainsString('and-foo', (string) $text);
 	}
 
 	function testReadMoreLinkFilter() {
@@ -79,7 +79,7 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase {
 			'read_more' => '',
 			'strip'    => false,
 		] );
-		$this->assertNotContains('</p>', (string) $text);
+		$this->assertStringNotContainsString('</p>', (string) $text);
 	}
 
 	function testGetExcerpt() {
@@ -96,7 +96,7 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase {
 			words: 3,
 			always_add_read_more: true
 		}) }}', [ 'post' => $post ] );
-		$this->assertRegExp( '/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $str );
+		$this->assertMatchesRegularExpression( '/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Read More<\/a>/', $str );
 
 		// excerpt set, force is false, no read more
 		$post->post_excerpt = 'this is excerpt longer than three words';
@@ -115,7 +115,7 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase {
 			'read_more'            => 'Custom more',
 			'always_add_read_more' => true,
 		] );
-		$this->assertRegExp('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', (string) $excerpt);
+		$this->assertMatchesRegularExpression('/this is super&hellip; <a href="http:\/\/example.org\/\?p=\d+" class="read-more">Custom more<\/a>/', (string) $excerpt);
 
 		// content with <!--more--> tag, force false
 		$post->post_content = 'this is super dooper<!--more--> trooper long words';

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -440,7 +440,7 @@ class TestTimberPost extends Timber_UnitTestCase {
 		$this->assertEquals('Bernstein', $post->modified_author()->name());
 	}
 
-	function tearDown() {
+	function tear_down() {
 		global $wpdb;
 		$query = "DELETE from $wpdb->users WHERE ID > 1";
 		$wpdb->query($query);
@@ -875,6 +875,7 @@ class TestTimberPost extends Timber_UnitTestCase {
 	function testCommentFormOnPost() {
 		$post_id = $this->factory->post->create();
 		$post = Timber::get_post($post_id);
+		$GLOBALS['post'] = $post; // ACF throws an error if not
 		$form = $post->comment_form();
 		$this->assertStringStartsWith('<div id="respond"', trim($form));
 	}
@@ -900,11 +901,10 @@ class TestTimberPost extends Timber_UnitTestCase {
 
 		$pid = $this->factory->post->create(array('post_content' => $quote));
 		$post = Timber::get_post($pid);
-		$expected = array(
-			'<audio class="wp-audio-shortcode" id="audio-1-1" preload="none" style="width: 100%;" controls="controls"><source type="audio/mpeg" src="http://www.noiseaddicts.com/samples_1w72b820/280.mp3?_=1" /><a href="http://www.noiseaddicts.com/samples_1w72b820/280.mp3">http://www.noiseaddicts.com/samples_1w72b820/280.mp3</a></audio>',
-		);
+		$expected = 'http://www.noiseaddicts.com/samples_1w72b820/280.mp3';
 
-		$this->assertEquals($expected, $post->audio());
+		$this->assertStringContainsString($expected, $post->audio()[0]);
+		$this->assertStringStartsWith('<audio', $post->audio()[0]);
 	}
 
 	function testPostWithAudioCustomField() {
@@ -914,11 +914,10 @@ class TestTimberPost extends Timber_UnitTestCase {
 
 		$pid = $this->factory->post->create(array('post_content' => $quote));
 		update_post_meta($pid, 'audio', 'foo');
-		$expected = array(
-			'<audio class="wp-audio-shortcode" id="audio-1-2" preload="none" style="width: 100%;" controls="controls"><source type="audio/mpeg" src="http://www.noiseaddicts.com/samples_1w72b820/280.mp3?_=2" /><a href="http://www.noiseaddicts.com/samples_1w72b820/280.mp3">http://www.noiseaddicts.com/samples_1w72b820/280.mp3</a></audio>',
-		);
+		$expected = 'http://www.noiseaddicts.com/samples_1w72b820/280.mp3';
 		$post = Timber::get_post($pid);
-		$this->assertEquals($expected, $post->audio());
+		$this->assertStringContainsString($expected, $post->audio()[0]);
+		$this->assertStringStartsWith('<audio', $post->audio()[0]);
 	}
 
 	function testPostWithoutVideo() {
@@ -941,7 +940,7 @@ class TestTimberPost extends Timber_UnitTestCase {
 			$video = array_shift( $video );
 		}
 		$expected = '/<iframe [^>]+ src="https:\/\/www\.youtube\.com\/embed\/Jf37RalsnEs\?feature=oembed" [^>]+>/i';
-		$this->assertRegExp( $expected, $video );;
+		$this->assertMatchesRegularExpression( $expected, $video );;
 	}
 
 	function testPathAndLinkWithPort() {

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -55,7 +55,7 @@ class TestTimberSite extends Timber_UnitTestCase {
 		$site = new Timber\Site();
 		$icon = $site->icon();
 		$this->assertEquals('Timber\Image', get_class($icon));
-		$this->assertContains('cardinals.jpg', $icon->src());
+		$this->assertStringContainsString('cardinals.jpg', $icon->src());
 	}
 
 
@@ -86,10 +86,10 @@ class TestTimberSite extends Timber_UnitTestCase {
 		$this->assertEquals('j. F Y', $ts->option('date_format'));
 	}
 
-	function setUp() {
+	function set_up() {
 		global $wp_theme_directories;
 
-		parent::setUp();
+		parent::set_up();
 
 		$this->backup_wp_theme_directories = $wp_theme_directories;
 		$wp_theme_directories = array( WP_CONTENT_DIR . '/themes' );
@@ -99,13 +99,13 @@ class TestTimberSite extends Timber_UnitTestCase {
 
 	}
 
-	function tearDown() {
+	function tear_down() {
 		global $wp_theme_directories;
 
 		$wp_theme_directories = $this->backup_wp_theme_directories;
 
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
-		parent::tearDown();
+		parent::tear_down();
 	}
 }

--- a/tests/test-timber-static.php
+++ b/tests/test-timber-static.php
@@ -5,7 +5,7 @@
  */
 class TestTimberStaticPages extends Timber_UnitTestCase {
 
-	function tearDown() {
+	function tear_down() {
 		update_option('show_on_front', 'posts');
 		update_option('page_on_front', '0');
 		update_option('page_for_posts', '0');

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -5,12 +5,12 @@
  */
 class TestTimberTermFactories extends Timber_UnitTestCase {
 
-	function setUp() {
+	function set_up() {
 		$this->truncate('term_relationships');
 		$this->truncate('term_taxonomy');
 		$this->truncate('terms');
 		$this->truncate('termmeta');
-		parent::setUp();
+		parent::set_up();
 	}
 
 	function testGetTerm() {

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -28,10 +28,9 @@ class TermTestPage extends Post {}
 			$this->assertEquals('Rangers',   $baseball_teams[1]->title());
 		}
 
-		/**
-		 * @expectedException InvalidArgumentException
-		 */
 		function testTermFromInvalidObject() {
+			$this->expectException(\InvalidArgumentException::class);
+
 			register_taxonomy('baseball', array('post'));
 			$term_id = $this->factory->term->create(['name' => 'Cardinals', 'taxonomy' => 'baseball']);
 			$post_id = $this->factory->post->create(['post_title' => 'Test Post']);
@@ -90,7 +89,7 @@ class TermTestPage extends Post {}
 		function testTermLink() {
 			$term_id = $this->factory->term->create();
 			$term = Timber::get_term($term_id);
-			$this->assertContains('http://', $term->link());
+			$this->assertStringContainsString('http://', $term->link());
 		}
 
 		function testTermPath() {

--- a/tests/test-timber-theme.php
+++ b/tests/test-timber-theme.php
@@ -97,10 +97,10 @@
 			switch_theme('default');
 		}
 
-		function setUp() {
+		function set_up() {
 			global $wp_theme_directories;
 
-			parent::setUp();
+			parent::set_up();
 
 			$this->backup_wp_theme_directories = $wp_theme_directories;
 			$wp_theme_directories = array( WP_CONTENT_DIR . '/themes' );
@@ -115,13 +115,13 @@
 
 		}
 
-		function tearDown() {
+		function tear_down() {
 			global $wp_theme_directories;
 
 			$wp_theme_directories = $this->backup_wp_theme_directories;
 
 			wp_clean_themes_cache();
 			unset( $GLOBALS['wp_themes'] );
-			parent::tearDown();
+			parent::tear_down();
 		}
 	}

--- a/tests/test-timber-twig-date-filter-default.php
+++ b/tests/test-timber-twig-date-filter-default.php
@@ -6,8 +6,8 @@
  * @group Timber\Date
  */
 class TestTimberTwigDateFilterDefault extends Timber_UnitTestCase {
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 
 		update_option( 'date_format', 'Y-m-d' );
 	}

--- a/tests/test-timber-twig-date-filter-immutable.php
+++ b/tests/test-timber-twig-date-filter-immutable.php
@@ -6,8 +6,8 @@
  * @group Timber\Date
  */
 class TestTimberTwigDateFilterImmutable extends Timber_UnitTestCase {
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 
 		update_option( 'date_format', 'F j, Y H:i' );
 		update_option( 'timezone_string', 'Europe/Paris' );
@@ -21,10 +21,10 @@ class TestTimberTwigDateFilterImmutable extends Timber_UnitTestCase {
 		 */
 	}
 
-	function tearDown() {
+	function tear_down() {
 		update_option( 'timezone_string', 'UTC' );
 
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	function get_context() {

--- a/tests/test-timber-twig-date-filter-interval.php
+++ b/tests/test-timber-twig-date-filter-interval.php
@@ -8,8 +8,8 @@ use Twig\Extension\CoreExtension;
  * @group Timber\Date
  */
 class TestTimberTwigDateFilterInterval extends Timber_UnitTestCase {
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 
 		update_option( 'date_format', 'F j, Y H:i' );
 		update_option( 'timezone_string', 'Europe/Paris' );
@@ -21,10 +21,10 @@ class TestTimberTwigDateFilterInterval extends Timber_UnitTestCase {
 		 */
 	}
 
-	function tearDown() {
+	function tear_down() {
 		update_option( 'timezone_string', 'UTC' );
 
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	function get_context() {

--- a/tests/test-timber-twig-date-filter.php
+++ b/tests/test-timber-twig-date-filter.php
@@ -6,8 +6,8 @@
  * @group Timber\Date
  */
 class TestTimberTwigDateFilter extends Timber_UnitTestCase {
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 
 		update_option( 'date_format', 'F j, Y H:i' );
 		update_option( 'timezone_string', 'Europe/Paris' );
@@ -21,10 +21,10 @@ class TestTimberTwigDateFilter extends Timber_UnitTestCase {
 		 */
 	}
 
-	function tearDown() {
+	function tear_down() {
 		update_option( 'timezone_string', 'UTC' );
 
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	function get_context() {

--- a/tests/test-timber-twig-number-format-filter-default.php
+++ b/tests/test-timber-twig-number-format-filter-default.php
@@ -6,18 +6,18 @@
  * @group Timber\Number
  */
 class TestTimberTwigNumberFormatFilterDefault extends Timber_UnitTestCase {
-	function setUp() {
+	function set_up() {
 		// Simulate fr_FR locale
 		global $wp_locale;
 		$wp_locale->number_format['decimal_point'] = ',';
 		$wp_locale->number_format['thousands_sep'] = ' ';
-		parent::setUp();
+		parent::set_up();
 	}
 
-	function tearDown() {
+	function tear_down() {
 		// Reset locale
 		$GLOBALS['wp_locale'] = new WP_Locale();
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	function get_context() {

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -5,7 +5,7 @@
 	 */
 	class TestTimberTwig extends Timber_UnitTestCase {
 
-		function tearDown() {
+		function tear_down() {
 			$lang_dir = get_stylesheet_directory().'/languages';
 			if (file_exists($lang_dir.'/en_US.po' )) {
 				unlink($lang_dir.'/en_US.po');
@@ -218,10 +218,8 @@
 
 		}
 
-		/**
-     	* @expectedException Twig\Error\SyntaxError
-     	*/
 		function testSetObject() {
+			$this->expectException(\Twig\Error\SyntaxError::class);
 			$pid = $this->factory->post->create(array('post_title' => 'Spaceballs'));
 			$post = Timber::get_post( $pid );
 			$result = Timber::compile('assets/set-object.twig', array('post' => $post));
@@ -334,10 +332,8 @@
 			);
 		}
 
-		/**
-		 * @expectedException \Twig\Error\SyntaxError
-		 */
 		function testRemoveADefaultFunction() {
+			$this->expectException(\Twig\Error\SyntaxError::class);
 			add_filter('timber/twig/functions', function($functions) {
 				unset($functions['shortcode']);
 				return $functions;
@@ -345,10 +341,8 @@
 			Timber::compile_string( "{{ text|shortcode }}", ['text' => 'A function has been removed'] );
 		}
 
-		/**
-		 * @expectedException \Twig\Error\SyntaxError
-		 */
 		function testRemoveADefaultFilter() {
+			$this->expectException(\Twig\Error\SyntaxError::class);
 			add_filter('timber/twig/filters', function($filters) {
 				unset($filters['wpautop']);
 				return $filters;

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -7,7 +7,7 @@ class TestTimberURLHelper extends Timber_UnitTestCase {
 
 	private $mockUploadDir = false;
 
-	function setUp() {
+	function set_up() {
 		$_SERVER['SERVER_PORT'] = 80;
 	}
 
@@ -110,8 +110,8 @@ class TestTimberURLHelper extends Timber_UnitTestCase {
 		$file = Timber\URLHelper::url_to_file_system($url);
 		$this->assertStringStartsWith(ABSPATH, $file);
 		$this->assertStringEndsWith('/2012/06/mypic.jpg', $file);
-		$this->assertNotContains($file, 'http://example.org');
-		$this->assertNotContains($file, '//');
+		$this->assertStringNotContainsString($file, 'http://example.org');
+		$this->assertStringNotContainsString($file, '//');
 	}
 
 	function testGetHost() {

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -7,8 +7,8 @@ use Timber\User;
 	 * @group users-api
 	 */
 	class TestTimberUser extends Timber_UnitTestCase {
-		function setUp() {
-			parent::setUp();
+		function set_up() {
+			parent::set_up();
 
 			// Restore integration-free Class Map for users.
 			$this->add_filter_temporarily('timber/user/classmap', function() {

--- a/tests/test-timber-wp-vip.php
+++ b/tests/test-timber-wp-vip.php
@@ -28,7 +28,7 @@ class TestTimberWPVIP extends TimberAttachment_UnitTestCase {
 		$data['crop'] = 'default';
 		Timber::compile( 'assets/image-test.twig', $data );
 		$resized_path = $upload_dir['path'].'/arch-'.$data['size']['width'].'x'.$data['size']['height'].'-c-'.$data['crop'].'.jpg';
-		$this->assertFileNotExists( $resized_path );
+		$this->assertFileDoesNotExist( $resized_path );
 		remove_filter( 'timber/allow_fs_write', '__return_false' );
 	}
 

--- a/tests/test-user-factory.php
+++ b/tests/test-user-factory.php
@@ -13,10 +13,10 @@ class BadUser {}
  * @group users-api
  */
 class TestUserFactory extends Timber_UnitTestCase {
-	public function tearDown() {
+	public function tear_down() {
 		global $wpdb;
 		$wpdb->query("TRUNCATE TABLE {$wpdb->users}");
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	public function testGetUser() {
@@ -126,10 +126,9 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertFalse($maybe_user);
 	}
 
-	/**
-	 * @expectedException InvalidArgumentException
-	 */
 	public function testInvalidUserClassThrowsError() {
+		$this->expectException(\InvalidArgumentException::class);
+
 		$bad_user_obj = new BadUser();
 
 		$normie_id = $this->factory->user->create([


### PR DESCRIPTION
Timber now officially supports PHP 8.0/8.1 🎉 
(I mean if @jarednova is ok with this 😅)

PR summary:

- Update PHPUnit 🎉 thanks to https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/
- Update/fix tests
- Test Timber on PHP 8.0/8.1 🎉

Side notes:
- PHPUnit has been removed as a dependency to let `yoast/phpunit-polyfills` handle the PHPUnit version to use as advised in link above
- You can now use PHPUnit ^9.0 assertions
- If you need to run tests on an older WP version (< 5.9), use `composer req phpunit/phpunit:^7.5 -W --dev` but don't commit changes made to `composer.json`
- When installing test suite, always use a branch (`5.8`, not `latest`, not `5.7.1`): `bash bin/install-wp-tests.sh wordpress_test <db_user> <db_pass> <db_host> 5.8`
- Read the [WordPress Core blog post](https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/) above for further details
