### PR TITLE
2.x Remove `Attachment::$caption` property in favor of `Attachment::caption()` method

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -905,7 +905,7 @@ The following functions and properties were **removed from the codebase**, eithe
 - `get_src()` – use `{{ image.src }}` instead
 - `get_url()` – use `{{ image.src }}` instead
 - `url()` – use `{{ image.src }}` instead
-- `$caption` property – use `caption()` method instead. You can still use `{{ image.caption }}` in Twig.
+- `$caption` property – use `caption()` method instead. You can still use `{{ image.caption }}` in Twig. In PHP `$image->caption` also still works because magic properties will automatically resolve to `$image->caption()`.
 
 ### Timber\MenuItem
 

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -848,7 +848,7 @@ The following functions are being deprecated and will be removed in a future ver
 
 ## Removed functions and properties
 
-The following functions were **removed from the codebase**, either because they were already deprecated or because they’re not used anymore.
+The following functions and properties were **removed from the codebase**, either because they were already deprecated or because they’re not used anymore.
 
 ### Timber\Timber
 
@@ -905,6 +905,7 @@ The following functions were **removed from the codebase**, either because they 
 - `get_src()` – use `{{ image.src }}` instead
 - `get_url()` – use `{{ image.src }}` instead
 - `url()` – use `{{ image.src }}` instead
+- `$caption` property – use `caption()` method instead. You can still use `{{ image.caption }}` in Twig.
 
 ### Timber\MenuItem
 

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -108,30 +108,6 @@ class Attachment extends Post
     ];
 
     /**
-     * Caption text.
-     *
-     * @api
-     * @var string The caption that is stored as post_excerpt in the posts table in the database.
-     */
-    public $caption;
-
-    /**
-     * Create and initialize a new instance of the called Post class
-     * (i.e. Timber\Attachment or a subclass).
-     *
-     * @internal
-     * @return Timber\Attachment
-     */
-    public static function build(WP_Post $wp_post): self
-    {
-        $post = parent::build($wp_post);
-
-        $post->caption = $post->post_excerpt;
-
-        return $post;
-    }
-
-    /**
      * Gets the src for an attachment.
      *
      * @api
@@ -307,6 +283,29 @@ class Attachment extends Post
         }
 
         return wp_get_attachment_url($this->ID);
+    }
+
+    /**
+     * Gets the caption of an attachment.
+     *
+     * @api
+     * @since 2.0
+     * @example
+     * ```twig
+     * <figure>
+     *     <img src="{{ post.thumbnail.src }}">
+     *
+     *     {% if post.thumbnail is not empty %}
+     *         <figcaption>{{ post.thumbnail.caption }}</figcaption
+     *     {% endif %}
+     * </figure>
+     * ```
+     *
+     * @return string
+     */
+    public function caption()
+    {
+        return $this->post_excerpt;
     }
 
     /**

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -116,6 +116,22 @@ class Attachment extends Post
     public $caption;
 
     /**
+     * Create and initialize a new instance of the called Post class
+     * (i.e. Timber\Attachment or a subclass).
+     *
+     * @internal
+     * @return Timber\Attachment
+     */
+    public static function build(WP_Post $wp_post): self
+    {
+        $post = parent::build($wp_post);
+
+        $post->caption = $post->post_excerpt;
+
+        return $post;
+    }
+
+    /**
      * Gets the src for an attachment.
      *
      * @api

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -305,7 +305,16 @@ class Attachment extends Post
      */
     public function caption()
     {
-        return $this->post_excerpt;
+        /**
+         * Filters the attachment caption.
+         *
+         * @since WordPress 4.6.0
+         * @since 2.0.0
+         *
+         * @param string $caption Caption for the given attachment.
+         * @param int    $post_id Attachment ID.
+         */
+        return apply_filters('wp_get_attachment_caption', $this->post_excerpt, $this->ID);
     }
 
     /**

--- a/tests/test-timber-attachment.php
+++ b/tests/test-timber-attachment.php
@@ -295,4 +295,18 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase
         ]);
         $this->assertEquals('PDF', $result);
     }
+
+    public function testAttachmentCaption()
+    {
+        $caption = 'Hummingbirds can’t walk.';
+        $post_id = $this->factory->post->create();
+        $attachment_id = self::get_attachment($post_id, 'dummy-pdf.pdf');
+        wp_update_post([
+            'ID' => $attachment_id,
+            'post_excerpt' => $caption,
+        ]);
+        $attachment = Timber::get_post($attachment_id);
+
+        $this->assertEquals($caption, $attachment->caption);
+    }
 }

--- a/tests/test-timber-attachment.php
+++ b/tests/test-timber-attachment.php
@@ -296,6 +296,10 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase
         $this->assertEquals('PDF', $result);
     }
 
+    /**
+     * @ticket https://github.com/timber/timber/issues/2607
+     * @return void
+     */
     public function testAttachmentCaption()
     {
         $caption = 'Hummingbirds can’t walk.';
@@ -307,6 +311,6 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase
         ]);
         $attachment = Timber::get_post($attachment_id);
 
-        $this->assertEquals($caption, $attachment->caption);
+        $this->assertEquals($caption, $attachment->caption());
     }
 }


### PR DESCRIPTION
**Ticket**: #2610

- Fixes #2607

## Issue

This pull request iterates on the work by @xavivars in #2610 (thanks, @xavivars). For 2.x, we missed that the caption of an attachment is set while initializing it. See this excerpt from 1.x:

https://github.com/timber/timber/blob/8d9bff23d2677652469badb75dcb607449a18204/lib/Image.php#L215-L217

## Solution

This pull request:

- Adds a test to confirm the bug in #2607.
- Removes the `Attachment::$caption` property and instead adds an `Attachment::caption()` method. I think this is the approach we choose more and more: Using methods instead of countless properties we have to initialize.
- Updates the Upgrade guide.
- Adds the `wp_get_attachment_caption` filter, which is used in the equivalent WordPress core function [`wp_get_attachment_caption()`](https://developer.wordpress.org/reference/functions/wp_get_attachment_caption/).

## Impact

This doesn’t break backwards compatibility, even if `Timber\Image::$caption` is used in PHP, because `Timber\Core::__get()` will automatically resolve to `Timber\Image::caption()`.

## Usage Changes

None.

## Considerations

Yes, `caption()` belongs in `Timber\Attachment` and not `Timber\Image`, because you can set captions in all kinds of attachments in WordPress, not just images.

## Testing

Yes.