### PR TITLE
2.x Don’t overwrite post global

### DIFF
--- a/lib/Post.php
+++ b/lib/Post.php
@@ -253,9 +253,16 @@ class Post extends CoreEntity implements DatedInterface, Setupable {
 		global $post;
 		global $wp_query;
 
-		// Overwrite post global.
+		/**
+		 * Overwrite post global.
+		 *
+		 * We have to overwrite the post global to be compatible with a couple of WordPress plugins
+		 * that work with the post global in certain conditions.
+		 */
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-		$post = $this;
+		if ( $post->ID !== $this->ID ) {
+			$post = get_post( $this->ID );
+		}
 
 		// Mimick WordPress behavior to improve compatibility with third party plugins.
 		$wp_query->in_the_loop = true;

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -253,22 +253,29 @@ class Post extends CoreEntity implements DatedInterface, Setupable {
 		global $post;
 		global $wp_query;
 
+		// @todo: Load $wp_post in Post::build() and save it in a property.
+		$wp_post = get_post( $this->ID );
+
+		// Mimick WordPress behavior to improve compatibility with third party plugins.
+		$wp_query->in_the_loop = true;
+
+		if ( ! $wp_post ) {
+			return $this;
+		}
+
 		/**
-		 * Overwrite post global.
+		 * Maybe set or overwrite post global.
 		 *
 		 * We have to overwrite the post global to be compatible with a couple of WordPress plugins
 		 * that work with the post global in certain conditions.
 		 */
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
-		if ( $post->ID !== $this->ID ) {
-			$post = get_post( $this->ID );
+		if ( ! $post || isset( $post->ID ) && $post->ID !== $this->ID ) {
+			$post = $wp_post;
 		}
 
-		// Mimick WordPress behavior to improve compatibility with third party plugins.
-		$wp_query->in_the_loop = true;
-
 		// The setup_postdata() function will call the 'the_post' action.
-		$wp_query->setup_postdata( $post->ID );
+		$wp_query->setup_postdata( $wp_post );
 
 		return $this;
 	}


### PR DESCRIPTION
**Ticket**: #2501

## Issue

Timber was overwriting the post global with a Timber post object.

## Solution

- Overwrite the post global with a WordPress post object.
- Overwrite the post global only if necessary.

## Impact

Fixes unexpected behavior.

## Usage Changes

None.

## Considerations

See #2501.

## Testing

No.