### PR TITLE
2.x Add missing query() method to `Timber\PostQuery`

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -788,6 +788,10 @@ The following functions are being deprecated and will be removed in a future ver
 - `preview()` - use `excerpt()` instead.
 - `update()` - use WordPress core’s `update_post_meta()` instead.
 
+### Timber\PostQuery
+
+- `get_query()`, use `query()` instead.
+
 ### Timber\Image and Timber\Attachment
 
 - `get_pathinfo()` – use `pathinfo()` instead.

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -133,7 +133,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
      * @since 2.0
      * @return WP_Query|null
      */
-    public function query()
+    public function query(): ?WP_Query
     {
         return $this->wp_query;
     }
@@ -144,7 +144,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
      * @deprecated 2.0.0, use PostQuery::query() instead.
      * @return WP_Query|null
      */
-    public function get_query()
+    public function get_query(): ?WP_Query
     {
         Helper::deprecated('Timber\PostQuery::get_query()', 'Timber\PostQuery::query()', '2.0.0');
 

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -139,6 +139,19 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     }
 
     /**
+     * Gets the original query used to get a collection of Timber posts.
+     *
+     * @deprecated 2.0.0, use PostQuery::query() instead.
+     * @return WP_Query|null
+     */
+    public function get_query()
+    {
+        Helper::deprecated('Timber\PostQuery::get_query()', 'Timber\PostQuery::query()', '2.0.0');
+
+        return $this->wp_query;
+    }
+
+    /**
      * Override data printed by var_dump() and similar. Realizes the collection before
      * returning. Due to a PHP bug, this only works in PHP >= 7.4.
      *

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -128,6 +128,17 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     }
 
     /**
+     * Gets the original query used to get a collection of Timber posts.
+     *
+     * @since 2.0
+     * @return WP_Query|null
+     */
+    public function query()
+    {
+        return $this->wp_query;
+    }
+
+    /**
      * Override data printed by var_dump() and similar. Realizes the collection before
      * returning. Due to a PHP bug, this only works in PHP >= 7.4.
      *

--- a/tests/test-timber-post-collection.php
+++ b/tests/test-timber-post-collection.php
@@ -137,6 +137,23 @@ class TestTimberPostQuery extends Timber_UnitTestCase
         $this->assertEquals([$post_ids[0]], $posts->query()->query_vars['post__in']);
     }
 
+    /**
+     * @ticket https://github.com/timber/timber/issues/2605
+     * @expectedDeprecated Timber\PostQuery::get_query()
+     * @return void
+     */
+    public function testQueryGetterDeprecated()
+    {
+        $post_ids = $this->factory->post->create_many(2);
+
+        $posts = Timber::get_posts([
+            'post_type' => 'post',
+            'post__in' => [$post_ids[0]],
+        ]);
+
+        $this->assertEquals([$post_ids[0]], $posts->get_query()->query_vars['post__in']);
+    }
+
     public function testTheLoop()
     {
         foreach (range(1, 3) as $i) {

--- a/tests/test-timber-post-collection.php
+++ b/tests/test-timber-post-collection.php
@@ -119,6 +119,24 @@ class TestTimberPostQuery extends Timber_UnitTestCase
         $this->assertEquals(0, $query->found_posts);
     }
 
+    /**
+     * @ticket https://github.com/timber/timber/issues/2605
+     * @return void
+     */
+    public function testQueryGetter()
+    {
+        $post_ids = $this->factory->post->create_many(2);
+
+        $posts = Timber::get_posts([
+            'post_type' => 'post',
+            'has_password' => true,
+            'post__in' => [$post_ids[0]],
+        ]);
+
+        $this->assertEquals(true, $posts->query()->query_vars['has_password']);
+        $this->assertEquals([$post_ids[0]], $posts->query()->query_vars['post__in']);
+    }
+
     public function testTheLoop()
     {
         foreach (range(1, 3) as $i) {


### PR DESCRIPTION
**Ticket**:

- Fixes #2605.

## Issue

The [`get_query()` method](https://github.com/timber/timber/blob/8d9bff23d2677652469badb75dcb607449a18204/lib/PostQuery.php#L50-L56) didn’t make it over to 2.x.

## Solution

This pull request:

- Adds the missing method and renames from `get_query()` to `query()` to match the naming convention.
- Deprecates the `get_query()` method.
- Adds a test.
- Updates the Upgrade Guide.

## Impact and Usage Changes

Mentioned in the Upgrade Guide.

## Considerations

–

## Testing

Yes.