### PR TITLE
2.x Remove unused Term::get_term_from_query() function

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -411,6 +411,14 @@ function get_term($term = null)
 - We removed the `$taxonomy` parameter. Timber needs the ID of a term or a `WP_Term` object. It can figure out the taxonomy itself.
 - We removed the `$TermClass` parameter. If you want to control the class your term should be instantiated with, use a [Term Class Map filter](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map).
 
+#### Removed edge case logic
+
+When you use `Timber::get_term()` without any parameter, Timber returns the queried term if the queried object is a term.
+
+There was a hidden logic in `Timber::get_term()` for cases where there was no queried term: When the global query already had a `tax_query` definition that queried specific terms, Timber would return the first of these terms.
+
+We [removed that logic](https://github.com/timber/timber/pull/2664/), because it could also lead to unexpected behavior.
+
 ### Timber::get_terms()
 
 #### Updated function signature for `Timber::get_terms()`

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -935,6 +935,7 @@ The following functions and properties were **removed from the codebase**, eithe
 
 - `get_link()` – use `{{ term.link }}` instead
 - `get_path()` – use `{{ term.path }}` instead
+- `get_term_from_query()` - use `Timber::get_term()` instead
 
 ### Timber\Image
 

--- a/src/Term.php
+++ b/src/Term.php
@@ -122,27 +122,8 @@ class Term extends CoreEntity
         return $termFactory->from($tid, $taxonomy);
     }
 
-
     /* Setup
     ===================== */
-
-    /**
-     * @internal
-     * @return integer
-     */
-    protected function get_term_from_query()
-    {
-        global $wp_query;
-        if (isset($wp_query->queried_object)) {
-            $qo = $wp_query->queried_object;
-            if (isset($qo->term_id)) {
-                return $qo->term_id;
-            }
-        }
-        if (isset($wp_query->tax_query->queries[0]['terms'][0])) {
-            return $wp_query->tax_query->queries[0]['terms'][0];
-        }
-    }
 
     /**
      * @internal


### PR DESCRIPTION
Related:

- #2659

## Issue

I found a function that is not used anymore.

## Solution

Remove the function.

## Impact

Minimal. The function that gets the term from the main query is now covered through `Timber::get_term()` and the term factory.

https://github.com/timber/timber/blob/056c6a1c0c345f6c1f08857beed97730a3267187/src/Timber.php#L714-L718

Only the protected function `Term::get_term_from_query()` can’t be used anymore.

## Considerations

There’s an additional check for a tax query that was added in https://github.com/timber/timber/pull/521: 

https://github.com/timber/timber/blob/056c6a1c0c345f6c1f08857beed97730a3267187/src/Term.php#L142-L144

The logic there seems to be: When the global query includes a tax query, get the first term from that query. Is that a case we still want to support? Is this the intended behavior for `Timber::get_term()`? Or could it also be considered as unexcepted?

## Testing

Do we need more testing?