### PR TITLE
Test against Latest WP Version instead of Trunk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
-          # PHP 8.1
+          # PHP 8.1 / expiremntal
           - php: '8.1'
             wp: 'trunk'
             dependency-version: 'prefer-stable'
@@ -56,6 +56,11 @@ jobs:
             experimental: true
           # PHP 8.0
           - php: '8.0'
+            wp: 'latest'
+            dependency-version: 'prefer-stable'
+            multisite: '0'
+          # PHP 8.1
+          - php: '8.1'
             wp: 'latest'
             dependency-version: 'prefer-stable'
             multisite: '0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,19 +44,19 @@ jobs:
         include:
           # WP Trunk
           - php: '7.4'
-            wp: 'trunk'
+            wp: 'latest'
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
           # PHP 8.1
           - php: '8.1'
-            wp: 'trunk'
+            wp: 'latest'
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
           # PHP 8.0
           - php: '8.0'
-            wp: 'trunk'
+            wp: 'latest'
             dependency-version: 'prefer-stable'
             multisite: '0'
           # PHP with Imagick

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.4']
-        wp: ['5.3', '5.8'] # Always use branches not tags (e.g. 5.3 not 5.3.6), new test suite is only available in branches
+        wp: ['5.3', 'latest']
         multisite: ['0', '1']
         dependency-version: [prefer-stable] # prefer-lowest
         webp: [false]
@@ -44,7 +44,7 @@ jobs:
         include:
           # WP Trunk
           - php: '7.4'
-            wp: 'latest'
+            wp: 'trunk'
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true
@@ -61,13 +61,13 @@ jobs:
             multisite: '0'
           # PHP with Imagick
           - php: '7.4'
-            wp: '5.8'
+            wp: 'latest'
             dependency-version: 'prefer-stable'
             multisite: '0'
             extensions: 'imagick'
           # Coverage
           - php: '7.4'
-            wp: '5.8'
+            wp: 'latest'
             dependency-version: 'prefer-stable'
             multisite: '0'
             coverage: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
             experimental: true
           # PHP 8.1
           - php: '8.1'
-            wp: 'latest'
+            wp: 'trunk'
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: true


### PR DESCRIPTION
**Ticket**: #2562 

## Issue
There appears to be an unrelated failure occurring due to `trunk` changes in WP on #2562. This begs the question — why test against trunk at all?


## Solution
Swap `trunk` for `latest`

## Impact
We'll be a bit behind should a breaking change come in WP's functions (whereas before we could have caught it before formal release). However, 

## Usage Changes
None

## Considerations
Should we maybe keep one trunk test in the matrix and allow failures?
