### PR TITLE
Allow the Timber\PostPreview::read_more to accept a boolean value

### DIFF
--- a/lib/PostPreview.php
+++ b/lib/PostPreview.php
@@ -69,7 +69,7 @@ class PostPreview {
 	/**
 	 * Read more text.
 	 *
-	 * @var string
+	 * @var string|bool
 	 */
 	protected $readmore = 'Read More';
 
@@ -187,7 +187,7 @@ class PostPreview {
 	 * ```twig
 	 * <p>{{ post.preview.read_more('Learn more') }}</p>
 	 * ```
-	 * @param string $readmore Text for the link. Default 'Read More'.
+	 * @param string|bool $readmore Text for the link. Default 'Read More'.
 	 * @return \Timber\PostPreview
 	 */
 	public function read_more( $readmore = 'Read More' ) {


### PR DESCRIPTION
## Issue
<!-- Description of the problem that this code change is solving -->

The [Timber\PostPreview::read_more](https://timber.github.io/docs/reference/timber-postpreview/#read_more) docs say:
> Set this to `false` to not add a "Read More" link.

But `Timber\PostPreview::read_more` doesn't actually accept a boolean value, it only accepts a `string` value type. 😬 

<img width="728" alt="Screen Shot 2022-04-29 at 11 37 53 AM" src="https://user-images.githubusercontent.com/459757/166006678-fb869f65-db2e-4aa2-86ed-f00589e69412.png">


## Solution

Add `bool` to the `readmore` docblock.

## Impact

Minimal to none?

## Usage Changes

No usage changes, to my knowlege.

## Considerations

None come to mind.

## Testing

I did not add tests. Not sure how to do so.