### PR TITLE
2.x user can args

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -374,6 +374,7 @@ class User extends CoreEntity
      * @since 1.8.5
      *
      * @param string $capability The capability to check.
+     * @param mixed ...$args Additional arguments to pass to the user_can function
      *
      * @example
      * Give moderation users another CSS class to style them differently.
@@ -384,11 +385,20 @@ class User extends CoreEntity
      * </span>
      * ```
      *
+     * @example
+     * Show edit link for posts that a user can edit
+     *
+     * ```twig
+     * {% if user.can('edit_post', post.id) %}
+     *     <a href="{{post.edit_link}}">Edit Post</a>
+     * {% endif %}
+     * ```
+     *
      * @return bool Whether the user has the capability.
      */
-    public function can($capability)
+    public function can($capability, ...$args)
     {
-        return user_can($this->ID, $capability);
+        return user_can($this->ID, $capability, ...$args);
     }
 
     /**

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -73,9 +73,29 @@ class TestTimberUser extends Timber_UnitTestCase
             'user_login' => 'mbottitta',
             'role' => 'editor',
         ]);
+
+        $subscriber_uid = $this->factory->user->create([
+            'display_name' => 'Baberaham Lincoln',
+            'user_login' => 'blincoln',
+            'role' => 'subscriber',
+        ]);
+
+        $post_id = wp_insert_post(
+            [
+                'post_title' => 'Baseball',
+                'post_content' => 'is fine, I guess',
+                'post_status' => 'publish',
+            ]
+        );
+
         $user = Timber::get_user_by('login', 'mbottitta');
+        $subscriber = Timber::get_user_by('login', 'blincoln');
+
         $this->assertTrue($user->can('edit_posts'));
+        $this->assertTrue($user->can('edit_post', $post_id));
         $this->assertFalse($user->can('activate_plugins'));
+        $this->assertFalse($subscriber->can('edit_posts'));
+        $this->assertFalse($subscriber->can('edit_post', $post_id));
     }
 
     public function testUserRole()


### PR DESCRIPTION
**Ticket**: #2532 

## Issue
fixes issue where `{{user.can('capability', arg)}}` doesn't work because arg is not passed to user_can

## Solution
Spreads arguments from `\Timber\User::can` to `user_can` function 

## Impact
No backward compatibility breaking changes (besides fixing the issue at hand)

## Usage Changes
The following now work:

```twig
{% if user.can('edit_post', post.id) %}
    {# do something with privileges #}
{% endif %}
```

```twig
{% if user.can('edit_term', term.id) %}
    {# do something with privileges #}
{% endif %}
```

```twig
{% if user.can('edit_user', user.id) %}
    {# do something with privileges #}
{% endif %}
```

```twig
{% if user.can('edit_comment', comment.id) %}
    {# do something with privileges #}
{% endif %}
```

## Considerations
The way timber 2.x tends to use this now is with `\Timber\Core::can_edit` https://github.com/timber/timber/blob/8d9bff23d2677652469badb75dcb607449a18204/lib/Core.php#L100-L108

However this method is in `\Timber\Core` and other classes such as `\Timber\User` and `\Timber\Term` also extend `\Timber\CoreEntity` (and thus `\Timber\Core`) and is not re-defined in sub-classes. This means that this code is checking against `edit_post` capability for the can_edit method of non Post classes. This code should should move to their specific sub-classes so there is no possibility of false negatives/false positives when id's match.

## Testing
Tests are written but un-tested. I've had some issues getting the tests to run correctly getting the error `Could not find /includes/functions.php`. Chasing down the error it has to do with the Yoast integration but I've hit a dead end in resolving that.
