### PR TITLE
Make snippets CS compliant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,8 @@
   "scripts": {
     "analyze": "phpstan",
     "cs": "ecs check",
+    "cs:docs": "ecs check-markdown docs/v2/**/*.md --fix",
+    "cs:docs:fix": "ecs check-markdown docs/v2/**/*.md",
     "cs:fix": "ecs check --fix",
     "grump": "grumphp run",
     "grump:install": "grumphp git:init",

--- a/docs/v2/getting-started/a-post-archive.md
+++ b/docs/v2/getting-started/a-post-archive.md
@@ -8,11 +8,9 @@ Here’s how a PHP template file for a WordPress archive looks like.
 **index.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-Timber::render( 'index.twig', $context );
+Timber::render('index.twig', $context);
 ```
 
 For basic archives, that’s all you need. Behind the scenes, Timber already prepared a `posts` variable for you that holds all the posts that you would normally find in [The Loop](https://developer.wordpress.org/themes/basics/the-loop/).
@@ -76,27 +74,25 @@ There are two new things that you see here:
 Sometimes you’ll want to use your own queries for archive pages or to display a list of posts in other places. For that, you can use `Timber::get_posts()`. Here’s an example for a more complex query, that selects posts that have certain movie genre and actor terms assigned. The parameters you use are the same as those for [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/).
 
 ```php
-<?php
-
 $args = [
     'post_type' => 'post',
     'tax_query' => [
         'relation' => 'AND',
         [
             'taxonomy' => 'movie_genre',
-            'field'    => 'slug',
-            'terms'    => [ 'action', 'comedy' ]
+            'field' => 'slug',
+            'terms' => ['action', 'comedy'],
         ],
         [
             'taxonomy' => 'actor',
-            'field'    => 'id',
-            'terms'    => [ 103, 115, 206 ],
-            'operator' => 'NOT IN'
-        ]
-    ]
+            'field' => 'id',
+            'terms' => [103, 115, 206],
+            'operator' => 'NOT IN',
+        ],
+    ],
 ];
 
-$context['posts'] = Timber::get_posts( $args );
+$context['posts'] = Timber::get_posts($args);
 ```
 
 ### An example: related posts
@@ -108,25 +104,23 @@ First, you would prepare the data in your PHP template. For this, we add `relate
 **single.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
 $post = $context['post'];
 
-$context['related_posts'] = Timber::get_posts( [
-	'post_type'      => 'post',
+$context['related_posts'] = Timber::get_posts([
+    'post_type' => 'post',
     'posts_per_page' => 3,
-    'orderby'        => 'date',
-    'order'          => 'DESC',
-    'post__not_in'   => [ $post->ID ],
-    'category__in'   => $post->terms( [
+    'orderby' => 'date',
+    'order' => 'DESC',
+    'post__not_in' => [$post->ID],
+    'category__in' => $post->terms([
         'taxonomy' => 'category',
-        'fields'   => 'ids',
-    ] ),
-] );
+        'fields' => 'ids',
+    ]),
+]);
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 And then, in your singular view, you would loop over them. We can also reuse the **teaser.twig** view, that we introduced earlier.

--- a/docs/v2/getting-started/a-single-post.md
+++ b/docs/v2/getting-started/a-single-post.md
@@ -104,11 +104,9 @@ This is what a PHP template for a singular post in Timber looks like:
 **single.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 For very basic themes, this is all you need to start working. But for more advanced functionality, you might have to add your own data. For that, you can add your data to `$context`.
@@ -116,14 +114,12 @@ For very basic themes, this is all you need to start working. But for more advan
 Here’s an example where you would call a function to calculate the reading time for a post.
 
 ```php
-<?php
-
 $context = Timber::context();
-$post    = $context['post'];
+$post = $context['post'];
 
-$context['reading_time'] = reading_time( $post );
+$context['reading_time'] = reading_time($post);
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 Now, you can head on to the next chapter about [Post Archives](https://timber.github.io/docs/v2/getting-started/a-post-archive/).

--- a/docs/v2/getting-started/introduction.md
+++ b/docs/v2/getting-started/introduction.md
@@ -38,9 +38,7 @@ To render a view, you can use `Timber::render()`.
 **index.php**
 
 ```php
-<?php
-
-Timber::render( 'index.twig' );
+Timber::render('index.twig');
 ```
 
 This will look for an **index.twig** file in the **views** folder of your theme and render the contents of that template.
@@ -54,13 +52,11 @@ This will look for an **index.twig** file in the **views** folder of your theme 
 We don’t have any data yet. Let’s create an array with data that we then pass to our view with the second parameter for `Timber::render()`.
 
 ```php
-<?php
-
 $data = [
     'title' => 'A Timber Tutorial',
 ];
 
-Timber::render( 'index.twig', $data );
+Timber::render('index.twig', $data);
 ```
 
 **index.twig**
@@ -80,13 +76,11 @@ The `title` variable is still a static string. Let’s make it a little more dyn
 **index.php**
 
 ```php
-<?php
-
 $data = [
     'title' => get_the_title(),
 ];
 
