### PR TITLE
Add webp support to letterbox filter

### DIFF
--- a/lib/Image/Operation/Letterbox.php
+++ b/lib/Image/Operation/Letterbox.php
@@ -115,7 +115,10 @@ class Letterbox extends ImageOperation {
 					$quality = $quality / 10;
 					$quality = round(10 - $quality);
 				}
-			}
+			} else if ( $ext == 'webp' ) {
+                $func = 'imagecreatefromwebp';
+                $save_func = 'imagewebp';
+            }
 			$image = $func($save_filename);
 			imagecopy($bg, $image, $x, $y, 0, 0, $owt, $oht);
 			if ( $save_func === 'imagegif' ) {

--- a/lib/Image/Operation/Letterbox.php
+++ b/lib/Image/Operation/Letterbox.php
@@ -116,9 +116,9 @@ class Letterbox extends ImageOperation {
 					$quality = round(10 - $quality);
 				}
 			} else if ( $ext == 'webp' ) {
-                $func = 'imagecreatefromwebp';
-                $save_func = 'imagewebp';
-            }
+				$func = 'imagecreatefromwebp';
+				$save_func = 'imagewebp';
+			}
 			$image = $func($save_filename);
 			imagecopy($bg, $image, $x, $y, 0, 0, $owt, $oht);
 			if ( $save_func === 'imagegif' ) {


### PR DESCRIPTION
**Ticket**: None

## Issue
The letterbox class does not support webp images.


## Solution
Add support for webp images


## Impact
The 'imagewebp' & 'imagecreatefromwebp' functions were added in PHP 5.4. The Timber Wordpress page reports a minimum PHP version of 5.6, however, the current composer.json shows 5.3. I'm not sure if the composer.json is out of date or not.


## Usage Changes
There should be none


## Considerations
See Impact

## Testing
There doesn't seem to be specific tests for the different extensions.
