### PR TITLE
2.x Use assertTrue() and get_class() instead of assertInstanceOf() in certain tests

### DIFF
--- a/tests/test-comment-factory.php
+++ b/tests/test-comment-factory.php
@@ -69,8 +69,8 @@ class TestCommentFactory extends Timber_UnitTestCase {
 		$post_comment   = $commentFactory->from($post_comment_id);
 		$page_comment   = $commentFactory->from($page_comment_id);
 
-		$this->assertInstanceOf(PostComment::class, $post_comment);
-		$this->assertInstanceOf(PageComment::class, $page_comment);
+		$this->assertTrue(PostComment::class === get_class($post_comment));
+		$this->assertTrue(PageComment::class === get_class($page_comment));
 
 		remove_filter( 'timber/comment/classmap', $my_class_map );
 	}
@@ -89,7 +89,7 @@ class TestCommentFactory extends Timber_UnitTestCase {
 		$commentFactory = new CommentFactory();
 		$post_comment   = $commentFactory->from($post_comment_id);
 
-		$this->assertInstanceOf(DummyComment::class, $post_comment);
+		$this->assertTrue(DummyComment::class === get_class($post_comment));
 
 		remove_filter( 'timber/comment/class', $my_class_filter, 10 );
 	}
@@ -144,8 +144,8 @@ class TestCommentFactory extends Timber_UnitTestCase {
 		$post_comment   = $commentFactory->from($post_comment_id);
 		$page_comment   = $commentFactory->from($page_comment_id);
 
-		$this->assertInstanceOf(PostComment::class, $post_comment);
-		$this->assertInstanceOf(PageComment::class, $page_comment);
+		$this->assertTrue(PostComment::class === get_class($post_comment));
+		$this->assertTrue(PageComment::class === get_class($page_comment));
 
 		remove_filter( 'timber/comment/classmap', $my_class_map );
 	}

