### PR TITLE
Setup  on attachment

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -116,6 +116,22 @@ class Attachment extends Post
     public $caption;
 
     /**
+     * Create and initialize a new instance of the called Post class
+     * (i.e. Timber\Attachment or a subclass).
+     *
+     * @internal
+     * @return Timber\Attachment
+     */
+    public static function build(WP_Post $wp_post): self
+    {
+        $post = parent::build($wp_post);
+
+        $post->caption = $post->post_excerpt;
+
+        return $post;
+    }
+
+    /**
      * Gets the src for an attachment.
      *
      * @api


### PR DESCRIPTION
**Ticket**: 
Fixes: https://github.com/timber/timber/issues/2607

## Issue
Caption on images is empty, and not intitialized.


## Solution
Implements `Attachment::build` method that will be used in `PostFactory` so `caption` is defined.

## Impact
It's really a bugfix.


## Considerations
Not 100% sure this is the way that it's meant to be implemented. An alternative (that would break backwards compatibility) would be to just remove the field, and document it so `post_excerpt` is used instead.


## Testing
I didn't add any test.
