### PR TITLE
Use newest version of Upstatement/routes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "php": ">=5.3.0 || 7.*",
     "twig/twig": "^1.41 || ^2.10",
-    "upstatement/routes": "0.8.*",
+    "upstatement/routes": "0.9.*",
     "composer/installers": "^1.0 || ^2.0",
     "twig/cache-extension": "^1.5"
   },


### PR DESCRIPTION
**Ticket**: #2584 

## Issue
Changes in WP 6.0 broke how the underlying Routes library handled requests

## Solution
Deploy the fix from that library! https://github.com/Upstatement/routes/pull/41

## Impact
Compatible w/ both WordPress 5.* and WordPress 6.0


## Usage Changes
None