-Timber::render( 'index.twig', $data );
+Timber::render('index.twig', $data);
 ```
 
 See how there’s no HTML in our PHP file? And do you see how we fetch the data we need in PHP and output it in Twig? This is an important concept called [*separation of concerns*](https://en.wikipedia.org/wiki/Separation_of_concerns).
@@ -100,11 +94,9 @@ Most of Timber’s templates look like this:
 **index.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-Timber::render( 'index.twig', $context );
+Timber::render('index.twig', $context);
 ```
 
 What happens here? In Timber, you can use the `Timber::context()` function to get **an array of data that you need in most of your templates**. It includes things like the site name, the site description or the navigation menu that you probably need in every template. You can read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context/) whenever you’re ready.

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -211,20 +211,19 @@ Here’s an example from the [Twenty Twenty theme](https://github.com/WordPress/
 
 	<?php
 
-	if ( have_posts() ) {
+    if (have_posts()) {
+        while (have_posts()) {
+            the_post();
 
-		while ( have_posts() ) {
-			the_post();
+            get_template_part('template-parts/content', get_post_type());
+        }
+    }
 
-			get_template_part( 'template-parts/content', get_post_type() );
-		}
-	}
-
-	?>
+    ?>
 
 </main>
 
-<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
+<?php get_template_part('template-parts/footer-menus-widgets'); ?>
 
 <?php get_footer(); ?>
 ```
@@ -237,19 +236,19 @@ If you wanted to introduce Timber, you could start replacing different parts of 
 <main id="site-content" role="main">
 
     <?php
-        $template = sprintf( 'content-%s.twig', get_post_type() );
-        $post     = Timber::get_post();
+        $template = sprintf('content-%s.twig', get_post_type());
+        $post = Timber::get_post();
 
         $post->setup();
 
-        Timber::render( $template, [
+        Timber::render($template, [
             'post' => $post,
-        ] );
+        ]);
     ?>
 
 </main>
 
-<?php get_template_part( 'template-parts/footer-menus-widgets' ); ?>
+<?php get_template_part('template-parts/footer-menus-widgets'); ?>
 
 <?php get_footer(); ?>
 ```

--- a/docs/v2/guides/cheatsheet.md
+++ b/docs/v2/guides/cheatsheet.md
@@ -8,7 +8,7 @@ Here are some helpful conversions for functions you’re probably well familiar 
 ```php
 $context = Timber::context();
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 ## Blog Info

--- a/docs/v2/guides/class-maps.md
+++ b/docs/v2/guides/class-maps.md
@@ -30,14 +30,14 @@ The Post Class Map is used:
 use Book;
 use Page;
 
-add_filter( 'timber/post/classmap', function( $classmap ) {
+add_filter('timber/post/classmap', function ($classmap) {
     $custom_classmap = [
         'page' => Page::class,
         'book' => Book::class,
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 Post types that you don’t list in the Post Class Map will take the default `Timber\Post` class.
@@ -46,13 +46,12 @@ In case you need more fine-grained control over which class is used for your pos
 
 ```php
 use Book;
-use Page;
 use PreciousBook;
 
-add_filter( 'timber/post/classmap', function( $classmap ) {
+add_filter('timber/post/classmap', function ($classmap) {
     $custom_classmap = [
-        'book' => function( \WP_Post $post ) {
-            if ( $post->id === 3 ) {
+        'book' => function (\WP_Post $post) {
+            if ($post->id === 3) {
                 return PreciousBook::class;
             }
 
@@ -60,8 +59,8 @@ add_filter( 'timber/post/classmap', function( $classmap ) {
         },
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 The callback function receives a `WP_Post` object and should return the name of the class to use.
@@ -72,10 +71,10 @@ Here’s another example, where you could use a different attachment class for a
 use BookAttachment;
 use Timber\Attachment;
 
-add_filter( 'timber/post/classmap', function( $classmap ) {
+add_filter('timber/post/classmap', function ($classmap) {
     $custom_classmap = [
-        'attachment' => function( \WP_Post $post ) {
-            if ( 'book' === get_post_type( $post->post_parent ) {
+        'attachment' => function (\WP_Post $post) {
+            if ('book' === get_post_type($post->post_parent)) {
                 return BookAttachment::class;
             }
 
@@ -83,8 +82,8 @@ add_filter( 'timber/post/classmap', function( $classmap ) {
         },
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 ## The Term Class Map
@@ -102,13 +101,13 @@ The Term Class Map is used:
 ```php
 use Genre;
 
-add_filter( 'timber/term/classmap', function( $classmap ) {
+add_filter('timber/term/classmap', function ($classmap) {
     $custom_classmap = [
         'genre' => Genre::class,
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 Taxonomies that you don’t list in the Term Class Map will take the default `Timber\Term` class.
@@ -119,10 +118,10 @@ When you need more fine-grained control over which class is used for your term o
 use ComedyGenre;
 use Genre;
 
-add_filter( 'timber/term/classmap', function( $classmap ) {
+add_filter('timber/term/classmap', function ($classmap) {
     $custom_classmap = [
-        'genre' => function( \WP_Term $term ) {
-            if ( $term->term_id === 2 ) {
+        'genre' => function (\WP_Term $term) {
+            if ($term->term_id === 2) {
                 return ComedyGenre::class;
             }
 
@@ -130,8 +129,8 @@ add_filter( 'timber/term/classmap', function( $classmap ) {
         },
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 The callback function receives a `WP_Term` object and should return the name of the class to use.
@@ -148,17 +147,17 @@ The Comment Class Map is used:
 **functions.php**
 
 ```php
-use CommentPost;
 use CommentBook;
+use CommentPost;
 
-add_filter( 'timber/comment/classmap', function( $classmap ) {
+add_filter('timber/comment/classmap', function ($classmap) {
     $custom_classmap = [
         'post' => CommentPost::class,
         'book' => CommentBook::class,
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 Comments for post types that you don’t list in the Comment Class Map will take the default `Timber\Comment` class name as an argument.
@@ -166,15 +165,15 @@ Comments for post types that you don’t list in the Comment Class Map will take
 When you need more fine-grained control over which class is used for your comment object, you can use a callback function:
 
 ```php
-use BookComment;
 use BookChildComment;
+use BookComment;
 
-add_filter( 'timber/comment/classmap', function( $classmap ) {
+add_filter('timber/comment/classmap', function ($classmap) {
     $custom_classmap = [
-        'book' => function( \WP_Comment $comment ) {
-            $post = get_post( $comment->comment_post_ID );
+        'book' => function (\WP_Comment $comment) {
+            $post = get_post($comment->comment_post_ID);
 
-            if ( 0 !== $post->post_parent ) {
+            if (0 !== $post->post_parent) {
                 return BookChildComment::class;
             }
 
@@ -182,8 +181,8 @@ add_filter( 'timber/comment/classmap', function( $classmap ) {
         },
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 The callback function receives a `WP_Comment` object and should return the name of the class to use. If you need the post ID a comment is associated with, you can get that through `$comment->comment_post_ID`.
@@ -201,14 +200,14 @@ Here’s an a example for a basic filter where we select different menu objects 
 **functions.php**
 
 ```php
-add_filter( 'timber/menu/classmap', function( $classmap ) {
+add_filter('timber/menu/classmap', function ($classmap) {
     $custom_classmap = [
-        'primary'   => MenuPrimary::class,
+        'primary' => MenuPrimary::class,
         'secondary' => MenuSecondary::class,
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-}, 10 );
+    return array_merge($classmap, $custom_classmap);
+}, 10);
 ```
 
 Menu locations that you don’t list in the class map will use `Timber\Menu` as a default class.
@@ -218,13 +217,13 @@ If selecting a menu class based on the location isn’t enough for you, you can 
 The following example demonstrates how you can use custom classes (`SingleLevelMenu` or `MultiLevelMenu`)  based on the depth of the menu.
 
 ```php
-add_filter( 'timber/menu/class', function( $class, $term, $args ) {
-    if ( $args['depth'] === 1 ) {
+add_filter('timber/menu/class', function ($class, $term, $args) {
+    if ($args['depth'] === 1) {
         return SingleLevelMenu::class;
     }
 
     return MultiLevelMenu::class;
-}, 10, 3 );
+}, 10, 3);
 ```
 
 ## The MenuItem class filter
@@ -238,13 +237,13 @@ The MenuItem class filter is used:
 **functions.php**
 
 ```php
-add_filter( 'timber/menuitem/class', function( $class, $item, $menu ) {
-    if ( $menu instanceof MenuPrimary ) {
+add_filter('timber/menuitem/class', function ($class, $item, $menu) {
+    if ($menu instanceof MenuPrimary) {
         return MenuItemPrimary::class;
     }
 
     return $class;
-}, 10, 3 );
+}, 10, 3);
 ```
 
 In the above example, the MenuItem class filter receives the default `Timber\MenuItem` class name, the WordPress menu item (which is an instance of `WP_Post`) and the `Timber\Menu` object that the item is assigend to. You should be able to decide which class to use based on these parameters. This example demonstrates how you can use a custom class (`MenuItemPrimary`) when the parent menu has a (custom) class of `MenuPrimary`.
@@ -252,15 +251,13 @@ In the above example, the MenuItem class filter receives the default `Timber\Men
 Here’s another example where you would use a different class if the menu item is in a menu assigned to the `secondary` menu location.
 
 ```php
-use MenuItemSecondary;
-
-add_filter( 'timber/menuitem/class', function( $class, $item, $menu ) {
-    if ( 'secondary' === $menu->theme_location ) {
+add_filter('timber/menuitem/class', function ($class, $item, $menu) {
+    if ('secondary' === $menu->theme_location) {
         return MenuItemPrimary::class;
     }
 
     return $class;
-}, 10, 3 );
+}, 10, 3);
 ```
 
 ## The Pages Menu Class filter
@@ -278,9 +275,9 @@ Here’s an a example for a basic filter where you would always return your cust
 ```php
 use ExtendedPagesMenu;
 
-add_filter( 'timber/pages_menu/class', function( $class ) {
+add_filter('timber/pages_menu/class', function ($class) {
     return ExtendedPagesMenu::class;
-} );
+});
 ```
 
 ## The User class filter
@@ -298,9 +295,9 @@ The User Class Map is used:
 ```php
 use UserExtended;
 
-add_filter( 'timber/user/class', function( $class, \WP_User $user ) {
+add_filter('timber/user/class', function ($class, \WP_User $user) {
     return UserExtended::class;
-}, 10, 2 );
+}, 10, 2);
 ```
 
 In the above example, the User class filter receives the default User class and a `WP_User` object as arguments. You should be able to decide which class to use based on that user object.
@@ -308,40 +305,40 @@ In the above example, the User class filter receives the default User class and 
 In case you need a different User class based on the current template you’re displaying, you can use [Conditional Tags](https://developer.wordpress.org/themes/references/list-of-conditional-tags/).
 
 ```php
-add_filter( 'timber/user/class', function( $class, \WP_User $user ) {
+add_filter('timber/user/class', function ($class, \WP_User $user) {
     // Use Author class for single post template.
-    if ( is_singular( 'post' ) ) {
+    if (is_singular('post')) {
         return Author::class;
     }
 
     return $class;
-}, 10, 2 );
+}, 10, 2);
 ```
 
 If you need to have a special class based on the capabilities a user has, work with `$user->has_cap()`.
 
 ```php
-add_filter( 'timber/user/class', function( $class, \WP_User $user ) {
-    if ( $user->has_cap( 'manage_options' ) ) {
+add_filter('timber/user/class', function ($class, \WP_User $user) {
+    if ($user->has_cap('manage_options')) {
         return Administrator::class;
-    } elseif ( $user->has_cap( 'edit_pages' ) ) {
+    } elseif ($user->has_cap('edit_pages')) {
         return Editor::class;
     }
 
     return $class;
-}, 10, 2 );
+}, 10, 2);
 ```
 
 If you need to check for user roles, check the `$user->roles` array. Don’t work with `$user->has_cap()` to check for roles, because it may lead to unreliable results.
 
 ```php
-add_filter( 'timber/user/class', function( $class, \WP_User $user ) {
-    if ( in_array( 'editor', $user->roles, true ) ) {
+add_filter('timber/user/class', function ($class, \WP_User $user) {
+    if (in_array('editor', $user->roles, true)) {
         return Editor::class;
-    } elseif ( in_array( 'author', $user->roles, true ) ) {
+    } elseif (in_array('author', $user->roles, true)) {
         return Author::class;
     }
 
     return $class;
-}, 10, 2 );
+}, 10, 2);
 ```

--- a/docs/v2/guides/comments.md
+++ b/docs/v2/guides/comments.md
@@ -45,8 +45,10 @@ You can implement threaded comments this way (if you don't mind using WordPressâ
 **functions.php**
 ```php
 //Include the comment reply Javascript
-add_action('wp_print_scripts', function(){
-  if ( (!is_admin()) && is_singular() && comments_open() && get_option('thread_comments') ) wp_enqueue_script( 'comment-reply' );
+add_action('wp_print_scripts', function () {
+    if ((!is_admin()) && is_singular() && comments_open() && get_option('thread_comments')) {
+        wp_enqueue_script('comment-reply');
+    }
 });
 ```
 

--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -10,14 +10,12 @@ In the following example, `$data` is an associative array of values. Each of the
 **single.php**
 
 ```php
-<?php
-
-$data = array(
+$data = [
     'message' => 'This can be any variable you want',
-    'author'  => 'Tom',
-);
+    'author' => 'Tom',
+];
 
-Timber::render( 'single.twig', $data );
+Timber::render('single.twig', $data);
 ```
 
 **single.twig**
@@ -36,7 +34,7 @@ You don’t have to figure out all the variables you need in a template for your
 ```php
 $context = Timber::context();
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 Follow this guide to get an overview of what’s in the context, or use `var_dump( $context );` in PHP or `{{ dump() }}` in Twig to display the contents of the context in your browser.
@@ -48,19 +46,19 @@ After you’ve called `Timber::context()`, you can add additional variables or o
 ```php
 $context = Timber::get_context();
 
-$context['today'] = wp_date( 'Ymd' );
+$context['today'] = wp_date('Ymd');
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 Another way to do this is to pass your custom data to the `Timber::context()` function itself:
 
 ```php
-$context = Timber::get_context( [
-    'today' => wp_date( 'Ymd' )
-] );
+$context = Timber::get_context([
+    'today' => wp_date('Ymd'),
+]);
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 ## Global context
@@ -88,11 +86,11 @@ Here’s an example for how you could **add a navigation menu** to your context 
 
 ```php
 // Example: Add a menu to the global context.
-add_filter( 'timber/context', function( $context ) {
-    $context['menu'] = Timber::get_menu( 'primary-menu' );
+add_filter('timber/context', function ($context) {
+    $context['menu'] = Timber::get_menu('primary-menu');
 
     return $context;
-} );
+});
 ```
 
 For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus).
@@ -107,12 +105,12 @@ Having a cached global context can be useful if you need the context in other pl
 /**
  * Shortcode for address inside a WYSIWG field.
  */
-add_shortcode( 'company_address', function() {
+add_shortcode('company_address', function () {
     return Timber::compile(
         'shortcode/company-address.twig',
         Timber::context_global()
     );
-} );
+});
 ```
 
 In this example, we've provided all the global context variables to **shortcode/company-address.twig** via `Timber::context_global()`. Whenever you only need the global context, you should use the `Timber::context_global()` function. You can call that function multiple times without losing performance.
@@ -134,7 +132,7 @@ The `post` variable will be available in singular templates (when [ `is_singular
 ```php
 $context = Timber::context();
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 By calling `Timber::get_post()` without any arguments, Timber will use the `$post` global for the current singular template.
@@ -148,7 +146,7 @@ $context = Timber::context();
 
 $post = $context['post'];
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 #### Using a custom post class
@@ -159,24 +157,24 @@ If you want to overwrite the existing `post` variable in the context, you can do
 
 ```php
 // Getting another post.
-$post = Timber::get_post( 12 );
+$post = Timber::get_post(12);
 $post->setup();
 
 // Get context with your post.
-$context = Timber::context( [
+$context = Timber::context([
     'post' => $post,
-] );
+]);
 ```
 
 Or even shorter:
 
 ```php
 // Getting another post.
-$post = Timber::get_post( 12 );
+$post = Timber::get_post(12);
 
-$context = Timber::context( [
+$context = Timber::context([
     'post' => $post->setup(),
-] )
+]);
 ```
 
 **Be aware!** Whenever you set up **a post in a singular template** (instead of relying on `Timber::context()` to do it for you), **you need to set up your post through `$post->setup()`**. The `setup()` function improves compatibility with third-party plugins.
@@ -202,7 +200,7 @@ The `posts` variable will contain an object that implements `Timber\PostCollecti
 ```php
 $context = Timber::context();
 
-Timber::render( 'archive.twig', $context );
+Timber::render('archive.twig', $context);
 ```
 
 #### Write your own query
@@ -212,13 +210,13 @@ When you don’t need the default query, you can pass in your own arguments to `
 **archive.php**
 
 ```php
-$context = Timber::context(
-    'posts' => Timber::get_posts( [
-        'post_type'      => 'book',
+$context = Timber::context([
+    'posts' => Timber::get_posts([
+        'post_type' => 'book',
         'posts_per_page' => -1,
-        'post_status'    => 'publish',
-    ] ),
-);
+        'post_status' => 'publish',
+    ]),
+]);
 ```
 
 #### Change arguments for default query
@@ -228,18 +226,18 @@ Sometimes you don’t want to use the default query, but build on the default qu
 **archive.php**
 
 ```php
-$context = Timber::context(
+$context = Timber::context([
     'posts' => Timber::get_posts(
         [
-            'author__in' => [ 1, 6, 14 ],
+            'author__in' => [1, 6, 14],
         ],
         [
             'merge_default' => true,
         ]
     ),
-);
+]);
 
-Timber::render( 'archive.twig', $context );
+Timber::render('archive.twig', $context);
 ```
 
 Timber will accept the parameters that can be found in WordPress’s [WP_Query class](https://codex.wordpress.org/Class_Reference/WP_Query).

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -114,19 +114,17 @@ This is where we’ll start in PHP.
 **single.php**
 
 ```php
-<?php
-
 $post = Timber::get_post();
 
-if ( isset( $post->hero_image ) && strlen( $post->hero_image ) ) {
-    $post->hero_image = Timber::get_image( $post->hero_image );
+if (isset($post->hero_image) && strlen($post->hero_image)) {
+    $post->hero_image = Timber::get_image($post->hero_image);
 }
 
-$data = Timber::context( [
-    'post' => $post
-] );
+$data = Timber::context([
+    'post' => $post,
+]);
 
-Timber::render( 'single.twig', $data );
+Timber::render('single.twig', $data);
 ```
 
 `Timber\Image` should be initialized using a WordPress image ID. It can also take URLs and image objects, but that requires extra processing.

--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -29,7 +29,7 @@ This method is the **recommended way to access meta values**. You’ll get value
 **PHP**
 
 ```php
-$my_custom_field = $post->meta( 'my_custom_field' );
+$my_custom_field = $post->meta('my_custom_field');
 ```
 
 ### The `raw_meta()` method
@@ -55,15 +55,17 @@ Sometimes you need to modify a meta value before it is returned. You can do that
 **PHP**
 
 ```php
-class CustomPost extends Timber\Post {
+class CustomPost extends Timber\Post
+{
     /**
      * Gets formatted price.
      */
-    public function price() {
-        $price = $this->meta( 'price' );
+    public function price()
+    {
+        $price = $this->meta('price');
 
         // Remove decimal digits.
-        return number_format( $price, 0, '', '' );
+        return number_format($price, 0, '', '');
     }
 }
 ```
@@ -172,12 +174,12 @@ Please be aware that using this might conflict with existing Timber methods on t
 This example that uses a [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.
 
 ```php
-$args = array(
+$args = [
     'numberposts' => -1,
-    'post_type'   => 'post',
-    'meta_key'    => 'color',
-    'meta_value'  => 'red',
-);
+    'post_type' => 'post',
+    'meta_key' => 'color',
+    'meta_value' => 'red',
+];
 
-$context['posts'] = Timber::get_posts( $args );
+$context['posts'] = Timber::get_posts($args);
 ```

--- a/docs/v2/guides/custom-integrations.md
+++ b/docs/v2/guides/custom-integrations.md
@@ -11,9 +11,11 @@ To achieve this, that class implements an interface: `Timber\Integrations\Integr
 ```php
 namespace Timber\Integration;
 
-interface IntegrationInterface {
-    public function should_init() : bool;
-    public function init() : void;
+interface IntegrationInterface
+{
+    public function should_init(): bool;
+
+    public function init(): void;
 }
 ```
 
@@ -38,24 +40,28 @@ use ACF;
 /**
  * Class used to handle integration with Advanced Custom Fields
  */
-class MyAcfIntegration implements IntegrationInterface {
-    public function should_init() : bool {
-        return class_exists( ACF::class );
+class MyAcfIntegration implements IntegrationInterface
+{
+    public function should_init(): bool
+    {
+        return class_exists(ACF::class);
     }
 
-    public function init() : void {
+    public function init(): void
+    {
         // Hook into Timber’s post meta logic.
-        add_filter( 'timber/post/pre_meta', [ $this, 'post_get_meta_field' ], 10, 5 );
+        add_filter('timber/post/pre_meta', [$this, 'post_get_meta_field'], 10, 5);
     }
 
-    public static function post_get_meta_field( $value, $post_id, $field_name, $post, $args ) {
-      $args = wp_parse_args( $args, array(
-          // Apply formatting logic (defined when configuring the field).
-          'format_value' => true,
-      ) );
+    public static function post_get_meta_field($value, $post_id, $field_name, $post, $args)
+    {
+        $args = wp_parse_args($args, [
+            // Apply formatting logic (defined when configuring the field).
+            'format_value' => true,
+        ]);
 
-      // NOTE: get_field() is defined by ACF itself. We’re simply delegating.
-      return get_field( $field_name, $post_id, $args['format_value'] );
+        // NOTE: get_field() is defined by ACF itself. We’re simply delegating.
+        return get_field($field_name, $post_id, $args['format_value']);
     }
 }
 ```
@@ -79,11 +85,11 @@ The hard part’s over. Now you need to tell Timber about your class:
 ```php
 use MyProject\MyAcfIntegration;
 
-add_filter( 'timber/integrations', function( array $classes ) : array {
+add_filter('timber/integrations', function (array $classes): array {
     $classes[] = MyAcfIntegration::class;
 
     return $classes;
-} );
+});
 ```
 
 Timber will call the method(s) you defined and initialize your integration if applicable.

--- a/docs/v2/guides/custom-page-templates.md
+++ b/docs/v2/guides/custom-page-templates.md
@@ -19,10 +19,10 @@ If you're using the [Timber Starter Theme](https://github.com/timber/starter-the
 In the **page.php** file you'll find this code:
 
 ```php
-Timber::render( array(
+Timber::render([
     'page-' . $post->post_name . '.twig',
-    'page.twig'
-), $context );
+    'page.twig',
+], $context);
 ```
 
 This is telling PHP to first look for a Twig file named **page-{{ slug }}.twig** and then fall back to **page.twig** if that doesn't exist. With the array notation, you can add as many fallbacks as you need.
@@ -40,7 +40,6 @@ and populate it with the necessary PHP. You can use the contents of the starter 
 Create a file with the following comment header:
 
 ```php
-<?php
 /**
  * Template Name: My Custom Page
  * Description: A Page Template with a darker design.

--- a/docs/v2/guides/date-time.md
+++ b/docs/v2/guides/date-time.md
@@ -88,7 +88,7 @@ $datetime = date_create_immutable_from_format(
 );
 
 // Note that we’re reassigning here, since PHP’s immutable functions/methods return new values.
-$datetime = $datetime->setTimezone( wp_timezone() );
+$datetime = $datetime->setTimezone(wp_timezone());
 
 $timestamp = $datetime->getTimestamp();
 ```
@@ -105,13 +105,13 @@ Here’s the same example explained with code:
 
 ```php
 // Current time is 00:30, timezone is UTC + 1
-$datetime = date_create_immutable_from_format( 'Y-m-d', '2016-10-31' );
+$datetime = date_create_immutable_from_format('Y-m-d', '2016-10-31');
 
 // 2016-10-31 23:30
-echo $datetime->format( 'Y-m-d H:i' );
+echo $datetime->format('Y-m-d H:i');
 
 // 2016-11-01 00:30
-echo wp_date( 'Y-m-d H:i', $datetime->getTimestamp() );
+echo wp_date('Y-m-d H:i', $datetime->getTimestamp());
 ```
 
 To work around that, **use `wp_timezone()`** when creating your datetime object.
@@ -127,10 +127,10 @@ $datetime = date_create_immutable_from_format(
 );
 
 // 2016-10-31 00:30
-echo $datetime->format( 'Y-m-d H:i' );
+echo $datetime->format('Y-m-d H:i');
 
 // 2016-10-31 00:30
-echo wp_date( 'Y-m-d H:i', $datetime->getTimestamp() );
+echo wp_date('Y-m-d H:i', $datetime->getTimestamp());
 ```
 
 #### strtotime()
@@ -138,18 +138,18 @@ echo wp_date( 'Y-m-d H:i', $datetime->getTimestamp() );
 If you don’t know the exact format of the date, you can try using `strtotime()` or `date_create_immutable()`. Valid formats are explained in [Supported Date and Time Formats](https://www.php.net/manual/en/datetime.formats.php).
 
 ```php
-$timestamp = strtotime( '2008-08-07 18:11:31' );
+$timestamp = strtotime('2008-08-07 18:11:31');
 
 // No timezone needed, because it’s already included in the string.
-$datetime = date_create_immutable( '2020-01-02T00:09:30+02:00' );
+$datetime = date_create_immutable('2020-01-02T00:09:30+02:00');
 
 // Either with or without a timezone, depending on how you saved your dates.
-$datetime = date_create_immutable( '2008-08-07 18:11:31', wp_timezone() );
-$datetime = date_create_immutable( '2008-08-07 18:11:31' );
+$datetime = date_create_immutable('2008-08-07 18:11:31', wp_timezone());
+$datetime = date_create_immutable('2008-08-07 18:11:31');
 
 // Either with or without a timezone, depending on how you saved your dates.
-$datetime = new DateTimeImmutable( '2008-08-07 18:11:31', wp_timezone() );
-$datetime = new DateTimeImmutable( '2008-08-07 18:11:31' );
+$datetime = new DateTimeImmutable('2008-08-07 18:11:31', wp_timezone());
+$datetime = new DateTimeImmutable('2008-08-07 18:11:31');
 ```
 
 ## Control the date display format
@@ -160,16 +160,16 @@ By default, Timber uses the date format set in *Settings* &rarr; *General*. That
 
 ```php
 // With a timestamp.
-wp_date( 'F j, Y @ g:i a', $timestamp );
+wp_date('F j, Y @ g:i a', $timestamp);
 
 // With a DateTime object.
-wp_date( 'F j, Y @ g:i a', $datetime->getTimestamp() );
+wp_date('F j, Y @ g:i a', $datetime->getTimestamp());
 ```
 
 If you want to display a date in a different timezone than the site’s timezone, use the `$timezone` parameter in [`wp_date()`](https://developer.wordpress.org/reference/functions/wp_date/).
 
 ```php
-wp_date( 'F j, Y @ g:i a', $timestamp, 'Australia/Sydney' );
+wp_date('F j, Y @ g:i a', $timestamp, 'Australia/Sydney');
 ```
 
 ### Post dates
@@ -227,12 +227,12 @@ Don’t use the `date()` function in PHP to get the current date in a custom for
 $timestamp = time();
 
 $datetime_object = current_datetime();
-$formatted_date  = $datetime_object->format( 'Ymd' );
+$formatted_date = $datetime_object->format('Ymd');
 
-$formatted_date = wp_date( 'Ymd' );
+$formatted_date = wp_date('Ymd');
 
 // Don’t do this.
-$today = date( 'Ymd' );
+$today = date('Ymd');
 ```
 
 In Twig, you’ll have more options with the `date()` function or the `now` keyword. Yes, while you shouldn’t use `date()` in PHP, you can use it in Twig.
@@ -256,7 +256,7 @@ In Timber, you can use the `Timber\DateTimeHelper::time_ago()` function. The fun
 **PHP**
 
 ```php
-DateTimeHelper::time_ago( $post->date() )
+DateTimeHelper::time_ago($post->date());
 ```
 
 **Twig**
@@ -280,11 +280,11 @@ When you want to compare dates, then compare Unix timestamps, `DateTimeInterface
 ```php
 $same = $timestamp === $timestamp;
 $same = new DateTimeImmutable() === new DateTimeImmutable();
-$same = wp_date( 'U' ) === time();
+$same = wp_date('U') === time();
 
 // Check if post publishing date is before today.
-$before_today = $post->date( 'Ymd' ) < wp_date( 'Ymd' );
-$before_today = $post->date( 'U' ) < current_datetime()->getTimestamp();
+$before_today = $post->date('Ymd') < wp_date('Ymd');
+$before_today = $post->date('U') < current_datetime()->getTimestamp();
 ```
 
 In Twig, there’s the [`date()`](https://twig.symfony.com/doc/functions/date.html) function which you can use to compare dates.

--- a/docs/v2/guides/debugging.md
+++ b/docs/v2/guides/debugging.md
@@ -10,12 +10,12 @@ To use debugging, the constant `WP_DEBUG` needs to be set to `true`.
 **wp-config.php**
 
 ```php
-define( 'WP_DEBUG', true );
+define('WP_DEBUG', true);
 ```
 
 ## Using Twig’s native functions
 
-Twig includes a `dump` function that can output the properties of an object. 
+Twig includes a `dump` function that can output the properties of an object.
 
 **Twig**
 
@@ -48,8 +48,15 @@ An easier solution is to use the [Timber Dump Extension](https://github.com/nlem
 It also works in PHP. Instead of using `var_dump` or `print_r`, you will use `dump()` as well:
 
 ```php
-dump( $post );
+dump($post);
 ```
+
+If you want to dump and stop code execution, you can "dump & die" using `dd`:
+```php
+dd($post);
+```
+
+You can also make use of the [VarDumper Configurator](https://github.com/nlemoine/var-dumper-configurator) which will enhance a bit further the output by creating links on classes, objects, etc. that will open the related file in your favorite IDE/editor.
 
 ## Commented Twig includes
 
@@ -80,9 +87,9 @@ Then, you need to reference the path to the cached files in ***Settings/Preferen
 Remember that you can set the location of the cache files through the `timber/cache/location` filter:
 
 ```php
-add_filter( 'timber/cache/location', function() {
+add_filter('timber/cache/location', function () {
     return '/absolute/path/to/your/cached/twig/files';
-} );
+});
 ```
 
 ### Twig breakpoints in other IDEs
@@ -100,15 +107,15 @@ And then add it to Timber’s Twig environment:
 **functions.php**
 
 ```php
-add_filter( 'timber/twig', function( \Twig\Environment $twig ) {
-    if ( defined( 'WP_DEBUG' ) && WP_DEBUG
-        && class_exists( 'Ajgl\Twig\Extension\BreakpointExtension' )
+add_filter('timber/twig', function (\Twig\Environment $twig) {
+    if (defined('WP_DEBUG') && WP_DEBUG
+        && class_exists('Ajgl\Twig\Extension\BreakpointExtension')
     ) {
-        $twig->addExtension( new Ajgl\Twig\Extension\BreakpointExtension() );
+        $twig->addExtension(new Ajgl\Twig\Extension\BreakpointExtension());
     }
 
     return $twig;
-} );
+});
 ```
 
 Finally, you can set a breakpoint anywhere in your Twig file:
@@ -125,5 +132,5 @@ The [**Timber Debugger**](https://github.com/djboris88/timber-debugger) package 
 
 ## Using Timber Debug Bar plugin
 
-There’s a [Timber add-on](http://wordpress.org/plugins/debug-bar-timber/) for the [WordPress debug bar](https://wordpress.org/plugins/debug-bar/).  
+There’s a [Timber add-on](http://wordpress.org/plugins/debug-bar-timber/) for the [WordPress debug bar](https://wordpress.org/plugins/debug-bar/).
 **Warning:** this currently requires PHP 5.4.

--- a/docs/v2/guides/escaping.md
+++ b/docs/v2/guides/escaping.md
@@ -14,11 +14,11 @@ If you want to enable Twig’s `autoescape` behavior, you can enable it with the
 **functions.php**
 
 ```php
-add_filter( 'timber/twig/environment/options', function( $options ) {
-	$options['autoescape'] = 'html';
+add_filter('timber/twig/environment/options', function ($options) {
+    $options['autoescape'] = 'html';
 
-	return $options;
-} );
+    return $options;
+});
 ```
 
 ## Why should I escape?

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -16,30 +16,30 @@ Let’s look at how we could add a method to **calculate the reading time for a 
 **src/BlogPost.php**
 
 ```php
-<?php
-
 /**
  * Class BlogPost
  */
-class BlogPost extends \Timber\Post {
-   /**
-    * Estimates time required to read a post.
-    *
-    * The words per minute are based on the English language, which e.g. is much
-    * faster than German or French.
-    *
-    * @link https://www.irisreading.com/average-reading-speed-in-various-languages/
-    *
-    * @return string
-    */
-    public function reading_time() {
+class BlogPost extends \Timber\Post
+{
+    /**
+     * Estimates time required to read a post.
+     *
+     * The words per minute are based on the English language, which e.g. is much
+     * faster than German or French.
+     *
+     * @link https://www.irisreading.com/average-reading-speed-in-various-languages/
+     *
+     * @return string
+     */
+    public function reading_time()
+    {
         $words_per_minute = 228;
 
-        $words   = str_word_count( wp_strip_all_tags( $this->content() ) );
-        $minutes = round( $words / $words_per_minute );
+        $words = str_word_count(wp_strip_all_tags($this->content()));
+        $minutes = round($words / $words_per_minute);
 
         /* translators: %s: Time duration in minute or minutes. */
-        return sprintf( _n( '%s minute', '%s minutes', $minutes ), (int) $minutes );
+        return sprintf(_n('%s minute', '%s minutes', $minutes), (int) $minutes);
     }
 }
 ```
@@ -53,15 +53,15 @@ To register your own classes with Timber, you use Class Maps. Refer to the [Clas
 **functions.php**
 
 ```php
-require_once( 'src/BlogPost.php' );
+require_once('src/BlogPost.php');
 
-add_filter( 'timber/post/classmap', function( $classmap ) {
+add_filter('timber/post/classmap', function ($classmap) {
     $custom_classmap = [
         'post' => BlogPost::class,
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 With that, Timber will use the `BlogPost` class for all your posts with the post type `post`, whenever you use a Timber function that returns a `Timber\Post`.
@@ -114,11 +114,10 @@ Then, you would use that namespace for your `BlogPost` class.
 **src/BlogPost.php**
 
 ```php
-<?php
-
 namespace Theme;
 
-class BlogPost {
+class BlogPost
+{
     // ...
 }
 ```
@@ -128,13 +127,13 @@ And in your Class Map, you could reference that class with the `use` statement.
 ```php
 use Theme\BlogPost;
 
-add_filter( 'timber/post/classmap', function( $classmap ) {
+add_filter('timber/post/classmap', function ($classmap) {
     $custom_classmap = [
         'post' => BlogPost::class,
     ];
 
-    return array_merge( $classmap, $custom_classmap );
-} );
+    return array_merge($classmap, $custom_classmap);
+});
 ```
 
 ## Move your logic from your template files to your classes
@@ -142,55 +141,55 @@ add_filter( 'timber/post/classmap', function( $classmap ) {
 In the Getting Started Guide for [Archive Pages](/docs/v2/getting-started/a-post-archive/), we looked at how you can load related posts and add them to the context.
 
 ```php
-<?php
-
 $context = Timber::context();
 
 $post = $context['post'];
 
-$context['related_posts'] = Timber::get_posts( [
-	'post_type'      => 'post',
+$context['related_posts'] = Timber::get_posts([
+    'post_type' => 'post',
     'posts_per_page' => 3,
-    'orderby'        => 'date',
-    'order'          => 'DESC',
-    'post__not_in'   => [ $post->ID ],
-    'category__in'   => $post->terms( [
+    'orderby' => 'date',
+    'order' => 'DESC',
+    'post__not_in' => [$post->ID],
+    'category__in' => $post->terms([
         'taxonomy' => 'category',
-        'fields'   => 'ids',
-    ] ),
-] );
+        'fields' => 'ids',
+    ]),
+]);
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 We can move this function over to the `BlogPost` class. The only difference is that instead of using `$post`, you would use `$this` to reference properties and methods.
 
 ```php
-<?php
-
-class MySitePost extends \Timber\Post {
+class MySitePost extends \Timber\Post
+{
+}
 
 /**
  * Class BlogPost
  */
-class BlogPost extends \Timber\Post {
+class BlogPost extends \Timber\Post
+{
     /**
      * Gets related posts for that post object.
      *
      * @return \Timber\PostQuery
      */
-    public function related_posts() {
-        return Timber::get_posts( [
-            'post_type'      => $this->post_type,
+    public function related_posts()
+    {
+        return Timber::get_posts([
+            'post_type' => $this->post_type,
             'posts_per_page' => 3,
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-            'post__not_in'   => [ $this->ID ],
-            'category__in'   => $this->terms( [
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'post__not_in' => [$this->ID],
+            'category__in' => $this->terms([
                 'taxonomy' => 'category',
-                'fields'   => 'ids',
-            ] ),
-        ] );
+                'fields' => 'ids',
+            ]),
+        ]);
     }
 }
 ```
@@ -212,12 +211,11 @@ Now, you can still loop over your related posts in your Twig template:
 However, because of the if-statement, we call the `related_posts()` method twice. This might be bad for performance, because we call `Timber::get_posts()` twice. So let’s add a small cache via a `related_posts` property. This way, we can call `related_posts()` as many times as we need.
 
 ```php
-<?php
-
 /**
  * Class BlogPost
  */
-class BlogPost extends \Timber\Post {
+class BlogPost extends \Timber\Post
+{
     /**
      * Related posts cache.
      *
@@ -230,23 +228,24 @@ class BlogPost extends \Timber\Post {
      *
      * @return \Timber\PostCollectionInterface
      */
-    public function related_posts() {
+    public function related_posts()
+    {
         // Return related posts early if we already loaded them.
-        if ( ! empty( $this->related_posts ) ) {
+        if (!empty($this->related_posts)) {
             return $this->related_posts;
         }
 
-        $this->related_posts = Timber::get_posts( [
-            'post_type'      => $this->post_type,
+        $this->related_posts = Timber::get_posts([
+            'post_type' => $this->post_type,
             'posts_per_page' => 3,
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-            'post__not_in'   => [ $this->ID ],
-            'category__in'   => $this->terms( [
+            'orderby' => 'date',
+            'order' => 'DESC',
+            'post__not_in' => [$this->ID],
+            'category__in' => $this->terms([
                 'taxonomy' => 'category',
-                'fields'   => 'ids',
-            ] ),
-        ] );
+                'fields' => 'ids',
+            ]),
+        ]);
 
         return $this->related_posts;
     }
@@ -269,11 +268,12 @@ Let’s look at an example where you work with a post’s relationship to other 
 Of course, `Timber\Post` has no built-in concept of an issue. Imagine there’s a custom taxonomy called `issue`. So we're going to extend `Timber\Post` to give it an `issue()` method.
 
 ```php
-<?php
+class MySitePost extends \Timber\Post
+{
+}
 
-class MySitePost extends \Timber\Post {
-
-class MagazinePost extends \Timber\Post {
+class MagazinePost extends \Timber\Post
+{
     /**
      * Issue cache.
      *
@@ -286,16 +286,17 @@ class MagazinePost extends \Timber\Post {
      *
      * @return \Timber\Term|null;
      */
-    public function issue() {
-        if ( ! empty( $this->_issue ) ) {
+    public function issue()
+    {
+        if (!empty($this->_issue)) {
             return $this->issue;
         }
 
-        $issues = $this->terms( [
-            'taxonomy' => 'issues'
-        ] );
+        $issues = $this->terms([
+            'taxonomy' => 'issues',
+        ]);
 
-        if ( is_array( $issues ) && ! empty( $issues ) ) {
+        if (is_array($issues) && !empty($issues)) {
             $this->issue = $issues[0];
         }
 
@@ -326,20 +327,22 @@ But you could also define your own `date_display` method to display that date.
 /**
  * Class Event
  */
-class Event extends \Timber\Post {
+class Event extends \Timber\Post
+{
     /**
      * Gets display date.
      *
      * @return string
      */
-    public function date_display( $date_format = 'F j Y' ) {
-        $date_start = DateTimeImmutable::createFromFormat( 'Ymd', $this->meta( 'date_start' ) );
+    public function date_display($date_format = 'F j Y')
+    {
+        $date_start = DateTimeImmutable::createFromFormat('Ymd', $this->meta('date_start'));
 
-        if ( empty( $date_start ) ) {
+        if (empty($date_start)) {
             return '';
         }
 
-        return wp_date( $date_format, $date_start->getTimestamp() );
+        return wp_date($date_format, $date_start->getTimestamp());
     }
 }
 ```
@@ -369,7 +372,8 @@ You can also make the date formats a little more dynamic here by using an argume
 /**
  * Class Event
  */
-class Event extends \Timber\Post {
+class Event extends \Timber\Post
+{
     /**
      * Gets display date.
      *
@@ -377,43 +381,44 @@ class Event extends \Timber\Post {
      *
      * @return string
      */
-    public function date_display( $formats = [] ) {
-        $formats = wp_parse_args( $formats, [
-            'single'           => 'F j Y',
-            'yearless'         => 'F j',
+    public function date_display($formats = [])
+    {
+        $formats = wp_parse_args($formats, [
+            'single' => 'F j Y',
+            'yearless' => 'F j',
             'same_month_start' => 'j',
-            'same_month_end'   => 'j F Y'
-        ] );
+            'same_month_end' => 'j F Y',
+        ]);
 
         $date_start = DateTimeImmutable::createFromFormat(
             'Ymd',
-            $this->meta( 'date_start' )
+            $this->meta('date_start')
         );
         $date_end = DateTimeImmutable::createFromFormat(
             'Ymd',
-            $this->meta( 'date_end' )
+            $this->meta('date_end')
         );
 
-        if ( empty( $date_start ) ) {
+        if (empty($date_start)) {
             return '';
         }
 
-        if ( empty( $date_end ) ) {
+        if (empty($date_end)) {
             // There’s only a start date.
-            $date_string = wp_date( $formats['single'], $date_start->getTimestamp() );
+            $date_string = wp_date($formats['single'], $date_start->getTimestamp());
         } else {
             // Different format if month is the same.
-            if ( $date_start->format( 'm' ) === $date_end->format( 'm' ) ) {
+            if ($date_start->format('m') === $date_end->format('m')) {
                 $date_string = sprintf(
                     '%1$s &ndash %2$s',
-                    wp_date( $formats['same_month_start'], $date_start->getTimestamp() ),
-                    wp_date( $formats['same_month_end'], $date_end->getTimestamp() )
+                    wp_date($formats['same_month_start'], $date_start->getTimestamp()),
+                    wp_date($formats['same_month_end'], $date_end->getTimestamp())
                 );
             } else {
                 $date_string = sprintf(
                     '%1$s &ndash %2$s',
-                    wp_date( $formats['yearless'], $date_start->getTimestamp() ),
-                    wp_date( $formats['single'], $date_end->getTimestamp() )
+                    wp_date($formats['yearless'], $date_start->getTimestamp()),
+                    wp_date($formats['single'], $date_end->getTimestamp())
                 );
             }
         }
@@ -438,37 +443,37 @@ In Twig, you could use it like this:
 You could make it even more dynamic and use the default date format you set in your WordPress settings.
 
 ```php
-$formats = wp_parse_args( $formats, [
-    'single'           => get_option( 'date_format' ),
-    'yearless'         => trim(
-        preg_replace( '/[Yy]/', '', get_option( 'date_format' ) )
+$formats = wp_parse_args($formats, [
+    'single' => get_option('date_format'),
+    'yearless' => trim(
+        preg_replace('/[Yy]/', '', get_option('date_format'))
     ),
     'same_month_start' => 'j',
-    'same_month_end'   => 'j F Y'
-] );
+    'same_month_end' => 'j F Y',
+]);
 ```
 
 Or you could add a filter to update your date formats globally.
 
 ```php
-$formats = wp_parse_args( $formats, [
-    'single'           => 'F j Y',
-    'yearless'         => 'F j',
+$formats = wp_parse_args($formats, [
+    'single' => 'F j Y',
+    'yearless' => 'F j',
     'same_month_start' => 'j',
-    'same_month_end'   => 'j F Y'
-] );
+    'same_month_end' => 'j F Y',
+]);
 
-$formats = apply_filters( 'theme/event/date_formats', $formats );
+$formats = apply_filters('theme/event/date_formats', $formats);
 ```
 
 You would use that filter like this.
 
 ```php
-add_filter( 'theme/event/date_formats', function( $formats ) {
+add_filter('theme/event/date_formats', function ($formats) {
     $formats['same_month_end'] = 'j M Y';
 
     return $formats;
-} );
+});
 ```
 
 And with this, we have a method or even a class that we can reuse in other projects.
@@ -499,7 +504,8 @@ But you could also reduce the logic you have in Twig an move it your custom clas
 /**
  * Class Event
  */
-class Event extends \Timber\Post {
+class Event extends \Timber\Post
+{
     /**
      * Sponsors cache.
      *
@@ -512,12 +518,13 @@ class Event extends \Timber\Post {
      *
      * @return \Timber\PostCollectionInterface
      */
-    public function sponsors() {
-        if ( empty( $this->sponsors ) ) {
+    public function sponsors()
+    {
+        if (empty($this->sponsors)) {
             return $this->sponsors;
         }
 
-        $this->sponsors = Timber::get_posts( $this->meta( 'sponsors' ) )
+        $this->sponsors = Timber::get_posts($this->meta('sponsors'));
 
         return $this->sponsors;
     }

--- a/docs/v2/guides/extending-twig.md
+++ b/docs/v2/guides/extending-twig.md
@@ -16,13 +16,13 @@ By default, you’ll have to use `{{ fn('function_name') }}` to call a function 
 **functions.php**
 
 ```php
-add_filter( 'timber/twig/functions', function( $functions ) {
+add_filter('timber/twig/functions', function ($functions) {
     $functions['edit_post_link'] = [
         'callable' => 'edit_post_link',
     ];
 
     return $functions;
-} );
+});
 ```
 
 The `$functions` variable is an array of functions that Timber already adds by default.
@@ -50,11 +50,11 @@ Timber already comes with a list of functions it adds by default. If you want to
 **functions.php**
 
 ```php
-add_filter( 'timber/twig/functions', function( $functions ) {
-    var_dump( $functions );
+add_filter('timber/twig/functions', function ($functions) {
+    var_dump($functions);
 
     return $functions;
-} );
+});
 ```
 
 ### Changing functions
@@ -62,17 +62,17 @@ add_filter( 'timber/twig/functions', function( $functions ) {
 You can replace a function with your own function or even remove a function by updating the array items in `$functions`.
 
 ```php
-add_filter( 'timber/twig/filters', function( $functions ) {
+add_filter('timber/twig/filters', function ($functions) {
     // Replace a function.
     $functions['get_image'] = [
         'callable' => 'custom_get_image',
     ];
 
     // Remove a function.
-    unset( $filters['get_image'] );
+    unset($filters['get_image']);
 
     return $filters;
-} );
+});
 ```
 
 ### function_wrapper
@@ -88,7 +88,7 @@ Here’s an example where we add our own `|price` filter. We pass the name of th
 **functions.php**
 
 ```php
-add_filter( 'timber/twig/filters', function( $filters ) {
+add_filter('timber/twig/filters', function ($filters) {
     // Add your own filters.
     $filters['price'] = [
         'callable' => 'format_price',
@@ -99,7 +99,7 @@ add_filter( 'timber/twig/filters', function( $filters ) {
     ];
 
     return $filters;
-} );
+});
 ```
 
 In Twig, we can then use it like this:
@@ -115,11 +115,11 @@ In Twig, we can then use it like this:
 You could use the same filter to dump a list of all available filters for debugging:
 
 ```php
-add_filter( 'timber/twig/filters', function( $filters ) {
-    var_dump( $filters );
+add_filter('timber/twig/filters', function ($filters) {
+    var_dump($filters);
 
     return $filters;
-} );
+});
 ```
 
 ### Changing filters
@@ -127,17 +127,17 @@ add_filter( 'timber/twig/filters', function( $filters ) {
 You can replace a filter with your own function or even remove a filter by updating the array items in `$filters`.
 
 ```php
-add_filter( 'timber/twig/filters', function( $filters ) {
+add_filter('timber/twig/filters', function ($filters) {
     // Replace a filter.
     $filters['list'] = [
         'callable' => 'custom_list_filter',
     ];
 
     // Remove a filter.
-    unset( $filters['list'] );
+    unset($filters['list']);
 
     return $filters;
-} );
+});
 ```
 
 ## Adding functionality with the Twig Environment filter

--- a/docs/v2/guides/functions.md
+++ b/docs/v2/guides/functions.md
@@ -62,5 +62,5 @@ The concept of Timber (and templating engines like Twig in general) is to prepar
 - If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) you can use `FunctionWrapper`:
 
 ```php
-$context['my_custom_function'] = new FunctionWrapper( 'my_custom_function', $array_of_arguments );
+$context['my_custom_function'] = new FunctionWrapper('my_custom_function', $array_of_arguments);
 ```

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -20,24 +20,25 @@ Before you can start using ACF Blocks, you must install the Advanced Custom Fiel
 To create a content block, you first have to register it in **functions.php** or in a separate plugin:
 
 ```php
-add_action( 'acf/init', 'my_acf_init' );
+add_action('acf/init', 'my_acf_init');
 
-function my_acf_init() {
+function my_acf_init()
+{
     // Bail out if function doesn’t exist.
-    if ( ! function_exists( 'acf_register_block' ) ) {
+    if (!function_exists('acf_register_block')) {
         return;
     }
 
     // Register a new block.
-    acf_register_block( array(
-        'name'            => 'example_block',
-        'title'           => __( 'Example Block', 'your-text-domain' ),
-        'description'     => __( 'A custom example block.', 'your-text-domain' ),
+    acf_register_block([
+        'name' => 'example_block',
+        'title' => __('Example Block', 'your-text-domain'),
+        'description' => __('A custom example block.', 'your-text-domain'),
         'render_callback' => 'my_acf_block_render_callback',
-        'category'        => 'formatting',
-        'icon'            => 'admin-comments',
-        'keywords'        => array( 'example' ),
-    ) );
+        'category' => 'formatting',
+        'icon' => 'admin-comments',
+        'keywords' => ['example'],
+    ]);
 }
 ```
 
@@ -51,18 +52,19 @@ Next, you you have to create your `render_callback()` function:
  * @param   string $content    The block content (emtpy string).
  * @param   bool   $is_preview True during AJAX preview.
  */
-function my_acf_block_render_callback( $block, $content = '', $is_preview = false ) {
-    $context = Timber::context( [
+function my_acf_block_render_callback($block, $content = '', $is_preview = false)
+{
+    $context = Timber::context([
         // Store block values.
-        'block'      => $block,
+        'block' => $block,
         // Store field values.
-        'fields'     => get_fields(),
+        'fields' => get_fields(),
         // Store $is_preview value.
         'is_preview' => $is_preview,
-    ] );
+    ]);
 
     // Render the block.
-    Timber::render( 'block/example-block.twig', $context );
+    Timber::render('block/example-block.twig', $context);
 }
 ```
 
@@ -101,14 +103,15 @@ Finally, you can create the template **block/example-block.twig**:
 If you would like to use an external stylesheet both inside of the block editor and the frontend you should add:
 
 ```php
-function my_acf_block_editor_style() {
+function my_acf_block_editor_style()
+{
     wp_enqueue_style(
         'example_block_css',
         get_template_directory_uri() . '/assets/example-block.css'
     );
 }
 
-add_action( 'enqueue_block_assets', 'my_acf_block_editor_style' );
+add_action('enqueue_block_assets', 'my_acf_block_editor_style');
 ```
 
 For more details about enqueueing assets read the [Block Editor Handbook](https://developer.wordpress.org/block-editor/tutorials/block-tutorial/applying-styles-with-stylesheets/#enqueueing-editor-only-block-assets).

--- a/docs/v2/guides/hosts-servers.md
+++ b/docs/v2/guides/hosts-servers.md
@@ -12,20 +12,20 @@ Automattic offers a paid service called [WordPress VIP](https://wpvip.com/) for 
 **functions.php**
 
 ```php
-add_filter('timber/cache/mode', function() {
-	return 'none';
+add_filter('timber/cache/mode', function () {
+    return 'none';
 });
 ```
 
 ```php
-add_filter( 'timber/allow_fs_write', '__return_false' );
+add_filter('timber/allow_fs_write', '__return_false');
 ```
 
 This means you will not be able to use on-the-fly image resizing through Timber. Don't despair! You can set custom image sizes for WordPress to use:
 
 **functions.php**
 ```php
-add_image_size( 'my_custom_size', 220, 220, array( 'left', 'top' ) );
+add_image_size('my_custom_size', 220, 220, ['left', 'top']);
 ```
 
 **single.twig**

--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -12,25 +12,25 @@ To get a menu object in Timber, you use `Timber::get_menu()`. This function is s
 You can pass the **slug of the menu** you want to use:
 
 ```php
-$menu = Timber::get_menu( 'primary-navigation' );
+$menu = Timber::get_menu('primary-navigation');
 ```
 
 Or the **ID** number of the menu:
 
 ```php
-$menu = Timber::get_menu( 3 );
+$menu = Timber::get_menu(3);
 ```
 
 Or the proper **name** from the admin:
 
 ```php
-$menu = Timber::get_menu( 'Primary Navigation' );
+$menu = Timber::get_menu('Primary Navigation');
 ```
 
 Or the **slug of the registered location**:
 
 ```php
-$menu = Timber::get_menu( 'primary' );
+$menu = Timber::get_menu('primary');
 ```
 
 What you get in return is a [`Timber\Menu`](https://timber.github.io/docs/reference/timber-menu/) object that holds a collection of [`Timber\MenuItem`](https://timber.github.io/docs/reference/timber-menuitem/) objects. If no menu can be found with the argument you provided, the function will return `null`.
@@ -42,9 +42,9 @@ In earlier versions of Timber, it was possible to pass in nothing. We’ve remov
 Optionally, you can send additional options to `Timber::get_menu()` in the second parameter.
 
 ```php
-$menu = Timber::get_menu( 'primary', [
+$menu = Timber::get_menu('primary', [
     'depth' => 2,
-] );
+]);
 ```
 
 Currently, only `depth` is supported (see [`wp_nav_menu()`](https://developer.wordpress.org/reference/functions/wp_nav_menu/) for reference).
@@ -59,13 +59,13 @@ Be aware that you first need to register your menu locations with [`register_nav
 /**
  * Register Menus
  */
-add_action( 'after_setup_theme', function() {
-    register_nav_menus( [
-        'primary'   => 'Primary Menu',
+add_action('after_setup_theme', function () {
+    register_nav_menus([
+        'primary' => 'Primary Menu',
         'secondary' => 'Secondary Menu',
-        'footer'    => 'Footer Menu',
-    ] );
-} );
+        'footer' => 'Footer Menu',
+    ]);
+});
 ```
 
 ## Extending menus
@@ -73,21 +73,21 @@ add_action( 'after_setup_theme', function() {
 If you need additional functionality that the `Timber\Menu` and `Timber\MenuItem` classes don’t provide or if you want to have cleaner Twig templates, you can extend the `Timber\Menu` or `Timber\MenuItem` class with your own classes:
 
 ```php
-class MenuPrimary extends \Timber\Menu {
-
+class MenuPrimary extends \Timber\Menu
+{
 }
 ```
 
 ```php
-class MenuItemPrimary extends \Timber\MenuItem {
-
+class MenuItemPrimary extends \Timber\MenuItem
+{
 }
 ```
 
 To initiate your new `MenuPrimary` menu that will hold `MenuItemPrimary` objects, you also use `Timber::get_menu()`.
 
 ```php
-$menu = Timber::get_menu( 'primary' );
+$menu = Timber::get_menu('primary');
 ```
 
 In the same way that you [can’t instantiate post objects directly](https://timber.github.io/docs/guides/posts/#extending-timber-post), you **can’t** instantiate `Timber\Menu` or `Timber\MenuItem` objects or an object that extends this class with a constructor. Timber will use the [Menu Class Map](https://timber.github.io/docs/guides/class-maps/#the-menu-class-map) and the [MenuItem Class Map](https://timber.github.io/docs/guides/class-maps/#the-menuitem-class-map) to sort out which class it should use.
@@ -106,8 +106,8 @@ If you want to extend a pages menu, you would do it like this:
 
 
 ```php
-class ExtendedPagesMenu extends \Timber\PagesMenu {
-
+class ExtendedPagesMenu extends \Timber\PagesMenu
+{
 }
 ```
 
@@ -120,19 +120,20 @@ Most of the time, you need the menu on every page. To achieve that, you can add 
 **functions.php**
 
 ```php
-add_filter( 'timber/context', 'add_to_context' );
+add_filter('timber/context', 'add_to_context');
 
 /**
  * Global Timber context.
  *
  * @param array $context Global context variables.
  */
-function add_to_context( $context ) {
+function add_to_context($context)
+{
     // So here you are adding data to Timber's context object, i.e...
     $context['foo'] = 'I am some other typical value set in your functions.php file, unrelated to the menu';
 
     // Now, in similar fashion, you add a Timber Menu and send it along to the context.
-    $context['menu'] = Timber::get_menu( 'primary' );
+    $context['menu'] = Timber::get_menu('primary');
 
     return $context;
 }
@@ -143,11 +144,9 @@ Now, when you call `Timber::context()`, your menu will already be set in the con
 **index.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-Timber::render( 'index.twig', $context );
+Timber::render('index.twig', $context);
 ```
 
 ### Set up all menus globally
@@ -157,24 +156,25 @@ Here’s a small snippet that you can use to automatically set up all your regis
 **functions.php**
 
 ```php
-add_filter( 'timber/context', 'add_to_context' );
+add_filter('timber/context', 'add_to_context');
 
 /**
  * Global Timber context.
  *
  * @param array $context Global context variables.
  */
-function add_to_context( $context ) {
+function add_to_context($context)
+{
     // Set all nav menus in context.
-    foreach ( array_keys( get_registered_nav_menus() ) as $location ) {
+    foreach (array_keys(get_registered_nav_menus()) as $location) {
         // Bail out if menu has no location.
-        if ( ! has_nav_menu( $location ) ) {
+        if (!has_nav_menu($location)) {
             continue;
         }
 
-        $menu = Timber::get_menu( $location );
+        $menu = Timber::get_menu($location);
 
-        $context[ $location ] = $menu;
+        $context[$location] = $menu;
     }
 
     return $context;

--- a/docs/v2/guides/pagination.md
+++ b/docs/v2/guides/pagination.md
@@ -23,11 +23,9 @@ The pagination for archive pages applies to template files with an active query 
 **archive.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-Timber::render( 'archive.twig', $context );
+Timber::render('archive.twig', $context);
 ```
 
 Because we’re on an archive page, Timber already prepared a `posts` variable in the context for us. You could then markup the output like so:
@@ -74,23 +72,21 @@ If you want to overwrite the default query, you can do that by overwriting `post
 **archive-event.php**
 
 ```php
-<?php
-
 global $paged;
 
-if ( ! isset( $paged ) || ! $paged ) {
+if (!isset($paged) || !$paged) {
     $paged = 1;
 }
 
-$context = Timber::context( [
-    'posts' => Timber::get_posts( [
-        'post_type'      => 'event',
+$context = Timber::context([
+    'posts' => Timber::get_posts([
+        'post_type' => 'event',
         'posts_per_page' => 5,
-        'paged'          => $paged
-    ] ),
-] );
+        'paged' => $paged,
+    ]),
+]);
 
-Timber::render( 'archive-event.twig', $context );
+Timber::render('archive-event.twig', $context);
 ```
 
 ### Pagination with `pre_get_posts`
@@ -98,23 +94,22 @@ Timber::render( 'archive-event.twig', $context );
 Custom `query_posts` sometimes shows 404 on example.com/page/2. In that case you can also use `pre_get_posts` in your **functions.php** file:
 
 ```php
-function my_home_query( $query ) {
-    if ( $query->is_main_query() && ! is_admin() ) {
-        $query->set( 'post_type', [ 'movie', 'post' ] );
+function my_home_query($query)
+{
+    if ($query->is_main_query() && !is_admin()) {
+        $query->set('post_type', ['movie', 'post']);
     }
 }
 
-add_action( 'pre_get_posts', 'my_home_query' );
+add_action('pre_get_posts', 'my_home_query');
 ```
 
 Your **archive.php** or **home.php** template wouldn’t change:
 
 ```php
-<?php
-
 $context = Timber::context();
 
-Timber::render( 'archive.twig', $context );
+Timber::render('archive.twig', $context);
 ```
 
 ## Adjacent post pagination for singular templates

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -18,11 +18,9 @@ You can still use plugins like [W3 Total Cache](https://wordpress.org/plugins/w3
 When rendering, use the `$expires` argument in [`Timber::render`](https://timber.github.io/docs/v2/reference/timber/#render). For example:
 
 ```php
-<?php
-
 $context['posts'] = Timber::get_posts();
 
-Timber::render( 'index.twig', $context, 600 );
+Timber::render('index.twig', $context, 600);
 ```
 
 In this example, Timber will cache the template for 10 minutes (600 / 60 = 10). But here’s the cool part: Timber hashes the fields in the view context. This means that **as soon as the data changes, the cache is automatically invalidated**. Yay!
@@ -34,7 +32,7 @@ This method is very effective, but crude - the whole template is cached. So if y
 As a fourth parameter for [Timber::render()](https://timber.github.io/docs/v2/reference/timber/#render), you can set the `$cache_mode`.
 
 ```php
-Timber::render( $filenames, $data, $expires, $cache_mode );
+Timber::render($filenames, $data, $expires, $cache_mode);
 ```
 
 The following cache modes are available:
@@ -66,20 +64,22 @@ use Twig\Extra\Cache\CacheExtension;
 use Twig\Extra\Cache\CacheRuntime;
 use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
-class RunTimeLoader implements RuntimeLoaderInterface {
-    public function load( $class ) {
-        if ( CacheRuntime::class === $class ) {
-            return new CacheRuntime( new TagAwareAdapter( new FilesystemAdapter() ) );
+class RunTimeLoader implements RuntimeLoaderInterface
+{
+    public function load($class)
+    {
+        if (CacheRuntime::class === $class) {
+            return new CacheRuntime(new TagAwareAdapter(new FilesystemAdapter()));
         }
     }
 }
 
-add_filter( 'timber/twig', function( $twig ) {
-    $twig->addExtension( new CacheExtension() );
-    $twig->addRuntimeLoader( new RunTimeLoader() );
+add_filter('timber/twig', function ($twig) {
+    $twig->addExtension(new CacheExtension());
+    $twig->addRuntimeLoader(new RunTimeLoader());
 
     return $twig;
-} );
+});
 ```
 
 You can then use it like this:
@@ -98,7 +98,7 @@ If you want to use something meaningful for the cache key, you can also generate
 
 ```php
 $generator = new Timber\Cache\KeyGenerator();
-$key       = $generator->generateKey( $posts );
+$key = $generator->generateKey($posts);
 ```
 
 ### Extra: TimberKeyGeneratorInterface
@@ -115,11 +115,11 @@ Every time you render a `.twig` file, Twig compiles all the HTML tags and variab
 **functions.php**
 
 ```php
-add_filter( 'timber/twig/environment/options', function( $options ) {
+add_filter('timber/twig/environment/options', function ($options) {
     $options['cache'] = true;
 
     return $options;
-} );
+});
 ```
 
 You can look in your your `/vendor/timber/timber/cache` directory to see what these files look like.
@@ -127,11 +127,11 @@ You can look in your your `/vendor/timber/timber/cache` directory to see what th
 If you want to change the path where Timber caches the Twig files, you can pass in an absolute path for the `cache` option:
 
 ```php
-add_filter( 'timber/twig/environment/options', function( $options ) {
+add_filter('timber/twig/environment/options', function ($options) {
     $options['cache'] = '/absolute/path/to/twig_cache';
 
     return $options;
-} );
+});
 ```
 
 This does not cache the _contents_ of the variables. But rather, the structure of the Twig files themselves (i.e. the HTML and where those variables appear in your template). Once enabled, any change you make to a `.twig` file (just tweaking the HTML for example) will not go live until the cache is flushed.
@@ -139,8 +139,8 @@ This does not cache the _contents_ of the variables. But rather, the structure o
 Thus, during development, you should enable the option for `auto_reload`:
 
 ```php
-add_filter( 'timber/twig/environment/options', function( $options ) {
-    $options['cache']       = true;
+add_filter('timber/twig/environment/options', function ($options) {
+    $options['cache'] = true;
     $options['auto_reload'] = true;
 
     return $options;
@@ -167,29 +167,27 @@ You can also use some [syntactic sugar](http://en.wikipedia.org/wiki/Syntactic_s
 **home.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-$context['main_stories'] = TimberHelper::transient( 'main_stories', function(){
+$context['main_stories'] = TimberHelper::transient('main_stories', function () {
     $posts = Timber::get_posts();
 
     // As an example, do something expensive with these posts
-    $extra_teases = get_field( 'my_extra_teases', 'options' );
+    $extra_teases = get_field('my_extra_teases', 'options');
 
-    foreach( $extra_teases as &$tease ){
-        $tease = Timber::get_post( $tease );
+    foreach ($extra_teases as &$tease) {
+        $tease = Timber::get_post($tease);
     }
 
     $main_stories = [
-        'posts'        => $posts,
+        'posts' => $posts,
         'extra_teases' => $extra_teases,
     ];
 
     return $main_stories;
-}, 600 );
+}, 600);
 
-Timber::render( 'home.twig', $context );
+Timber::render('home.twig', $context);
 ```
 
 Here `main_stories` is a totally made-up variable. It could be called `foo`, `bar`, `elephant`, etc.
@@ -203,17 +201,15 @@ Timber provides some quick shortcuts to measure page timing. Here’s an example
 **single.php**
 
 ```php
-<?php
-
 // This generates a starting time
 $start = Timber\Helper::start_timer();
 
-$context = Timber::context( [
+$context = Timber::context([
     'whatever' => get_my_foo(),
-] );
+]);
 
-Timber::render( 'single.twig', $context, 600 );
+Timber::render('single.twig', $context, 600);
 
 // This reports the time diff by passing the $start time
-echo Timber\Helper::stop_timer( $start);
+echo Timber\Helper::stop_timer($start);
 ```

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -6,7 +6,7 @@ order: "110"
 To get a post object in Timber, you use `Timber::get_post()` and pass the WordPress post ID as an argument.
 
 ```php
-$post = Timber::get_post( $post_id );
+$post = Timber::get_post($post_id);
 ```
 
 This function is similar to [`get_post()`](https://developer.wordpress.org/reference/functions/get_post/) and accepts one argument: a post ID. If you don’t pass in any argument, Timber will use `get_queried_object()` to try and work with the currently queried post.
@@ -15,8 +15,7 @@ This function is similar to [`get_post()`](https://developer.wordpress.org/refer
 $post = Timber::get_post();
 
 // Is the same as…
-
-$post = Timber::get_post( get_queried_object_id() );
+$post = Timber::get_post(get_queried_object_id());
 ```
 
 What you get in return is a [`Timber\Post`](https://timber.github.io/docs/v2/reference/timber-post/) object, which is similar to `WP_Post`. This object provides you with functions and properties for pretty much everything you need for developing theme templates.
@@ -65,9 +64,9 @@ It also works if you have an array of post IDs that you want to convert to `Timb
 If no valid post can be found with the post ID you provided, the `Timber::get_post()` function will return `null`. With this, you can always check for valid posts with a simple if statement.
 
 ```php
-$post = Timber::get_post( $post_id );
+$post = Timber::get_post($post_id);
 
-if ( $post ) {
+if ($post) {
     // Handle post.
 }
 ```
@@ -85,15 +84,15 @@ Or in Twig:
 If you need additional functionality that the `Timber\Post` class doesn’t provide or if you want to have cleaner Twig templates, you can [extend the `Timber\Post` class](/docs/v2/guides/extending-timber/) with your own classes:
 
 ```php
-class Book extends Timber\Post {
-
+class Book extends Timber\Post
+{
 }
 ```
 
 To initiate your new `Book` post, you also use `Timber::get_post()`.
 
 ```php
-$book = Timber::get_post( $post_id );
+$book = Timber::get_post($post_id);
 ```
 
 You **can’t** instantiate a `Timber\Post` object or an object that extends this class with a constructor – you can’t use `$post = new Book( $post_id )`. In Timber, we’ve chosen to go a different way to prevent a lot of problems that would come with direct instantiation.
@@ -105,7 +104,7 @@ So, how does Timber know about your `Book` class? Timber will use the [Post Clas
 If you want to get a collection of posts, you can use `Timber::get_posts()`.
 
 ```php
-$posts = Timber::get_posts( $query );
+$posts = Timber::get_posts($query);
 ```
 
 You can use this function similarly to how you use [`WP_Query`](https://developer.wordpress.org/reference/classes/wp_query/). If you don’t pass in any argument, Timber will use the global query.
@@ -115,16 +114,16 @@ You can use this function similarly to how you use [`WP_Query`](https://develope
 $posts = Timber::get_posts();
 
 // Using the WP_Query argument format.
-$posts = Timber::get_posts( [
-    'post_type'     => 'article',
+$posts = Timber::get_posts([
+    'post_type' => 'article',
     'category_name' => 'sports',
-] );
+]);
 ```
 
 The `Timber::get_posts()` function accepts a second parameter with options for the query. For example, with the `merge_default` option you can tell Timber that it should merge your query parameters with the default query parameters of the current template. You can check out `merge_default` and all the other options in the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/v2/reference/timber/#get-posts).
 
 ```php
-$posts = Timber::get_posts( $query, $options );
+$posts = Timber::get_posts($query, $options);
 ```
 
 ### The default query
@@ -142,9 +141,9 @@ The analogous `Timber` methods for getting Users, Terms, and Comments (`Timber::
 What you get as a **return value** when running `Timber::get_posts()` is not a pure array of posts, but an instance of `Timber\PostCollectionInterface`, an [`ArrayObject`](https://www.php.net/manual/en/class.arrayobject.php) that is very similar to an array as you know it. That means you can still loop over a `PostCollectionInterface` directly:
 
 ```php
-$posts = Timber::get_posts( /* optional args */ );
+$posts = Timber::get_posts( /* optional args */);
 
-foreach ( $posts as $post ) {
+foreach ($posts as $post) {
     echo $post->title();
 }
 ```
@@ -166,9 +165,9 @@ In Twig, you can also loop over the collection.
 What **doesn’t work** with objects that implement `Timber\PostCollectionInterface` are PHP’s [Array functions](https://www.php.net/manual/en/ref.array.php) like `array_filter()` or WordPress helper functions like [`wp_list_filter()`](https://developer.wordpress.org/reference/functions/wp_list_filter/). If you want to work with those, you can turn a `Timber\PostCollectionInterface` instance into a pure array with `to_array()`. But be aware that when you do that, you lose the pagination functionality and compatibility optimizations with The Loop.
 
 ```php
-$filtered = wp_list_filter( $posts->to_array(), [
-    'comment_status' => 'open'
-] );
+$filtered = wp_list_filter($posts->to_array(), [
+    'comment_status' => 'open',
+]);
 ```
 
 ### Types of Post Collections
@@ -201,29 +200,28 @@ $wp_posts = fancy_plugin_get_custom_posts(); // -> an array of WP_Posts
 In this scenario, you can still easily map each of these posts to instances of `Timber\Post` or the appropriate subclass, according to the [Class Map](/docs/v2/guides/class-maps/#the-post-class-map) you’ve defined:
 
 ```php
-$timber_posts = Timber::get_posts( $wp_posts ); // -> Timber\PostArrayObject
+$timber_posts = Timber::get_posts($wp_posts); // -> Timber\PostArrayObject
 ```
 
 Here’s an example:
 
 ```php
-use MyProject\MyPage;
-use MyProject\CustomPost;
-
 // Define your Post Class Map.
-add_filter( 'timber/post/classmap', function( $classmap ) {
-    return array_merge( [
-        'page'   => MyPage,
+add_filter('timber/post/classmap', function ($classmap) {
+    return array_merge([
+        'page' => MyPage,
         'custom' => CustomPost,
-      	// Omitting an entry for "post" here means it defaults to Timber\Post.
-    ] );
+        // Omitting an entry for "post" here means it defaults to Timber\Post.
+    ]);
 });
 
-$timber_posts = Timber::get_posts( $wp_posts );
+$timber_posts = Timber::get_posts($wp_posts);
 
-array_map( function( $p ) { return $p->post_type; }, $wp_posts );
+array_map(function ($p) {
+    return $p->post_type;
+}, $wp_posts);
 // -> ["post", "page", "custom"]
-array_map( 'get_class', $timber_posts );
+array_map('get_class', $timber_posts);
 // -> ["\Timber\Post", "\MyProject\MyPage", "\MyProject\MyCustom"]
 ```
 
@@ -238,7 +236,7 @@ $posts = Timber::get_posts(); // -> PostQuery containing only raw WP_Post instan
 
 $first = $posts[0]; // -> Timber\Post (or subclass) instance ON DEMAND!
 
-foreach ( $posts as $post ) {
+foreach ($posts as $post) {
     // $post is a Timber\Post instance, again created ON DEMAND.
 }
 ```
@@ -259,10 +257,10 @@ $posts = Timber::get_posts();
  * Before PHP 7.4, will dump a bunch of PostQuery internals,
  * but no Timber\Post instances!
  */
-var_dump( $posts );
+var_dump($posts);
 
 // Do this instead:
-var_dump( $posts->realize() );
+var_dump($posts->realize());
 ```
 
 See [Laziness and Caching](#laziness-and-caching) for details about how this interacts with caching.
@@ -272,11 +270,11 @@ See [Laziness and Caching](#laziness-and-caching) for details about how this int
 It might seem like `Timber::get_posts()` is the same as [`get_posts()`](https://developer.wordpress.org/reference/functions/get_posts/) in WordPress. But it isn’t. It’s more similar to using [`WP_Query`](https://developer.wordpress.org/reference/classes/wp_query/). WP core’s `get_posts()` function applies different default parameters and performs the same database query as it would when calling `Timber::get_posts()` like this:
 
 ```php
-$posts = Timber::get_posts( [
+$posts = Timber::get_posts([
     'ignore_sticky_posts' => true,
-    'suppress_filters'    => true,
-    'no_found_rows'       => true,
-] );
+    'suppress_filters' => true,
+    'no_found_rows' => true,
+]);
 ```
 
 If you’re used to using `get_posts()` instead of `WP_Query`, you will have to set these parameters separately in your queries.
@@ -296,8 +294,8 @@ $permalink = $post->link();
 Now let’s say you need to access that link in JavaScript, so you would convert your post data to JSON:
 
 ```php
-$post = Timber::get_post( 84 );
-$json = wp_json_encode( $post );
+$post = Timber::get_post(84);
+$json = wp_json_encode($post);
 ```
 
 Because `link` is a method of your post object, you wouldn’t have access to it in JavaScript, because when you JSON-encode a post, you will only get its properties.
@@ -311,8 +309,6 @@ Luckily, support for serialization is baked into Timber queries when you impleme
 Say you create a `Book` class that [extends](/docs/v2/guides/extending-timber/) `Timber\Post`. You define a `jsonSerialize()` method for that class. This method returns an array with all the data you want to use in JavaScript.
 
 ```php
-<?php
-
 use Timber\Post;
 
 /**
@@ -320,31 +316,33 @@ use Timber\Post;
  *
  * Implements custom JSON serialization.
  */
-class Book extends Post implements JsonSerializable {
+class Book extends Post implements JsonSerializable
+{
     /**
      * Defines data that is used when post is converted to JSON.
      *
      * @return array
      */
-	public function jsonSerialize() {
-		return [
-            'title'     => $this->title(),
-            'link'      => $this->link(),
-            'thumbnail' => $this->thumbnail()->src( 'thumbnail' ),
-            'price'     => $this->meta( 'price' ),
-		];
-	}
+    public function jsonSerialize()
+    {
+        return [
+            'title' => $this->title(),
+            'link' => $this->link(),
+            'thumbnail' => $this->thumbnail()->src('thumbnail'),
+            'price' => $this->meta('price'),
+        ];
+    }
 }
 ```
 
 Once you define with [Class Maps](/docs/v2/guides/class-maps/#the-post-class-map) that all `book` post types should be instantiated with your `Book` class, you can directly convert your posts query to JSON:
 
 ```php
-$posts = Timber::get_posts( [
+$posts = Timber::get_posts([
     'post_type' => 'book',
-] );
+]);
 
-$posts_json = wp_json_encode( $posts_json );
+$posts_json = wp_json_encode($posts_json);
 ```
 
 Now, when you access your posts in JavaScript, you will have all the data you defined in your `Book::jsonSerialize()` method as object properties of your post.
@@ -383,9 +381,9 @@ If you care about performance and want to change the query that WordPress runs b
 Whenever you query for a collection of posts, but you don’t need pagination for them, you should set `no_found_rows` to `true`.
 
 ```php
-$posts = Timber::get_posts( array(
+$posts = Timber::get_posts([
     'no_found_rows' => true,
-) );
+]);
 ```
 
 In the back, the query will not count the number of found rows. This can result in [better performance](https://kinsta.com/blog/wp-query/) if you have a large number of posts.
@@ -405,21 +403,21 @@ Here is a timeline of what normally happens when you call `Timber::get_posts()`:
 This is usually what you want. But sometimes, you may want to force Timber to realize a collection up front, such as if you are caching an expensive post query:
 
 ```php
-$eager_posts = \Timber\Helper::transient( 'my_posts', function() {
-    $query = \Timber\Timber::get_posts( [
+$eager_posts = \Timber\Helper::transient('my_posts', function () {
+    $query = \Timber\Timber::get_posts([
         'post_type' => 'some_post_type',
-    ] );
+    ]);
 
     // Run Post::setup() up front.
     return $query->realize();
-}, HOUR_IN_SECONDS );
+}, HOUR_IN_SECONDS);
 
-foreach ( $eager_posts as $post ) {
+foreach ($eager_posts as $post) {
     // No additional overhead here.
 }
 
 // Later...
-foreach ( get_transient( 'my_posts' ) as $post ) {
+foreach (get_transient('my_posts') as $post) {
     /**
      * Same deal!
      *
@@ -439,15 +437,13 @@ It’s recommended to use the [`post_password_required()`](https://developer.wor
 **single.php**
 
 ```php
-<?php
-
 $context = Timber::context();
 
-if ( post_password_required( $post->ID ) ) {
-    Timber::render( 'single-password.twig', $context );
+if (post_password_required($post->ID)) {
+    Timber::render('single-password.twig', $context);
 } else {
     Timber::render(
-        array( 'single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig' ),
+        ['single-' . $post->ID . '.twig', 'single-' . $post->post_type . '.twig', 'single.twig'],
         $context
     );
 }
@@ -476,16 +472,17 @@ Alternatively, with a WordPress filter, you can use a specific PHP template for 
  * By default, this will use the **password-protected.php** template file. If you want password
  * templates specific to a post type, use **password-protected-$posttype.php**.
  */
-add_filter( 'template_include', 'get_password_protected_template', 99 );
+add_filter('template_include', 'get_password_protected_template', 99);
 
-function get_password_protected_template( $template ) {
+function get_password_protected_template($template)
+{
     global $post;
 
-    if ( ! empty( $post ) && post_password_required( $post->ID ) ) {
-        $template = locate_template( [
+    if (!empty($post) && post_password_required($post->ID)) {
+        $template = locate_template([
             'password-protected.php',
             "password-protected-{$post->post_type}.php",
-        ] ) ?: $template;
+        ]) ?: $template;
     }
 
     return $template;
@@ -495,12 +492,12 @@ function get_password_protected_template( $template ) {
 With this filter, you can use a **password-protected.php** template file with the following contents:
 
 ```php
-$context = Timber::context( [
-    'post'          => Timber::get_post(),
+$context = Timber::context([
+    'post' => Timber::get_post(),
     'password_form' => get_the_password_form(),
-] );
+]);
 
-Timber::render( 'password-protected.twig', $context );
+Timber::render('password-protected.twig', $context);
 ```
 
 To display the password on the page, you could then use `{{ password_form }}` in your Twig file.

--- a/docs/v2/guides/shortcodes.md
+++ b/docs/v2/guides/shortcodes.md
@@ -11,17 +11,20 @@ For the desired usage of `[youtube id=xxxx]`, we only need a few lines of code:
 
 ```php
 // Should be called from within an init action hook
-add_shortcode( 'youtube', 'youtube_shortcode' );
+add_shortcode('youtube', 'youtube_shortcode');
 
-function youtube_shortcode( $atts ) {
-    if( isset( $atts['id'] ) ) {
-        $id = sanitize_text_field( $atts['id'] );
+function youtube_shortcode($atts)
+{
+    if (isset($atts['id'])) {
+        $id = sanitize_text_field($atts['id']);
     } else {
         $id = false;
     }
 
     // This time we use Timber::compile since shortcodes should return the code
-    return Timber::compile( 'youtube-short.twig', array( 'id' => $id ) );
+    return Timber::compile('youtube-short.twig', [
+        'id' => $id,
+    ]);
 }
 ```
 

--- a/docs/v2/guides/sidebars.md
+++ b/docs/v2/guides/sidebars.md
@@ -13,9 +13,7 @@ Create a **sidebar.php** file in your theme directory (so **wp-content/themes/my
 **sidebar.php**
 
 ```php
-<?php
-
-$context = array();
+$context = [];
 $context['widget'] = my_function_to_get_widget();
 $context['ad'] = my_function_to_get_an_ad();
 Timber::render('sidebar.twig', $context);
@@ -26,13 +24,11 @@ Use that php file within your main PHP file (home.php, single.php, archive.php, 
 **single.php**
 
 ```php
-<?php
+$context = Timber::context([
+    'sidebar' => Timber::get_sidebar('sidebar.php'),
+]);
 
-$context = Timber::context( [
-    'sidebar' => Timber::get_sidebar( 'sidebar.php' ),
-] );
-
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 In the final twig file make sure you reserve a spot for your sidebar:
@@ -66,26 +62,26 @@ Send data to it via your main PHP file:
 **single.php**
 
 ```php
-$post     = Timber::get_post();
-$post_cat = $post->get_terms( 'category' );
+$post = Timber::get_post();
+$post_cat = $post->get_terms('category');
 
 $post_cat = $post_cat[0]->ID;
 
-$sidebar_context = array(
-	'related' => Timber::get_posts( [
-	    'cat' => $post_cat
-    ] ),
-);
+$sidebar_context = [
+    'related' => Timber::get_posts([
+        'cat' => $post_cat,
+    ]),
+];
 
-$context = Timber::context( [
-    'post'    => $post,
+$context = Timber::context([
+    'post' => $post,
     'sidebar' => Timber::get_sidebar(
         'sidebar-related.twig',
         $sidebar_context
     ),
-] );
+]);
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 In the final twig file, make sure you have spot for your sidebar:
@@ -103,9 +99,8 @@ In the final twig file, make sure you have spot for your sidebar:
 This is using WordPress's built-in dynamic_sidebar tools (which, confusingly, are referred to as "Widgets" in the interface). Since sidebar is already used; I used widgets in the code to describe these:
 
 ```php
-<?php
 $context = [
-    'dynamic_sidebar' => Timber::get_widgets( 'dynamic_sidebar' ),
+    'dynamic_sidebar' => Timber::get_widgets('dynamic_sidebar'),
 ];
 
 Timber::render('sidebar.twig', $context);

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -4,7 +4,7 @@ order: "75"
 ---
 
 ```php
-Timber::render( 'teaser.twig' );
+Timber::render('teaser.twig');
 ```
 
 When you use [`Timber::render()`](https://timber.github.io/docs/v2/reference/timber-timber/#render), [`Timber::compile()`](https://timber.github.io/docs/v2/reference/timber-timber/#compile), or [Twig includes](https://timber.github.io/docs/v2/guides/twig/#includes) to render a Twig template file, Timber will look for that template in different directories. It will first look in the child theme and then falls back to the parent theme (it’s the same logic as in WordPress).
@@ -43,7 +43,7 @@ Timber::$dirname = [
         'templates',
         'templates/shared/mods',
         'twigs',
-        'views'
+        'views',
     ],
 ];
 ```
@@ -53,7 +53,7 @@ Timber::$dirname = [
 You can always reference **subdirectories** in your template folders relatively. For example:
 
 ```php
-Timber::render( 'shared/headers/header-home.twig' );
+Timber::render('shared/headers/header-home.twig');
 ```
 
 ... might correspond to a file in
@@ -66,10 +66,10 @@ You can set your own locations for your twig files with...
 **functions.php**
 
 ```php
-add_filter( 'timber/locations', function($paths) {
-	$paths[] = array('/Users/lukas/Sandbox/templates');
+add_filter('timber/locations', function ($paths) {
+    $paths[] = ['/Users/lukas/Sandbox/templates'];
 
-	return $paths;
+    return $paths;
 });
 ```
 
@@ -78,14 +78,14 @@ Use the full file path to make sure Timber knows what you're trying to draw from
 **functions.php**
 
 ```php
-add_filter( 'timber/locations', function($paths) {
-	$paths[] = array(
-		'/Users/lukas/Sandbox/templates',
-		'~/Sites/timber-templates/',
-		ABSPATH.'/wp-content/templates'
-	);
+add_filter('timber/locations', function ($paths) {
+    $paths[] = [
+        '/Users/lukas/Sandbox/templates',
+        '~/Sites/timber-templates/',
+        ABSPATH . '/wp-content/templates',
+    ];
 
-	return $paths;
+    return $paths;
 });
 ```
 
@@ -96,12 +96,12 @@ You can use [namespaces](https://symfony.com/doc/current/templating/namespaced_p
 **functions.php**
 
 ```php
-add_filter( 'timber/locations', function($paths) {
-	$paths['styleguide'] = [
-		ABSPATH . '/wp-content/styleguide'
-	];
+add_filter('timber/locations', function ($paths) {
+    $paths['styleguide'] = [
+        ABSPATH . '/wp-content/styleguide',
+    ];
 
-	return $paths;
+    return $paths;
 });
 ```
 
@@ -117,13 +117,13 @@ You can also register multiple paths for the same namespace. Order is important 
 **functions.php**
 
 ```php
-add_filter( 'timber/locations', function($paths) {
-	$paths['styleguide'] = array(
-		ABSPATH.'/wp-content/styleguide',
-		'/Users/lukas/Sandbox/styleguide'
-	);
+add_filter('timber/locations', function ($paths) {
+    $paths['styleguide'] = [
+        ABSPATH . '/wp-content/styleguide',
+        '/Users/lukas/Sandbox/styleguide',
+    ];
 
-	return $paths;
+    return $paths;
 });
 ```
 

--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -8,7 +8,7 @@ order: "120"
 To get a term object in Timber, you use `Timber::get_term()` and pass the WordPress term ID as an argument.
 
 ```php
-$term = Timber::get_term( $term_id );
+$term = Timber::get_term($term_id);
 ```
 
 This function is similar to [`get_term()`](https://developer.wordpress.org/reference/functions/get_term/) and accepts one argument: a term ID. If you don’t pass in any argument, Timber will use `get_queried_object()` to try and work with the currently queried term.
@@ -18,7 +18,7 @@ $term = Timber::get_term();
 
 // Is the same as…
 
-$term = Timber::get_term( get_queried_object_id() );
+$term = Timber::get_term(get_queried_object_id());
 ```
 
 What you get in return is a [`Timber\Term`](https://timber.github.io/docs/v2/reference/timber-term/) object, which is similar to `WP_Term`.
@@ -29,10 +29,10 @@ If you don’t have a term ID, you can also get a term by other fields, like `sl
 
 ```php
 // Get a term by slug.
-$term = Timber::get_term_by( 'slug', 'news', 'category' );
+$term = Timber::get_term_by('slug', 'news', 'category');
 
 // Get a term by name.
-$term = Timber::get_term_by( 'name', 'News', 'category' );
+$term = Timber::get_term_by('name', 'News', 'category');
 ```
 
 ## Twig
@@ -56,10 +56,9 @@ If you have an array of terms IDs that you want to convert to `Timber\Term` obje
 If no valid term can be found with the term ID you provided, the `Timber::get_term()` function will return `null`. With this, you can always check for a valid term with a simple if statement.
 
 ```php
-$term = Timber::get_term( $term_id );
+$term = Timber::get_term($term_id);
 
-if ( $term ) {
-
+if ($term) {
 }
 ```
 
@@ -76,15 +75,15 @@ Or in Twig:
 If you need additional functionality that the `Timber\Term` class doesn’t provide or if you want to have cleaner Twig templates, you can extend the `Timber\Term` class with your own classes:
 
 ```php
-class BookGenre extends Timber\Term {
-
+class BookGenre extends Timber\Term
+{
 }
 ```
 
 To initiate your new `BookGenre` term, you also use `Timber::get_term()`.
 
 ```php
-$term = Timber::get_term( $term_id );
+$term = Timber::get_term($term_id);
 ```
 
 In the same way that you [can’t instantiate post objects directly](https://timber.github.io/docs/v2/guides/posts/#extending-timber-post), you **can’t** instantiate a `Timber\Term` object or an object that extends this class with a constructor. Timber will use the [Term Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map) to sort out which class it should use.
@@ -103,10 +102,10 @@ You can pass the same arguments to this function that you know from using [`WP_T
 
 ```php
 // Using the WP_Term_Query argument format.
-$terms = Timber::get_terms( [
+$terms = Timber::get_terms([
     'taxonomy' => 'book_genre',
-    'count'    => true,
- ] );
+    'count' => true,
+]);
 ```
 
 Also check out the documentation for [`Timber::get_terms()`](https://timber.github.io/docs/v2/reference/timber-timber/#get_terms).
@@ -114,7 +113,7 @@ Also check out the documentation for [`Timber::get_terms()`](https://timber.gith
 You get array of terms as a return value that you can loop over.
 
 ```php
-foreach ( $terms as $term ) {
+foreach ($terms as $term) {
     echo $term->title();
 }
 ```

--- a/docs/v2/guides/testing.md
+++ b/docs/v2/guides/testing.md
@@ -46,9 +46,9 @@ Warning: this one will take a while.
 Copy `/wordpress-trunk/public_html/wp-tests-config-sample.php` to `/wordpress-trunk/public_html/wp-tests-config.php`. Assuming you're using VVV's defaults, we just need to specify how to access the database:
 
 ```php
-define( 'DB_NAME', 'wordpress_unit_tests' );
-define( 'DB_USER', 'root' );
-define( 'DB_PASSWORD', 'root' );
+define('DB_NAME', 'wordpress_unit_tests');
+define('DB_USER', 'root');
+define('DB_PASSWORD', 'root');
 ```
 
 ### 5. Install WordPress tests

--- a/docs/v2/guides/twig-filters.md
+++ b/docs/v2/guides/twig-filters.md
@@ -17,7 +17,7 @@ Makes sure a variable is an array to safely loop over it without running into an
 $things = 'thing';
 
 // Or
-$things = [ 'thing', 'thang' ];
+$things = ['thing', 'thang'];
 ```
 
 **Twig**
@@ -215,11 +215,11 @@ Converts an array of strings into a comma-separated list.
 **PHP**
 
 ```php
-$context['contributors'] = array(
+$context['contributors'] = [
     'Blake Allen',
     'Rachel White',
-    'Maddy May'
-);
+    'Maddy May',
+];
 ```
 
 **Twig**

--- a/docs/v2/guides/twig.md
+++ b/docs/v2/guides/twig.md
@@ -39,7 +39,7 @@ Consider this array with a key that has a dash in it:
 
 ```php
 $item = [
-    'id'          => 7,
+    'id' => 7,
     'has-balcony' => true,
 ];
 ```
@@ -201,9 +201,10 @@ If you want anything from the template’s context, you'll need to pass that man
 **functions.php**
 
 ```php
-add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
+add_action('my_action_with_args', 'my_function_with_args', 10, 2);
 
-function my_function_with_args( $foo, $post ){
+function my_function_with_args($foo, $post)
+{
     echo 'I say ' . $foo . '!';
     echo 'For the post with title ' . $post->title();
 }
@@ -236,10 +237,11 @@ Or you can use a filter with the [Twig apply tag](https://twig.symfony.com/doc/3
 In **PHP**, you can get the content of the block with the first parameter and the rest of parameters like that.
 
 ```php
-add_filter( 'default_message', 'my_default_message', 10, 4 );
+add_filter('default_message', 'my_default_message', 10, 4);
 
-function my_default_message( $tag, $param1, $param2, $param3 ) {
-    var_dump( $tag, $param1, $param2, $param3 ); // 'I love pizza', 'foo', 'bar, 'baz'
+function my_default_message($tag, $param1, $param2, $param3)
+{
+    var_dump($tag, $param1, $param2, $param3); // 'I love pizza', 'foo', 'bar, 'baz'
 
     echo 'I have a message: ' . $tag; // I have a message: I love pizza
 }
@@ -253,8 +255,8 @@ Sometimes in **WooCommerce** we find very long lines of code:
 echo '<li class="woocommerce-notice woocommerce-notice--info woocommerce-info">' . apply_filters(
     'woocommerce_no_available_payment_methods_message',
     WC()->customer->get_billing_country()
-        ? esc_html__( 'Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce' )
-        : esc_html__( 'Please fill in your details above to see available payment methods.', 'woocommerce' )
+        ? esc_html__('Sorry, it seems that there are no available payment methods for your state. Please contact us if you require assistance or wish to make alternate arrangements.', 'woocommerce')
+        : esc_html__('Please fill in your details above to see available payment methods.', 'woocommerce')
 ) . '</li>';
 ```
 

--- a/docs/v2/guides/users.md
+++ b/docs/v2/guides/users.md
@@ -6,7 +6,7 @@ order: "130"
 To get a user object in Timber, you use `Timber::get_user()` and pass the WordPress user ID as an argument.
 
 ```php
-$user = Timber::get_user( $user_id );
+$user = Timber::get_user($user_id);
 ```
 
 This function is similar to [`get_userdata()`](https://developer.wordpress.org/reference/functions/get_userdata/) and accepts one argument: a user ID. If you don’t pass in any argument, Timber will use `get_current_user_id()` to work with the currently logged in user.
@@ -16,7 +16,7 @@ $user = Timber::get_user();
 
 // Is the same as…
 
-$user = Timber::get_user( get_current_user_id() );
+$user = Timber::get_user(get_current_user_id());
 ```
 
 What you get in return is a [`Timber\User`](https://timber.github.io/docs/v2/reference/timber-user/) object, which is similar to `WP_User`.
@@ -27,10 +27,10 @@ If you don’t have a user ID, you can also get a user by other fields, like `em
 
 ```php
 // Get a user by email.
-$user = Timber::get_user_by( 'email', 'user@example.com' );
+$user = Timber::get_user_by('email', 'user@example.com');
 
 // Get a user by login.
-$user = Timber::get_user_by( 'login', 'keanu-reeves' );
+$user = Timber::get_user_by('login', 'keanu-reeves');
 ```
 
 ## Twig
@@ -54,9 +54,9 @@ It also works if you have an array of user IDs that you want to convert to `Timb
 If no user can be found with the user ID you provided, the `Timber::get_user()` function will return `null`. With this, you can always check for valid users in a template a simple if statement.
 
 ```php
-$user = Timber::get_user( $user_id );
+$user = Timber::get_user($user_id);
 
-if ( $user ) {
+if ($user) {
     // Handle user.
 }
 ```
@@ -76,7 +76,7 @@ Similar to checking for valid users, you can also check whether a user is curren
 ```php
 $user = Timber::get_user();
 
-if ( $user ) {
+if ($user) {
     // A user is logged in.
 } else {
     // No user is logged in.
@@ -98,15 +98,15 @@ This allows you to check for a login state with an if statement.
 If you need additional functionality that the `Timber\User` class doesn’t provide or if you want to have cleaner Twig templates, you can extend the `Timber\User` class with your own classes:
 
 ```php
-class Author extends Timber\User {
-
+class Author extends Timber\User
+{
 }
 ```
 
 To initiate your new `Author` user, you also use `Timber::get_user()`.
 
 ```php
-$author = Timber::get_user( $user_id );
+$author = Timber::get_user($user_id);
 ```
 
 You **can’t** instantiate a `Timber\User` object or an object that extends this class with a constructor – you can’t use `$author = new Author( $user_id )`. In Timber, we’ve chosen to go a different way to prevent a lot of problems that would come with direct instantiation.
@@ -118,27 +118,27 @@ So, how does Timber know about your `User` class? Timber will use the [User Clas
 If you want to get an array of users, you can use `Timber::get_user()`.
 
 ```php
-$users = Timber::get_users( $query );
+$users = Timber::get_users($query);
 ```
 
 You can use this function in a similar way to how you use [`WP_User_Query`](https://developer.wordpress.org/reference/classes/wp_user_query/).
 
 ```php
 // Get all users that only have a subscriber role.
-$subscribers = Timber::get_users( [
+$subscribers = Timber::get_users([
     'role' => 'subscriber',
-] );
+]);
 
 // Get all users that have published posts.
-$post_authors = Timber::get_users( [
-    'has_published_posts' => [ 'post' ],
-] );
+$post_authors = Timber::get_users([
+    'has_published_posts' => ['post'],
+]);
 ```
 
 Instead of a query, you can also pass an **array of user IDs**.
 
 ```php
-$users = Timber::get_users( [ 27, 83, 161 ] );
+$users = Timber::get_users([27, 83, 161]);
 ```
 
 If you don’t pass in any argument, `Timber::get_users()` will do nothing and return an empty array.

--- a/docs/v2/guides/widgets.md
+++ b/docs/v2/guides/widgets.md
@@ -7,7 +7,7 @@ Everyone loves widgets! Of course they do...
 
 ```php
 $data = [
-    'footer_widgets' => Timber::get_widgets( 'footer_widgets' ),
+    'footer_widgets' => Timber::get_widgets('footer_widgets'),
 ];
 ```
 
@@ -30,14 +30,18 @@ You can also use twig templates for your widgets! Let’s imagine we want a widg
 Inside the widget class, the widget function is used to show the widget:
 
 ```php
-public function widget( $args, $instance ) {
-    $number = rand();
+class My_Widget extends WP_Widget
+{
+    public function widget($args, $instance)
+    {
+        $number = rand();
 
-    Timber::render( 'random-widget.twig', array(
-        'args' => $args,
-        'instance' => $instance,
-        'number' => $number
-    ) );
+        Timber::render('random-widget.twig', [
+            'args' => $args,
+            'instance' => $instance,
+            'number' => $number,
+        ]);
+    }
 }
 ```
 
@@ -57,18 +61,22 @@ The raw filter is needed here to embed the widget properly.
 You may also want to check if the Timber plugin was loaded before using it:
 
 ```php
-public function widget( $args, $instance ) {
-    if ( ! class_exists( 'Timber' ) ) {
-        // if you want to show some error message, this is the right place
-        return;
+class My_Widget extends WP_Widget
+{
+    public function widget($args, $instance)
+    {
+        if (!class_exists('Timber')) {
+            // if you want to show some error message, this is the right place
+            return;
+        }
+
+        $number = rand();
+
+        Timber::render('random-widget.twig', [
+            'args' => $args,
+            'instance' => $instance,
+            'number' => $number,
+        ]);
     }
-
-    $number = rand();
-
-    Timber::render( 'random-widget.twig', array(
-        'args' => $args,
-        'instance' => $instance,
-        'number' => $number
-    ) );
 }
 ```

--- a/docs/v2/guides/woocommerce.md
+++ b/docs/v2/guides/woocommerce.md
@@ -7,11 +7,12 @@ title: "WooCommerce"
 The first step to get your WooCommerce project integrated with Timber is declaring WooCommerce support in your theme’s **functions.php** file like so:
 
 ```php
-function theme_add_woocommerce_support() {
-    add_theme_support( 'woocommerce' );
+function theme_add_woocommerce_support()
+{
+    add_theme_support('woocommerce');
 }
 
-add_action( 'after_setup_theme', 'theme_add_woocommerce_support' );
+add_action('after_setup_theme', 'theme_add_woocommerce_support');
 ```
 
 For more information about how you can enable or disable features and change settings through theme support, refer to the [WooCommerce Theme Developer Handbook](https://docs.woocommerce.com/document/woocommerce-theme-developer-handbook).
@@ -19,43 +20,41 @@ For more information about how you can enable or disable features and change set
 Once that’s done you can start integrating WooCommerce into your theme by creating a file named **woocommerce.php** in the root of your theme. That will establish the context and data to be passed to your Twig files:
 
 ```php
-<?php
-
-if ( ! class_exists( 'Timber' ) ) {
+if (!class_exists('Timber')) {
     echo 'Timber not activated. Make sure you activate the plugin in <a href="/wp-admin/plugins.php#timber">/wp-admin/plugins.php</a>';
 
     return;
 }
 
-$context            = Timber::context();
-$context['sidebar'] = Timber::get_widgets( 'shop-sidebar' );
+$context = Timber::context();
+$context['sidebar'] = Timber::get_widgets('shop-sidebar');
 
-if ( is_singular( 'product' ) ) {
-    $context['post']    = Timber::get_post();
-    $product            = wc_get_product( $context['post']->ID );
+if (is_singular('product')) {
+    $context['post'] = Timber::get_post();
+    $product = wc_get_product($context['post']->ID);
     $context['product'] = $product;
 
     // Get related products
-    $related_limit               = wc_get_loop_prop( 'columns' );
-    $related_ids                 = wc_get_related_products( $context['post']->id, $related_limit );
-    $context['related_products'] =  Timber::get_posts( $related_ids );
+    $related_limit = wc_get_loop_prop('columns');
+    $related_ids = wc_get_related_products($context['post']->id, $related_limit);
+    $context['related_products'] = Timber::get_posts($related_ids);
 
     // Restore the context and loop back to the main query loop.
     wp_reset_postdata();
 
-    Timber::render( 'views/woo/single-product.twig', $context );
+    Timber::render('views/woo/single-product.twig', $context);
 } else {
     $posts = Timber::get_posts();
     $context['products'] = $posts;
 
-    if ( is_product_category() ) {
+    if (is_product_category()) {
         $queried_object = get_queried_object();
         $term_id = $queried_object->term_id;
-        $context['category'] = get_term( $term_id, 'product_cat' );
-        $context['title'] = single_term_title( '', false );
+        $context['category'] = get_term($term_id, 'product_cat');
+        $context['title'] = single_term_title('', false);
     }
 
-    Timber::render( 'views/woo/archive.twig', $context );
+    Timber::render('views/woo/archive.twig', $context);
 }
 ```
 
@@ -185,11 +184,12 @@ This should all sound familiar by now, except for one line:
 For some reason, products in the loop don’t get the right context by default. This line will call the following function that you need to add somewhere in your **functions.php** file:
 
 ```php
-function timber_set_product( $post ) {
+function timber_set_product($post)
+{
     global $product;
 
-    if ( is_woocommerce() ) {
-        $product = wc_get_product( $post->ID );
+    if (is_woocommerce()) {
+        $product = wc_get_product($post->ID);
     }
 }
 ```
@@ -209,7 +209,7 @@ One way to get around this is by building your own image calls, that means remov
 To remove the default image, add the following to your **functions.php** file:
 
 ```php
-remove_action( 'woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail' );
+remove_action('woocommerce_before_shop_loop_item_title', 'woocommerce_template_loop_product_thumbnail');
 ```
 
 This comes with the added benefit that you’ll have total control over where your image is created in the markup.

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -16,13 +16,11 @@ Let’s look at a simple example. First, we prepare the data in our PHP file.
 **single.php**
 
 ```php
-<?php
-
 use Timber\Timber;
 
 $context = Timber::context();
 
-Timber::render( 'single.twig', $context );
+Timber::render('single.twig', $context);
 ```
 
 And then we render that data in your Twig template.
@@ -55,10 +53,8 @@ Timber makes Posts, Terms, Users, Comments and Menus more object-oriented. You c
 For example, have you ever tried to get the thumbnail of a post? Here’s how that looks like in traditional WordPress themes:
 
 ```php
-<?php
-
-$thumb_id = get_post_thumbnail_id( $post->ID );
-$url      = wp_get_attachment_url( $thumb_id );
+$thumb_id = get_post_thumbnail_id($post->ID);
+$url = wp_get_attachment_url($thumb_id);
 
 ?>
 
@@ -84,9 +80,9 @@ Timber works with your existing themes to unlock new power. You don’t have to 
 **home.php**
 
 ```php
-$data['welcome_message'] = get_option( 'welcome_message' );
+$data['welcome_message'] = get_option('welcome_message');
 
-Timber::render( 'welcome.twig',  $data );
+Timber::render('welcome.twig', $data);
 ```
 
 **welcome.twig**

--- a/docs/v2/installation/installation.md
+++ b/docs/v2/installation/installation.md
@@ -25,8 +25,6 @@ You can choose yourself where in your project you want to include Timber.
 If your theme or project is not already set up to pull in Composer’s autoload file, you will need to add the following line at the top of your **functions.php** file:
 
 ```php
-<?php
-
 // Load Composer dependencies.
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -17,7 +17,7 @@ If you’ve worked with ACF before, you’re use to use `get_field( 'my_acf_fiel
 **PHP**
 
 ```php
-$meta = $post->meta( 'my_acf_field' );
+$meta = $post->meta('my_acf_field');
 ```
 
 ### Unformatted values
@@ -33,9 +33,9 @@ In ACF, all values are filtered. If you want to use unfiltered, raw values from 
 **PHP**
 
 ```php
-$meta = $post->meta( 'my_acf_field', [
+$meta = $post->meta('my_acf_field', [
     'format_value' => false,
-] );
+]);
 ```
 
 You can also use the **faster `raw_meta()` method**, which accesses values directly from the database and bypasses any ACF filters:
@@ -77,13 +77,13 @@ This is where we’ll start in PHP.
 ```php
 $post = Timber::get_post();
 
-if (isset($post->hero_image) && strlen($post->hero_image)){
-    $post->hero_image = Timber::get_image( $post->hero_image );
+if (isset($post->hero_image) && strlen($post->hero_image)) {
+    $post->hero_image = Timber::get_image($post->hero_image);
 }
 
-$context = Timber::context( [
+$context = Timber::context([
     'post' => $post,
-] );
+]);
 
 Timber::render('single.twig', $context);
 ```
@@ -261,7 +261,7 @@ To prevent errors with include files that can’t be found, you can optionally u
 **PHP**
 
 ```php
-$context['site_copyright_info'] = get_field( 'copyright_info', 'options' );
+$context['site_copyright_info'] = get_field('copyright_info', 'options');
 
 Timber::render('index.twig', $context);
 ```
@@ -275,9 +275,9 @@ Timber::render('index.twig', $context);
 ### Get all info from your options page
 
 ```php
-$context['options'] = get_fields( 'options' );
+$context['options'] = get_fields('options');
 
-Timber::render( 'index.twig', $context );
+Timber::render('index.twig', $context);
 ```
 
 ACF Pro has a built in options page, and changes the `get_fields( 'options' )` to `get_fields( 'option' )`.
@@ -291,7 +291,7 @@ ACF Pro has a built in options page, and changes the `get_fields( 'options' )` t
 To use any options fields site wide, add the `option` context to your **functions.php** file:
 
 ```php
-add_filter( 'timber/context', 'global_timber_context' );
+add_filter('timber/context', 'global_timber_context');
 
 /**
  * Filters global context.
@@ -299,8 +299,9 @@ add_filter( 'timber/context', 'global_timber_context' );
  * @param array $context An array of existing context variables.
  * @return mixed
  */
-function global_timber_context( $context ) {
-    $context['options'] = get_fields( 'option' );
+function global_timber_context($context)
+{
+    $context['options'] = get_fields('option');
 
     return $context;
 }
@@ -321,7 +322,7 @@ You can grab specific field label data like so:
 **single.php**
 
 ```php
-$context['acf'] = get_field_objects( $data['post']->ID );
+$context['acf'] = get_field_objects($data['post']->ID);
 ```
 
 ```twig

--- a/docs/v2/upgrade-guides/1.0.md
+++ b/docs/v2/upgrade-guides/1.0.md
@@ -44,7 +44,7 @@ If you haven't already, you'll need to load Composer's autoload file into your t
 **functions.php**
 
 ```php
-require_once( 'vendor/autoload.php' );
+require_once('vendor/autoload.php');
 ```
 
 ### 3. Update your Routes
@@ -55,7 +55,7 @@ Now just update the PHP for your old routes to the new ones. It'll be basically 
 
 ```php
 Timber::add_route('myfoo/bar', 'my_callback_function');
-Timber::add_route('my-events/:event', function($params) {
+Timber::add_route('my-events/:event', function ($params) {
     $query = new WP_Query('post_type=event');
     Timber::load_view('single.php', $query, 200, $params);
 });
@@ -65,7 +65,7 @@ Timber::add_route('my-events/:event', function($params) {
 
 ```php
 Routes::map('myfoo/bar', 'my_callback_function');
-Routes::map('my-events/:event', function($params) {
+Routes::map('my-events/:event', function ($params) {
     $query = new WP_Query('post_type=event');
     /* please note the different order of arguments vs. Timber::load_template */
     Routes::load('single.php', $params, $query, 200);

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -56,7 +56,7 @@ $timber = Timber\Timber::init();
 If you need to check what Timber version is installed, you can use `Timber::version`.
 
 ```php
-if ( version_compare( Timber::$version, '2.0.0', '>=' ) ) {
+if (version_compare(Timber::$version, '2.0.0', '>=')) {
     // Timber 2.x is installed.
 }
 ```
@@ -92,7 +92,7 @@ And then, you can enable it with the following filter:
 **functions.php**
 
 ```php
-add_filter( 'timber/cache/enable_extension', '__return_true' );
+add_filter('timber/cache/enable_extension', '__return_true');
 ```
 
 ### Removed support for Co-Authors Plus
@@ -202,7 +202,7 @@ $post = Timber::get_post();
 
 ```php
 // Pass in a post ID to get a particular post.
-$post = Timber::get_post( 56 );
+$post = Timber::get_post(56);
 ```
 
 #### Updated function signature for `Timber::get_post()`
@@ -212,13 +212,17 @@ We updated the function parameters for `Timber::get_post()`.
 **Old**
 
 ```php
-function get_post( $query = false, $PostClass = 'Timber\Post' );
+function get_post($query = false, $PostClass = 'Timber\Post')
+{
+};
 ```
 
 **New**
 
 ```php
-function get_post( mixed $query = false, array $options = [] );
+function get_post(mixed $query = false, array $options = [])
+{
+};
 ```
 
 We deprecated the `$PostClass` parameter. If you want to control the class your post should be instantiated with, use a [Class Map filter](https://timber.github.io/docs/v2/guides/class-maps/#the-post-class-map). Instead, we now have an `$options` array.
@@ -240,7 +244,7 @@ $query = [
     'post_status' => 'publish',
 ];
 
-$latest_books = new Timber\PostQuery( $query );
+$latest_books = new Timber\PostQuery($query);
 ```
 
 **New**
@@ -252,9 +256,9 @@ $query = [
     'post_status' => 'publish',
 ];
 
-$latest_books = Timber::get_posts( $query );
+$latest_books = Timber::get_posts($query);
 
-foreach ( $latest_books->to_array() as $book ) {
+foreach ($latest_books->to_array() as $book) {
     // Do something.
 }
 ```
@@ -266,15 +270,15 @@ It will no longer be possible to pass in arguments to `Timber::get_posts()` as a
 **Old**
 
 ```php
-Timber::get_posts( 'post_type=article' );
+Timber::get_posts('post_type=article');
 ```
 
 **New**
 
 ```php
-Timber::get_posts( [
+Timber::get_posts([
     'post_type' => 'article',
-] );
+]);
 ```
 
 #### Updated function signature for `Timber::get_posts()`
@@ -284,13 +288,17 @@ We updated the function parameters for `Timber::get_posts()`.
 **Old**
 
 ```php
-function get_posts( $query = false, $PostClass = 'Timber\Post', $return_collection = false );
+function get_posts($query = false, $PostClass = 'Timber\Post', $return_collection = false)
+{
+}
 ```
 
 **New**
 
 ```php
-function get_posts( array $query, array $options = [] );
+function get_posts(array $query, array $options = [])
+{
+}
 ```
 
 The function still accepts the `$query` parameters as the first argument. Most of your queries will still work.
@@ -308,26 +316,26 @@ $posts_as_array = Timber::get_posts()->to_array();
 
 ```php
 $args = [
-    'post_type'      => 'book',
+    'post_type' => 'book',
     'posts_per_page' => 10,
-    'post_status'    => 'publish',
+    'post_status' => 'publish',
 ];
 
-$latest_books_collection = Timber::get_posts( $args, 'Book', true );
-$latest_books_array      = Timber::get_posts( $args, 'Book' );
+$latest_books_collection = Timber::get_posts($args, 'Book', true);
+$latest_books_array = Timber::get_posts($args, 'Book');
 ```
 
 **New**
 
 ```php
 $args = [
-    'post_type'      => 'book',
+    'post_type' => 'book',
     'posts_per_page' => 10,
-    'post_status'    => 'publish',
+    'post_status' => 'publish',
 ];
 
-$latest_books_collection = Timber::get_posts( $args );
-$latest_books_array      = Timber::get_posts( $args )->to_array();
+$latest_books_collection = Timber::get_posts($args);
+$latest_books_array = Timber::get_posts($args)->to_array();
 ```
 
 The new `$options` parameter can be used to pass in options for the query. Check out the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/reference/timber/#get-posts) to see all options.
@@ -377,7 +385,7 @@ It’s not possible anymore to directly instantiate a term with `new Timber\Term
 
 ```php
 // Pass in a term ID (or a WP_Term object) to get a particular term.
-$term = Timber::get_term( 17 );
+$term = Timber::get_term(17);
 ```
 
 #### Updated function signature for `Timber::get_term()`
@@ -387,13 +395,17 @@ We updated the function parameters for `Timber::get_term()`.
 **Old**
 
 ```php
-function get_term( $term, $taxonomy = 'post_tag', $TermClass = 'Timber\Term' );
+function get_term($term, $taxonomy = 'post_tag', $TermClass = 'Timber\Term')
+{
+};
 ```
 
 **New**
 
 ```php
-function get_term( $term = null );
+function get_term($term = null)
+{
+};
 ```
 
 - We removed the `$taxonomy` parameter. Timber needs the ID of a term or a `WP_Term` object. It can figure out the taxonomy itself.
@@ -408,13 +420,17 @@ We updated the function parameters for `Timber::get_terms()`.
 **Old**
 
 ```php
-function get_terms( $args = null, $maybe_args = array(), $TermClass = 'Timber\Term' );
+function get_terms($args = null, $maybe_args = [], $TermClass = 'Timber\Term')
+{
+};
 ```
 
 **New**
 
 ```php
-function get_terms( $args = null, array $options = [] );
+function get_terms($args = null, array $options = [])
+{
+};
 ```
 
 - The function still accepts an `$args` parameter where you pass in the same arguments that you would pass to [`WP_Term_Query()`](https://developer.wordpress.org/reference/classes/WP_Term_Query/__construct/). Most of your calls to `Timber::get_terms()` should still work the same.
@@ -428,10 +444,10 @@ Before Timber 2.0, we set the default argument `hide_empty` to `false` in the te
 If you **need empty terms**, you need to explicitly set `hide_empty` to `false`.
 
 ```php
-$terms = Timber::get_terms( [
-    'taxonomy'   => 'category',
+$terms = Timber::get_terms([
+    'taxonomy' => 'category',
     'hide_empty' => false,
-] );
+]);
 ```
 
 ## Comments
@@ -447,13 +463,13 @@ Before version 2.0, when you wanted to get a menu, the standard way was to use `
 **Old**
 
 ```php
-$menu = new Timber\Menu( 'primary' );
+$menu = new Timber\Menu('primary');
 ```
 
 **New**
 
 ```php
-$menu = Timber::get_menu( 'primary' );
+$menu = Timber::get_menu('primary');
 ```
 
 ### A parameter is always required
@@ -473,7 +489,7 @@ $menu = new Timber\Menu();
 Always pass a parameter.
 
 ```php
-$menu = Timber::get_menu( 'primary' );
+$menu = Timber::get_menu('primary');
 ```
 
 ### The Pages Menu
@@ -530,22 +546,22 @@ Here’s an example: Instead of setting a `posts` variable in `$context` after y
 ```php
 $context = Timber::context();
 
-$context['posts'] = new Timber::get_posts( [
+$context['posts'] = Timber::get_posts([
     'query' => [
-        'post_type'      => 'book',
+        'post_type' => 'book',
         'posts_per_page' => -1,
-        'post_status'    => 'publish',
+        'post_status' => 'publish',
     ],
-] );
+]);
 
-Timber::render( 'archive.twig', $context );
+Timber::render('archive.twig', $context);
 ```
 
 **Another way to do it**
 
 ```php
 $context = Timber::context( [
-	'posts' => new Timber::get_posts( [
+	'posts' => Timber::get_posts( [
         'post_type'      => 'book',
         'posts_per_page' => -1,
         'post_status'    => 'publish',
@@ -607,8 +623,8 @@ Timber will automatically load the timezone as well as the default date format f
 
 ```php
 // Don’t do this!
-$twig = new \Twig\Environment( $loader );
-$twig->getExtension( \Twig\Extension\CoreExtension::class )->setTimezone( 'Europe/Paris' );
+$twig = new \Twig\Environment($loader);
+$twig->getExtension(\Twig\Extension\CoreExtension::class)->setTimezone('Europe/Paris');
 ```
 
 Also refer to the new [Date/Time Guide](https://timber.github.io/docs/v2/guides/date-time/) for extended information on working with dates in Timber.
@@ -622,9 +638,10 @@ In version 1.x of Timber, you would always get the context as a last argument in
 ```
 
 ```php
-add_action( 'my_action_with_args', 'my_function_with_args', 10, 3 );
+add_action('my_action_with_args', 'my_function_with_args', 10, 3);
 
-function my_function_with_args( $foo, $post, $context ) {
+function my_function_with_args($foo, $post, $context)
+{
     echo 'I say ' . $foo . '!';
     echo 'For the post with title ' . $context['post']->title();
 }
@@ -636,9 +653,10 @@ In version 2.0, **a context argument will no longer be passed to the hook functi
 {% do action('my_action', 'foo', post) %}
 ```
 ```php
-add_action( 'my_action_with_args', 'my_function_with_args', 10, 2 );
+add_action('my_action_with_args', 'my_function_with_args', 10, 2);
 
-function my_function_with_args( $foo, $post ) {
+function my_function_with_args($foo, $post)
+{
     echo 'I say ' . $foo . '!';
     echo 'For the post with title ' . $post->title();
 }
@@ -1019,10 +1037,14 @@ The `Timber\Term::terms()` function already supported using an array of query ar
 
 ```php
 // Old
-function terms( $args = [], $merge = true, $term_class = '' );
+function terms($args = [], $merge = true, $term_class = '')
+{
+};
 
 // New
-function terms( $query_args = [], $options = [] );
+function terms($query_args = [], $options = [])
+{
+};
 ```
 
 **Old usage**
@@ -1030,17 +1052,17 @@ function terms( $query_args = [], $options = [] );
 In PHP:
 
 ```php
-$terms = $post->terms( 'category' );
+$terms = $post->terms('category');
 
 // or
 
-$terms = $post->terms( [
+$terms = $post->terms([
     'query' => [
         'taxonomy' => 'custom_tax',
-        'orderby'  => 'count',
+        'orderby' => 'count',
     ],
-    'merge'        => false,
-] );
+    'merge' => false,
+]);
 ```
 
 And in Twig:
@@ -1064,18 +1086,18 @@ And in Twig:
 In PHP:
 
 ```php
-$terms = $post->terms( [
-    'taxonomy' => 'category'
-] );
+$terms = $post->terms([
+    'taxonomy' => 'category',
+]);
 
 // or
 
-$terms = $post->terms( [
+$terms = $post->terms([
     'taxonomy' => 'custom_tax',
-    'orderby'  => 'count',
+    'orderby' => 'count',
 ], [
-    'merge'        => false,
-] );
+    'merge' => false,
+]);
 ```
 
 And in Twig:
@@ -1101,10 +1123,14 @@ We changed the function parameters for the `Timber\Term::posts()` function to be
 
 ```php
 // Old
-function posts( $numberposts_or_args = 10, $post_type_or_class = 'any', $post_class = '' );
+function posts($numberposts_or_args = 10, $post_type_or_class = 'any', $post_class = '')
+{
+};
 
 // New
-function posts( $query_args = [] );
+function posts($query_args = [])
+{
+};
 ```
 
 **Old usage**
@@ -1112,7 +1138,7 @@ function posts( $query_args = [] );
 In PHP:
 
 ```php
-$genre->posts( -1, 'book' );
+$genre->posts(-1, 'book');
 ```
 
 And in Twig:
@@ -1126,11 +1152,11 @@ And in Twig:
 In PHP:
 
 ```php
-$genre->posts( [
-    'post_type'     => 'book',
+$genre->posts([
+    'post_type' => 'book',
     'post_per_page' => -1,
-    'orderby'       => 'menu_order'
-] );
+    'orderby' => 'menu_order',
+]);
 ```
 
 And in Twig:
@@ -1146,16 +1172,16 @@ And in Twig:
 You can still also pass an int as the sole argument, to tell it how many posts you want:
 
 ```php
-$genre->posts( 3 );
+$genre->posts(3);
 ```
 
 This is equivalent to:
 
 ```php
-$genre->posts( [
+$genre->posts([
     'posts_per_page' => 3,
-    'post_type'      => 'any',
-] );
+    'post_type' => 'any',
+]);
 ```
 
 ## Post Excerpts
@@ -1184,7 +1210,7 @@ You can control this behavior with these two new parameters for excerpts:
 There’s a new `timber/post/excerpt/defaults` filter that can be used to update default options for excerpts, including `always_add_read_more` and `always_add_end`.
 
 ```php
-add_filter( 'timber/post/excerpt/defaults', function( $defaults ) {
+add_filter('timber/post/excerpt/defaults', function ($defaults) {
     // Only add a read more link if the post content isn’t longer than the excerpt.
     $defaults['always_add_read_more'] = false;
 
@@ -1192,7 +1218,7 @@ add_filter( 'timber/post/excerpt/defaults', function( $defaults ) {
     $defaults['words'] = 240;
 
     return $defaults;
-} );
+});
 ```
 
 ### `post.excerpt` takes arguments in array/hash notation
@@ -1202,14 +1228,14 @@ The `{{ post.excerpt }}` function was added as a replacement for `{{ post.previe
 **PHP**
 
 ```php
-$post->excerpt( [
-    'words'     => 50,
-    'chars'     => false,
-    'end'       => '&hellip;',
-    'force'     => false,
-    'strip'     => true,
+$post->excerpt([
+    'words' => 50,
+    'chars' => false,
+    'end' => '&hellip;',
+    'force' => false,
+    'strip' => true,
     'read_more' => 'Read More',
-] );
+]);
 ```
 
 **Twig**
@@ -1339,11 +1365,11 @@ You can control this behavior using the [`timber/sideload_image/subdir`](https:/
 While Twig has escaping enabled by default, Timber doesn’t automatically enable espacing for Twig. To enable autoescaping in Timber 1.x, you would use `Timber::$autoescape = true`. The value `true` was deprecated for Twig 2.0, you now have to use `html` or [another auto-escaping strategy](https://twig.symfony.com/doc/2.x/api.html#environment-options) instead. You’ll need to use the `timber/twig/environment/options` filter:
 
 ```php
-add_filter( 'timber/twig/environment/options', function( $options ) {
-	$options['autoescape'] = 'html';
+add_filter('timber/twig/environment/options', function ($options) {
+    $options['autoescape'] = 'html';
 
-	return $options;
-} );
+    return $options;
+});
 ```
 
 Read more about this in the [Escaping Guide](@todo).

--- a/src/Factory/TermFactory.php
+++ b/src/Factory/TermFactory.php
@@ -48,7 +48,7 @@ class TermFactory
         return null;
     }
 
-    protected function from_id(int $id)
+    protected function from_id(int $id): ?Term
     {
         $wp_term = get_term($id);
 


### PR DESCRIPTION
- Fix CS on all v2 docs code snippets
- Fix PHP syntax errors in snippets
- Self promote var-dumper-configurator package :)

The choice of ECS to run coding standards checks was also motivated by its ability to fix code snippets in markdown files to avoid too much manual maintenance of docs snippets. Note that for the CS fixing to work properly, the snippets have to be valid PHP. 

This PR has been a chance to fix many syntax errors in those snippets (missing parenthesis, bracket, etc.).