### PR TITLE
Improve composer version ranges

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "php": ">=5.3.0|7.*",
     "twig/twig": "^1.41|^2.10",
     "upstatement/routes": "0.8.*",
-    "composer/installers": "^2.0",
+    "composer/installers": "^1.0 || ^2.0",
     "twig/cache-extension": "^1.5"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,19 +28,19 @@
     "docs": "https://timber.github.io/docs/"
   },
   "require": {
-    "php": ">=5.3.0|7.*",
-    "twig/twig": "^1.41|^2.10",
+    "php": ">=5.3.0 || 7.*",
+    "twig/twig": "^1.41 || ^2.10",
     "upstatement/routes": "0.8.*",
     "composer/installers": "^1.0 || ^2.0",
     "twig/cache-extension": "^1.5"
   },
   "require-dev": {
     "johnpbloch/wordpress": "*",
-    "phpunit/phpunit": "5.7.16|6.*",
+    "phpunit/phpunit": "5.7.16 || 6.*",
     "squizlabs/php_codesniffer": "3.*",
     "wp-coding-standards/wpcs": "^2.0",
     "wpackagist-plugin/advanced-custom-fields": "5.*",
-    "wpackagist-plugin/co-authors-plus": "3.2.*|3.4.*",
+    "wpackagist-plugin/co-authors-plus": "3.2.* || 3.4.*",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "yoast/phpunit-polyfills": "^1.0"
   },


### PR DESCRIPTION
**Ticket**: #2543

## Issue

- We should probably allow both version for `composer/installers` as also suggested in https://github.com/timber/timber/pull/2543 and https://github.com/timber/timber/pull/2546#pullrequestreview-894393017.
- We’re using an old pipe format for Composer versions.

## Solution

- Allow both versions `^1.0` and `^2.0` for `composer/installers`.
- Use modern pipe format using ` || ` instead of `|`. See https://getcomposer.org/doc/articles/versions.md#version-range for more information.

## Impact

Better compatibility in various environments.

## Usage Changes

None.

## Considerations

No.

## Testing

No.