### PR TITLE
Introduce Timber::init() as official way to initialize Timber

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 <a href="https://upstatement.com/timber/"><img src="http://i.imgur.com/PbEwvZ9.png" style="display:block; margin:auto; width:100%; max-width:100%"/></a>
 </div>
 
-By 
-[Jared Novack](https://github.com/jarednova) ([@jarednova](https://twitter.com/jarednova)), 
-[Lukas Gächter](https://github.com/gchtr) ([@lgaechter](https://twitter.com/lgaechter)), 
+By
+[Jared Novack](https://github.com/jarednova) ([@jarednova](https://twitter.com/jarednova)),
+[Lukas Gächter](https://github.com/gchtr) ([@lgaechter](https://twitter.com/lgaechter)),
 [Coby Tamayo](https://github.com/acobster) ([@cobytamayo](https://keybase.io/acobster)),
 [Maciej Palmowski](https://github.com/palmiak) ([@palmiak_fp](https://twitter.com/palmiak_fp)),
 [Nicolas Lemoine](https://github.com/nlemoine) ([@nlemoine](https://niconico.fr/))
@@ -54,21 +54,23 @@ Once Timber is installed, it gives any WordPress theme the ability to take advan
 
 The GitHub version of Timber requires [Composer](https://getcomposer.org/download/) and is setup for inclusion _within_ a theme or plugin. If you'd prefer one-click installation for your site, you should use the [WordPress.org](https://wordpress.org/plugins/timber-library/) version.
 
-```shell
+```bash
 cd ~/wp-content/themes/my-theme
 composer require timber/timber
 ```
 
-If your theme/plugin is not setup to pull in Composer's autoload file, you will need to
+If your theme/plugin is not setup to pull in Composer’s autoload file, you will need to load the vendor dependencies.
+
+**functions.php**
 
 ```php
-/* functions.php */
-require_once(__DIR__ . '/vendor/autoload.php');
+require_once __DIR__ . '/vendor/autoload.php';
 ```
 
 After this line, initialize Timber with
+
 ```php
-$timber = new \Timber\Timber();
+Timber\Timber::init();
 ```
 
 ### What Now?

--- a/docs/v2/installation/installation.md
+++ b/docs/v2/installation/installation.md
@@ -31,7 +31,7 @@ If your theme or project is not already set up to pull in Composer’s autoload 
 require_once __DIR__ . '/vendor/autoload.php';
 
 // Initialize Timber.
-new Timber\Timber();
+Timber\Timber::init();
 ```
 
 ## Use the Starter Theme

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -21,6 +21,36 @@ We upgraded Timber to work with more modern PHP and functionalities that only we
 
 As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/v2/getting-started/setup/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
 
+## Initializing Timber
+
+Up until now, you had to initialize Timber by instantiating a new object of the `Timber\Timber` class. The constructor of that class is now protected and you’ll run into an error (`Call to protected Timber\Timber::__construct() from invalid context`) if you try to intialize Timber with it.
+
+**🚫 Before**
+
+```php
+new Timber\Timber();
+```
+
+The new way to initialize Timber is to call `Timber\Timber::init()`.
+
+**✅ After**
+
+```php
+Timber\Timber::init();
+```
+
+## Don’t use a `$timber` global
+
+The `Timber\Timber::init()` method doesn’t return anything. If you use an older pattern where you use a global variable to assign Timber, then it won’t do anything:
+
+**🚫 Don’t do this**
+
+```php
+global $timber;
+
+$timber = Timber\Timber::init();
+```
+
 ## Checking Timber’s version
 
 If you need to check what Timber version is installed, you can use `Timber::version`.

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -96,7 +96,7 @@ class Timber {
 		}
 	}
 
-	public function init_constants() {
+	protected function init_constants() {
 		defined("TIMBER_LOC") or define("TIMBER_LOC", realpath(dirname(__DIR__)));
 	}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,10 +26,8 @@ require_once "{$_tests_dir}/includes/functions.php";
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	global $timber;
-
 	require dirname( __FILE__ ) . '/../vendor/autoload.php';
-	$timber = new \Timber\Timber();
+	\Timber\Timber::init();
 
 	require dirname( __FILE__ ) . '/../wp-content/plugins/advanced-custom-fields/acf.php';
 	if ( file_exists( dirname( __FILE__ ) . '/../wp-content/plugins/co-authors-plus/co-authors-plus.php') ) {

--- a/tests/test-timber-class.php
+++ b/tests/test-timber-class.php
@@ -1,15 +1,12 @@
 <?php
 
 class TestTimberClass extends Timber_UnitTestCase {
-
 	/**
 	 * @doesNotPerformAssertions
 	 */
 	function testConstantsDefining() {
-		$timber = $GLOBALS['timber'];
-		$timber->init_constants();
-		$timber->init_constants();
-		/* just testing to make sure the double call doesnt error-out */
+		// Just testing to make sure the double call doesn’t error-out.
+		Timber\Timber::init();
+		Timber\Timber::init();
 	}
-
 }

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -45,9 +45,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		]);
 		$pagination = Timber::get_pagination();
 
-		global $timber;
-		$timber->active_query = false;
-		unset($timber->active_query);
 		$this->assertCount(4, $pagination['pages']);
 	}
 


### PR DESCRIPTION
**Ticket**: #2404

## Issue

Instantiating a new object to initialize a library is a pattern we should avoid.

We can’t init Timber automatically, either because of compatibility issues with environments like Bedrock. With Bedrock, Composer initializes earlier, when WordPress might not be loaded yet, which would lead to fatal errors. More details in https://github.com/timber/timber/issues/979#issuecomment-220094476 and https://github.com/timber/timber/pull/1041.

## Solution

- Introduce `Timber\Timber::init()` as the official way to initialize Timber. This follows the [pattern that we already use](https://github.com/timber/timber/blob/91f4a50d8fe2e1139dc145c8752571ecf0d0c518/lib/Timber.php#L115-L117) to initialize certain other functionality inside Timber.
- Make the `Timber::init_constants()` function protected, because it can’t called by an instance of Timber anyway.
- Update Changelog
- Update Readme

## Impact

Causes a `Call to protected Timber\Timber::__construct() from invalid context` error.

## Usage Changes

The new way to initialize Timber is to call `Timber\Timber::init()`

**🚫 Before**

```php
new Timber\Timber();
```

**✅ After**

```php
Timber\Timber::init();
```

## Considerations

There was an instance in the tests where a `$timber` global was used.

```php
global $timber;
$timber->active_query = false;
unset($timber->active_query);
```

I assume this was used to test whether certain functionality that once lived in Timber could be overwritten without causing an error. But do we actually still need the pattern where we a `$timber` global is used? I assume not, so I removed it and also mentioned this in the Upgrade Guide.

## Testing

Yes. Tests are updated.
