### PR TITLE
Update composer/installers from v1 to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": "^7.4|^8.0",
     "twig/twig": "^2.12|^3.0",
-    "composer/installers": "^1.9",
+    "composer/installers": "^2.0",
     "twig/cache-extension": "^1.5.0"
   },
   "require-dev": {


### PR DESCRIPTION
**Ticket**: #2533

## Issue
Bedrock (from Roots) recently upgraded to composer/installers v2 and it makes it very hard to use Timber with Bedrock without also upgrading Timber's dependency.

## Solution
Upgrade Timber's "composer/installers" dependency to match Bedrock's (https://github.com/roots/bedrock/commit/43e2a97792104d141661193e478dfcb656bc1274)

**The upstatement/routes package also needs updating before this issue can be resolved.**

## Impact
Shouldn't have much impact. Anyone who still has a dependency on v1 of composer/installers would be able to use a previously tagged version of Timber if needed.


## Considerations
The alternative would be to add support for v1 or v2 like so:
`"composer/installers": "~1.0|^2.0"`
