### PR TITLE
Fix bugs with latest plugin release 1.21.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,8 +139,8 @@ jobs:
         if: ${{ matrix.wp < '5.9' }}
         run: composer req phpunit/phpunit:^7.5 yoast/wp-test-utils:^1.0 -W --dev
 
-      - name: Upgrade PHPUnit to ^9.0 when prefer lowest
-        if: ${{ matrix.dependency-version == 'prefer-lowest' }}
+      - name: Upgrade PHPUnit to ^9.0 when prefer lowest and PHP 8.0+
+        if: ${{ matrix.dependency-version == 'prefer-lowest' && matrix.php >= '8.0' }}
         run: composer req phpunit/phpunit:^9.0 yoast/wp-test-utils:^1.0 -W --dev
 
       - name: Install tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "name=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,12 @@ jobs:
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: false
+          # PHP 8.1 / Lowest dependencies
+          - php: '8.1'
+            wp: 'latest'
+            dependency-version: 'prefer-lowest'
+            multisite: '0'
+            experimental: false
           # PHP with Imagick
           - php: '7.4'
             wp: 'latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,12 @@ jobs:
             dependency-version: 'prefer-stable'
             multisite: '0'
             experimental: false
+          # PHP 8.0 / Lowest dependencies
+          - php: '8.0'
+            wp: 'latest'
+            dependency-version: 'prefer-lowest'
+            multisite: '0'
+            experimental: false
           # PHP 8.1
           - php: '8.1'
             wp: 'latest'
@@ -132,6 +138,10 @@ jobs:
       - name: Downgrade PHPUnit to ^7.5 when WP < 5.9
         if: ${{ matrix.wp < '5.9' }}
         run: composer req phpunit/phpunit:^7.5 yoast/wp-test-utils:^1.0 -W --dev
+
+      - name: Upgrade PHPUnit to ^9.0 when prefer lowest
+        if: ${{ matrix.dependency-version == 'prefer-lowest' }}
+        run: composer req phpunit/phpunit:^9.0 yoast/wp-test-utils:^1.0 -W --dev
 
       - name: Install tests
         run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "name=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
         uses: actions/cache@v2

