### PR TITLE
External image (Fixes #2627)

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -831,7 +831,9 @@ The following functions are being deprecated and will be removed in a future ver
 
 - `get_pathinfo()` – use `pathinfo()` instead.
 - `get_dimensions()` – use `width()` or `height()` instead.
-- `get_dimensions_loaded()` – use `get_dimension_loaded()` instead.
+- `get_dimensions_loaded()` – use `width()` or `height()` instead.
+- `get_dimension()` – use `width()` or `height()` instead.
+- `get_dimension_loaded()` – use `width()` or `height()` instead.
 - `get_post_custom()` – use `meta()` instead.
 
 ### Timber\Term

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -42,22 +42,13 @@ class Attachment extends Post
     public $file_loc;
 
     /**
-     * Raw file size.
-     *
-     * @api
-     * @since 2.0.0
-     * @var int Raw file size in bytes.
-     */
-    public $file_size_raw = null;
-
-    /**
      * Formatted file size.
      *
      * @api
      * @since 2.0.0
-     * @var null|string File size string.
+     * @var FileSize File size string.
      */
-    public $file_size = null;
+    private $file_size = null;
 
     /**
      * File extension.
@@ -120,59 +111,6 @@ class Attachment extends Post
     }
 
     /**
-     * Inits the object with an absolute path.
-     *
-     * @internal
-     *
-     * @param string $file_path An absolute path to a file.
-     */
-    protected function init_with_file_path($file_path)
-    {
-        $url = URLHelper::file_system_to_url($file_path);
-
-        $this->abs_url = $url;
-        $this->file_loc = $file_path;
-        $this->file = $file_path;
-    }
-
-    /**
-     * Inits the object with a relative path.
-     *
-     * @internal
-     *
-     * @param string $relative_path A relative path to a file.
-     */
-    protected function init_with_relative_path($relative_path)
-    {
-        $file_path = URLHelper::get_full_path($relative_path);
-
-        $this->abs_url = home_url($relative_path);
-        $this->file_loc = $file_path;
-        $this->file = $file_path;
-    }
-
-    /**
-     * Inits the object with an URL.
-     *
-     * @internal
-     *
-     * @param string $url An URL on the same host.
-     */
-    protected function init_with_url($url)
-    {
-        $this->abs_url = $url;
-
-        if (URLHelper::is_local($url)) {
-            $this->file = URLHelper::remove_double_slashes(
-                ABSPATH . URLHelper::get_rel_url($url)
-            );
-            $this->file_loc = URLHelper::remove_double_slashes(
-                ABSPATH . URLHelper::get_rel_url($url)
-            );
-        }
-    }
-
-    /**
      * Gets the attachment information.
      *
      * @internal
@@ -197,23 +135,9 @@ class Attachment extends Post
             $data['file_loc'] = $basedir . DIRECTORY_SEPARATOR . $data['file'];
         }
 
+        $data['file_size'] = new FileSize($data['file_loc']);
+
         return $data;
-    }
-
-    /**
-     * Secures an URL based on the current environment.
-     *
-     * @param  string $url The URL to evaluate.
-     *
-     * @return string An URL with or without http/https, depending on what’s appropriate for server.
-     */
-    protected function maybe_secure_url($url)
-    {
-        if (is_ssl() && strpos($url, 'https') !== 0 && strpos($url, 'http') === 0) {
-            $url = 'https' . substr($url, strlen('http'));
-        }
-
-        return $url;
     }
 
     /**
@@ -279,7 +203,7 @@ class Attachment extends Post
     public function src()
     {
         if (isset($this->abs_url)) {
-            return $this->maybe_secure_url($this->abs_url);
+            return URLHelper::maybe_secure_url($this->abs_url);
         }
 
         return wp_get_attachment_url($this->ID);
@@ -340,12 +264,11 @@ class Attachment extends Post
      */
     public function size()
     {
-        if (!$this->file_size) {
-            $formatted_size = size_format($this->size_raw());
-            $this->file_size = str_replace(' ', '&nbsp;', $formatted_size);
+        if ($this->file_size) {
+            return $this->file_size->size();
         }
 
-        return $this->file_size;
+        return false;
     }
 
     /**
@@ -371,11 +294,11 @@ class Attachment extends Post
      */
     public function size_raw()
     {
-        if (!$this->file_size_raw) {
-            $this->file_size_raw = filesize($this->file_loc);
+        if ($this->file_size) {
+            return $this->file_size->size_raw();
         }
 
-        return $this->file_size_raw;
+        return false;
     }
 
     /**

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -48,7 +48,7 @@ class Attachment extends Post
      * @since 2.0.0
      * @var FileSize File size string.
      */
-    private $file_size = null;
+    public $file_size = null;
 
     /**
      * File extension.

--- a/src/CoreEntity.php
+++ b/src/CoreEntity.php
@@ -81,7 +81,6 @@ abstract class CoreEntity extends Core implements CoreInterface, CoreEntityInter
      */
     protected function fetch_meta($field_name = '', $args = [], $apply_filters = true)
     {
-
         /**
          * Filters whether to transform a meta value.
          *

--- a/src/ExternalImage.php
+++ b/src/ExternalImage.php
@@ -1,0 +1,484 @@
+<?php
+
+namespace Timber;
+
+/**
+ * Class ExternalImage
+ *
+ * The `Timber\ExternalImage` class represents an external image loaded via http.
+ *
+ * @api
+ * @example
+ * ```php
+ * $context = Timber::context();
+ *
+ * // Lets say you have an external image that you want to use in your theme
+ *
+ * $context['cover_image'] = Timber::get_external_image($url);
+ *
+ * Timber::render('single.twig', $context);
+ * ```
+ *
+ * ```twig
+ * <article>
+ *   <img src="{{cover_image.src}}" class="cover-image" />
+ *   <h1 class="headline">{{post.title}}</h1>
+ *   <div class="body">
+ *     {{post.content}}
+ *   </div>
+ *
+ *  <img
+ *    src="{{ get_image(post.custom_field_with_image_id).src }}"
+ *    alt="Another way to initialize images as Timber\Image objects, but within Twig" />
+ * </article>
+ * ```
+ *
+ * ```html
+ * <article>
+ *   <img src="http://example.org/wp-content/uploads/2015/06/nevermind.jpg" class="cover-image" />
+ *   <h1 class="headline">Now you've done it!</h1>
+ *   <div class="body">
+ *     Whatever whatever
+ *   </div>
+ *   <img
+ *     src="http://example.org/wp-content/uploads/2015/06/kurt.jpg"
+ *     alt="Another way to initialize images as Timber\Image objects, but within Twig" />
+ * </article>
+ * ```
+ */
+class ExternalImage implements ImageInterface
+{
+    /**
+     * File.
+     *
+     * @api
+     * @var string
+     */
+    private $alt_text;
+
+    protected function __construct($alt)
+    {
+        $this->alt_text = $alt;
+    }
+
+
+    /**
+     * File.
+     *
+     * @api
+     * @var mixed
+     */
+    public $file;
+
+    /**
+     * File location.
+     *
+     * @api
+     * @var string The absolute path to the attachmend file in the filesystem
+     *             (Example: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
+     */
+    public $file_loc;
+
+
+    /**
+     * Absolute URL.
+     *
+     * @var string The absolute URL to the attachment.
+     */
+    public $abs_url;
+
+    /**
+     * File extension.
+     *
+     * @api
+     * @since 2.0.0
+     * @var null|string A file extension.
+     */
+    public $file_extension = null;
+
+    /**
+     * Formatted file size.
+     *
+     * @api
+     * @since 2.0.0
+     * @var FileSize File size string.
+     */
+    private $file_size = null;
+
+    /**
+     * File types.
+     *
+     * @var array An array of supported relative file types.
+     */
+    private $image_file_types = [
+        'jpg',
+        'jpeg',
+        'png',
+        'svg',
+        'bmp',
+        'ico',
+        'gif',
+        'tiff',
+        'pdf',
+    ];
+
+    /**
+     * Image dimensions.
+     *
+     * @internal
+     * @var ImageDimensions stores Image Dimensions in a structured way.
+     */
+    protected ImageDimensions $imageDimensions;
+
+    /**
+     * Inits the ExternalImage object.
+     *
+     * @internal
+     *
+     * @param $url string URL to load the image from.
+     * @param $alt string ALT text for the image.
+     */
+    public static function build($url, $alt)
+    {
+        if (!is_numeric($url) && is_string($url)) {
+            $external_image = new ExternalImage($alt);
+            if (strstr($url, '://')) {
+                // Assume URL.
+                $external_image->init_with_url($url);
+
+                return $external_image;
+            } elseif (strstr($url, ABSPATH)) {
+                // Assume absolute path.
+                $external_image->init_with_file_path($url);
+
+                return $external_image;
+            } else {
+                // Check for image file types.
+                foreach ($external_image->image_file_types as $type) {
+                    // Assume a relative path.
+                    if (strstr(strtolower($url), $type)) {
+                        $external_image->init_with_relative_path($url);
+
+                        return $external_image;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Gets the source URL for the image.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ post.thumbnail.src }}">
+     * <img src="{{ post.thumbnail.src('medium') }}">
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" />
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic-800-600.jpg">
+     * ```
+     *
+     * @param string $size Ignored. For compatibility with Timber\Image.
+     *
+     * @return string The src URL for the image.
+     */
+    public function src($size = 'full')
+    {
+        return URLHelper::maybe_secure_url($this->abs_url);
+    }
+
+    /**
+     * Gets the relative path to an attachment.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ image.path }}" />
+     * ```
+     * ```html
+     * <img src="/wp-content/uploads/2015/08/pic.jpg" />
+     * ```
+     *
+     * @return string The relative path to an attachment.
+     */
+    public function path()
+    {
+        return URLHelper::get_rel_path($this->src());
+    }
+
+    /**
+     * Gets filesize in a human readable format.
+     *
+     * This can be useful if you want to display the human readable filesize for a file. It’s
+     * easier to read «16 KB» than «16555 bytes» or «1 MB» than «1048576 bytes».
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     *
+     * Use filesize information in a link that downloads a file:
+     *
+     * ```twig
+     * <a class="download" href="{{ attachment.src }}" download="{{ attachment.title }}">
+     *     <span class="download-title">{{ attachment.title }}</span>
+     *     <span class="download-info">(Download, {{ attachment.size }})</span>
+     * </a>
+     * ```
+     *
+     * @return mixed|null The filesize string in a human readable format.
+     */
+    public function size()
+    {
+        if ($this->file_size) {
+            return $this->file_size->size();
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets filesize in bytes.
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     *
+     * ```twig
+     * <table>
+     *     {% for attachment in Attachment(attachment_ids) %}
+     *         <tr>
+     *             <td>{{ attachment.title }}</td>
+     *             <td>{{ attachment.extension }}</td>
+     *             <td>{{ attachment.size_raw }} bytes</td>
+     *         </tr>
+     *     {% endfor %}
+     * </table>
+     * ```
+     *
+     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
+     */
+    public function size_raw()
+    {
+        if ($this->file_size) {
+            return $this->file_size->size_raw();
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets the src for an attachment.
+     *
+     * @return string The src of the attachment.
+     * @api
+     *
+     */
+    public function __toString()
+    {
+        return $this->src();
+    }
+
+
+    /**
+     * Gets the extension of the attached file.
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     *
+     * Use extension information in a link that downloads a file:
+     *
+     * ```twig
+     * <a class="download" href="{{ attachment.src }}" download="{{ attachment.title }}">
+     *     <span class="download-title">{{ attachment.title }}</span>
+     *     <span class="download-info">
+     *         (Download {{ attachment.extension|upper }}, {{ attachment.size }})
+     *     </span>
+     * </a>
+     * ```
+     *
+     * @return null|string An uppercase extension string.
+     */
+    public function extension()
+    {
+        if (!$this->file_extension) {
+            $file_info = wp_check_filetype($this->file);
+
+            if (!empty($file_info['ext'])) {
+                $this->file_extension = strtoupper($file_info['ext']);
+            }
+        }
+
+        return $this->file_extension;
+    }
+
+    /**
+     * Gets the width of the image in pixels.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" width="{{ image.width }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" width="1600" />
+     * ```
+     *
+     * @return int The width of the image in pixels.
+     */
+    public function width()
+    {
+        return $this->imageDimensions->width();
+    }
+
+    /**
+     * Gets the height of the image in pixels.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" height="{{ image.height }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" height="900" />
+     * ```
+     *
+     * @return int The height of the image in pixels.
+     */
+    public function height()
+    {
+        return $this->imageDimensions->height();
+    }
+
+    /**
+     * Gets the aspect ratio of the image.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if post.thumbnail.aspect < 1 %}
+     *   {# handle vertical image #}
+     *   <img src="{{ post.thumbnail.src|resize(300, 500) }}" alt="A basketball player" />
+     * {% else %}
+     *   <img src="{{ post.thumbnail.src|resize(500) }}" alt="A sumo wrestler" />
+     * {% endif %}
+     * ```
+     *
+     * @return float The aspect ratio of the image.
+     */
+    public function aspect()
+    {
+        return $this->imageDimensions->aspect();
+    }
+
+    /**
+     * Inits the object with an absolute path.
+     *
+     * @param string $file_path An absolute path to a file.
+     * @internal
+     *
+     */
+    protected function init_with_file_path($file_path)
+    {
+        $url = URLHelper::file_system_to_url($file_path);
+
+        $this->abs_url = $url;
+        $this->file_loc = $file_path;
+        $this->file = $file_path;
+        $this->imageDimensions = new ImageDimensions($file_path);
+        $this->file_size = new FileSize($file_path);
+    }
+
+
+    /**
+     * Inits the object with a relative path.
+     *
+     * @param string $relative_path A relative path to a file.
+     * @internal
+     *
+     */
+    protected function init_with_relative_path($relative_path)
+    {
+        $file_path = URLHelper::get_full_path($relative_path);
+
+        $this->abs_url = home_url($relative_path);
+        $this->file_loc = $file_path;
+        $this->file = $file_path;
+        $this->imageDimensions = new ImageDimensions($file_path);
+        $this->file_size = new FileSize($file_path);
+    }
+
+    /**
+     * Inits the object with an URL.
+     *
+     * @param string $url An URL on the same host.
+     * @internal
+     *
+     */
+    protected function init_with_url($url)
+    {
+        $this->abs_url = $url;
+
+        if (URLHelper::is_local($url)) {
+            $this->file = URLHelper::remove_double_slashes(
+                ABSPATH . URLHelper::get_rel_url($url)
+            );
+            $this->file_loc = URLHelper::remove_double_slashes(
+                ABSPATH . URLHelper::get_rel_url($url)
+            );
+            $this->imageDimensions = new ImageDimensions($this->file_loc);
+            $this->file_size = new FileSize($this->file_loc);
+        } else {
+            $this->imageDimensions = new ImageDimensions();
+        }
+    }
+
+    /**
+     * Gets the alt text for an image.
+     *
+     * For better accessibility, you should always add an alt attribute to your images, even if it’s
+     * empty.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" alt="{{ image.alt }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg"
+     *     alt="You should always add alt texts to your images for better accessibility" />
+     * ```
+     *
+     * @return string Alt text stored in WordPress.
+     */
+    public function alt()
+    {
+        return $this->alt_text;
+    }
+
+    public function caption()
+    {
+        return "";
+    }
+
+    public function img_sizes($size = "full")
+    {
+        return [$size];
+    }
+
+    public function srcset($size = "full")
+    {
+        $source = array(
+            'url'        => $this->src(),
+            'descriptor' => 'w',
+            'value'      => $size,
+        );
+
+        return str_replace( ' ', '%20', $source['url'] ) . ' ' . $source['value'] . $source['descriptor'] ;
+    }
+}

--- a/src/ExternalImage.php
+++ b/src/ExternalImage.php
@@ -61,7 +61,6 @@ class ExternalImage implements ImageInterface
         $this->alt_text = $alt;
     }
 
-
     /**
      * File.
      *
@@ -78,7 +77,6 @@ class ExternalImage implements ImageInterface
      *             (Example: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
      */
     public $file_loc;
-
 
     /**
      * Absolute URL.
@@ -133,10 +131,10 @@ class ExternalImage implements ImageInterface
     /**
      * Inits the ExternalImage object.
      *
-     * @internal
-     *
      * @param $url string URL to load the image from.
      * @param $alt string ALT text for the image.
+     * @internal
+     *
      */
     public static function build($url, $alt)
     {
@@ -168,10 +166,12 @@ class ExternalImage implements ImageInterface
         return null;
     }
 
-
     /**
      * Gets the source URL for the image.
      *
+     * @param string $size Ignored. For compatibility with Timber\Image.
+     *
+     * @return string The src URL for the image.
      * @api
      * @example
      * ```twig
@@ -183,9 +183,6 @@ class ExternalImage implements ImageInterface
      * <img src="http://example.org/wp-content/uploads/2015/08/pic-800-600.jpg">
      * ```
      *
-     * @param string $size Ignored. For compatibility with Timber\Image.
-     *
-     * @return string The src URL for the image.
      */
     public function src($size = 'full')
     {
@@ -195,7 +192,7 @@ class ExternalImage implements ImageInterface
     /**
      * Gets the relative path to an attachment.
      *
-     * @api
+     * @return string The relative path to an attachment.
      * @example
      * ```twig
      * <img src="{{ image.path }}" />
@@ -204,7 +201,7 @@ class ExternalImage implements ImageInterface
      * <img src="/wp-content/uploads/2015/08/pic.jpg" />
      * ```
      *
-     * @return string The relative path to an attachment.
+     * @api
      */
     public function path()
     {
@@ -217,7 +214,7 @@ class ExternalImage implements ImageInterface
      * This can be useful if you want to display the human readable filesize for a file. It’s
      * easier to read «16 KB» than «16555 bytes» or «1 MB» than «1048576 bytes».
      *
-     * @api
+     * @return mixed|null The filesize string in a human readable format.
      * @since 2.0.0
      * @example
      *
@@ -230,7 +227,7 @@ class ExternalImage implements ImageInterface
      * </a>
      * ```
      *
-     * @return mixed|null The filesize string in a human readable format.
+     * @api
      */
     public function size()
     {
@@ -244,7 +241,7 @@ class ExternalImage implements ImageInterface
     /**
      * Gets filesize in bytes.
      *
-     * @api
+     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
      * @since 2.0.0
      * @example
      *
@@ -260,7 +257,7 @@ class ExternalImage implements ImageInterface
      * </table>
      * ```
      *
-     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
+     * @api
      */
     public function size_raw()
     {
@@ -283,11 +280,10 @@ class ExternalImage implements ImageInterface
         return $this->src();
     }
 
-
     /**
      * Gets the extension of the attached file.
      *
-     * @api
+     * @return null|string An uppercase extension string.
      * @since 2.0.0
      * @example
      *
@@ -302,7 +298,7 @@ class ExternalImage implements ImageInterface
      * </a>
      * ```
      *
-     * @return null|string An uppercase extension string.
+     * @api
      */
     public function extension()
     {
@@ -320,7 +316,7 @@ class ExternalImage implements ImageInterface
     /**
      * Gets the width of the image in pixels.
      *
-     * @api
+     * @return int The width of the image in pixels.
      * @example
      * ```twig
      * <img src="{{ image.src }}" width="{{ image.width }}" />
@@ -329,7 +325,7 @@ class ExternalImage implements ImageInterface
      * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" width="1600" />
      * ```
      *
-     * @return int The width of the image in pixels.
+     * @api
      */
     public function width()
     {
@@ -339,7 +335,7 @@ class ExternalImage implements ImageInterface
     /**
      * Gets the height of the image in pixels.
      *
-     * @api
+     * @return int The height of the image in pixels.
      * @example
      * ```twig
      * <img src="{{ image.src }}" height="{{ image.height }}" />
@@ -348,7 +344,7 @@ class ExternalImage implements ImageInterface
      * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" height="900" />
      * ```
      *
-     * @return int The height of the image in pixels.
+     * @api
      */
     public function height()
     {
@@ -358,7 +354,7 @@ class ExternalImage implements ImageInterface
     /**
      * Gets the aspect ratio of the image.
      *
-     * @api
+     * @return float The aspect ratio of the image.
      * @example
      * ```twig
      * {% if post.thumbnail.aspect < 1 %}
@@ -369,7 +365,7 @@ class ExternalImage implements ImageInterface
      * {% endif %}
      * ```
      *
-     * @return float The aspect ratio of the image.
+     * @api
      */
     public function aspect()
     {
@@ -393,7 +389,6 @@ class ExternalImage implements ImageInterface
         $this->imageDimensions = new ImageDimensions($file_path);
         $this->file_size = new FileSize($file_path);
     }
-
 
     /**
      * Inits the object with a relative path.
@@ -444,7 +439,7 @@ class ExternalImage implements ImageInterface
      * For better accessibility, you should always add an alt attribute to your images, even if it’s
      * empty.
      *
-     * @api
+     * @return string Alt text stored in WordPress.
      * @example
      * ```twig
      * <img src="{{ image.src }}" alt="{{ image.alt }}" />
@@ -454,7 +449,7 @@ class ExternalImage implements ImageInterface
      *     alt="You should always add alt texts to your images for better accessibility" />
      * ```
      *
-     * @return string Alt text stored in WordPress.
+     * @api
      */
     public function alt()
     {
@@ -473,12 +468,12 @@ class ExternalImage implements ImageInterface
 
     public function srcset($size = "full")
     {
-        $source = array(
-            'url'        => $this->src(),
+        $source = [
+            'url' => $this->src(),
             'descriptor' => 'w',
-            'value'      => $size,
-        );
+            'value' => $size,
+        ];
 
-        return str_replace( ' ', '%20', $source['url'] ) . ' ' . $source['value'] . $source['descriptor'] ;
+        return str_replace(' ', '%20', $source['url']) . ' ' . $source['value'] . $source['descriptor'];
     }
 }

--- a/src/FileSize.php
+++ b/src/FileSize.php
@@ -21,6 +21,22 @@ class FileSize
      */
     public $file_loc;
 
+    /**
+     * Pre-calculated human-friendly file size.
+     *
+     * @api
+     * @var string The precalculed file size
+     */
+    private $file_size;
+
+    /**
+     * Pre-calculated file size.
+     *
+     * @api
+     * @var string The precalculed file size
+     */
+    private $file_size_raw;
+
     public function __construct($file_loc)
     {
         $this->file_loc = $file_loc;

--- a/src/FileSize.php
+++ b/src/FileSize.php
@@ -2,6 +2,14 @@
 
 namespace Timber;
 
+/**
+ * Class FileSize
+ *
+ * Helper class to deal with File sizes logic
+ *
+ * @api
+ * @since 2.0.0
+ */
 class FileSize
 {
     /**
@@ -26,7 +34,7 @@ class FileSize
      * This can be useful if you want to display the human readable filesize for a file. It’s
      * easier to read «16 KB» than «16555 bytes» or «1 MB» than «1048576 bytes».
      *
-     * @api
+     * @return mixed|null The filesize string in a human readable format.
      * @since 2.0.0
      * @example
      *
@@ -39,7 +47,7 @@ class FileSize
      * </a>
      * ```
      *
-     * @return mixed|null The filesize string in a human readable format.
+     * @api
      */
     public function size()
     {
@@ -54,7 +62,7 @@ class FileSize
     /**
      * Gets filesize in bytes.
      *
-     * @api
+     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
      * @since 2.0.0
      * @example
      *
@@ -70,7 +78,7 @@ class FileSize
      * </table>
      * ```
      *
-     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
+     * @api
      */
     public function size_raw()
     {

--- a/src/FileSize.php
+++ b/src/FileSize.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Timber;
+
+class FileSize
+{
+    /**
+     * File location.
+     *
+     * @api
+     * @var string The absolute path to the image in the filesystem
+     *             (Example: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
+     */
+    public $file_loc;
+
+
+    public function __construct($file_loc)
+    {
+        $this->file_loc = $file_loc;
+    }
+
+
+    /**
+     * Gets filesize in a human readable format.
+     *
+     * This can be useful if you want to display the human readable filesize for a file. It’s
+     * easier to read «16 KB» than «16555 bytes» or «1 MB» than «1048576 bytes».
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     *
+     * Use filesize information in a link that downloads a file:
+     *
+     * ```twig
+     * <a class="download" href="{{ attachment.src }}" download="{{ attachment.title }}">
+     *     <span class="download-title">{{ attachment.title }}</span>
+     *     <span class="download-info">(Download, {{ attachment.size }})</span>
+     * </a>
+     * ```
+     *
+     * @return mixed|null The filesize string in a human readable format.
+     */
+    public function size()
+    {
+        if (!$this->file_size) {
+            $formatted_size = size_format($this->size_raw());
+            $this->file_size = str_replace(' ', '&nbsp;', $formatted_size);
+        }
+
+        return $this->file_size;
+    }
+
+    /**
+     * Gets filesize in bytes.
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     *
+     * ```twig
+     * <table>
+     *     {% for attachment in Attachment(attachment_ids) %}
+     *         <tr>
+     *             <td>{{ attachment.title }}</td>
+     *             <td>{{ attachment.extension }}</td>
+     *             <td>{{ attachment.size_raw }} bytes</td>
+     *         </tr>
+     *     {% endfor %}
+     * </table>
+     * ```
+     *
+     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
+     */
+    public function size_raw()
+    {
+        if (!$this->file_size_raw) {
+            $this->file_size_raw = filesize($this->file_loc);
+        }
+
+        return $this->file_size_raw;
+    }
+}

--- a/src/FileSize.php
+++ b/src/FileSize.php
@@ -21,12 +21,10 @@ class FileSize
      */
     public $file_loc;
 
-
     public function __construct($file_loc)
     {
         $this->file_loc = $file_loc;
     }
-
 
     /**
      * Gets filesize in a human readable format.

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -73,7 +73,6 @@ class Helper
     protected static function handle_transient_locking($slug, $callback, $transient_time, $lock_timeout, $force, $enable_transients)
     {
         if ($enable_transients && self::_is_transient_locked($slug)) {
-
             /**
              * Filters …
              *

--- a/src/Image.php
+++ b/src/Image.php
@@ -97,7 +97,7 @@ class Image extends Attachment implements ImageInterface
      */
     protected function get_info(WP_Post $wp_post)
     {
-        $data = get_object_vars(parent::get_info($wp_post));
+        $data = parent::get_info($wp_post);
 
         if (isset($data['file_loc'])) {
             $data['imageDimensions'] = new ImageDimensions($data['file_loc']);

--- a/src/Image.php
+++ b/src/Image.php
@@ -48,7 +48,7 @@ namespace Timber;
  * </article>
  * ```
  */
-class Image extends Attachment
+class Image extends Attachment implements ImageInterface
 {
     /**
      * Representation.
@@ -70,10 +70,10 @@ class Image extends Attachment
      * Image dimensions.
      *
      * @internal
-     * @var array An index array of image dimensions, where the first is the width and the second
-     *            item is the height of the image in pixels.
+     * @var ImageDimensions stores Image Dimensions in a structured way.
      */
-    protected $dimensions;
+    protected ImageDimensions $imageDimensions;
+
 
     /**
      * @return string the src of the file
@@ -87,6 +87,25 @@ class Image extends Attachment
     }
 
     /**
+     * Gets the Image information.
+     *
+     * @internal
+     *
+     * @param int $image_id The ID number of the image in the WP database.
+     * @return array Image info as an array or ID
+     */
+    protected function get_info(WP_Post $wp_post)
+    {
+        $data = get_object_vars(parent::get_info($wp_post));
+
+        if (isset($data['file_loc'])) {
+            $data['imageDimensions'] = new ImageDimensions($data['file_loc']);
+        }
+
+        return $data;
+    }
+
+    /**
      * Processes an image's dimensions.
      * @deprecated 2.0.0, use `{{ image.width }}` or `{{ image.height }}` in Twig
      * @internal
@@ -97,10 +116,10 @@ class Image extends Attachment
     {
         Helper::deprecated(
             'Image::get_dimensions',
-            'Image::get_dimension',
+            'Image::get_width | Image::get_height',
             '2.0.0'
         );
-        return [$this->width(), $this->height()];
+        return [$this->imageDimensions->width(), $this->imageDimensions->height()];
     }
 
     /**
@@ -113,45 +132,10 @@ class Image extends Attachment
     {
         Helper::deprecated(
             'Image::get_dimensions',
-            'Image::get_dimension',
+            'Image::get_width | Image::get_height',
             '2.0.0'
         );
-        $dim = strtolower($dim);
-        if ($dim == 'h' || $dim == 'height') {
-            return $this->height();
-        }
-        return $this->width();
-    }
-
-    /**
-     * Retrieve dimensions from SVG file
-     *
-     * @internal
-     * @param string $svg SVG Path
-     * @return array
-     */
-    protected function get_dimensions_svg($svg)
-    {
-        $svg = simplexml_load_file($svg);
-        $width = '0';
-        $height = '0';
-
-        if (false !== $svg) {
-            $attributes = $svg->attributes();
-            if (isset($attributes->viewBox)) {
-                $viewbox = explode(' ', $attributes->viewBox);
-                $width = $viewbox[2];
-                $height = $viewbox[3];
-            } elseif ($attributes->width && $attributes->height) {
-                $width = (string) $attributes->width;
-                $height = (string) $attributes->height;
-            }
-        }
-
-        return (object) [
-            'width' => $width,
-            'height' => $height,
-        ];
+        return $this->imageDimensions->get_dimension($dim);
     }
 
     /**
@@ -198,7 +182,7 @@ class Image extends Attachment
     public function src($size = 'full')
     {
         if (isset($this->abs_url)) {
-            return $this->maybe_secure_url($this->abs_url);
+            return URLHelper::maybe_secure_url($this->abs_url);
         }
 
         if (!$this->is_image()) {
@@ -250,7 +234,7 @@ class Image extends Attachment
      */
     public function width()
     {
-        return $this->get_dimension('width');
+        return $this->imageDimensions->width();
     }
 
     /**
@@ -269,7 +253,7 @@ class Image extends Attachment
      */
     public function height()
     {
-        return $this->get_dimension('height');
+        return $this->imageDimensions->height();
     }
 
     /**
@@ -290,10 +274,7 @@ class Image extends Attachment
      */
     public function aspect()
     {
-        $w = intval($this->width());
-        $h = intval($this->height());
-
-        return $w / $h;
+        return $this->imageDimensions->aspect();
     }
 
     /**
@@ -322,7 +303,7 @@ class Image extends Attachment
 
     /**
      * Gets dimension for an image.
-     *
+     * @deprecated 2.0.0, use `{{ image.width }}` or `{{ image.height }}` in Twig
      * @internal
      *
      * @param string $dimension The requested dimension. Either `width` or `height`.
@@ -330,27 +311,12 @@ class Image extends Attachment
      */
     protected function get_dimension($dimension)
     {
-        // Load from internal cache.
-        if (isset($this->dimensions)) {
-            return $this->get_dimension_loaded($dimension);
-        }
-
-        // Load dimensions.
-        if (file_exists($this->file_loc) && filesize($this->file_loc)) {
-            if (ImageHelper::is_svg($this->file_loc)) {
-                $svg_size = $this->get_dimensions_svg($this->file_loc);
-                $this->dimensions = [$svg_size->width, $svg_size->height];
-            } else {
-                list($width, $height) = getimagesize($this->file_loc);
-
-                $this->dimensions = [];
-                $this->dimensions[0] = $width;
-                $this->dimensions[1] = $height;
-            }
-            return $this->get_dimension_loaded($dimension);
-        }
-
-        return null;
+        Helper::deprecated(
+            'Image::get_dimension',
+            'Image::get_width | Image::get_height',
+            '2.0.0'
+        );
+        return $this->imageDimensions->get_dimension($dimension);
     }
 
     /**
@@ -363,13 +329,7 @@ class Image extends Attachment
      */
     protected function get_dimension_loaded($dim = null)
     {
-        $dim = strtolower($dim);
-
-        if ('h' === $dim || 'height' === $dim) {
-            return $this->dimensions[1];
-        }
-
-        return $this->dimensions[0];
+        return $this->imageDimensions->get_dimension($dim);
     }
 
     /**

--- a/src/Image.php
+++ b/src/Image.php
@@ -2,6 +2,8 @@
 
 namespace Timber;
 
+use WP_Post;
+
 /**
  * Class Image
  *

--- a/src/Image.php
+++ b/src/Image.php
@@ -74,7 +74,6 @@ class Image extends Attachment implements ImageInterface
      */
     protected ImageDimensions $imageDimensions;
 
-
     /**
      * @return string the src of the file
      */

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -2,6 +2,14 @@
 
 namespace Timber;
 
+/**
+ * Class FileSize
+ *
+ * Helper class to deal with Image Dimensions
+ *
+ * @api
+ * @since 2.0.0
+ */
 class ImageDimensions
 {
     /**
@@ -22,17 +30,15 @@ class ImageDimensions
      */
     public $file_loc;
 
-
     public function __construct($file_loc)
     {
         $this->file_loc = $file_loc;
     }
 
-
     /**
      * Gets the width of the image in pixels.
      *
-     * @api
+     * @return int The width of the image in pixels.
      * @example
      * ```twig
      * <img src="{{ image.src }}" width="{{ image.width }}" />
@@ -41,7 +47,7 @@ class ImageDimensions
      * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" width="1600" />
      * ```
      *
-     * @return int The width of the image in pixels.
+     * @api
      */
     public function width()
     {
@@ -51,7 +57,7 @@ class ImageDimensions
     /**
      * Gets the height of the image in pixels.
      *
-     * @api
+     * @return int The height of the image in pixels.
      * @example
      * ```twig
      * <img src="{{ image.src }}" height="{{ image.height }}" />
@@ -60,7 +66,7 @@ class ImageDimensions
      * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" height="900" />
      * ```
      *
-     * @return int The height of the image in pixels.
+     * @api
      */
     public function height()
     {
@@ -70,7 +76,7 @@ class ImageDimensions
     /**
      * Gets the aspect ratio of the image.
      *
-     * @api
+     * @return float The aspect ratio of the image.
      * @example
      * ```twig
      * {% if post.thumbnail.aspect < 1 %}
@@ -81,7 +87,7 @@ class ImageDimensions
      * {% endif %}
      * ```
      *
-     * @return float The aspect ratio of the image.
+     * @api
      */
     public function aspect()
     {
@@ -143,7 +149,6 @@ class ImageDimensions
         return $this->dimensions[0];
     }
 
-
     /**
      * Retrieve dimensions from SVG file
      *
@@ -164,12 +169,12 @@ class ImageDimensions
                 $width = $viewbox[2];
                 $height = $viewbox[3];
             } elseif ($attributes->width && $attributes->height) {
-                $width = (string)$attributes->width;
-                $height = (string)$attributes->height;
+                $width = (string) $attributes->width;
+                $height = (string) $attributes->height;
             }
         }
 
-        return (object)[
+        return [
             'width' => $width,
             'height' => $height,
         ];

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -113,12 +113,12 @@ class ImageDimensions
         }
 
         // Load dimensions.
-        if (file_exists($this->image->file_loc) && filesize($this->image->file_loc)) {
-            if (ImageHelper::is_svg($this->image->file_loc)) {
-                $svg_size = $this->get_dimensions_svg($this->image->file_loc);
+        if (file_exists($this->file_loc) && filesize($this->file_loc)) {
+            if (ImageHelper::is_svg($this->file_loc)) {
+                $svg_size = $this->get_dimensions_svg($this->file_loc);
                 $this->dimensions = [$svg_size->width, $svg_size->height];
             } else {
-                list($width, $height) = getimagesize($this->image->file_loc);
+                list($width, $height) = getimagesize($this->file_loc);
 
                 $this->dimensions = [];
                 $this->dimensions[0] = $width;

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -174,7 +174,7 @@ class ImageDimensions
             }
         }
 
-        return [
+        return (object) [
             'width' => $width,
             'height' => $height,
         ];

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -30,7 +30,7 @@ class ImageDimensions
      */
     public $file_loc;
 
-    public function __construct($file_loc)
+    public function __construct($file_loc = '')
     {
         $this->file_loc = $file_loc;
     }

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Timber;
+
+class ImageDimensions
+{
+    /**
+     * Image dimensions.
+     *
+     * @internal
+     * @var array An index array of image dimensions, where the first is the width and the second
+     *            item is the height of the image in pixels.
+     */
+    protected $dimensions;
+
+    /**
+     * File location.
+     *
+     * @api
+     * @var string The absolute path to the image in the filesystem
+     *             (Example: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
+     */
+    public $file_loc;
+
+
+    public function __construct($file_loc)
+    {
+        $this->file_loc = $file_loc;
+    }
+
+
+    /**
+     * Gets the width of the image in pixels.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" width="{{ image.width }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" width="1600" />
+     * ```
+     *
+     * @return int The width of the image in pixels.
+     */
+    public function width()
+    {
+        return $this->get_dimension('width');
+    }
+
+    /**
+     * Gets the height of the image in pixels.
+     *
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" height="{{ image.height }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" height="900" />
+     * ```
+     *
+     * @return int The height of the image in pixels.
+     */
+    public function height()
+    {
+        return $this->get_dimension('height');
+    }
+
+    /**
+     * Gets the aspect ratio of the image.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if post.thumbnail.aspect < 1 %}
+     *   {# handle vertical image #}
+     *   <img src="{{ post.thumbnail.src|resize(300, 500) }}" alt="A basketball player" />
+     * {% else %}
+     *   <img src="{{ post.thumbnail.src|resize(500) }}" alt="A sumo wrestler" />
+     * {% endif %}
+     * ```
+     *
+     * @return float The aspect ratio of the image.
+     */
+    public function aspect()
+    {
+        $w = intval($this->width());
+        $h = intval($this->height());
+
+        return $w / $h;
+    }
+
+    /**
+     * Gets dimension for an image.
+     *
+     * @param string $dimension The requested dimension. Either `width` or `height`.
+     * @return int|null The requested dimension. Null if image file couldn’t be found.
+     * @internal
+     *
+     */
+    public function get_dimension($dimension)
+    {
+        // Load from internal cache.
+        if (isset($this->dimensions)) {
+            return $this->get_dimension_loaded($dimension);
+        }
+
+        // Load dimensions.
+        if (file_exists($this->image->file_loc) && filesize($this->image->file_loc)) {
+            if (ImageHelper::is_svg($this->image->file_loc)) {
+                $svg_size = $this->get_dimensions_svg($this->image->file_loc);
+                $this->dimensions = [$svg_size->width, $svg_size->height];
+            } else {
+                list($width, $height) = getimagesize($this->image->file_loc);
+
+                $this->dimensions = [];
+                $this->dimensions[0] = $width;
+                $this->dimensions[1] = $height;
+            }
+            return $this->get_dimension_loaded($dimension);
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets already loaded dimension values.
+     *
+     * @param string|null $dim Optional. The requested dimension. Either `width` or `height`.
+     * @return int The requested dimension in pixels.
+     * @internal
+     *
+     */
+    protected function get_dimension_loaded($dim = null)
+    {
+        $dim = strtolower($dim);
+
+        if ('h' === $dim || 'height' === $dim) {
+            return $this->dimensions[1];
+        }
+
+        return $this->dimensions[0];
+    }
+
+
+    /**
+     * Retrieve dimensions from SVG file
+     *
+     * @param string $svg SVG Path
+     * @return array
+     * @internal
+     */
+    protected function get_dimensions_svg($svg)
+    {
+        $svg = simplexml_load_file($svg);
+        $width = '0';
+        $height = '0';
+
+        if (false !== $svg) {
+            $attributes = $svg->attributes();
+            if (isset($attributes->viewBox)) {
+                $viewbox = explode(' ', $attributes->viewBox);
+                $width = $viewbox[2];
+                $height = $viewbox[3];
+            } elseif ($attributes->width && $attributes->height) {
+                $width = (string)$attributes->width;
+                $height = (string)$attributes->height;
+            }
+        }
+
+        return (object)[
+            'width' => $width,
+            'height' => $height,
+        ];
+    }
+}

--- a/src/ImageInterface.php
+++ b/src/ImageInterface.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Timber;
+
+
+use WP_Post;
+
+/**
+ * Class Image
+ *
+ * The `Timber\Image` class represents WordPress attachments that are images.
+ *
+ * @api
+ * @example
+ * ```php
+ * $context = Timber::context();
+ *
+ * // Lets say you have an alternate large 'cover image' for your post
+ * // stored in a custom field which returns an image ID.
+ * $cover_image_id = $context['post']->cover_image;
+ *
+ * $context['cover_image'] = Timber::get_post($cover_image_id);
+ *
+ * Timber::render('single.twig', $context);
+ * ```
+ *
+ * ```twig
+ * <article>
+ *   <img src="{{cover_image.src}}" class="cover-image" />
+ *   <h1 class="headline">{{post.title}}</h1>
+ *   <div class="body">
+ *     {{post.content}}
+ *   </div>
+ *
+ *  <img
+ *    src="{{ get_image(post.custom_field_with_image_id).src }}"
+ *    alt="Another way to initialize images as Timber\Image objects, but within Twig" />
+ * </article>
+ * ```
+ *
+ * ```html
+ * <article>
+ *   <img src="http://example.org/wp-content/uploads/2015/06/nevermind.jpg" class="cover-image" />
+ *   <h1 class="headline">Now you've done it!</h1>
+ *   <div class="body">
+ *     Whatever whatever
+ *   </div>
+ *   <img
+ *     src="http://example.org/wp-content/uploads/2015/06/kurt.jpg"
+ *     alt="Another way to initialize images as Timber\Image objects, but within Twig" />
+ * </article>
+ * ```
+ */
+interface ImageInterface
+{
+    /**
+     * Gets the relative path to an attachment.
+     *
+     * @return string The relative path to an attachment.
+     * @example
+     * ```twig
+     * <img src="{{ image.path }}" />
+     * ```
+     * ```html
+     * <img src="/wp-content/uploads/2015/08/pic.jpg" />
+     * ```
+     *
+     * @api
+     */
+    public function path();
+
+    /**
+     * Gets the caption of an attachment.
+     *
+     * @return string
+     * @since 2.0
+     * @example
+     * ```twig
+     * <figure>
+     *     <img src="{{ post.thumbnail.src }}">
+     *
+     *     {% if post.thumbnail is not empty %}
+     *         <figcaption>{{ post.thumbnail.caption }}</figcaption
+     *     {% endif %}
+     * </figure>
+     * ```
+     *
+     * @api
+     */
+    public function caption();
+
+    /**
+     * Gets filesize in a human readable format.
+     *
+     * This can be useful if you want to display the human readable filesize for a file. It’s
+     * easier to read «16 KB» than «16555 bytes» or «1 MB» than «1048576 bytes».
+     *
+     * @return mixed|null The filesize string in a human readable format.
+     * @since 2.0.0
+     * @example
+     *
+     * Use filesize information in a link that downloads a file:
+     *
+     * ```twig
+     * <a class="download" href="{{ attachment.src }}" download="{{ attachment.title }}">
+     *     <span class="download-title">{{ attachment.title }}</span>
+     *     <span class="download-info">(Download, {{ attachment.size }})</span>
+     * </a>
+     * ```
+     *
+     * @api
+     */
+    public function size();
+
+    /**
+     * Gets filesize in bytes.
+     *
+     * @return mixed|null The filesize string in bytes, or false if the filesize can’t be read.
+     * @since 2.0.0
+     * @example
+     *
+     * ```twig
+     * <table>
+     *     {% for attachment in Attachment(attachment_ids) %}
+     *         <tr>
+     *             <td>{{ attachment.title }}</td>
+     *             <td>{{ attachment.extension }}</td>
+     *             <td>{{ attachment.size_raw }} bytes</td>
+     *         </tr>
+     *     {% endfor %}
+     * </table>
+     * ```
+     *
+     * @api
+     */
+    public function size_raw();
+
+    /**
+     * Gets the extension of the attached file.
+     *
+     * @return null|string An uppercase extension string.
+     * @since 2.0.0
+     * @example
+     *
+     * Use extension information in a link that downloads a file:
+     *
+     * ```twig
+     * <a class="download" href="{{ attachment.src }}" download="{{ attachment.title }}">
+     *     <span class="download-title">{{ attachment.title }}</span>
+     *     <span class="download-info">
+     *         (Download {{ attachment.extension|upper }}, {{ attachment.size }})
+     *     </span>
+     * </a>
+     * ```
+     *
+     * @api
+     */
+    public function extension();
+
+    /**
+     * @return string the src of the file
+     */
+    public function __toString();
+
+    /**
+     * Gets the source URL for the image.
+     *
+     * You can use WordPress image sizes (including the ones you registered with your theme or
+     * plugin) by passing the name of the size to this function (like `medium` or `large`). If the
+     * WordPress size has not been generated, it will return an empty string.
+     *
+     * @param string $size Optional. The requested image size. This can be a size that was in
+     *                     WordPress. Example: `medium` or `large`. Default `full`.
+     *
+     * @return bool|string The src URL for the image.
+     * @api
+     * @example
+     * ```twig
+     * <img src="{{ post.thumbnail.src }}">
+     * <img src="{{ post.thumbnail.src('medium') }}">
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" />
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic-800-600.jpg">
+     * ```
+     *
+     */
+    public function src($size = 'full');
+
+    /**
+     * Gets the width of the image in pixels.
+     *
+     * @return int The width of the image in pixels.
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" width="{{ image.width }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" width="1600" />
+     * ```
+     *
+     * @api
+     */
+    public function width();
+
+    /**
+     * Gets the height of the image in pixels.
+     *
+     * @return int The height of the image in pixels.
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" height="{{ image.height }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg" height="900" />
+     * ```
+     *
+     * @api
+     */
+    public function height();
+
+    /**
+     * Gets the aspect ratio of the image.
+     *
+     * @return float The aspect ratio of the image.
+     * @example
+     * ```twig
+     * {% if post.thumbnail.aspect < 1 %}
+     *   {# handle vertical image #}
+     *   <img src="{{ post.thumbnail.src|resize(300, 500) }}" alt="A basketball player" />
+     * {% else %}
+     *   <img src="{{ post.thumbnail.src|resize(500) }}" alt="A sumo wrestler" />
+     * {% endif %}
+     * ```
+     *
+     * @api
+     */
+    public function aspect();
+
+    /**
+     * Gets the alt text for an image.
+     *
+     * For better accessibility, you should always add an alt attribute to your images, even if it’s
+     * empty.
+     *
+     * @return string Alt text stored in WordPress.
+     * @example
+     * ```twig
+     * <img src="{{ image.src }}" alt="{{ image.alt }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2015/08/pic.jpg"
+     *     alt="You should always add alt texts to your images for better accessibility" />
+     * ```
+     *
+     * @api
+     */
+    public function alt();
+
+    /**
+     * @param string $size a size known to WordPress (like "medium")
+     * @return bool|string
+     * @example
+     * ```twig
+     * <h1>{{ post.title }}</h1>
+     * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumbnail.srcset }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w" />
+     * ```
+     * @api
+     */
+    public function srcset($size = "full");
+
+    /**
+     * @param string $size a size known to WordPress (like "medium")
+     * @return bool|string
+     * @example
+     * ```twig
+     * <h1>{{ post.title }}</h1>
+     * <img src="{{ post.thumbnail.src }}" srcset="{{ post.thumbnail.srcset }}" sizes="{{ post.thumbnail.img_sizes }}" />
+     * ```
+     * ```html
+     * <img src="http://example.org/wp-content/uploads/2018/10/pic.jpg" srcset="http://example.org/wp-content/uploads/2018/10/pic.jpg 1024w, http://example.org/wp-content/uploads/2018/10/pic-600x338.jpg 600w, http://example.org/wp-content/uploads/2018/10/pic-300x169.jpg 300w sizes="(max-width: 1024px) 100vw, 102" />
+     * ```
+     * @api
+     */
+    public function img_sizes($size = "full");
+}

--- a/src/ImageInterface.php
+++ b/src/ImageInterface.php
@@ -3,8 +3,6 @@
 namespace Timber;
 
 
-use WP_Post;
-
 /**
  * Class Image
  *

--- a/src/ImageInterface.php
+++ b/src/ImageInterface.php
@@ -2,7 +2,6 @@
 
 namespace Timber;
 
-
 /**
  * Class Image
  *

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -222,7 +222,6 @@ class Loader
 
         // Run through template array
         foreach ($templates as $template) {
-
             // Remove any whitespace around the template name
             $template = trim($template);
             // Use the Twig loader to test for existance

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -353,7 +353,6 @@ class Timber
         return ($post instanceof Image) ? $post : null;
     }
 
-
     /**
      * Gets an external image.
      *
@@ -367,15 +366,10 @@ class Timber
      *
      * @return ExternalImage|null
      */
-    public static function get_external_image($url = fals)
+    public static function get_external_image($url = false, $alt = '')
     {
-        $post = static::get_post($query, $options);
-
-        // @todo make this determination at the Factory level.
-        // No need to instantiate a Post we're not going to use.
-        return ($post instanceof Image) ? $post : null;
+        return ExternalImage::build($url, $alt);
     }
-
 
     /**
      * Gets a collection of posts.

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -366,9 +366,13 @@ class Timber
      *
      * @return ExternalImage|null
      */
-    public static function get_external_image($url = false, $alt = '')
+    public static function get_external_image($url = false, array $args = [])
     {
-        return ExternalImage::build($url, $alt);
+        $args = wp_parse_args($args, [
+            'alt' => '',
+        ]);
+
+        return ExternalImage::build($url, $args);
     }
 
     /**

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -353,6 +353,30 @@ class Timber
         return ($post instanceof Image) ? $post : null;
     }
 
+
+    /**
+     * Gets an external image.
+     *
+     * Behaves just like Timber::get_image(), except that it uses a URL to load an image
+     *
+     * @api
+     * @since 2.0.0
+     * @see Timber::get_image()
+     *
+     * @param string $url   Url where to load an image from
+     *
+     * @return ExternalImage|null
+     */
+    public static function get_external_image($url = fals)
+    {
+        $post = static::get_post($query, $options);
+
+        // @todo make this determination at the Factory level.
+        // No need to instantiate a Post we're not going to use.
+        return ($post instanceof Image) ? $post : null;
+    }
+
+
     /**
      * Gets a collection of posts.
      *

--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -568,7 +568,6 @@ class URLHelper
         return $params[$i] ?? false;
     }
 
-
     /**
      * Secures an URL based on the current environment.
      *

--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -567,4 +567,21 @@ class URLHelper
 
         return $params[$i] ?? false;
     }
+
+
+    /**
+     * Secures an URL based on the current environment.
+     *
+     * @param  string $url The URL to evaluate.
+     *
+     * @return string An URL with or without http/https, depending on what’s appropriate for server.
+     */
+    public static function maybe_secure_url($url)
+    {
+        if (is_ssl() && strpos($url, 'https') !== 0 && strpos($url, 'http') === 0) {
+            $url = 'https' . substr($url, strlen('http'));
+        }
+
+        return $url;
+    }
 }

--- a/tests/test-image-dimensions.php
+++ b/tests/test-image-dimensions.php
@@ -1,0 +1,49 @@
+<?php
+
+
+class ImageDimensionsTestable extends \Timber\ImageDimensions
+{
+    public function __construct($file_loc)
+    {
+        parent::__construct($file_loc);
+    }
+
+    public function set_dimensions($width, $height)
+    {
+        $this->dimensions = [$width, $height];
+    }
+}
+
+/**
+ * @group image
+ */
+class TestImageDimensions extends Timber_UnitTestCase
+{
+    public function ratioProvider()
+    {
+        return [
+            [200, 100, 2],
+            [100, 200, 0.5],
+        ];
+    }
+
+    /**
+     * @dataProvider ratioProvider
+     */
+    public function testRatio($w, $h, $r)
+    {
+        $imageDimensions = new ImageDimensionsTestable('');
+        $imageDimensions->set_dimensions($w, $h);
+
+        $this->assertEquals($r, $imageDimensions->aspect());
+    }
+
+    public function testDimensions()
+    {
+        $imageDimensions = new ImageDimensionsTestable('');
+        $imageDimensions->set_dimensions(100, 200);
+
+        $this->assertEquals(100, $imageDimensions->width());
+        $this->assertEquals(200, $imageDimensions->height());
+    }
+}

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -328,7 +328,6 @@ class TestTimberHelper extends Timber_UnitTestCase
 
     public function testConvertWPObject()
     {
-
         // Test WP_Post -> \Timber\Post
         $post_id = $this->factory->post->create();
         $wp_post = get_post($post_id);

--- a/tests/test-timber-image-helper.php
+++ b/tests/test-timber-image-helper.php
@@ -2,6 +2,7 @@
 
 /**
  * @group called-post-constructor
+ * @group image
  */
 class TestTimberImageHelper extends TimberAttachment_UnitTestCase
 {

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -8,6 +8,7 @@ use Timber\Post;
 /**
  * @group posts-api
  * @group attachments
+ * @group image
  */
 class TestTimberImage extends TimberAttachment_UnitTestCase
 {

--- a/tests/test-timber-integration-wpml.php
+++ b/tests/test-timber-integration-wpml.php
@@ -32,7 +32,6 @@ class TestTimberIntegrationWPML extends Timber_UnitTestCase
 
     public function testWPMLurlRemote()
     {
-
         // this test replicates the url issue caused by the WPML language identifier in the url
         // However, WPML can't be installed with composer so this test mocks the WPML plugin
 

--- a/tests/test-timber-twig.php
+++ b/tests/test-timber-twig.php
@@ -206,7 +206,6 @@ class TestTimberTwig extends Timber_UnitTestCase
 
     public function testEscHtml()
     {
-
         // Simple string
         $html = "The quick brown fox.";
 


### PR DESCRIPTION
**Ticket**: #2627 

## Issue
Adding a `Timber\ExternalImage` class, compatible with `Timber\Image` when using it in Twig, to get feature parity with Timber 1.x


## Solution
A new class, `Timber\ExternalImage`, that implements `Timber\ImageInterface`, compatible with `Timber\Image`


## Impact
There is some common logic that has been extracted from both `Timber\Image` and `Timber\Attachment` into their own classes, to avoid code duplication and being able to use it from `Timber\ExternalImage`.



## Considerations


## Testing
Not yet.
