### PR TITLE
Improve GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,14 @@ First off, hello!
 
 Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
 Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
---> 
+-->
 
-**Ticket**: # <!-- Ignore this if not relevant -->
+<!-- Remove this if no related tickets exist. -->
+<!-- You can add the related ticket numbers here using #. Example: #2471 -->
+Related:
+
+- Ticket 1
+- Ticket 2
 
 ## Issue
 <!-- Description of the problem that this code change is solving -->
@@ -23,7 +28,7 @@ Have any questions? Read this section in CONTRIBUTING.md: https://github.com/tim
 <!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
 
 Alternatively, you’re very welcome to directly edit the readme.txt file with:
-- A quick summary, including your Github handle.
+- A quick summary, including your GitHub handle.
 - A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
 - New usage instructions, possibly with a short code example.
 -->


### PR DESCRIPTION
Let’s update the GitHub pull request template and use a notation for related tickets. This will automatically enhance the tickets with the proper ticket / pull request titles and the status of the related tickets. This that can be seen in the following screenshot:

![](https://user-images.githubusercontent.com/2084481/190325078-022d4042-45d8-4b25-ba94-a0a28f884ccd.png)