### PR TITLE
Update pagination return type

### DIFF
--- a/lib/PostQuery.php
+++ b/lib/PostQuery.php
@@ -59,7 +59,7 @@ class PostQuery extends PostCollection {
 	 * Set pagination for the collection. Optionally could be used to get pagination with custom preferences.
 	 *
 	 * @param 	array $prefs
-	 * @return 	Timber\Pagination object
+	 * @return 	\Timber\Pagination object
 	 */
 	public function pagination( $prefs = array() ) {
 		if ( !$this->pagination && is_a($this->queryIterator, 'Timber\QueryIterator') ) {


### PR DESCRIPTION
## Issue
When running static analysis with a tool like [PHPStan](https://github.com/phpstan/phpstan) or similar, checks fail when calling the `pagination()` method in the `PostQuery` class since the return type is defined relative to the `Timber` namespace:

<img width="705" alt="Screen Shot 2022-04-11 at 5 08 31 PM" src="https://user-images.githubusercontent.com/3286676/162852797-52deffec-9de4-445f-a25d-e4bda96d9a4b.png">

## Solution
Update the doc comment for the return type to reflect the absolute namespaced type.

