### PR TITLE
wp_body_open support

### DIFF
--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -265,6 +265,7 @@ class Timber {
 			 */
 			self::$context_cache['wp_head'] = new FunctionWrapper( 'wp_head' );
 			self::$context_cache['wp_footer'] = new FunctionWrapper( 'wp_footer' );
+			self::$context_cache['wp_body_open'] = new FunctionWrapper( 'wp_body_open' );
 
 			self::$context_cache = apply_filters('timber_context', self::$context_cache);
 			self::$context_cache = apply_filters('timber/context', self::$context_cache);


### PR DESCRIPTION
## Issue
Proposal to add `wp_body_open` support similar to `wp_head` and `wp_footer`.

## Solution
Add `wp_body_open` to get_context() return array, similar to `wp_head` and `wp_footer`.

## Testing
There is not much to test as it just adds `wp_body_open` to the context array.
