### PR TITLE
Added AVIF support

### DIFF
--- a/docs/guides/cookbook-images.md
+++ b/docs/guides/cookbook-images.md
@@ -83,6 +83,19 @@ Similar to the `|tojpg` filter, there’s a `|towebp` filter.
 </picture>
 ```
 
+### Using AVIF images
+
+Similar to the `|towebp` filter, there’s a `|toavif` filter.
+
+```twig
+<picture>
+   <source srcset="{{ post.thumbnail.src|toavif }}" type="image/avif">
+   <source srcset="{{ post.thumbnail.src|towebp }}" type="image/webp">
+   <source srcset="{{ post.thumbnail.src|tojpg }}" type="image/jpeg">
+   <img src="{{ post.thumbnail.src|tojpg }}" alt="{{ post.title }}">
+</picture>
+```
+
 ## Generating retina sizes
 
 You can use Timber to generate @2x image sizes for retina devices. For example, using `srcset`:

--- a/lib/Image.php
+++ b/lib/Image.php
@@ -542,7 +542,7 @@ class Image extends Post implements CoreInterface {
 	 */
 	protected function is_image() {
 		$src = wp_get_attachment_url($this->ID);
-		$image_exts = array( 'gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp' );
+		$image_exts = array( 'gif', 'jpg', 'jpeg', 'jpe', 'png', 'webp', 'avif' );
 		$check = wp_check_filetype(PathHelper::basename($src), null);
 		return in_array($check['ext'], $image_exts);
 	}

--- a/lib/Image/Operation/Letterbox.php
+++ b/lib/Image/Operation/Letterbox.php
@@ -118,6 +118,9 @@ class Letterbox extends ImageOperation {
 			} else if ( $ext == 'webp' ) {
 				$func = 'imagecreatefromwebp';
 				$save_func = 'imagewebp';
+			} else if ( $ext == 'avif' ) {
+				$func = 'imagecreatefromavif';
+				$save_func = 'imageavif';
 			}
 			$image = $func($save_filename);
 			imagecopy($bg, $image, $x, $y, 0, 0, $owt, $oht);

--- a/lib/Image/Operation/ToAvif.php
+++ b/lib/Image/Operation/ToAvif.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Timber\Image\Operation;
+
+use Timber\Helper as Helper;
+use Timber\Image\Operation as ImageOperation;
+use Timber\ImageHelper;
+
+/**
+ * This class is used to process avif images. Not all server configurations support avif. 
+ * If avif is not enabled, Timber will generate avif images instead
+ * @codeCoverageIgnore
+ */
+class ToAvif extends ImageOperation {
+
+	private $quality;
+
+	/**
+	 * @param string $quality  ranges from 0 (worst quality, smaller file) to 100 (best quality, biggest file)
+	 */
+	public function __construct( $quality ) {
+		$this->quality = $quality;
+	}
+
+	/**
+	 * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
+	 * @param   string    $src_extension    ignored
+	 * @return  string    the final filename to be used (ex: my-awesome-pic.avif)
+	 */
+	public function filename( $src_filename, $src_extension = 'avif' ) {
+		$new_name = $src_filename  . '.avif';
+		return $new_name;
+	}
+
+	/**
+	 * Performs the actual image manipulation,
+	 * including saving the target file.
+	 *
+	 * @param  string $load_filename filepath (not URL) to source file (ex: /src/var/www/wp-content/uploads/my-pic.avif)
+	 * @param  string $save_filename filepath (not URL) where result file should be saved
+	 *                               (ex: /src/var/www/wp-content/uploads/my-pic.avif)
+	 * @return bool                  true if everything went fine, false otherwise
+	 */
+	public function run( $load_filename, $save_filename ) {
+        if (!is_file($load_filename)) {
+            return false;
+        }
+
+        // Attempt to check if SVG.
+		if ( ImageHelper::is_svg($load_filename) ) {
+			return false;
+		}
+
+		$ext = wp_check_filetype($load_filename);
+		if ( isset($ext['ext']) ) {
+			$ext = $ext['ext'];
+		}
+		$ext = strtolower($ext);
+		$ext = str_replace('jpg', 'jpeg', $ext);
+
+		$imagecreate_function = 'imagecreatefrom' . $ext;
+		if ( !function_exists($imagecreate_function) ) {
+			return false;
+		}
+
+		$input = $imagecreate_function($load_filename);
+
+        if ( !imageistruecolor($input) ) {
+            imagepalettetotruecolor($input);
+        }
+
+		if (!function_exists('imageavif')) {
+			Helper::error_log('The function imageavif does not exist on this server to convert image to '.$save_filename.'.');
+			return false;
+		}
+
+		return imageavif($input, $save_filename, $this->quality);
+    }
+}

--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -5,6 +5,7 @@ namespace Timber;
 use Timber\Image;
 use Timber\Image\Operation\ToJpg;
 use Timber\Image\Operation\ToWebp;
+use Timber\Image\Operation\ToAvif;
 use Timber\Image\Operation\Resize;
 use Timber\Image\Operation\Retina;
 use Timber\Image\Operation\Letterbox;
@@ -215,6 +216,20 @@ class ImageHelper {
      */
     public static function img_to_webp( $src, $quality = 80, $force = false ) {
         $op = new Image\Operation\ToWebp($quality);
+        return self::_operate($src, $op, $force);
+    }
+
+    /**
+     * Generates a new image by converting the source into AVIF if supported by the server
+     *
+     * @param string  $src      a url or path to the image (http://example.org/wp-content/uploads/2014/image.avif)
+     *							or (/wp-content/uploads/2014/image.jpg)
+     *							If avif is not supported, a jpeg image will be generated
+	 * @param int     $quality  ranges from 0 (worst quality, smaller file) to 100 (best quality, biggest file)
+     * @param bool    $force
+     */
+    public static function img_to_avif( $src, $quality = 80, $force = false ) {
+        $op = new Image\Operation\ToAvif($quality);
         return self::_operate($src, $op, $force);
     }
 

--- a/lib/Twig.php
+++ b/lib/Twig.php
@@ -178,6 +178,7 @@ class Twig {
 		$twig->addFilter(new Twig_Filter('letterbox', array('Timber\ImageHelper', 'letterbox')));
 		$twig->addFilter(new Twig_Filter('tojpg', array('Timber\ImageHelper', 'img_to_jpg')));
 		$twig->addFilter(new Twig_Filter('towebp', array('Timber\ImageHelper', 'img_to_webp')));
+		$twig->addFilter(new Twig_Filter('toavif', array('Timber\ImageHelper', 'img_to_avif')));
 
 		/* debugging filters */
 		$twig->addFilter(new Twig_Filter('get_class', 'get_class'));

--- a/tests/test-timber-image-toavif.php
+++ b/tests/test-timber-image-toavif.php
@@ -1,0 +1,66 @@
+<?php
+
+	class TestTimberImageToAVIF extends Timber_UnitTestCase {
+
+		function setUp() {
+			parent::setUp();
+			if ( ! function_exists( 'imageavif' ) ) {
+				self::markTestSkipped( 'AVIF conversion tests requires imageavif function' );
+			}
+		}
+
+		function testTIFtoAVIF() {
+			$filename = TestTimberImage::copyTestImage( 'white-castle.tif' );
+			$str = Timber::compile_string('{{file|toavif}}', array('file' => $filename));
+			$this->assertEquals($filename, $str);
+		}
+
+		function testPNGtoAVIF() {
+			$filename = TestTimberImage::copyTestImage( 'flag.png' );
+			$str = Timber::compile_string('{{file|toavif}}', array('file' => $filename));
+			$renamed = str_replace('.png', '.avif', $filename);
+			$this->assertFileExists($renamed);
+			$this->assertGreaterThan(1000, filesize($renamed));
+			$this->assertEquals('image/png', mime_content_type($filename));
+			$this->assertEquals('image/avif', mime_content_type($renamed));
+		}
+
+		function testGIFtoJPG() {
+			$filename = TestTimberImage::copyTestImage( 'boyer.gif' );
+			$str = Timber::compile_string('{{file|toavif}}', array('file' => $filename));
+			$renamed = str_replace('.gif', '.avif', $filename);
+			$this->assertFileExists($renamed);
+			$this->assertGreaterThan(1000, filesize($renamed));
+			$this->assertEquals('image/gif', mime_content_type($filename));
+			$this->assertEquals('image/avif', mime_content_type($renamed));
+		}
+
+		function testJPGtoAVIF() {
+			$filename = TestTimberImage::copyTestImage( 'stl.jpg' );
+			$original_size = filesize($filename);
+			$str = Timber::compile_string('{{file|toavif(100)}}', array('file' => $filename));
+			$renamed = str_replace('.jpg', '.avif', $filename);
+			$this->assertGreaterThan(1000, filesize($renamed));
+			$this->assertEquals('image/jpeg', mime_content_type($filename));
+			$this->assertEquals('image/avif', mime_content_type($renamed));
+		}
+
+		function testJPEGtoJPG() {
+			$filename = TestTimberImage::copyTestImage( 'jarednova.jpeg' );
+			$str = Timber::compile_string('{{file|toavif}}', array('file' => $filename));
+			$renamed = str_replace('.jpeg', '.avif', $filename);
+			$this->assertFileExists($renamed);
+			$this->assertGreaterThan(1000, filesize($renamed));
+			$this->assertEquals('image/jpeg', mime_content_type($filename));
+			$this->assertEquals('image/avif', mime_content_type($renamed));
+		}
+
+		function testAVIFtoAVIF() {
+			$filename = TestTimberImage::copyTestImage( 'mountains.avif' );
+			$original_size = filesize($filename);
+			$str = Timber::compile_string('{{file|toavif}}', array('file' => $filename));
+			$new_size = filesize($filename);
+			$this->assertEquals($original_size, $new_size);
+			$this->assertEquals('image/avif', mime_content_type($filename));
+		}
+	}


### PR DESCRIPTION
**Ticket**: [#2596](https://github.com/timber/timber/issues/2596)

## Issue
Added a ```toavif``` filter for even smaller file compression


## Solution
Duplicated the ```towebp``` code but instead used PHP 8.1's native ```imageavif``` function.


## Impact
If ```imageavif``` isn't available, it should fail gracefully ensuring backwards compatibility. 


## Usage Changes
I've added in the docs for the ```toavif``` filter.


## Testing
I've duplicated the WEBP tests as they should be the same for AVIF.
