### PR TITLE
imagehelper -  filename (towebp, tojpg)

### DIFF
--- a/lib/Image/Operation/ToJpg.php
+++ b/lib/Image/Operation/ToJpg.php
@@ -28,7 +28,8 @@ class ToJpg extends ImageOperation {
 	 * @return  string    the final filename to be used (ex: my-awesome-pic.jpg)
 	 */
 	public function filename( $src_filename, $src_extension = 'jpg' ) {
-		$new_name = $src_filename.'.jpg';
+		$newbase = $src_filename.'-tojpg';
+		$new_name = $newbase.'.jpg';
 		return $new_name;
 	}
 

--- a/lib/Image/Operation/ToWebp.php
+++ b/lib/Image/Operation/ToWebp.php
@@ -28,7 +28,8 @@ class ToWebp extends ImageOperation {
 	 * @return  string    the final filename to be used (ex: my-awesome-pic.webp)
 	 */
 	public function filename( $src_filename, $src_extension = 'webp' ) {
-		$new_name = $src_filename  . '.webp';
+		$newbase = $src_filename.'-towebp';
+		$new_name = $newbase  . '.webp';
 		return $new_name;
 	}
 

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -274,7 +274,7 @@ class ImageHelper {
 
 
 	/**
-	 * Deletes the auto-generated files for resize and letterboxing created by Timber
+	 * Deletes the auto-generated files created by Timber (resize, letterboxing, jpg, webp, retina) 
 	 * @param string  $local_file   ex: /var/www/wp-content/uploads/2015/my-pic.jpg
 	 *	                            or: http://example.org/wp-content/uploads/2015/my-pic.jpg
 	 */
@@ -290,6 +290,8 @@ class ImageHelper {
 		self::process_delete_generated_files($filename, $ext, $dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.');
 		self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg.*');
 		self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg-[0-9999999]*');
+		self::process_delete_generated_files($filename, 'webp', $dir, '-towebp.*');
+		self::process_delete_generated_files($filename, 'webp', $dir, '-towebp-[0-9999999]*');
 	}
 
 	/**

--- a/tests/test-timber-image-tojpg.php
+++ b/tests/test-timber-image-tojpg.php
@@ -23,7 +23,7 @@
 		function testPNGtoJPG() {
 			$filename = TestTimberImage::copyTestImage( 'flag.png' );
 			$str = Timber::compile_string('{{file|tojpg}}', array('file' => $filename));
-			$renamed = str_replace('.png', '.jpg', $filename);
+			$renamed = str_replace('.png', '-tojpg.jpg', $filename);
 			$this->assertFileExists($renamed);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/png', mime_content_type($filename));
@@ -35,7 +35,7 @@
 		function testGIFtoJPG() {
 			$filename = TestTimberImage::copyTestImage( 'boyer.gif' );
 			$str = Timber::compile_string('{{file|tojpg}}', array('file' => $filename));
-			$renamed = str_replace('.gif', '.jpg', $filename);
+			$renamed = str_replace('.gif', '-tojpg.jpg', $filename);
 			$this->assertFileExists($renamed);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/gif', mime_content_type($filename));
@@ -57,7 +57,7 @@
 		function testJPEGtoJPG() {
 			$filename = TestTimberImage::copyTestImage( 'jarednova.jpeg' );
 			$str = Timber::compile_string('{{file|tojpg}}', array('file' => $filename));
-			$renamed = str_replace('.jpeg', '.jpg', $filename);
+			$renamed = str_replace('.jpeg', '-tojpg.jpg', $filename);
 			$this->assertFileExists($renamed);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/jpeg', mime_content_type($filename));

--- a/tests/test-timber-image-towebp.php
+++ b/tests/test-timber-image-towebp.php
@@ -18,7 +18,7 @@
 		function testPNGtoWEBP() {
 			$filename = TestTimberImage::copyTestImage( 'flag.png' );
 			$str = Timber::compile_string('{{file|towebp}}', array('file' => $filename));
-			$renamed = str_replace('.png', '.webp', $filename);
+			$renamed = str_replace('.png', '-towebp.webp', $filename);
 			$this->assertFileExists($renamed);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/png', mime_content_type($filename));
@@ -28,7 +28,7 @@
 		function testGIFtoJPG() {
 			$filename = TestTimberImage::copyTestImage( 'boyer.gif' );
 			$str = Timber::compile_string('{{file|towebp}}', array('file' => $filename));
-			$renamed = str_replace('.gif', '.webp', $filename);
+			$renamed = str_replace('.gif', '-towebp.webp', $filename);
 			$this->assertFileExists($renamed);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/gif', mime_content_type($filename));
@@ -39,7 +39,7 @@
 			$filename = TestTimberImage::copyTestImage( 'stl.jpg' );
 			$original_size = filesize($filename);
 			$str = Timber::compile_string('{{file|towebp(100)}}', array('file' => $filename));
-			$renamed = str_replace('.jpg', '.webp', $filename);
+			$renamed = str_replace('.jpg', '-towebp.webp', $filename);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/jpeg', mime_content_type($filename));
 			$this->assertEquals('image/webp', mime_content_type($renamed));
@@ -48,7 +48,7 @@
 		function testJPEGtoJPG() {
 			$filename = TestTimberImage::copyTestImage( 'jarednova.jpeg' );
 			$str = Timber::compile_string('{{file|towebp}}', array('file' => $filename));
-			$renamed = str_replace('.jpeg', '.webp', $filename);
+			$renamed = str_replace('.jpeg', '-towebp.webp', $filename);
 			$this->assertFileExists($renamed);
 			$this->assertGreaterThan(1000, filesize($renamed));
 			$this->assertEquals('image/jpeg', mime_content_type($filename));

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -958,7 +958,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$str = '<img src="{{'."'$gif_url'".'|tojpg}}" />';
 		$result = Timber::compile_string($str);
 		$jpg_url = str_replace('.gif', '.jpg', $gif_url);
-		$jpg_url = str_replace('loading', 'loading-tojpg');
+		$jpg_url = str_replace('loading', 'loading-tojpg', $jpg_url);
 		$this->assertEquals('<img src="'.$jpg_url.'" />', $result);
 	}
 

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -958,6 +958,7 @@ class TestTimberImage extends TimberImage_UnitTestCase {
 		$str = '<img src="{{'."'$gif_url'".'|tojpg}}" />';
 		$result = Timber::compile_string($str);
 		$jpg_url = str_replace('.gif', '.jpg', $gif_url);
+		$jpg_url = str_replace('loading', 'loading-tojpg');
 		$this->assertEquals('<img src="'.$jpg_url.'" />', $result);
 	}
 


### PR DESCRIPTION
Fixes #897 

## Issue
files are not deleted, when they were generated through timber filter. (webp, png)


## Solution
Change generated filenames to have target fileformat in the filename.
Added more calls to delete_generated_files with specific regex for fileformat

I hope it helps.