### PR TITLE
2.x Fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,11 @@ jobs:
             multisite: '0'
             experimental: true
           # PHP 8.1
-          #- php: '8.1'
-          #  wp: 'trunk'
-          #  dependency-version: 'prefer-stable'
-          #  multisite: '0'
-          #  experimental: true
+          - php: '8.1'
+            wp: 'trunk'
+            dependency-version: 'prefer-stable'
+            multisite: '0'
+            experimental: true
           # PHP 8.0
           - php: '8.0'
             wp: 'trunk'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,11 @@ jobs:
             multisite: '0'
             experimental: true
           # PHP 8.1
-          - php: '8.1'
-            wp: 'trunk'
-            dependency-version: 'prefer-stable'
-            multisite: '0'
-            experimental: true
+          #- php: '8.1'
+          #  wp: 'trunk'
+          #  dependency-version: 'prefer-stable'
+          #  multisite: '0'
+          #  experimental: true
           # PHP 8.0
           - php: '8.0'
             wp: 'trunk'

--- a/tests/test-timber-widgets.php
+++ b/tests/test-timber-widgets.php
@@ -1,7 +1,9 @@
 <?php
 
 class TestTimberWidgets extends Timber_UnitTestCase {
-
+	/**
+	 * @requires PHP < 8.1
+	 */
 	function testHTML() {
 		// replace this with some actual testing code
 		$widgets = wp_get_sidebars_widgets();
@@ -11,11 +13,13 @@ class TestTimberWidgets extends Timber_UnitTestCase {
 		$this->assertEquals('<', substr($content, 0, 1));
 	}
 
+	/**
+	 * @requires PHP < 8.1
+	 */
 	function testManySidebars() {
 		$widgets = wp_get_sidebars_widgets();
 		$sidebar1 = Timber::get_widgets('sidebar-1');
 		$sidebar2 = Timber::get_widgets('sidebar-2');
 		$this->assertGreaterThan(0, strlen($sidebar1));
 	}
-
 }


### PR DESCRIPTION
## Issue

Tests are broken, because of an error with PHP 8.1 in **wp-includes/block-supports/layout.php**. Here’s the relevant trac ticket: https://core.trac.wordpress.org/ticket/55119. The recommendation is to not use PHP 8.1 yet:

> WordPress core is not fully compatible with PHP 8.1 yet, there are still some deprecation notices. If you need a workaround, I would suggest switching to PHP 8.0 for now.

## Solution

Disable testing against PHP 8.1 when [WordPress doesn’t officially support it yet](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/) and let’s see if something else is broken, too.