### PR TITLE
Nav menus improvments

### DIFF
--- a/lib/Factory/MenuItemFactory.php
+++ b/lib/Factory/MenuItemFactory.php
@@ -7,51 +7,49 @@ use WP_Post;
 use Timber\CoreInterface;
 use Timber\Menu;
 use Timber\MenuItem;
-use Timber\Timber;
 
 /**
  * Internal API class for instantiating Menus
  */
 class MenuItemFactory {
-	public function from($wp_item, Menu $menu) {
-		if ($this->is_post($wp_item)) {
-			return $this->from_post($wp_item, $menu);
-		}
+	public function from($item, Menu $menu) {
+        if (is_numeric($item)) {
+			$item = get_post($item);
+        }
 
-		if (is_numeric($wp_item)) {
-			return $this->from_id((int)$wp_item, $menu);
-		}
-
-		return false;
-	}
-
-	protected function from_post(WP_Post $post, Menu $menu) {
-		$item = $this->build(Timber::get_post($post), $menu);
-		$item->import_classes($post);
-
-		return $item;
-	}
-
-	protected function from_id(int $id, Menu $menu) {
-		$post = get_post($id);
-
-		if ($post) {
-			$item = $this->build($post, $menu);
-			$item->import_classes($post);
-
-			return $item;
+		if (is_object($item) && $item instanceof WP_Post) {
+			return $this->build($item, $menu);
 		}
 
 		return false;
 	}
 
-	protected function is_post($item) : bool {
-		return is_object($item) && $item instanceof WP_Post;
-	}
-
-	protected function build($item, Menu $menu) : MenuItem {
-		$class = apply_filters('timber/menuitem/classmap', MenuItem::class, $item, $menu);
+	protected function build(WP_Post $item, Menu $menu) : CoreInterface {
+		$class = $this->get_menuitem_class($item, $menu);
 
 		return $class::build($item, $menu);
+	}
+
+	protected function get_menuitem_class($item, $menu) : string {
+		/**
+		 * Filters the menu item class
+		 *
+		 * @since 2.0.0
+		 * @example
+		 * ```
+		 * add_filter( 'timber/menuitem/class', function( $class, $item, $menu ) {
+		 *     if ($item->post_parent) {
+		 * 	       return SubMenuItem::class;
+		 *    }
+		 *     return MenuItem::class;
+		 * } );
+		 * ```
+		 *
+		 * @param string $class The class to use.
+		 * @param WP_Post $item The menu item.
+		 * @param Menu $menu The menu object.
+		 */
+		$class = apply_filters( 'timber/menuitem/class', MenuItem::class, $item, $menu );
+		return $class;
 	}
 }

--- a/lib/Factory/UserFactory.php
+++ b/lib/Factory/UserFactory.php
@@ -101,7 +101,7 @@ class UserFactory {
 		 * use Administrator;
 		 * use Editor;
 		 *
-		 * add_filter( 'timber/user/classmap', function( $class, \WP_User $user ) {
+		 * add_filter( 'timber/user/class', function( $class, \WP_User $user ) {
 		 *     if ( in_array( 'editor', $user->roles, true ) ) {
 		 *         return Editor::class;
 		 *     } elseif ( in_array( 'author', $user->roles, true ) ) {
@@ -116,7 +116,7 @@ class UserFactory {
 		 * @param \WP_User $user  The `WP_User` object that is used as the base for the
 		 *                        `Timber\User` object.
 		 */
-		$class = apply_filters( 'timber/user/classmap', User::class, $user );
+		$class = apply_filters( 'timber/user/class', User::class, $user );
 
 		return $class::build($user);
 	}

--- a/lib/Integration/CoAuthorsPlusIntegration.php
+++ b/lib/Integration/CoAuthorsPlusIntegration.php
@@ -19,7 +19,7 @@ class CoAuthorsPlusIntegration implements IntegrationInterface {
 	public function init() : void {
 		add_filter('timber/post/authors', [$this, 'authors'], 10, 2);
 
-		add_filter( 'timber/user/classmap', function( $class, WP_User $user ) {
+		add_filter( 'timber/user/class', function( $class, WP_User $user ) {
     		return CoAuthorsPlusUser::class;
 		}, 10, 2 );
 	}

--- a/tests/test-menu-factory.php
+++ b/tests/test-menu-factory.php
@@ -131,7 +131,7 @@ class TestMenuFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(Menu::class, $factory->from($term));
 	}
 
-	public function testFromWithOverride() {
+	public function testMenuClassFilter() {
 		$id = $this->factory->term->create([
 			'name'     => 'Main Menu',
 			'taxonomy' => 'nav_menu',
@@ -139,8 +139,31 @@ class TestMenuFactory extends Timber_UnitTestCase {
 
 		$factory = new MenuFactory();
 
-		$this->add_filter_temporarily('timber/menu/classmap', function() {
+		$this->add_filter_temporarily('timber/menu/class', function() {
 			return MyMenu::class;
+		});
+
+		$this->assertInstanceOf(MyMenu::class, $factory->from($id));
+	}
+
+	public function testMenuClassMapFilter() {
+		$id = $this->factory->term->create([
+			'name'     => 'Main Menu',
+			'taxonomy' => 'nav_menu',
+		]);
+
+		$factory = new MenuFactory();
+
+		// Set up our new custom menu location.
+		register_nav_menu('custom', 'Custom nav location');
+		$locations = get_theme_mod('nav_menu_locations');
+		$locations['custom'] = $id;
+		set_theme_mod('nav_menu_locations', $locations);
+
+		$this->add_filter_temporarily('timber/menu/classmap', function() {
+			return [
+				'custom' => MyMenu::class
+			];
 		});
 
 		$this->assertInstanceOf(MyMenu::class, $factory->from($id));

--- a/tests/test-menu-item-factory.php
+++ b/tests/test-menu-item-factory.php
@@ -112,7 +112,7 @@ class TestMenuItemFactory extends Timber_UnitTestCase {
 		$menu = Timber::get_menu($menu_term['term_id']);
 		$factory = new MenuItemFactory();
 
-		$this->add_filter_temporarily('timber/menuitem/classmap', function($class, WP_Post $item, Menu $menu) use ($two) {
+		$this->add_filter_temporarily('timber/menuitem/class', function($class, WP_Post $item, Menu $menu) use ($two) {
 			if ($item->ID === $two) {
 				return MyMenuItem::class;
 			}

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -483,7 +483,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 		$post    = Timber::get_post( $post_id );
 		$term    = Timber::get_term( $term_id );
 
-		$this->add_filter_temporarily('timber/user/classmap', function() {
+		$this->add_filter_temporarily('timber/user/class', function() {
 			return MetaUser::class;
 		});
 		$this->add_filter_temporarily('timber/comment/classmap', function() {
@@ -582,10 +582,10 @@ class TestTimberMeta extends Timber_UnitTestCase {
 
 		update_user_meta( $user_id, 'public_method_with_args', 'I am a meta value' );
 
-		$this->add_filter_temporarily('timber/user/classmap', function() {
+		$this->add_filter_temporarily('timber/user/class', function() {
 			return MetaUser::class;
 		});
-		$this->add_filter_temporarily('timber/user/classmap', function() {
+		$this->add_filter_temporarily('timber/user/class', function() {
 			return MetaUser::class;
 		});
 
@@ -651,7 +651,7 @@ class TestTimberMeta extends Timber_UnitTestCase {
 				'post_tag' => MetaTerm::class
 			];
 		});
-		$this->add_filter_temporarily('timber/user/classmap', function() {
+		$this->add_filter_temporarily('timber/user/class', function() {
 			return MetaUser::class;
 		});
 		$this->add_filter_temporarily('timber/comment/classmap', function() {

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -101,7 +101,7 @@ use Timber\User;
 		function testAvatar() {
 			// Restore integration-free Class Map for users.
 			// CoAuthorsPlus overrides avatar behavior, so we disable it explicitly.
-			$this->add_filter_temporarily('timber/user/classmap', function() {
+			$this->add_filter_temporarily('timber/user/class', function() {
 				return User::class;
 			});
 

--- a/tests/test-user-factory.php
+++ b/tests/test-user-factory.php
@@ -62,7 +62,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 				? AdminUser::class
 				: $class;
 		};
-		add_filter( 'timber/user/classmap', $my_class_map, 10, 2 );
+		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
 		$admin_id = $this->factory->user->create([
 			'user_email' => 'me@example.com',
@@ -79,7 +79,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(AdminUser::class, $admin);
 		$this->assertInstanceOf(User::class,      $normie);
 
-		remove_filter( 'timber/user/classmap', $my_class_map );
+		remove_filter( 'timber/user/class', $my_class_map );
 	}
 
 	public function testGetUserWithArrayOfIds() {
@@ -88,7 +88,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 				? AdminUser::class
 				: $class;
 		};
-		add_filter( 'timber/user/classmap', $my_class_map, 10, 2 );
+		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
 		$admin_id = $this->factory->user->create([
 			'user_email' => 'me@example.com',
@@ -106,7 +106,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(AdminUser::class, $admin);
 		$this->assertInstanceOf(User::class,      $normie);
 
-		remove_filter( 'timber/user/classmap', $my_class_map );
+		remove_filter( 'timber/user/class', $my_class_map );
 	}
 
 	public function testGetUserWithArrayOfIdsIncludingInvalidIds() {
@@ -146,7 +146,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 				? AdminUser::class
 				: $class;
 		};
-		add_filter( 'timber/user/classmap', $my_class_map, 10, 2 );
+		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
 		$admin_id = $this->factory->user->create([
 			'user_email' => 'me@example.com',
@@ -163,7 +163,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(AdminUser::class, $userFactory->from($admin_wp_user));
 		$this->assertInstanceOf(User::class, $userFactory->from($normie_wp_user));
 
-		remove_filter( 'timber/user/classmap', $my_class_map );
+		remove_filter( 'timber/user/class', $my_class_map );
 	}
 
 	public function testGetUserWithAssortedArray() {
@@ -172,7 +172,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 				? AdminUser::class
 				: $class;
 		};
-		add_filter( 'timber/user/classmap', $my_class_map, 10, 2 );
+		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
 		$admin_id = $this->factory->user->create([
 			'user_email' => 'me@example.com',
@@ -199,7 +199,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(User::class,      $users[1]);
 		$this->assertInstanceOf(User::class,      $users[2]);
 
-		remove_filter( 'timber/user/classmap', $my_class_map );
+		remove_filter( 'timber/user/class', $my_class_map );
 	}
 
 	public function testGetUserWithQueryArray() {
@@ -208,7 +208,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 				? AdminUser::class
 				: $class;
 		};
-		add_filter( 'timber/user/classmap', $my_class_map, 10, 2 );
+		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
 		$subscriber_id = $this->factory->user->create([
 			'user_login' => 'aaa',
@@ -238,7 +238,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(AdminUser::class, $users[0]);
 		$this->assertInstanceOf(User::class,      $users[1]);
 
-		remove_filter( 'timber/user/classmap', $my_class_map );
+		remove_filter( 'timber/user/class', $my_class_map );
 	}
 
 	public function testGetUserWithUserQuery() {
@@ -247,7 +247,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 				? AdminUser::class
 				: $class;
 		};
-		add_filter( 'timber/user/classmap', $my_class_map, 10, 2 );
+		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
 		$subscriber_id = $this->factory->user->create([
 			'user_login' => 'aaa',
@@ -277,7 +277,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$this->assertInstanceOf(AdminUser::class, $users[0]);
 		$this->assertInstanceOf(User::class,      $users[1]);
 
-		remove_filter( 'timber/user/classmap', $my_class_map );
+		remove_filter( 'timber/user/class', $my_class_map );
 	}
 
 }


### PR DESCRIPTION
**Ticket**: #2496

### Timber\Factory\MenuFactory

- Make `timber/menu/classmap` location based
- Add `timber/menu/class` to provide other ways to filter the menu class
- Rename `$options` to `$args`, make more sense in the a WP environment
- Fix tests

### Timber\Factory\MenuItemFactory

- Rename  `timber/menuitem/classmap` to `timber/menuitem/class`
- Refactor factory: avoid building items twice
- Pass a WP_Post object to the filter for better consistency
- Fix tests

### Timber\Factory\UserFactory

- Rename  `timber/user/classmap` to `timber/user/class`
- Fix tests

