### PR TITLE
2.x Remove twig/cache-extension, add support for twig/cache-extra

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,12 @@
     "wpackagist-plugin/co-authors-plus": "^3.3",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "php-stubs/wp-cli-stubs": "^2.2.0",
-    "yoast/phpunit-polyfills": "^1.0.1"
+    "yoast/phpunit-polyfills": "^1.0.1",
+    "twig/cache-extra": "^3.3"
   },
   "suggest": {
-    "php-coveralls/php-coveralls": "^2.0 for code coverage"
+    "php-coveralls/php-coveralls": "^2.0 for code coverage",
+    "twig/cache-extra": "For using the cache tag in Twig"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
   "require": {
     "php": "^7.4|^8.0",
     "twig/twig": "^2.12|^3.0",
-    "composer/installers": "^1.9",
-    "twig/cache-extension": "^1.5.0"
+    "composer/installers": "^1.9"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0",

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -45,6 +45,22 @@ composer require upstatement/routes
 
 Or you can use one of the available libraries and hook it into your code. Follow the [Routing Guide](https://timber.github.io/docs/v2/guides/routing/) for more information.
 
+### Removed Twig cache extension
+
+Timber used the [`twig/cache-extension`](https://github.com/twigphp/twig-cache-extension) package, which was abandoned. If you still need the package while transitioning to a different solution, you can still install it yourself:
+
+```bash
+composer require twig/cache-extension
+```
+
+And then, you can enable it with the following filter:
+
+**functions.php**
+
+```php
+add_filter( 'timber/cache/enable_extension', '__return_true' );
+```
+
 ### Removed support for Co-Authors Plus
 
 We dropped support for the [Co-Authors Plus](https://wordpress.org/plugins/co-authors-plus/) plugin, because of compatibility issues with Timber 2.0. Maybe we’ll add it back if we find a good way to support it.

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -77,7 +77,11 @@ Or you can use one of the available libraries and hook it into your code. Follow
 
 ### Removed Twig cache extension
 
-Timber used the [`twig/cache-extension`](https://github.com/twigphp/twig-cache-extension) package, which was abandoned. If you still need the package while transitioning to a different solution, you can still install it yourself:
+Timber used the [`twig/cache-extension`](https://github.com/twigphp/twig-cache-extension) package, which was abandoned. You only need this package if you’ve used the `{% cache %}` tag in Twig.
+
+You should use [`twig/cache-extra`](https://github.com/twigphp/cache-extra) instead, which you can implement yourself. Check you the [relevant section in the Performance/Caching Guide](https://timber.github.io/docs/v2/guides/performance/#cache-parts-of-the-twig-file-and-data) for more information.
+
+If you still need the `twig/cache-extension` package before moving to [`twig/cache-extra`](https://github.com/twigphp/cache-extra), you can still install it yourself:
 
 ```bash
 composer require twig/cache-extension

--- a/lib/Cache/KeyGenerator.php
+++ b/lib/Cache/KeyGenerator.php
@@ -18,8 +18,11 @@ class KeyGenerator {
 
 		$key = md5(json_encode($value));
 		if ( is_object($value) ) {
-			$key = get_class($value).'|'.$key;
+			$key = get_class( $value ) . ';' . $key;
 		}
+
+		// Replace any of the reserved characters.
+		$key = preg_replace( '/[{}()\/\\\@:]/', ';', $key );
 
 		return $key;
 	}

--- a/lib/Cache/KeyGenerator.php
+++ b/lib/Cache/KeyGenerator.php
@@ -2,10 +2,7 @@
 
 namespace Timber\Cache;
 
-use Twig\CacheExtension\CacheStrategy\KeyGeneratorInterface;
-
-class KeyGenerator implements KeyGeneratorInterface {
-
+class KeyGenerator {
 	/**
 	 * @param mixed $value
 	 * @return string
@@ -26,5 +23,4 @@ class KeyGenerator implements KeyGeneratorInterface {
 
 		return $key;
 	}
-
 }

--- a/lib/Cache/WPObjectCacheAdapter.php
+++ b/lib/Cache/WPObjectCacheAdapter.php
@@ -1,9 +1,8 @@
 <?php namespace Timber\Cache;
 
-use Twig\CacheExtension\CacheProviderInterface;
 use Timber\Loader;
 
-class WPObjectCacheAdapter implements CacheProviderInterface {
+class WPObjectCacheAdapter {
 
 	private $cache_group;
 

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -427,18 +427,20 @@ class Loader {
 				return null;
 			}));
 		}
+
 		/**
-		 * Filters the cache extension activation
+		 * Filters the cache extension activation.
 		 *
 		 * Allows users to disable the cache extension and use their own
 		 *
 		 * @since 2.0.0
-		 * @param bool $enable_cache_extension
+		 * @param bool $enable_cache_extension Whether to enable the cache extension.
 		 */
-		$enable_cache_extension = apply_filters('timber/cache/enable_extension', true);
-        if ( $enable_cache_extension ) {
-            $twig->addExtension($this->_get_cache_extension());
-        }
+		$enable_cache_extension = apply_filters( 'timber/cache/enable_extension', true );
+
+		if ( $enable_cache_extension && class_exists( '\Twig\CacheExtension\Extension' ) ) {
+			$twig->addExtension( $this->get_cache_extension() );
+		}
 
 		/**
 		 * Filters …
@@ -577,8 +579,7 @@ class Loader {
 	/**
 	 * @return \Twig\CacheExtension\Extension
 	 */
-	private function _get_cache_extension() {
-
+	private function get_cache_extension() {
 		$key_generator   = new \Timber\Cache\KeyGenerator();
 		$cache_provider  = new \Timber\Cache\WPObjectCacheAdapter($this);
 		$cache_lifetime  = apply_filters('timber/cache/extension/lifetime', 0);

--- a/lib/Loader.php
+++ b/lib/Loader.php
@@ -439,7 +439,7 @@ class Loader {
 		$enable_cache_extension = apply_filters( 'timber/cache/enable_extension', true );
 
 		if ( $enable_cache_extension && class_exists( '\Twig\CacheExtension\Extension' ) ) {
-			$twig->addExtension( $this->get_cache_extension() );
+			$twig->addExtension( $this->_get_cache_extension() );
 		}
 
 		/**
@@ -579,7 +579,7 @@ class Loader {
 	/**
 	 * @return \Twig\CacheExtension\Extension
 	 */
-	private function get_cache_extension() {
+	private function _get_cache_extension() {
 		$key_generator   = new \Timber\Cache\KeyGenerator();
 		$cache_provider  = new \Timber\Cache\WPObjectCacheAdapter($this);
 		$cache_lifetime  = apply_filters('timber/cache/extension/lifetime', 0);

--- a/tests/test-timber-cache-extra.php
+++ b/tests/test-timber-cache-extra.php
@@ -1,0 +1,81 @@
+<?php
+
+use Timber\Cache\TimberKeyGeneratorInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Twig\Extra\Cache\CacheExtension;
+use Twig\Extra\Cache\CacheRuntime;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
+
+class RunTimeLoader implements RuntimeLoaderInterface {
+	public function load( $class ) {
+		if ( CacheRuntime::class === $class ) {
+			return new CacheRuntime( new TagAwareAdapter( new FilesystemAdapter() ) );
+		}
+	}
+}
+
+class TestTimberCacheExtra extends Timber_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+
+		$this->add_filter_temporarily( 'timber/twig', function( $twig ) {
+			$twig->addExtension( new CacheExtension() );
+			$twig->addRuntimeLoader( new RunTimeLoader() );
+
+			return $twig;
+		} );
+	}
+
+	public function test_cache_tag() {
+		$post_id = $this->factory->post->create( [ 'post_title' => 'My Test Post' ] );
+		$post    = Timber::get_post( $post_id );
+
+		$twig = Timber::compile_string( "{% cache 'post' %}{{ post.title }}{% endcache %}", [
+			'post' => $post,
+		] );
+
+		$this->assertEquals( 'My Test Post', $twig );
+	}
+
+	public function test_cache_tags() {
+		$post_id = $this->factory->post->create( [ 'post_title' => 'My Test Post' ] );
+		$post    = Timber::get_post( $post_id );
+
+		$twig = Timber::compile_string( "{% cache 'post' tags('blog') %}{{ post.title }}{% endcache %}", [
+			'post' => $post,
+		] );
+
+		$this->assertEquals( 'My Test Post', $twig );
+	}
+
+	public function test_cache_tag_with_key_generator() {
+		$post_id = $this->factory->post->create( [ 'post_title' => 'My Test Post' ] );
+		$post    = Timber::get_post( $post_id );
+
+		$kg  = new Timber\Cache\KeyGenerator();
+		$key = $kg->generateKey( $post );
+
+		$twig = Timber::compile_string( "{% cache key %}{{ post.title }}{% endcache %}", [
+			'key'  => $key,
+			'post' => $post,
+		] );
+
+		$this->assertEquals( 'My Test Post', $twig );
+	}
+
+	public function test_cache_tag_with_key_generator_posts() {
+		$post_ids = $this->factory->post->create_many( 3, [ 'post_title' => 'My Test Post' ] );
+		$posts    = Timber::get_posts( $post_ids );
+
+		$kg  = new Timber\Cache\KeyGenerator();
+		$key = $kg->generateKey( $posts );
+
+		$twig = Timber::compile_string( "{% cache key %}{% for post in posts %}{{ post.title }}, {% endfor %}{% endcache %}", [
+			'key'  => $key,
+			'posts' => $posts,
+		] );
+
+		$this->assertEquals( 'My Test Post, My Test Post, My Test Post, ', $twig );
+	}
+}

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -131,11 +131,13 @@
         }
 
         function testKeyGenerator(){
-        	$kg = new Timber\Cache\KeyGenerator();
         	$post_id = $this->factory->post->create(array('post_title' => 'My Test Post'));
-					$post = Timber::get_post($post_id);
+			$post = Timber::get_post($post_id);
+
+        	$kg = new Timber\Cache\KeyGenerator();
         	$key = $kg->generateKey($post);
-        	$this->assertStringStartsWith('Timber\Post|', $key);
+
+        	$this->assertStringStartsWith('Timber;Post;', $key);
         }
 
         function testKeyGeneratorWithTimberKeyGeneratorInterface() {


### PR DESCRIPTION
**Ticket**: #2407

## Issue

Following the discussions in #2486, I think I may have a solution for replacing the `twig/cache-extension` package.

## Solution

This pull request:

- Removes the `twig/cache-extension` package.
- Removes all interfaces that it provided, but keeps the classes that used them.
- Adds the `twig/cache-extra` in composer.json’s `suggest` field.
- Adds tests to test the support for the `twig/cache-extra` package.
- Updates Timber’s Cache Key Generator to not use any of the characters that are forbidden to use as cache keys with the `twig/cache-extra` package.
- Adds documentation about using the `twig/cache-extra` package.
- Adds the relevant information in the Upgrade Guide.

## Impact

- Breaks compatibility for people who use the `{% cache %}` tag in Twig.

## Usage Changes

The `{% cache %}` works a little different. You don’t provide it with a variable that will be cached anymore. It will cache the contents of the tag based on what you provide as the cache key.

Timber’s Cache Key Generator still works with it and could be a helpful tool. For now, I added some documentation for how to use it.

## Considerations

- Is it bad to remove the interfaces?
- In the future, PSR-6 and PSR-16 might be helpful.

## Testing

Yes, I added some tests, but they only test that using the `twig/cache-extra` produces any errors and not if the contents are actually cached.