--- a/bin/deploy-to-wp-org.sh
+++ b/bin/deploy-to-wp-org.sh
@@ -10,7 +10,7 @@ function deploy () {
 	rm composer.lock
 
 	# Download dependencies for the maximum compatible PHP version.
-	composer config platform.php 8.0
+	composer config platform.php 7.2.5
 	composer install --no-dev --optimize-autoloader
 
 	# Install the lowest compatible version of Twig.

--- a/bin/deploy-to-wp-org.sh
+++ b/bin/deploy-to-wp-org.sh
@@ -8,8 +8,14 @@ function deploy () {
 	git clone git@github.com:Upstatement/timber-starter-theme.git
 	rm -rf ~/Sites/timber/timber-starter-theme/.git
 	rm composer.lock
-	composer config platform.php 5.6.20
+
+	# Download dependencies for the maximum compatible PHP version.
+	composer config platform.php 8.0
 	composer install --no-dev --optimize-autoloader
+
+	# Install the lowest compatible version of Twig.
+	composer update twig/twig:1.44.7 --no-dev
+
 	rm -rf ~/Sites/timber/vendor/upstatement/routes/.git
 	cd ~/Sites/timber-wp
 	mkdir tags/$1

--- a/bin/timber.php
+++ b/bin/timber.php
@@ -7,6 +7,7 @@ Author: Jared Novack + Upstatement
 Version: 1.21.0
 Author URI: http://upstatement.com/
 Requires PHP: 7.2.5
+Requires at least: 5.3.0
 */
 // we look for Composer files first in the plugins dir.
 // then in the wp-content dir (site install).

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=7.2.5 || ^8.0",
-    "twig/twig": "^1.44 || ^2.10",
+    "twig/twig": ">=1.44.7 || ^2.10",
     "upstatement/routes": "^0.9",
     "composer/installers": "^1.0 || ^2.0",
     "twig/cache-extension": "^1.5"
@@ -37,7 +37,8 @@
   "require-dev": {
     "wpackagist-plugin/advanced-custom-fields": "^5.0",
     "wpackagist-plugin/co-authors-plus": "^3.2 || ^3.4",
-    "yoast/wp-test-utils": "^1.0"
+    "yoast/wp-test-utils": "^1.0",
+    "phpunit/phpunit": "^9.0"
   },
   "suggest": {
     "satooshi/php-coveralls": "1.0.* for code coverage"

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,7 @@
   "require-dev": {
     "wpackagist-plugin/advanced-custom-fields": "^5.0",
     "wpackagist-plugin/co-authors-plus": "^3.2 || ^3.4",
-    "yoast/wp-test-utils": "^1.0",
-    "phpunit/phpunit": "^9.0"
+    "yoast/wp-test-utils": "^1.0"
   },
   "suggest": {
     "satooshi/php-coveralls": "1.0.* for code coverage"

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,12 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 
+= 1.22.0 =
+
+* Fixed included Twig version. In the plugin version 1.21.0 of Timber, Twig version 2.15.3 was accidentally included instead of Twig version 1.44.7.
+* Removed official support for PHP 8.1 in the plugin version. If you need to support PHP 8.1 in the future, please install [Timber through Composer](https://timber.github.io/docs/getting-started/setup/#via-github-for-developers) instead of installing Timber as a plugin. This will the only supported way of installing Timber when Timber version 2 will be released.
+* Updated minimum required WordPress version to 5.3.
+
 = 1.21.0 =
 
 * Updated minimum required PHP version to 7.2 to make the included Twig version support PHP 8.0 and 8.1, by @gchtr in #2640.

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Timber ===
 Contributors: jarednova
 Tags: template engine, templates, twig
-Requires at least: 4.9.8
 Tested up to: 6.0.0
 Stable tag: 1.21.0
 Requires PHP: 7.2.5
+Requires at least: 5.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/assets/test-shortcodes.twig
+++ b/tests/assets/test-shortcodes.twig
@@ -1,3 +1,3 @@
-{% filter shortcodes %}
+{% apply shortcodes %}
 	hello [timber_shortcode foo]
-{% endfilter %}
+{% endapply %}

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -5,12 +5,12 @@
 		function testTwigLoaderFilter() {
 		    $php_unit = $this;
 		    add_filter('timber/loader/loader', function ($loader) use ($php_unit) {
-		        $php_unit->assertInstanceOf('Twig_LoaderInterface', $loader);
+		        $php_unit->assertInstanceOf(Twig_LoaderInterface::class, $loader);
 		        return $loader;
 		    });
 		    $str = Timber::compile('assets/single.twig', array());
 		}
-				
+
 		function testBogusTemplate() {
 			$str = Timber::compile('assets/darkhelmet.twig');
 			$this->assertFalse($str);

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -1,13 +1,13 @@
 <?php
 
-use Twig_LoaderInterface;
+use Twig\Loader\LoaderInterface;
 
 	class TestTimberLoader extends Timber_UnitTestCase {
 
 		function testTwigLoaderFilter() {
 		    $php_unit = $this;
 		    add_filter('timber/loader/loader', function ($loader) use ($php_unit) {
-		        $php_unit->assertInstanceOf(Twig_LoaderInterface::class, $loader);
+		        $php_unit->assertInstanceOf(LoaderInterface::class, $loader);
 		        return $loader;
 		    });
 		    $str = Timber::compile('assets/single.twig', array());

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -1,5 +1,7 @@
 <?php
 
+use Twig_LoaderInterface;
+
 	class TestTimberLoader extends Timber_UnitTestCase {
 
 		function testTwigLoaderFilter() {


### PR DESCRIPTION
Resolves:

- #2654
- #2655
- #2652
- #2661 

## Issue

When the plugin version 1.21.0 of Timber was released, we accidentally included Twig 2.15.3 instead of Twig 1.44.7. This caused a lot of bugs for sites that auto-updated the Timber plugin (not recommended). We deactivated the 1.21.0 as the default release to disable that version from being found by auto-updates.

## Solution

As a solution, this pull request makes sure that Twig version 1.44.7 is used when deploying the plugin version of Timber. When Timber is installed through Composer, the 2.x will still be installed.

We also added a new test configuration that tests PHP 8.0 and PHP 8.1 with version 1.44.7 of Twig by using `prefer-lowest` when installing Composer dependencies (thanks @nlemoine).

Unfortunately, I didn’t manage to get this fully working with PHP 8.1. A deprecation warning is somehow caught as content in the output in a shortcode test. I couldn’t find out how to "only" raise a PHP Deprecation warning. Does anybody have some ideas?

That’s why I’m hesitant about officially supporting PHP 8.1 in version Timber 1.x **in the plugin version.**

## Impact

This pull request should fix the errors that people are seeing because we will revert to Twig 1.44.7:

- `Uncaught TypeError: Argument 1 passed to Twig\Environment::addFilter() must be an instance of Twig\TwigFilter, string given` in #2654, because passing only names as the first argument in `addFilter()` was removed as of Twig 2.0.
- `Uncaught Error: Class "Twig_Filter_Function" not found` in #2655, because `Twig_Filter_Function` was removed as of Twig 2.0.
- Twig’s `attribute` function not working in #2652, because attributes can’t be used to call macros anymore as of Twig 2.0, as explained by in @mrfsrf https://github.com/timber/timber/issues/2652#issuecomment-1284581094.
- `Fatal error: Uncaught LogicException: Unable to register extension “Twig\Extension\DebugExtension” as it is already registered.` in #2661, because registering an extension twice will throw a `LogicException` as of Twig 2.0.

## Usage Changes

None.

## Considerations

I already noted in the readme.txt that the new version should be 1.22.0. Though I’m not sure whether this qualifies as a hotfix and should be tagged with 1.21.1 instead. If guess if we require WordPress 5.3 as a minimum WordPress version, that wouldn’t qualify as a hotfix anymore.

## Testing

Yes.