### PR TITLE
2.x Make Timber\Request not implement Timber\CoreInterface

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -5,9 +5,9 @@ namespace Timber;
 /**
  * Class Request
  *
- * Timber\Request exposes $_GET and $_POST to the context
+ * Timber\Request exposes $_GET and $_POST to the context.
  */
-class Request extends Core implements CoreInterface
+class Request
 {
     public $post = [];
 
@@ -15,7 +15,6 @@ class Request extends Core implements CoreInterface
 
     /**
      * Constructs a Timber\Request object
-     * @example
      */
     public function __construct()
     {
@@ -29,24 +28,5 @@ class Request extends Core implements CoreInterface
     {
         $this->post = $_POST;
         $this->get = $_GET;
-    }
-
-    public function __call($field, $args)
-    {
-    }
-
-    public function __get($field)
-    {
-    }
-
-    /**
-     * @return boolean|null
-     */
-    public function __isset($field)
-    {
-    }
-
-    public function meta($key)
-    {
     }
 }


### PR DESCRIPTION
## Issue

While working on fixing some PHPStan issues, I found that the `Timber\Request` class extends `Timber\Core` and implements `Timber\CoreInterface`.

In the current state of Timber, I don’t see any reason why it should do so. Even when it was introduced in #853, it wasn’t clearly stated why it should extend `Timber\Core`.

The method required by `Timber\CoreInterface` are added as empty functions and they look like they were added only to serve the interface. But this request helper class doesn’t have anything to do with a Timber core object that usually matches core functionality in WordPress.

## Solution

Make `Timber\Request` not implement `Timber\CoreInterface`.

## Impact

This might break backwards compatibility with any class that extends `Timber\Request`. We will have to add a note to the Upgrade Guide.

## Usage Changes

None.

## Considerations

We could move this to a future release and not release this breaking change in 2.x. In that case, we would have to add a return to `__isset()` to fix the PHPStan issue.

I’d really like to get a second opinion on this one.

## Testing

No.