### PR TITLE
2.x Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,20 @@
-/.gitattributes export-ignore
 /.github export-ignore
 /bin export-ignore
 /docs export-ignore
+/lando-config export-ignore
 /tests export-ignore
 /.coveralls.yml export-ignore
 /.editorconfig export-ignore
+/.git-blame-ignore-revs export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore
 /.scrutinizer.yml export-ignore
-/.travis.yml export-ignore
 /CONTRIBUTING.md export-ignore
 /README.md export-ignore
 /composer.json export-ignore
+/ecs.php
+/grumphp.php
 /phpcs.xml export-ignore
 /phpstan.neon export-ignore
 /phpunit-nocover.xml export-ignore
-/phpunit.xml  export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
Some files are still downloaded when non-dev version of Timber is requested through Composer. This pull requests updates the **.gitattributes** file to not distribute these files to production releases.