--- a/tests/test-post-factory.php
+++ b/tests/test-post-factory.php
@@ -69,9 +69,9 @@ class TestPostFactory extends Timber_UnitTestCase {
 		$page        = $postFactory->from($page_id);
 		$custom      = $postFactory->from($custom_id);
 
-		$this->assertInstanceOf(MyPost::class, $post);
-		$this->assertInstanceOf(MyPage::class, $page);
-		$this->assertInstanceOf(MyCustom::class, $custom);
+		$this->assertTrue(MyPost::class === get_class($post));
+		$this->assertTrue(MyPage::class === get_class($page));
+		$this->assertTrue(MyCustom::class === get_class($custom));
 	}
 
 	public function testFromWithClassFilter() {
@@ -86,7 +86,7 @@ class TestPostFactory extends Timber_UnitTestCase {
 		$postFactory = new PostFactory();
 		$custom      = $postFactory->from($custom_id);
 
-		$this->assertInstanceOf(MyCustom::class, $custom);
+		$this->assertTrue(MyCustom::class === get_class($custom));
 	}
 
 	public function testFromWithCallable() {
@@ -115,10 +115,10 @@ class TestPostFactory extends Timber_UnitTestCase {
 		$custom      = $postFactory->from($custom_id);
 		$special     = $postFactory->from($special_id);
 
-		$this->assertInstanceOf(Post::class, $post);
-		$this->assertInstanceOf(MyPage::class, $page);
-		$this->assertInstanceOf(MyCustom::class, $custom);
-		$this->assertInstanceOf(MySpecialCustom::class, $special);
+		$this->assertTrue(Post::class === get_class($post));
+		$this->assertTrue(MyPage::class === get_class($page));
+		$this->assertTrue(MyCustom::class === get_class($custom));
+		$this->assertTrue(MySpecialCustom::class === get_class($special));
 	}
 
 	public function testFromWpPost() {
@@ -147,9 +147,9 @@ class TestPostFactory extends Timber_UnitTestCase {
 		$query       = new WP_Query(['post_type' => ['post', 'page', 'custom']]);
 		$posts       = $postFactory->from($query);
 
-		$this->assertInstanceOf(MyPost::class,   $posts[0]);
-		$this->assertInstanceOf(MyPage::class,   $posts[1]);
-		$this->assertInstanceOf(MyCustom::class, $posts[2]);
+		$this->assertTrue(MyPost::class === get_class($posts[0]));
+		$this->assertTrue(MyPage::class === get_class($posts[1]));
+		$this->assertTrue(MyCustom::class === get_class($posts[2]));
 	}
 
 	public function testFromAcfArray() {
@@ -198,9 +198,9 @@ class TestPostFactory extends Timber_UnitTestCase {
 
 		$this->assertTrue(true, is_array($res));
 		$this->assertCount(3, $res);
-		$this->assertInstanceOf(Post::class,     $res[0]);
-		$this->assertInstanceOf(MyPage::class,   $res[1]);
-		$this->assertInstanceOf(MyCustom::class, $res[2]);
+		$this->assertTrue(Post::class === get_class($res[0]));
+		$this->assertTrue(MyPage::class === get_class($res[1]));
+		$this->assertTrue(MyCustom::class === get_class($res[2]));
 	}
 
 	public function testFromAssortedArray() {
@@ -249,11 +249,11 @@ class TestPostFactory extends Timber_UnitTestCase {
 		]);
 
 		// Here we're operating on a PostQuery, which implements ArrayAccess.
-		$this->assertInstanceOf(PostQuery::class, $res);
+		$this->assertTrue(PostQuery::class === get_class($res));
 
-		$this->assertInstanceOf(Post::class,     $res[0]);
-		$this->assertInstanceOf(MyPage::class,   $res[1]);
-		$this->assertInstanceOf(MyCustom::class, $res[2]);
+		$this->assertTrue(Post::class === get_class($res[0]));
+		$this->assertTrue(MyPage::class === get_class($res[1]));
+		$this->assertTrue(MyCustom::class === get_class($res[2]));
 	}
 
 	/**
@@ -275,6 +275,6 @@ class TestPostFactory extends Timber_UnitTestCase {
 			'order'     => 'ASC',
 		]);
 
-		$this->assertInstanceOf(Post::class, $res[0]);
+		$this->assertTrue(Post::class === get_class($res[0]));
 	}
 }

--- a/tests/test-term-factory.php
+++ b/tests/test-term-factory.php
@@ -86,9 +86,9 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$cat				 = $termFactory->from($cat_id);
 		$whackness   = $termFactory->from($whackness_id);
 
-		$this->assertInstanceOf(MyTerm::class,         $tag);
-		$this->assertInstanceOf(MyTerm::class,         $cat);
-		$this->assertInstanceOf(WhacknessLevel::class, $whackness);
+		$this->assertTrue(MyTerm::class === get_class($tag));
+		$this->assertTrue(MyTerm::class === get_class($cat));
+		$this->assertTrue(WhacknessLevel::class === get_class($whackness));
 	}
 
 	public function testGetTermWithClassFilter() {
@@ -102,7 +102,7 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$termFactory = new TermFactory();
 		$cat				 = $termFactory->from($cat_id);
 
-		$this->assertInstanceOf(WhacknessLevel::class, $cat);
+		$this->assertTrue(WhacknessLevel::class === get_class($cat));
 	}
 
 	public function testGetTermWithCallable() {
@@ -133,10 +133,10 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$whackness   = $termFactory->from($whackness_id);
 		$hellawhack  = $termFactory->from($hella_id);
 
-		$this->assertInstanceOf(Term::class,           $tag);
-		$this->assertInstanceOf(MyTerm::class,         $cat);
-		$this->assertInstanceOf(WhacknessLevel::class, $whackness);
-		$this->assertInstanceOf(HellaWhackTerm::class, $hellawhack);
+		$this->assertTrue(Term::class === get_class($tag));
+		$this->assertTrue(MyTerm::class === get_class($cat));
+		$this->assertTrue(WhacknessLevel::class === get_class($whackness));
+		$this->assertTrue(HellaWhackTerm::class === get_class($hellawhack));
 	}
 
 	public function testFromArray() {
@@ -181,8 +181,8 @@ class TestTermFactory extends Timber_UnitTestCase {
 
 		$this->assertTrue(true, is_array($res));
 		$this->assertCount(2, $res);
-		$this->assertInstanceOf(MyTerm::class, $res[0]);
-		$this->assertInstanceOf(MyTerm::class, $res[1]);
+		$this->assertTrue(MyTerm::class === get_class($res[0]));
+		$this->assertTrue(MyTerm::class === get_class($res[1]));
 	}
 
 	public function testFromWpTermObject() {
@@ -200,8 +200,8 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$toyota = get_term($toyota_id);
 
 		$termFactory = new TermFactory();
-		$this->assertInstanceOf(MyTerm::class, $termFactory->from($toyota));
-		$this->assertInstanceOf(Term::class,   $termFactory->from($cat));
+		$this->assertTrue(MyTerm::class === get_class($termFactory->from($toyota)));
+		$this->assertTrue(Term::class === get_class($termFactory->from($cat)));
 	}
 
 	public function testFromTermQuery() {
@@ -228,8 +228,8 @@ class TestTermFactory extends Timber_UnitTestCase {
 		$res = $termFactory->from($termQuery);
 
 		$this->assertCount(2, $res);
-		$this->assertInstanceOf(MyTerm::class, $res[0]);
-		$this->assertInstanceOf(MyTerm::class, $res[1]);
+		$this->assertTrue(MyTerm::class === get_class($res[0]));
+		$this->assertTrue(MyTerm::class === get_class($res[1]));
 	}
 
 	public function testFromAssortedArray() {
@@ -255,9 +255,9 @@ class TestTermFactory extends Timber_UnitTestCase {
 		]);
 
 		$this->assertCount(3, $res);
-		$this->assertInstanceOf(MyTerm::class, $res[0]);
-		$this->assertInstanceOf(MyTerm::class, $res[1]);
-		$this->assertInstanceOf(MyTerm::class, $res[2]);
+		$this->assertTrue(MyTerm::class === get_class($res[0]));
+		$this->assertTrue(MyTerm::class === get_class($res[1]));
+		$this->assertTrue(MyTerm::class === get_class($res[2]));
 	}
 
 	public function testFromTermQueryArray() {
@@ -283,8 +283,8 @@ class TestTermFactory extends Timber_UnitTestCase {
 		]);
 
 		$this->assertCount(2, $res);
-		$this->assertInstanceOf(MyTerm::class, $res[0]);
-		$this->assertInstanceOf(MyTerm::class, $res[1]);
+		$this->assertTrue(MyTerm::class === get_class($res[0]));
+		$this->assertTrue(MyTerm::class === get_class($res[1]));
 	}
 
 	public function testTermBy() {

--- a/tests/test-user-factory.php
+++ b/tests/test-user-factory.php
@@ -60,7 +60,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$my_class_map = function(string $class, WP_User $user) {
 			return in_array('administrator', $user->roles)
 				? AdminUser::class
-				: $class;
+				: User::class;
 		};
 		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
@@ -86,7 +86,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$my_class_map = function(string $class, WP_User $user) {
 			return in_array('administrator', $user->roles)
 				? AdminUser::class
-				: $class;
+				: User::class;
 		};
 		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
@@ -143,7 +143,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$my_class_map = function(string $class, WP_User $user) {
 			return in_array('administrator', $user->roles)
 				? AdminUser::class
-				: $class;
+				: User::class;
 		};
 		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
@@ -169,7 +169,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$my_class_map = function(string $class, WP_User $user) {
 			return in_array('administrator', $user->roles)
 				? AdminUser::class
-				: $class;
+				: User::class;
 		};
 		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
@@ -205,7 +205,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$my_class_map = function(string $class, WP_User $user) {
 			return in_array('administrator', $user->roles)
 				? AdminUser::class
-				: $class;
+				: User::class;
 		};
 		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 
@@ -244,7 +244,7 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$my_class_map = function(string $class, WP_User $user) {
 			return in_array('administrator', $user->roles)
 				? AdminUser::class
-				: $class;
+				: User::class;
 		};
 		add_filter( 'timber/user/class', $my_class_map, 10, 2 );
 

--- a/tests/test-user-factory.php
+++ b/tests/test-user-factory.php
@@ -76,8 +76,8 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$admin       = $userFactory->from($admin_id);
 		$normie      = $userFactory->from($normie_id);
 
-		$this->assertInstanceOf(AdminUser::class, $admin);
-		$this->assertInstanceOf(User::class,      $normie);
+		$this->assertTrue(AdminUser::class === get_class($admin));
+		$this->assertTrue(User::class === get_class($normie));
 
 		remove_filter( 'timber/user/class', $my_class_map );
 	}
@@ -103,8 +103,8 @@ class TestUserFactory extends Timber_UnitTestCase {
 		// pass a list of IDs
 		list($admin, $normie) = $userFactory->from([$admin_id, $normie_id]);
 
-		$this->assertInstanceOf(AdminUser::class, $admin);
-		$this->assertInstanceOf(User::class,      $normie);
+		$this->assertTrue(AdminUser::class === get_class($admin));
+		$this->assertTrue(User::class === get_class($normie));
 
 		remove_filter( 'timber/user/class', $my_class_map );
 	}
@@ -159,8 +159,8 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$normie_wp_user = get_user_by('id', $normie_id);
 
 		$userFactory = new UserFactory();
-		$this->assertInstanceOf(AdminUser::class, $userFactory->from($admin_wp_user));
-		$this->assertInstanceOf(User::class, $userFactory->from($normie_wp_user));
+		$this->assertTrue(AdminUser::class === get_class($userFactory->from($admin_wp_user)));
+		$this->assertTrue(User::class === get_class($userFactory->from($normie_wp_user)));
 
 		remove_filter( 'timber/user/class', $my_class_map );
 	}
@@ -194,9 +194,9 @@ class TestUserFactory extends Timber_UnitTestCase {
 		// pass an array containing a User, a WP_User instance, and an ID
 		$users = $userFactory->from([$admin_user, $normie_wp_user, $editor_id]);
 
-		$this->assertInstanceOf(AdminUser::class, $users[0]);
-		$this->assertInstanceOf(User::class,      $users[1]);
-		$this->assertInstanceOf(User::class,      $users[2]);
+		$this->assertTrue(AdminUser::class === get_class($users[0]));
+		$this->assertTrue(User::class === get_class($users[1]));
+		$this->assertTrue(User::class === get_class($users[2]));
 
 		remove_filter( 'timber/user/class', $my_class_map );
 	}
@@ -234,8 +234,8 @@ class TestUserFactory extends Timber_UnitTestCase {
 		]);
 
 		$this->assertCount(2, $users);
-		$this->assertInstanceOf(AdminUser::class, $users[0]);
-		$this->assertInstanceOf(User::class,      $users[1]);
+		$this->assertTrue(AdminUser::class === get_class($users[0]));
+		$this->assertTrue(User::class === get_class($users[1]));
 
 		remove_filter( 'timber/user/class', $my_class_map );
 	}
@@ -273,10 +273,9 @@ class TestUserFactory extends Timber_UnitTestCase {
 		$users = $userFactory->from($userQuery);
 
 		$this->assertCount(2, $users);
-		$this->assertInstanceOf(AdminUser::class, $users[0]);
-		$this->assertInstanceOf(User::class,      $users[1]);
+		$this->assertTrue(AdminUser::class === get_class($users[0]));
+		$this->assertTrue(User::class === get_class($users[1]));
 
 		remove_filter( 'timber/user/class', $my_class_map );
 	}
-
 }


### PR DESCRIPTION
**Ticket**: #2572

## Issue

#2572

## Solution

Update the tests where class maps are tested.

## Impact

Found an instance in the user class maps where a wrong class was returned because the CoAuthors Plus Integrations adds a filter that is also applied in the user tests:

https://github.com/timber/timber/blob/69aebbf42b9df6661129a6d92f6290691aa58529/lib/Integration/CoAuthorsPlusIntegration.php#L22-L24

## Usage Changes

None.

## Considerations

None.

## Testing

Yes.