### PR TITLE
2.x images

### DIFF
--- a/lib/Image.php
+++ b/lib/Image.php
@@ -405,8 +405,13 @@ class Image extends Post implements CoreInterface {
 	 * @return float
 	 */
 	public function aspect() {
-		$w = intval($this->width());
 		$h = intval($this->height());
+
+		if ( 0 === $h ) {
+			return 0;
+		}
+
+		$w = intval($this->width());
 		return $w / $h;
 	}
 

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -320,6 +320,11 @@ class Image extends Post implements CoreInterface {
 			$this->file = reset($this->_wp_attached_file);
 			$this->file_loc = $basedir.DIRECTORY_SEPARATOR.$this->file;
 		}
+
+		if ( ! file_exists( $this->file_loc ) ) {
+			Helper::error_log("Image {$this->file_loc} doesn't exists");
+		}
+
 		if ( isset($image_info['id']) ) {
 			$this->ID = $image_info['id'];
 		} else if ( is_numeric($iid) ) {

--- a/lib/Post.php
+++ b/lib/Post.php
@@ -169,6 +169,11 @@ class Post extends Core implements CoreInterface {
 	protected $__type;
 
 	/**
+	 * @var Image $thumbnail post type thumbnail if exists
+	 */
+	protected $thumbnail;
+
+	/**
 	 * If you send the constructor nothing it will try to figure out the current post id based on being inside The_Loop
 	 * @example
 	 * ```php
@@ -1576,8 +1581,14 @@ class Post extends Core implements CoreInterface {
 		$tid = get_post_thumbnail_id($this->ID);
 		if ( $tid ) {
 			//return new Image($tid);
-			return new $this->ImageClass($tid);
+			if ( null === $this->thumbnail ) {
+				$this->thumbnail = new $this->ImageClass($tid);
+			}
+
+			return $this->thumbnail;
 		}
+
+		return false;
 	}
 
 


### PR DESCRIPTION
**Ticket**: [#2537](https://github.com/timber/timber/issues/2537)

## Issue
`Timber\Image` class generates DivisionByZeroError error when calling `aspect` method of image was deleted manually from uploads directory. While being deleted attachment object itself and its metadata still present in database and will return something. When calling `image.aspect` it defines image dimensions and in case if it is not exists returns `0` for both height and width which causes zero divided by zero issue

## Solution
Check if image height has `0` value and if it is return 0 as a result. This qay we will prevent site crashing. On `init()` method we will check if file exists and if not log it with `Image path/to/image doesn't exists`

Also added `protected $thumbnail` property to `Post` object and define it on `thumbnail` method as instance of `Image` - currently with `thumbnail()` method it will initialize `Image` every time it called

```twig
{% if post.thumbnail.aspect > 1.5 %}
    <img src="{{ post.thumbnail.src }}" alt="{{ post.thumbnail.alt }}">
{% endif %}
```

In this example `Image` will be initialized 3 times

## Impact
Fixes fatal error if image was deleted from uploads directory but not from WordPress media uploader. Also prevents Image object from initializing multiple times


## Usage Changes
All lefts the same


## Considerations
Partially discussed in [#2537](https://github.com/timber/timber/issues/2537)


## Testing
Steps to reproduce issue: [#2537](https://github.com/timber/timber/issues/2537)

- `{{ post.thumbnail.aspect }}` will return `0` if image file does not exists (but its object exists in database as an attachment post type)
- {{ post.thumbnail }} instantiation will log error `Image path/to/image doesn't exists` (not causing site crash but gives developer a clue what is may be wrong)
- Post thumbnail will be initialized once
