### PR TITLE
2.x Update Upgrade Guide with Twig deprecations

### DIFF
--- a/docs/v2/guides/twig.md
+++ b/docs/v2/guides/twig.md
@@ -221,16 +221,16 @@ Timber already comes with a [set of useful filters](https://timber.github.io/doc
 {{ "my custom string"|apply_filters('default_message', param1, param2, ...) }}
 ```
 
-Or you can use a filter with the [Twig filter tag](https://twig.symfony.com/doc/2.x/tags/filter.html).
+Or you can use a filter with the [Twig apply tag](https://twig.symfony.com/doc/3.x/tags/apply.html).
 
 ```twig
-{% filter apply_filters('default_message') %}
+{% apply apply_filters('default_message') %}
     {{ post.content }}
-{% endfilter %}
+{% endapply %}
 
-{% filter apply_filters('default_message', 'foo', 'bar, 'baz' ) %}
+{% apply apply_filters('default_message', 'foo', 'bar, 'baz' ) %}
     I love pizza
-{% endfilter %}
+{% endapply %}
 ```
 
 In **PHP**, you can get the content of the block with the first parameter and the rest of parameters like that.
@@ -274,16 +274,15 @@ And with the `filter` tag, it would look like this:
 
 ```twig
 <li class="woocommerce-notice woocommerce-notice--info woocommerce-info">
-    {% filter apply_filters('woocommerce_no_available_payment_methods_message') %}
+    {% apply apply_filters('woocommerce_no_available_payment_methods_message') %}
         {% if customer.get_billing_country() %}
             {{ __('Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce') }}
         {% else %}
             {{ __('Please fill in your details above to see available payment methods.', 'woocommerce')  }}
         {% endif %}
-    {% endfilter %}
+    {% endapply %}
 </li>
 ```
-
 
 ## Using Twig vars in live type
 

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -630,10 +630,52 @@ In addition, the confusingly named (and non-functional) `|get_type` filter has b
 
 ### Twig deprecations
 
-Apart from the deprecations listed here, you should also consider the deprecations by Twig itself.
+Apart from the deprecations listed above, you should also consider the deprecations by Twig itself.
 
 - [Deprecated features in Twig 2.x](https://twig.symfony.com/doc/2.x/deprecated.html) – Make sure you check out the deprecated features for [Tags](https://twig.symfony.com/doc/2.x/deprecated.html#tags).
 - [Deprecated features in Twig 3.x](https://twig.symfony.com/doc/3.x/deprecated.html) – Twig mainly removes all deprecated features in 2.x.
+
+There are a couple we want to highlight:
+
+#### Spaceless
+
+The `spaceless` tag is deprecated, you should use the [`apply` tag](https://twig.symfony.com/doc/tags/apply.html) using the [`spaceless` filter](https://twig.symfony.com/doc/2.x/filters/spaceless.html) instead.
+
+**🚫 Before**
+
+```twig
+{% spaceless %}
+
+{% endspaceless %}
+```
+
+**✅ After**
+
+```twig
+{% apply spaceless %}
+
+{% endapply %}
+```
+
+#### Filter tag
+
+The `filter` tag is deprecated. Use the [`apply` tag](https://twig.symfony.com/doc/tags/apply.html) in combination with `apply_filters()` instead.
+
+**🚫 Before**
+
+```twig
+{% filter apply_filters('your_filter_name') %}
+
+{% endapply %}
+```
+
+**✅ After**
+
+```twig
+{% apply apply_filters('your_filter_name') %}
+
+{% endapply %}
+```
 
 ## Meta
 

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -628,6 +628,13 @@ The following Twig filters have been deprecated and will be removed in future ve
 
 In addition, the confusingly named (and non-functional) `|get_type` filter has been removed.
 
+### Twig deprecations
+
+Apart from the deprecations listed here, you should also consider the deprecations by Twig itself.
+
+- [Deprecated features in Twig 2.x](https://twig.symfony.com/doc/2.x/deprecated.html) – Make sure you check out the deprecated features for [Tags](https://twig.symfony.com/doc/2.x/deprecated.html#tags).
+- [Deprecated features in Twig 3.x](https://twig.symfony.com/doc/3.x/deprecated.html) – Twig mainly removes all deprecated features in 2.x.
+
 ## Meta
 
 ### Deprecating direct access to meta values


### PR DESCRIPTION
**Ticket**: #2482

We should mention that Twig also has some deprecations.

I didn’t mention all the relevant deprecations, like the filter or the spaceless tag. Let’s see what issues come by people who find it hard to find a solution.