### PR TITLE
2.x Use assertSame instead of assertEquals for certain values

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -128,13 +128,13 @@ class Image extends Attachment
      *
      * @internal
      * @param string $svg SVG Path
-     * @return array
+     * @return object
      */
     protected function get_dimensions_svg($svg)
     {
         $svg = simplexml_load_file($svg);
-        $width = '0';
-        $height = '0';
+        $width = 0;
+        $height = 0;
 
         if (false !== $svg) {
             $attributes = $svg->attributes();
@@ -143,14 +143,14 @@ class Image extends Attachment
                 $width = $viewbox[2];
                 $height = $viewbox[3];
             } elseif ($attributes->width && $attributes->height) {
-                $width = (string) $attributes->width;
-                $height = (string) $attributes->height;
+                $width = $attributes->width;
+                $height = $attributes->height;
             }
         }
 
         return (object) [
-            'width' => $width,
-            'height' => $height,
+            'width' => (int) $width,
+            'height' => (int) $height,
         ];
     }
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -673,7 +673,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      */
     public function comment_count()
     {
-        return get_comments_number($this->ID);
+        return (int) get_comments_number($this->ID);
     }
 
     /**

--- a/tests/test-timber-archives.php
+++ b/tests/test-timber-archives.php
@@ -16,8 +16,8 @@ class TestTimberArchives extends Timber_UnitTestCase
             'show_year' => false,
             'limit' => 3,
         ]);
-        $this->assertEquals(3, count($archives->items));
-        $this->assertEquals(2, $archives->items[1]['post_count']);
+        $this->assertSame(3, count($archives->items));
+        $this->assertSame(2, $archives->items[1]['post_count']);
     }
 
     public function testArchiveMonthly()
@@ -34,8 +34,8 @@ class TestTimberArchives extends Timber_UnitTestCase
             'show_year' => false,
         ]);
         $this->assertEquals('December', $archives->items[0]['name']);
-        $this->assertEquals(3, count($archives->items));
-        $this->assertEquals(2, $archives->items[1]['post_count']);
+        $this->assertSame(3, count($archives->items));
+        $this->assertSame(2, $archives->items[1]['post_count']);
         $archives = new Timber\Archives([
             'type' => 'monthly',
             'show_year' => true,
@@ -56,8 +56,8 @@ class TestTimberArchives extends Timber_UnitTestCase
             'type' => 'yearly',
             'show_year' => false,
         ]);
-        $this->assertEquals(3, count($archives->items));
-        $this->assertEquals(2, $archives->items[2]['post_count']);
+        $this->assertSame(3, count($archives->items));
+        $this->assertSame(2, $archives->items[2]['post_count']);
     }
 
     public function testArchiveDaily()
@@ -73,8 +73,8 @@ class TestTimberArchives extends Timber_UnitTestCase
         $archives = new Timber\Archives([
             'type' => 'daily',
         ]);
-        $this->assertEquals(5, count($archives->items));
-        $this->assertEquals(2, $archives->items[2]['post_count']);
+        $this->assertSame(5, count($archives->items));
+        $this->assertSame(2, $archives->items[2]['post_count']);
     }
 
     public function testArchiveYearlyMonthly()
@@ -90,15 +90,15 @@ class TestTimberArchives extends Timber_UnitTestCase
         $archives = new Timber\Archives([
             'type' => 'monthly-nested',
         ]);
-        $this->assertEquals(2, count($archives->items));
-        $this->assertEquals(4, $archives->items[1]['post_count']);
-        $this->assertEquals(2, $archives->items[1]['children'][1]['post_count']);
+        $this->assertSame(2, count($archives->items));
+        $this->assertSame(4, $archives->items[1]['post_count']);
+        $this->assertSame(2, $archives->items[1]['children'][1]['post_count']);
         $archives = new Timber\Archives([
             'type' => 'yearlymonthly',
         ]);
-        $this->assertEquals(2, count($archives->items));
-        $this->assertEquals(4, $archives->items[1]['post_count']);
-        $this->assertEquals(2, $archives->items[1]['children'][1]['post_count']);
+        $this->assertSame(2, count($archives->items));
+        $this->assertSame(4, $archives->items[1]['post_count']);
+        $this->assertSame(2, $archives->items[1]['children'][1]['post_count']);
     }
 
     public function testArchiveWeekly()
@@ -114,8 +114,8 @@ class TestTimberArchives extends Timber_UnitTestCase
         $archives = new Timber\Archives([
             'type' => 'weekly',
         ]);
-        $this->assertEquals(3, count($archives->items));
-        $this->assertEquals(3, $archives->items[0]['post_count']);
+        $this->assertSame(3, count($archives->items));
+        $this->assertSame(3, $archives->items[0]['post_count']);
     }
 
     public function testArchiveAlpha()
@@ -148,7 +148,7 @@ class TestTimberArchives extends Timber_UnitTestCase
         $archives = new Timber\Archives([
             'type' => 'alpha',
         ]);
-        $this->assertEquals(4, count($archives->items));
+        $this->assertSame(4, count($archives->items));
         $this->assertEquals('Quack Quack', $archives->items[3]['name']);
     }
 
@@ -173,11 +173,11 @@ class TestTimberArchives extends Timber_UnitTestCase
         $this->go_to('/');
         $archives = new Timber\Archives();
 
-        $this->assertEquals(2, count($archives->items));
+        $this->assertSame(2, count($archives->items));
         $archives = new Timber\Archives([
             'post_type' => 'book',
             'type' => 'monthly',
         ]);
-        $this->assertEquals(5, count($archives->items));
+        $this->assertSame(5, count($archives->items));
     }
 }

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -365,7 +365,7 @@ class TestTimberCache extends Timber_UnitTestCase
         global $wpdb;
         $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
         $data = $wpdb->get_results($query);
-        $this->assertEquals(1, $wpdb->num_rows);
+        $this->assertSame(1, $wpdb->num_rows);
     }
 
     public function testTimberLoaderCacheTransientsAdminLoggedIn()
@@ -509,7 +509,7 @@ class TestTimberCache extends Timber_UnitTestCase
         global $wpdb;
         $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
         $data = $wpdb->get_results($query);
-        $this->assertEquals(2, $wpdb->num_rows);
+        $this->assertSame(2, $wpdb->num_rows);
         $this->assertEquals('foo', get_transient('random_600'));
     }
 }

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -308,7 +308,7 @@ class TestTimberCache extends Timber_UnitTestCase
         global $wpdb;
         $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
         $wpdb->query($query);
-        $this->assertEquals(0, $wpdb->num_rows);
+        $this->assertSame(0, $wpdb->num_rows);
     }
 
     public function testTimberLoaderCacheObject()
@@ -482,7 +482,7 @@ class TestTimberCache extends Timber_UnitTestCase
         global $wpdb;
         $query = "SELECT * FROM $wpdb->options WHERE option_name LIKE '_transient_timberloader_%'";
         $data = $wpdb->get_results($query);
-        $this->assertEquals(0, $wpdb->num_rows);
+        $this->assertSame(0, $wpdb->num_rows);
         $_wp_using_ext_object_cache = false;
     }
 

--- a/tests/test-timber-comment-thread.php
+++ b/tests/test-timber-comment-thread.php
@@ -48,13 +48,13 @@ class TestTimberCommentThread extends Timber_UnitTestCase
         $comment = get_comment($comment_id);
 
         $post = Timber::get_post($post_id);
-        $this->assertEquals(0, count($post->comments()));
+        $this->assertSame(0, count($post->comments()));
 
         $_GET['unapproved'] = $comment->comment_ID;
         $_GET['moderation-hash'] = wp_hash($comment->comment_date_gmt);
         $post = Timber::get_post($post_id);
         if (!function_exists('wp_get_unapproved_comment_author_email')) {
-            $this->assertEquals(0, count($post->comments()));
+            $this->assertSame(0, count($post->comments()));
         } else {
             $timber_comment = $post->comments()[0];
             $this->assertEquals($quote, $timber_comment->comment_content);

--- a/tests/test-timber-comment-thread.php
+++ b/tests/test-timber-comment-thread.php
@@ -16,7 +16,7 @@ class TestTimberCommentThread extends Timber_UnitTestCase
         ]);
         $args = [];
         $ct = new Timber\CommentThread($post_id, $args);
-        $this->assertEquals(5, count($ct));
+        $this->assertSame(5, count($ct));
     }
 
     public function testCommentThreadCountMethod()
@@ -29,7 +29,7 @@ class TestTimberCommentThread extends Timber_UnitTestCase
         ]);
         $args = [];
         $ct = new Timber\CommentThread($post_id, $args);
-        $this->assertEquals(5, $ct->count());
+        $this->assertSame(5, $ct->count());
     }
 
     public function testShowUnmoderatedCommentIfByAnon()

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -244,10 +244,10 @@ class TestTimberComment extends Timber_UnitTestCase
         $this->assertEquals(3, count($comments));
         $this->assertEquals(1, count($children));
 
-        $this->assertEquals(0, $comments[1]->depth());
+        $this->assertSame(0, $comments[1]->depth());
         $this->assertEquals(1, $children[0]->depth());
         $this->assertEquals(2, $grand_children[0]->depth());
-        $this->assertEquals(0, $comments[2]->depth());
+        $this->assertSame(0, $comments[2]->depth());
 
         $comment_id = $this->factory->comment->create([
             'comment_post_ID' => $post_id,

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -174,8 +174,8 @@ class TestTimberComment extends Timber_UnitTestCase
         ]);
         $post = Timber::get_post($post_id);
         $comments = $post->comments();
-        $this->assertEquals(2, count($comments));
-        $this->assertEquals(1, count($comments[1]->children()));
+        $this->assertSame(2, count($comments));
+        $this->assertSame(1, count($comments[1]->children()));
         $twig_string = '{{comment.author.name}}';
         $result = Timber::compile_string($twig_string, [
             'comment' => $comments[0],
@@ -241,12 +241,12 @@ class TestTimberComment extends Timber_UnitTestCase
         $comments = $post->comments();
         $children = $comments[1]->children();
         $grand_children = $children[0]->children();
-        $this->assertEquals(3, count($comments));
-        $this->assertEquals(1, count($children));
+        $this->assertSame(3, count($comments));
+        $this->assertSame(1, count($children));
 
         $this->assertSame(0, $comments[1]->depth());
-        $this->assertEquals(1, $children[0]->depth());
-        $this->assertEquals(2, $grand_children[0]->depth());
+        $this->assertSame(1, $children[0]->depth());
+        $this->assertSame(2, $grand_children[0]->depth());
         $this->assertSame(0, $comments[2]->depth());
 
         $comment_id = $this->factory->comment->create([

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -19,7 +19,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase
         echo $wrapper;
         $content = trim(ob_get_contents());
         ob_end_clean();
-        $this->assertEquals(1, $content);
+        $this->assertSame(1, $content);
     }
 
     public function testToStringWithClassObject()
@@ -29,7 +29,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase
         echo $wrapper;
         $content = trim(ob_get_contents());
         ob_end_clean();
-        $this->assertEquals(1, $content);
+        $this->assertSame(1, $content);
     }
 
     public function testToStringWithClassString()
@@ -39,7 +39,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase
         echo $wrapper;
         $content = trim(ob_get_contents());
         ob_end_clean();
-        $this->assertEquals(1, $content);
+        $this->assertSame(1, $content);
     }
 
     public function testWPHead()

--- a/tests/test-timber-function-wrapper.php
+++ b/tests/test-timber-function-wrapper.php
@@ -19,7 +19,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase
         echo $wrapper;
         $content = trim(ob_get_contents());
         ob_end_clean();
-        $this->assertSame(1, $content);
+        $this->assertSame('1', $content);
     }
 
     public function testToStringWithClassObject()
@@ -29,7 +29,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase
         echo $wrapper;
         $content = trim(ob_get_contents());
         ob_end_clean();
-        $this->assertSame(1, $content);
+        $this->assertSame('1', $content);
     }
 
     public function testToStringWithClassString()
@@ -39,7 +39,7 @@ class TestTimberFunctionWrapper extends Timber_UnitTestCase
         echo $wrapper;
         $content = trim(ob_get_contents());
         ob_end_clean();
-        $this->assertSame(1, $content);
+        $this->assertSame('1', $content);
     }
 
     public function testWPHead()

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -161,7 +161,7 @@ class TestTimberHelper extends Timber_UnitTestCase
         $obj2->skill = 'cooking';
         $arr = [$obj1, $obj2];
         $index = Timber\Helper::get_object_index_by_property($arr, 'skill', 'cooking');
-        $this->assertEquals(1, $index);
+        $this->assertSame(1, $index);
         $obj = Timber\Helper::get_object_by_property($arr, 'skill', 'cooking');
         $this->assertEquals('austin', $obj->name);
     }
@@ -186,7 +186,7 @@ class TestTimberHelper extends Timber_UnitTestCase
         $obj2['skill'] = 'cooking';
         $arr = [$obj1, $obj2];
         $index = \Timber\Helper::get_object_index_by_property($arr, 'skill', 'cooking');
-        $this->assertEquals(1, $index);
+        $this->assertSame(1, $index);
         $this->assertFalse(\Timber\Helper::get_object_index_by_property('butts', 'skill', 'cooking'));
     }
 
@@ -214,7 +214,7 @@ class TestTimberHelper extends Timber_UnitTestCase
         $arr = ['Buster', 'GOB', 'Michael', 'Lindsay'];
         $arr = Timber\Helper::array_truncate($arr, 2);
         $this->assertContains('Buster', $arr);
-        $this->assertEquals(2, count($arr));
+        $this->assertSame(2, count($arr));
         $this->assertFalse(in_array('Lindsay', $arr));
     }
 
@@ -264,7 +264,7 @@ class TestTimberHelper extends Timber_UnitTestCase
         $this->assertEquals('Michael', $people[0]->name);
         $this->assertEquals('Lauren', $people[1]->name);
         $this->assertEquals('Robbie', $people[2]->name);
-        $this->assertEquals(1984, $people[1]->year);
+        $this->assertSame(1984, $people[1]->year);
     }
 
     /**

--- a/tests/test-timber-helper.php
+++ b/tests/test-timber-helper.php
@@ -106,7 +106,7 @@ class TestTimberHelper extends Timber_UnitTestCase
         //since we're testing with twentyfourteen -- need to remove its filters on wp_title
         remove_all_filters('wp_title');
         remove_theme_support('title-tag');
-        $this->assertEquals('', Timber\Helper::get_wp_title());
+        $this->assertSame('', Timber\Helper::get_wp_title());
     }
 
     public function testWPTitleSingle()
@@ -323,7 +323,7 @@ class TestTimberHelper extends Timber_UnitTestCase
         $str = Timber::compile_string($template, [
             'posts' => 'foobar',
         ]);
-        $this->assertEquals('', $str);
+        $this->assertSame('', $str);
     }
 
     public function testConvertWPObject()

--- a/tests/test-timber-image-helper-internals.php
+++ b/tests/test-timber-image-helper-internals.php
@@ -7,7 +7,7 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         $src = 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/myimage.jpg';
         $parts = Timber\ImageHelper::analyze_url($src);
         $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/myimage.jpg', $parts['url']);
-        $this->assertSame(1, $parts['absolute']);
+        $this->assertSame(true, $parts['absolute']);
         $this->assertSame(1, $parts['base']);
         $this->assertSame('', $parts['subdir']);
         $this->assertEquals('myimage', $parts['filename']);
@@ -20,7 +20,7 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         $src = 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg';
         $parts = Timber\ImageHelper::analyze_url($src);
         $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg', $parts['url']);
-        $this->assertSame(1, $parts['absolute']);
+        $this->assertSame(true, $parts['absolute']);
         $this->assertSame(1, $parts['base']);
         $this->assertEquals('/2017/02', $parts['subdir']);
         $this->assertEquals('myimage', $parts['filename']);

--- a/tests/test-timber-image-helper-internals.php
+++ b/tests/test-timber-image-helper-internals.php
@@ -9,7 +9,7 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/myimage.jpg', $parts['url']);
         $this->assertEquals(1, $parts['absolute']);
         $this->assertEquals(1, $parts['base']);
-        $this->assertEquals('', $parts['subdir']);
+        $this->assertSame('', $parts['subdir']);
         $this->assertEquals('myimage', $parts['filename']);
         $this->assertEquals('jpg', $parts['extension']);
         $this->assertEquals('myimage.jpg', $parts['basename']);

--- a/tests/test-timber-image-helper-internals.php
+++ b/tests/test-timber-image-helper-internals.php
@@ -7,8 +7,8 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         $src = 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/myimage.jpg';
         $parts = Timber\ImageHelper::analyze_url($src);
         $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/myimage.jpg', $parts['url']);
-        $this->assertEquals(1, $parts['absolute']);
-        $this->assertEquals(1, $parts['base']);
+        $this->assertSame(1, $parts['absolute']);
+        $this->assertSame(1, $parts['base']);
         $this->assertSame('', $parts['subdir']);
         $this->assertEquals('myimage', $parts['filename']);
         $this->assertEquals('jpg', $parts['extension']);
@@ -20,8 +20,8 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         $src = 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg';
         $parts = Timber\ImageHelper::analyze_url($src);
         $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg', $parts['url']);
-        $this->assertEquals(1, $parts['absolute']);
-        $this->assertEquals(1, $parts['base']);
+        $this->assertSame(1, $parts['absolute']);
+        $this->assertSame(1, $parts['base']);
         $this->assertEquals('/2017/02', $parts['subdir']);
         $this->assertEquals('myimage', $parts['filename']);
         $this->assertEquals('jpg', $parts['extension']);
@@ -34,8 +34,8 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         // $src = 'http://'.$_SERVER['HTTP_HOST'].'/wp-content/themes/'.get_stylesheet().'/logo.jpg';
         // $parts = Timber\ImageHelper::analyze_url($src);
         // $this->assertEquals('http://'.$_SERVER['HTTP_HOST'].'/wp-content/themes/'.get_stylesheet().'/logo.jpg', $parts['url']);
-        // $this->assertEquals(1, $parts['absolute']);
-        // $this->assertEquals(2, $parts['base']);
+        // $this->assertSame(1, $parts['absolute']);
+        // $this->assertSame(2, $parts['base']);
         // $this->assertEquals('/themes/'.get_stylesheet(), $parts['subdir']);
         // $this->assertEquals('logo', $parts['filename']);
         // $this->assertEquals('jpg', $parts['extension']);

--- a/tests/test-timber-image-letterbox.php
+++ b/tests/test-timber-image-letterbox.php
@@ -39,7 +39,7 @@ class TestTimberImageLetterbox extends TimberAttachment_UnitTestCase
         $image = imagecreatefromjpeg($location_of_image);
         $pixel_rgb = imagecolorat($image, 1, 1);
         $colors = imagecolorsforindex($image, $pixel_rgb);
-        $this->assertEquals(0, $colors['red']);
+        $this->assertSame(0, $colors['red']);
         $this->assertEquals(255, $colors['green']);
     }
 

--- a/tests/test-timber-image-letterbox.php
+++ b/tests/test-timber-image-letterbox.php
@@ -40,7 +40,7 @@ class TestTimberImageLetterbox extends TimberAttachment_UnitTestCase
         $pixel_rgb = imagecolorat($image, 1, 1);
         $colors = imagecolorsforindex($image, $pixel_rgb);
         $this->assertSame(0, $colors['red']);
-        $this->assertEquals(255, $colors['green']);
+        $this->assertSame(255, $colors['green']);
     }
 
     public function testLetterboxTransparent()
@@ -100,9 +100,9 @@ class TestTimberImageLetterbox extends TimberAttachment_UnitTestCase
         $image = imagecreatefromjpeg($location_of_image);
         $pixel_rgb = imagecolorat($image, 1, 1);
         $colors = imagecolorsforindex($image, $pixel_rgb);
-        $this->assertEquals(255, $colors['red']);
-        $this->assertEquals(255, $colors['blue']);
-        $this->assertEquals(255, $colors['green']);
+        $this->assertSame(255, $colors['red']);
+        $this->assertSame(255, $colors['blue']);
+        $this->assertSame(255, $colors['green']);
     }
 
     public function testImageLetterboxFilterNotAnImage()

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -594,7 +594,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
         $colors = imagecolorsforindex($image, $pixel_rgb);
         $this->assertEquals(255, $colors['red']);
         $this->assertEquals(255, $colors['green']);
-        $this->assertEquals(0, $colors['blue']);
+        $this->assertSame(0, $colors['blue']);
     }
 
     public function testImageDeletionSimilarNames()

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -194,10 +194,10 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
     {
         $post = $this->get_post_with_image();
         $image = $post->thumbnail();
-        $this->assertEquals(1500, $image->width());
-        $this->assertEquals(1000, $image->height());
+        $this->assertSame(1500, $image->width());
+        $this->assertSame(1000, $image->height());
         $this->assertEquals($post->ID, $image->parent()->id);
-        $this->assertEquals(1.5, $image->aspect());
+        $this->assertSame(1.5, $image->aspect());
     }
 
     public function testImageSrcset()
@@ -266,7 +266,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
         $new_file = Timber\ImageHelper::resize($upload_dir['url'] . '/stl.jpg', 500, 200, 'default', true);
         $location_of_image = Timber\ImageHelper::get_server_location($new_file);
         $size = getimagesize($location_of_image);
-        $this->assertEquals(500, $size[0]);
+        $this->assertSame(500, $size[0]);
     }
 
     public function testUpSizing2Param()
@@ -277,8 +277,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
         $new_file = Timber\ImageHelper::resize($upload_dir['url'] . '/stl.jpg', 500, 300, 'default', true);
         $location_of_image = Timber\ImageHelper::get_server_location($new_file);
         $size = getimagesize($location_of_image);
-        $this->assertEquals(500, $size[0]);
-        $this->assertEquals(300, $size[1]);
+        $this->assertSame(500, $size[0]);
+        $this->assertSame(300, $size[1]);
     }
 
     public function testImageResizeRelative()
@@ -592,8 +592,8 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
         $image = imagecreatefromjpeg($location_of_image);
         $pixel_rgb = imagecolorat($image, 1, 1);
         $colors = imagecolorsforindex($image, $pixel_rgb);
-        $this->assertEquals(255, $colors['red']);
-        $this->assertEquals(255, $colors['green']);
+        $this->assertSame(255, $colors['red']);
+        $this->assertSame(255, $colors['green']);
         $this->assertSame(0, $colors['blue']);
     }
 
@@ -1253,7 +1253,7 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
     {
         $pid = $this->factory->post->create();
         $image = Timber::get_image(self::get_attachment($pid, 'icon-twitter.svg'));
-        $this->assertEquals(23, $image->width());
-        $this->assertEquals(20, $image->height());
+        $this->assertSame(23, $image->width());
+        $this->assertSame(20, $image->height());
     }
 }

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -455,8 +455,8 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase
         $file = $post->meta($field_file_name, [
             'transform_value' => true,
         ]);
-        $this->assertEquals(false, $image);
-        $this->assertEquals(false, $file);
+        $this->assertSame(false, $image);
+        $this->assertSame(false, $file);
     }
 
     private function register_field($field_name, $field_type, $field_args = [])

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -75,10 +75,10 @@ class TestTimberLoader extends Timber_UnitTestCase
         add_filter('timber/loader/paths', function ($paths) use ($php_unit) {
             $paths = call_user_func_array('array_merge', array_values($paths));
             $count = count($paths);
-            $php_unit->assertEquals(3, count($paths));
+            $php_unit->assertSame(3, count($paths));
             $pos = array_search('/', $paths);
             unset($paths[$pos]);
-            $php_unit->assertEquals(2, count($paths));
+            $php_unit->assertSame(2, count($paths));
             return $paths;
         });
         $str = Timber::compile('assets/single.twig', []);

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -380,7 +380,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $menu = Timber::get_menu($menu_arr['term_id']);
         $defaults['menu'] = $menu_arr['term_id'];
         $this->assertIsInt($menu->depth);
-        $this->assertEquals(0, $menu->depth);
+        $this->assertSame(0, $menu->depth);
         $this->assertIsArray($menu->raw_args);
         $this->assertIsObject($menu->args);
         $this->assertEquals((object) $defaults, $menu->args);
@@ -404,7 +404,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         ];
         $menu = Timber::get_menu('Menu One', $args);
         $this->assertIsInt($menu->depth);
-        $this->assertEquals(0, $menu->depth);
+        $this->assertSame(0, $menu->depth);
     }
 
     public function testMenuOptions_Depth()
@@ -418,7 +418,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         // Confirm that none of them have "children" set.
         $items = $menu->get_items();
         foreach ($items as $item) {
-            $this->assertEquals(null, $item->children);
+            $this->assertSame(null, $item->children);
         }
 
         // Confirm two levels deep
@@ -429,7 +429,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         foreach ($items as $item) {
             if ($item->children) {
                 foreach ($item->children as $child) {
-                    $this->assertEquals(null, $child->children);
+                    $this->assertSame(null, $child->children);
                 }
             }
         }
@@ -661,7 +661,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $menu_arr = self::_createTestMenu();
         $menu = Timber::get_menu($menu_arr['term_id']);
         $parent = $menu->items[0];
-        $this->assertEquals(0, $parent->level);
+        $this->assertSame(0, $parent->level);
         $child = $parent->children[0];
         $this->assertEquals(1, $child->level);
         $olderGrandchild = $child->children[0];
@@ -677,7 +677,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $menu_arr = self::_createTestMenu();
         $menu = Timber::get_menu($menu_arr['term_id']);
         $parent = $menu->items[0];
-        $this->assertEquals(0, $parent->level);
+        $this->assertSame(0, $parent->level);
         $children = $parent->children();
         $this->assertEquals(1, count($children));
         $this->assertEquals('Child Page', $children[0]->title());

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -392,7 +392,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $menu = Timber::get_menu('Menu One', $args);
         $args['menu'] = 'Menu One';
         $this->assertIsInt($menu->depth);
-        $this->assertEquals(1, $menu->depth);
+        $this->assertSame(1, $menu->depth);
         $this->assertIsArray($menu->raw_args);
         $this->assertEquals($args, $menu->raw_args);
         $this->assertIsObject($menu->args);
@@ -462,7 +462,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         ]);
 
         $filter = function ($classes, $item, $args) {
-            $this->assertEquals(3, $args->depth);
+            $this->assertSame(3, $args->depth);
 
             return $classes;
         };
@@ -663,13 +663,13 @@ class TestTimberMenu extends Timber_UnitTestCase
         $parent = $menu->items[0];
         $this->assertSame(0, $parent->level);
         $child = $parent->children[0];
-        $this->assertEquals(1, $child->level);
+        $this->assertSame(1, $child->level);
         $olderGrandchild = $child->children[0];
         $this->assertEquals('Grandchild Page', $olderGrandchild->title());
-        $this->assertEquals(2, $olderGrandchild->level);
+        $this->assertSame(2, $olderGrandchild->level);
         $youngerGrandchild = $child->children[1];
         $this->assertEquals('Other Grandchild Page', $youngerGrandchild->title());
-        $this->assertEquals(2, $youngerGrandchild->level);
+        $this->assertSame(2, $youngerGrandchild->level);
     }
 
     public function testMenuLevelsChildren()
@@ -679,7 +679,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $parent = $menu->items[0];
         $this->assertSame(0, $parent->level);
         $children = $parent->children();
-        $this->assertEquals(1, count($children));
+        $this->assertSame(1, count($children));
         $this->assertEquals('Child Page', $children[0]->title());
     }
 
@@ -749,7 +749,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $this->buildMenu('Fancy Suit', $items);
 
         $menu = Timber::get_menu('Fancy Suit');
-        $this->assertEquals(3, count($menu->get_items()));
+        $this->assertSame(3, count($menu->get_items()));
     }
 
     public function testConstructMenuBySlug()
@@ -771,7 +771,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         $this->buildMenu('Jolly Jeepers', $items);
 
         $menu = Timber::get_menu('jolly-jeepers');
-        $this->assertEquals(3, count($menu->get_items()));
+        $this->assertSame(3, count($menu->get_items()));
     }
 
     public function testGetCurrentItem()

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -418,7 +418,7 @@ class TestTimberMenu extends Timber_UnitTestCase
         // Confirm that none of them have "children" set.
         $items = $menu->get_items();
         foreach ($items as $item) {
-            $this->assertSame(null, $item->children);
+            $this->assertSame(false, $item->children);
         }
 
         // Confirm two levels deep

--- a/tests/test-timber-meta-deprecated.php
+++ b/tests/test-timber-meta-deprecated.php
@@ -34,7 +34,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase
     {
         $filter = function ($meta, $object_id, $field_name, $object) {
             $this->assertEquals('name', $field_name);
-            $this->assertEquals(null, $meta);
+            $this->assertSame(null, $meta);
             $this->assertSame($object->ID, $object_id);
 
             return $meta;
@@ -58,7 +58,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase
     public function testDeprecatedTimberPostGetMetaPreAction()
     {
         $action = function ($meta, $object_id, $object) {
-            $this->assertEquals(null, $meta);
+            $this->assertSame(null, $meta);
             $this->assertSame($object->ID, $object_id);
         };
 
@@ -203,7 +203,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase
     public function testDeprecatedTimberUserGetMetaPreFilter()
     {
         $filter = function ($meta, $object_id, $object) {
-            $this->assertEquals(null, $meta);
+            $this->assertSame(null, $meta);
             $this->assertSame($object->ID, $object_id);
 
             return $meta;
@@ -228,7 +228,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase
     {
         $filter = function ($meta, $object_id, $field_name, $object) {
             $this->assertEquals('name', $field_name);
-            $this->assertEquals(null, $meta);
+            $this->assertSame(null, $meta);
             $this->assertSame($object->ID, $object_id);
 
             return $meta;
@@ -302,7 +302,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase
     {
         $filter = function ($meta, $object_id, $field_name, $object) {
             $this->assertEquals('name', $field_name);
-            $this->assertEquals(null, $meta);
+            $this->assertSame(null, $meta);
             $this->assertSame($object->ID, $object_id);
 
             return $meta;
@@ -326,7 +326,7 @@ class TestTimberMetaDeprecated extends Timber_UnitTestCase
     public function testDeprecatedTimberCommentGetMetaPreAction()
     {
         $action = function ($meta, $object_id) {
-            $this->assertEquals(null, $meta);
+            $this->assertSame(null, $meta);
         };
 
         add_action('timber_comment_get_meta_pre', $action, 10, 2);

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -366,16 +366,16 @@ class TestTimberMeta extends Timber_UnitTestCase
         );
 
         $this->assertSame(null, $post->raw_meta('my_custom_property_inexistent'));
-        $this->assertSame(null, $post_string);
+        $this->assertSame('', $post_string);
 
         $this->assertSame(null, $term->raw_meta('my_custom_property_inexistent'));
-        $this->assertSame(null, $term_string);
+        $this->assertSame('', $term_string);
 
         $this->assertSame(null, $user->raw_meta('my_custom_property_inexistent'));
-        $this->assertSame(null, $user_string);
+        $this->assertSame('', $user_string);
 
         $this->assertSame(null, $comment->raw_meta('my_custom_property_inexistent'));
-        $this->assertSame(null, $comment_string);
+        $this->assertSame('', $comment_string);
     }
 
     /**

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -87,10 +87,10 @@ class TestTimberMeta extends Timber_UnitTestCase
         $user = Timber::get_user($user_id);
         $comment = Timber::get_comment($comment_id);
 
-        $this->assertEquals(null, $post->meta('not_found'));
-        $this->assertEquals(null, $term->meta('not_found'));
-        $this->assertEquals(null, $user->meta('not_found'));
-        $this->assertEquals(null, $comment->meta('not_found'));
+        $this->assertSame(null, $post->meta('not_found'));
+        $this->assertSame(null, $term->meta('not_found'));
+        $this->assertSame(null, $user->meta('not_found'));
+        $this->assertSame(null, $comment->meta('not_found'));
     }
 
     public function testPreMetaFilter()
@@ -176,18 +176,18 @@ class TestTimberMeta extends Timber_UnitTestCase
         $term = Timber::get_term($term_id);
         $comment = Timber::get_comment($comment_id);
 
-        $this->assertEquals(false, $this->is_get_post_meta_hit);
-        $this->assertEquals(false, $this->is_get_term_meta_hit);
-        $this->assertEquals(false, $this->is_get_comment_meta_hit);
+        $this->assertSame(false, $this->is_get_post_meta_hit);
+        $this->assertSame(false, $this->is_get_term_meta_hit);
+        $this->assertSame(false, $this->is_get_comment_meta_hit);
 
         // Run fetch.
         $post->meta();
         $term->meta();
         $comment->meta();
 
-        $this->assertEquals(false, $this->is_get_post_meta_hit);
-        $this->assertEquals(false, $this->is_get_term_meta_hit);
-        $this->assertEquals(false, $this->is_get_comment_meta_hit);
+        $this->assertSame(false, $this->is_get_post_meta_hit);
+        $this->assertSame(false, $this->is_get_term_meta_hit);
+        $this->assertSame(false, $this->is_get_comment_meta_hit);
     }
 
     public function testMetaFilter()
@@ -313,16 +313,16 @@ class TestTimberMeta extends Timber_UnitTestCase
         $comment = Timber::get_comment($comment_id);
 
         $this->assertEquals('I am a meta value', $post->raw_meta('meta_value'));
-        $this->assertEquals(false, $post->meta('meta_value'));
+        $this->assertSame(false, $post->meta('meta_value'));
 
         $this->assertEquals('I am a meta value', $term->raw_meta('meta_value'));
-        $this->assertEquals(false, $term->meta('meta_value'));
+        $this->assertSame(false, $term->meta('meta_value'));
 
         $this->assertEquals('I am a meta value', $user->raw_meta('meta_value'));
-        $this->assertEquals(false, $user->meta('meta_value'));
+        $this->assertSame(false, $user->meta('meta_value'));
 
         $this->assertEquals('I am a meta value', $comment->raw_meta('meta_value'));
-        $this->assertEquals(false, $comment->meta('meta_value'));
+        $this->assertSame(false, $comment->meta('meta_value'));
     }
 
     /**
@@ -365,17 +365,17 @@ class TestTimberMeta extends Timber_UnitTestCase
             ]
         );
 
-        $this->assertEquals(null, $post->raw_meta('my_custom_property_inexistent'));
-        $this->assertEquals(null, $post_string);
+        $this->assertSame(null, $post->raw_meta('my_custom_property_inexistent'));
+        $this->assertSame(null, $post_string);
 
-        $this->assertEquals(null, $term->raw_meta('my_custom_property_inexistent'));
-        $this->assertEquals(null, $term_string);
+        $this->assertSame(null, $term->raw_meta('my_custom_property_inexistent'));
+        $this->assertSame(null, $term_string);
 
-        $this->assertEquals(null, $user->raw_meta('my_custom_property_inexistent'));
-        $this->assertEquals(null, $user_string);
+        $this->assertSame(null, $user->raw_meta('my_custom_property_inexistent'));
+        $this->assertSame(null, $user_string);
 
-        $this->assertEquals(null, $comment->raw_meta('my_custom_property_inexistent'));
-        $this->assertEquals(null, $comment_string);
+        $this->assertSame(null, $comment->raw_meta('my_custom_property_inexistent'));
+        $this->assertSame(null, $comment_string);
     }
 
     /**
@@ -885,8 +885,8 @@ class TestTimberMeta extends Timber_UnitTestCase
             'post' => $post,
         ]);
 
-        $this->assertEquals('', $string);
-        $this->assertEquals(false, $post->custom);
+        $this->assertSame('', $string);
+        $this->assertSame(false, $post->custom);
     }
 
     /**
@@ -905,8 +905,8 @@ class TestTimberMeta extends Timber_UnitTestCase
             'term' => $term,
         ]);
 
-        $this->assertEquals('', $string);
-        $this->assertEquals(false, $term->custom);
+        $this->assertSame('', $string);
+        $this->assertSame(false, $term->custom);
     }
 
     /**
@@ -925,8 +925,8 @@ class TestTimberMeta extends Timber_UnitTestCase
             'user' => $user,
         ]);
 
-        $this->assertEquals('', $string);
-        $this->assertEquals(false, $user->custom);
+        $this->assertSame('', $string);
+        $this->assertSame(false, $user->custom);
     }
 
     /**
@@ -945,8 +945,8 @@ class TestTimberMeta extends Timber_UnitTestCase
             'comment' => $comment,
         ]);
 
-        $this->assertEquals('', $string);
-        $this->assertEquals(false, $comment->custom);
+        $this->assertSame('', $string);
+        $this->assertSame(false, $comment->custom);
     }
 
     /**
@@ -1009,17 +1009,17 @@ class TestTimberMeta extends Timber_UnitTestCase
             ]
         );
 
-        $this->assertEquals('', $post_string);
-        $this->assertEquals(false, $post->inexistent);
+        $this->assertSame('', $post_string);
+        $this->assertSame(false, $post->inexistent);
 
-        $this->assertEquals('', $term_string);
-        $this->assertEquals(false, $term->inexistent);
+        $this->assertSame('', $term_string);
+        $this->assertSame(false, $term->inexistent);
 
-        $this->assertEquals('', $user_string);
-        $this->assertEquals(false, $user->inexistent);
+        $this->assertSame('', $user_string);
+        $this->assertSame(false, $user->inexistent);
 
-        $this->assertEquals('', $comment_string);
-        $this->assertEquals(false, $comment->inexistent);
+        $this->assertSame('', $comment_string);
+        $this->assertSame(false, $comment->inexistent);
     }
 
     /**

--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -79,14 +79,14 @@ class TestTimberMultisite extends Timber_UnitTestCase
             // display all posts
         }
 
-        $this->assertEquals(6, count($timber_posts));
-        $this->assertEquals(6, count($wp_posts));
+        $this->assertSame(6, count($timber_posts));
+        $this->assertSame(6, count($wp_posts));
 
         // ensure tha the current site's post count is distinct from our test condition
         $current_site_all_posts = get_posts([
             'post_type' => 'post',
         ]);
-        $this->assertEquals(2, count($current_site_all_posts));
+        $this->assertSame(2, count($current_site_all_posts));
     }
 
     /**
@@ -179,12 +179,12 @@ class TestTimberMultisite extends Timber_UnitTestCase
             // display all posts
         }
 
-        $this->assertEquals(3, count($timber_posts));
-        $this->assertEquals(3, count($wp_posts));
+        $this->assertSame(3, count($timber_posts));
+        $this->assertSame(3, count($wp_posts));
 
         // ensure tha the current site's post count is distinct from our test condition
         $current_site_all_posts = get_posts();
-        $this->assertEquals(5, count($current_site_all_posts));
+        $this->assertSame(5, count($current_site_all_posts));
     }
 
     /**

--- a/tests/test-timber-pages-menu.php
+++ b/tests/test-timber-pages-menu.php
@@ -265,7 +265,7 @@ class TestTimberPagesMenu extends Timber_UnitTestCase
             'menu_order' => 1,
         ]);
         $pages_menu = Timber::get_pages_menu();
-        $this->assertEquals(2, count($pages_menu->items));
+        $this->assertSame(2, count($pages_menu->items));
         $this->assertEquals('Bar Page', $pages_menu->items[0]->title());
         self::_createTestMenu();
 
@@ -296,7 +296,7 @@ class TestTimberPagesMenu extends Timber_UnitTestCase
             'include' => [$page_id_1],
         ]);
 
-        $this->assertEquals(1, count($pages_menu->items));
+        $this->assertSame(1, count($pages_menu->items));
         $this->assertEquals('Foo Page', $pages_menu->items[0]->title());
     }
 
@@ -348,7 +348,7 @@ class TestTimberPagesMenu extends Timber_UnitTestCase
             'menu_order' => 1,
         ]);
         $pages_menu = Timber::get_pages_menu();
-        $this->assertEquals(2, count($pages_menu->items));
+        $this->assertSame(2, count($pages_menu->items));
         $this->assertEquals('Bar Page', $pages_menu->items[0]->title());
         self::_createTestMenu();
         //make sure other menus are still more powerful
@@ -383,14 +383,14 @@ class TestTimberPagesMenu extends Timber_UnitTestCase
         $pages_menu = Timber::get_pages_menu([
             'depth' => 0,
         ]);
-        $this->assertEquals(2, count($pages_menu->get_items()));
-        $this->assertEquals(2, count($pages_menu->get_items()[0]->children()));
+        $this->assertSame(2, count($pages_menu->get_items()));
+        $this->assertSame(2, count($pages_menu->get_items()[0]->children()));
 
         // Get first level only.
         $pages_menu = Timber::get_pages_menu([
             'depth' => 1,
         ]);
-        $this->assertEquals(2, count($pages_menu->get_items()));
+        $this->assertSame(2, count($pages_menu->get_items()));
         $this->assertEmpty($pages_menu->get_items()[0]->children());
     }
 

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -80,7 +80,7 @@ class TestTimberPagination extends Timber_UnitTestCase
         $this->go_to(home_url('/portfolio/page/3'));
         query_posts('post_type=portfolio&paged=3');
         $pagination = Timber::get_pagination();
-        $this->assertEquals(6, count($pagination['pages']));
+        $this->assertSame(6, count($pagination['pages']));
     }
 
     /**
@@ -173,7 +173,7 @@ class TestTimberPagination extends Timber_UnitTestCase
         ]);
         query_posts('post_type=portfolio');
         $pagination = Timber::get_pagination(4);
-        $this->assertEquals(5, count($pagination['pages']));
+        $this->assertSame(5, count($pagination['pages']));
     }
 
     /**
@@ -347,7 +347,7 @@ class TestTimberPagination extends Timber_UnitTestCase
         $this->go_to(home_url('/portfolio/page/3'));
         $posts = new PostQuery(new WP_Query('post_type=portfolio&paged=3'));
         $pagination = $posts->pagination();
-        $this->assertEquals(6, count($pagination->pages));
+        $this->assertSame(6, count($pagination->pages));
     }
 
     public function testCollectionPaginationWithSize()
@@ -358,7 +358,7 @@ class TestTimberPagination extends Timber_UnitTestCase
         ]);
         $posts = new PostQuery(new WP_Query('post_type=portfolio&posts_per_page=20'));
         $pagination = $posts->pagination();
-        $this->assertEquals(5, count($pagination->pages));
+        $this->assertSame(5, count($pagination->pages));
     }
 
     public function testCollectionPaginationSearchPrettyWithPostname()
@@ -481,12 +481,12 @@ class TestTimberPagination extends Timber_UnitTestCase
         ]);
         $recipes = new PostQuery(new WP_Query('post_type=recipe'));
         $pagination = $recipes->pagination();
-        $this->assertEquals(5, count($pagination->pages));
+        $this->assertSame(5, count($pagination->pages));
         $pids = $this->factory->post->create_many(13);
 
         $posts = new PostQuery(new WP_Query('post_type=post'));
         $pagination = $posts->pagination();
-        $this->assertEquals(2, count($pagination->pages));
+        $this->assertSame(2, count($pagination->pages));
 
         // clean up
         unregister_post_type('recipe');
@@ -569,7 +569,7 @@ class TestTimberPagination extends Timber_UnitTestCase
         $pagination = $posts->pagination([
             'show_all' => false,
         ]);
-        $this->assertEquals(11, count($pagination->pages));
+        $this->assertSame(11, count($pagination->pages));
         // Test mid_size
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -580,7 +580,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'show_all' => false,
             'mid_size' => 1,
         ]);
-        $this->assertEquals(7, count($pagination->pages));
+        $this->assertSame(7, count($pagination->pages));
         // Test mid_size = 0
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -591,7 +591,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'show_all' => false,
             'mid_size' => 0,
         ]);
-        $this->assertEquals(5, count($pagination->pages));
+        $this->assertSame(5, count($pagination->pages));
         // Test end_size
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -602,7 +602,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'show_all' => false,
             'end_size' => 2,
         ]);
-        $this->assertEquals(13, count($pagination->pages));
+        $this->assertSame(13, count($pagination->pages));
         // Test end_size = 0
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -613,7 +613,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'show_all' => false,
             'end_size' => 0,
         ]);
-        $this->assertEquals(9, count($pagination->pages));
+        $this->assertSame(9, count($pagination->pages));
         // Test start_size
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -624,7 +624,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'show_all' => false,
             'start_size' => 2,
         ]);
-        $this->assertEquals(12, count($pagination->pages));
+        $this->assertSame(12, count($pagination->pages));
         // Test start_size = 0
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -635,7 +635,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'show_all' => false,
             'start_size' => 0,
         ]);
-        $this->assertEquals(10, count($pagination->pages));
+        $this->assertSame(10, count($pagination->pages));
         // Test start_size, end_size
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -647,7 +647,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'start_size' => 2,
             'end_size' => 3,
         ]);
-        $this->assertEquals(14, count($pagination->pages));
+        $this->assertSame(14, count($pagination->pages));
         // Test start_size, end_size  = 0
         $posts = Timber::get_posts([
             'post_type' => 'post',
@@ -659,6 +659,6 @@ class TestTimberPagination extends Timber_UnitTestCase
             'start_size' => 2,
             'end_size' => 0,
         ]);
-        $this->assertEquals(11, count($pagination->pages));
+        $this->assertSame(11, count($pagination->pages));
     }
 }

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -523,7 +523,7 @@ class TestTimberPagination extends Timber_UnitTestCase
             'mid_size' => 1,
             'end_size' => 2,
         ]);
-        $this->assertEquals(0, count($pagination->pages));
+        $this->assertSame(0, count($pagination->pages));
     }
 
     /**

--- a/tests/test-timber-post-collection.php
+++ b/tests/test-timber-post-collection.php
@@ -116,7 +116,7 @@ class TestTimberPostQuery extends Timber_UnitTestCase
         ]));
 
         $this->assertCount(10, $query);
-        $this->assertEquals(0, $query->found_posts);
+        $this->assertSame(0, $query->found_posts);
     }
 
     /**
@@ -133,7 +133,7 @@ class TestTimberPostQuery extends Timber_UnitTestCase
             'post__in' => [$post_ids[0]],
         ]);
 
-        $this->assertEquals(true, $posts->query()->query_vars['has_password']);
+        $this->assertSame(true, $posts->query()->query_vars['has_password']);
         $this->assertEquals([$post_ids[0]], $posts->query()->query_vars['post__in']);
     }
 

--- a/tests/test-timber-post-collection.php
+++ b/tests/test-timber-post-collection.php
@@ -103,7 +103,7 @@ class TestTimberPostQuery extends Timber_UnitTestCase
         $query = new PostQuery(new WP_Query('post_type=post'));
 
         $this->assertCount(10, $query);
-        $this->assertEquals(20, $query->found_posts);
+        $this->assertSame(20, $query->found_posts);
     }
 
     public function testFoundPostsInQueryWithNoFoundRows()
@@ -230,7 +230,7 @@ class TestTimberPostQuery extends Timber_UnitTestCase
         $query = new PostQuery(new WP_Query('post_type=post&posts_per_page=3'));
 
         $this->assertCount(3, $query);
-        $this->assertEquals(10, $query->found_posts);
+        $this->assertSame(10, $query->found_posts);
     }
 
     public function testArrayAccess()

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -42,7 +42,7 @@ class TestTimberPostComments extends Timber_UnitTestCase
             'post_content' => $quote,
         ]);
         $post = Timber::get_post($post_id);
-        $this->assertEquals(0, $post->get_comment_count());
+        $this->assertSame(0, $post->get_comment_count());
     }
 
     public function testShowUnmoderatedCommentIfByLoggedInUser()
@@ -61,7 +61,7 @@ class TestTimberPostComments extends Timber_UnitTestCase
         $this->assertEquals(1, count($post->comments()));
         wp_set_current_user(0);
         $post = Timber::get_post($post_id);
-        $this->assertEquals(0, count($post->comments()));
+        $this->assertSame(0, count($post->comments()));
     }
 
     public function testPostWithCustomCommentClass()

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -42,7 +42,7 @@ class TestTimberPostComments extends Timber_UnitTestCase
             'post_content' => $quote,
         ]);
         $post = Timber::get_post($post_id);
-        $this->assertSame(0, $post->get_comment_count());
+        $this->assertSame(0, $post->comment_count());
     }
 
     public function testShowUnmoderatedCommentIfByLoggedInUser()

--- a/tests/test-timber-post-comments.php
+++ b/tests/test-timber-post-comments.php
@@ -18,8 +18,8 @@ class TestTimberPostComments extends Timber_UnitTestCase
             'comment_post_ID' => $post_id,
         ]);
         $post = Timber::get_post($post_id);
-        $this->assertEquals(5, count($post->comments()));
-        $this->assertEquals(5, $post->comment_count());
+        $this->assertSame(5, count($post->comments()));
+        $this->assertSame(5, $post->comment_count());
     }
 
     public function testCommentCount()
@@ -31,8 +31,8 @@ class TestTimberPostComments extends Timber_UnitTestCase
             'comment_post_ID' => $post_id,
         ]);
         $post = Timber::get_post($post_id);
-        $this->assertEquals(2, count($post->comments(2)));
-        $this->assertEquals(5, count($post->comments()));
+        $this->assertSame(2, count($post->comments(2)));
+        $this->assertSame(5, count($post->comments()));
     }
 
     public function testCommentCountZero()
@@ -58,7 +58,7 @@ class TestTimberPostComments extends Timber_UnitTestCase
             'comment_approved' => 0,
         ]);
         $post = Timber::get_post($post_id);
-        $this->assertEquals(1, count($post->comments()));
+        $this->assertSame(1, count($post->comments()));
         wp_set_current_user(0);
         $post = Timber::get_post($post_id);
         $this->assertSame(0, count($post->comments()));
@@ -103,7 +103,7 @@ class TestTimberPostComments extends Timber_UnitTestCase
             'comment_author_email' => 'jarednova@upstatement.com',
         ]);
         $post = Timber::get_post($post_id);
-        $this->assertEquals(1, count($post->comments()));
+        $this->assertSame(1, count($post->comments()));
     }
 
     public function testMultilevelThreadedComments()
@@ -129,11 +129,11 @@ class TestTimberPostComments extends Timber_UnitTestCase
         ]);
         $post = Timber::get_post($post_id);
         $comments = $post->comments();
-        $this->assertEquals(1, count($comments));
+        $this->assertSame(1, count($comments));
         $children = $comments[0]->children();
-        $this->assertEquals(1, count($children));
+        $this->assertSame(1, count($children));
         $grand_children = $children[0]->children();
-        $this->assertEquals(2, count($grand_children));
+        $this->assertSame(2, count($grand_children));
     }
 
     public function testMultilevelThreadedCommentsCorrectParents()

--- a/tests/test-timber-post-excerpt-object.php
+++ b/tests/test-timber-post-excerpt-object.php
@@ -392,7 +392,7 @@ class TestTimberPostExcerptObject extends Timber_UnitTestCase
         $str = Timber::compile_string($template, [
             'post' => $post,
         ]);
-        $this->assertEquals('', $str);
+        $this->assertSame('', $str);
     }
 
     /**

--- a/tests/test-timber-post-excerpt.php
+++ b/tests/test-timber-post-excerpt.php
@@ -17,7 +17,7 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase
             'force' => true,
         ]);
 
-        $this->assertEquals(1, substr_count((string) $excerpt, '&hellip;'));
+        $this->assertSame(1, substr_count((string) $excerpt, '&hellip;'));
     }
 
     public function testReadMoreClassFilter()

--- a/tests/test-timber-post-terms.php
+++ b/tests/test-timber-post-terms.php
@@ -74,7 +74,7 @@ class TestTimberPostTerms extends Timber_UnitTestCase
         $terms = $post->terms([], [
             'merge' => true,
         ]);
-        $this->assertEquals(3, count($terms));
+        $this->assertSame(3, count($terms));
     }
 
     /**

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -143,8 +143,7 @@ class TestTimberPost extends Timber_UnitTestCase
         $str = Timber::compile_string($template, [
             'post' => $post,
         ]);
-        $this->assertEquals('', $str);
-        //$this->assertFalse( $post->donkey() );
+        $this->assertSame('', $str);
     }
 
     public function testNext()
@@ -1061,7 +1060,7 @@ class TestTimberPost extends Timber_UnitTestCase
         $pid = $this->factory->post->create();
         $post = Timber::get_post($pid);
 
-        $this->assertEquals(null, $post->gallery());
+        $this->assertSame(null, $post->gallery());
     }
 
     public function testPostWithoutAudio()

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -1060,7 +1060,7 @@ class TestTimberPost extends Timber_UnitTestCase
         $pid = $this->factory->post->create();
         $post = Timber::get_post($pid);
 
-        $this->assertSame(null, $post->gallery());
+        $this->assertSame(false, $post->gallery());
     }
 
     public function testPostWithoutAudio()

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -639,7 +639,7 @@ class TestTimberPost extends Timber_UnitTestCase
             'post_parent' => $parent_id,
         ]);
         $parent = Timber::get_post($parent_id);
-        $this->assertEquals(8, count($parent->children()));
+        $this->assertSame(8, count($parent->children()));
     }
 
     public function testPostChildrenOfInheritStatus()
@@ -653,7 +653,7 @@ class TestTimberPost extends Timber_UnitTestCase
             'post_status' => 'inherit',
         ]);
         $parent = Timber::get_post($parent_id);
-        $this->assertEquals(8, count($parent->children()));
+        $this->assertSame(8, count($parent->children()));
     }
 
     public function testPostChildrenOfParentType()
@@ -669,7 +669,7 @@ class TestTimberPost extends Timber_UnitTestCase
             'post_type' => 'foo',
         ]);
         $parent = Timber::get_post($parent_id);
-        $this->assertEquals(4, count($parent->children('parent')));
+        $this->assertSame(4, count($parent->children('parent')));
     }
 
     public function testPostChildrenWithArray()
@@ -686,7 +686,7 @@ class TestTimberPost extends Timber_UnitTestCase
             'post_type' => 'foo',
         ]);
         $parent = Timber::get_post($parent_id);
-        $this->assertEquals(12, count($parent->children(['foo', 'bar'])));
+        $this->assertSame(12, count($parent->children(['foo', 'bar'])));
     }
 
     public function testPostNoConstructorArgument()
@@ -795,7 +795,7 @@ class TestTimberPost extends Timber_UnitTestCase
         $this->assertTrue($post->has_term('Patriots', 'team'));
 
         // 4 teams + 1 tag + default category (Uncategorized)
-        $this->assertEquals(6, count($post->terms()));
+        $this->assertSame(6, count($post->terms()));
 
         // test tags method - wrapper for $this->get_terms('tags')
         $this->assertEquals($post->tags(), $post->terms('post_tag'));
@@ -805,7 +805,7 @@ class TestTimberPost extends Timber_UnitTestCase
 
         // test using an array of taxonomies
         $post_tag_terms = $post->terms(['post_tag']);
-        $this->assertEquals(1, count($post_tag_terms));
+        $this->assertSame(1, count($post_tag_terms));
         $post_team_terms = $post->terms(['team']);
         $this->assertEquals(count($team_names), count($post_team_terms));
 
@@ -870,7 +870,7 @@ class TestTimberPost extends Timber_UnitTestCase
                 'taxonomy' => ['post_tag'],
             ],
         ]);
-        $this->assertEquals(1, count($post_tag_terms));
+        $this->assertSame(1, count($post_tag_terms));
         $post_team_terms = $post->terms([
             'query' => [
                 'taxonomy' => ['team'],
@@ -915,8 +915,8 @@ class TestTimberPost extends Timber_UnitTestCase
             ],
             'merge' => false,
         ]);
-        $this->assertEquals(4, count($team_and_book_terms['team']));
-        $this->assertEquals(3, count($team_and_book_terms['book']));
+        $this->assertSame(4, count($team_and_book_terms['team']));
+        $this->assertSame(3, count($team_and_book_terms['book']));
     }
 
     public function testPostTermQueryArgs()

--- a/tests/test-timber-term-factories.php
+++ b/tests/test-timber-term-factories.php
@@ -79,7 +79,7 @@ class TestTimberTermFactories extends Timber_UnitTestCase
             'taxonomy' => 'baseball',
             'hide_empty' => false,
         ]), 'baseball');
-        $this->assertEquals(2, count($baseball_teams));
+        $this->assertSame(2, count($baseball_teams));
         $this->assertEquals('Cardinals', $baseball_teams[0]->name);
     }
 

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -535,7 +535,7 @@ class TestTimberTerm extends Timber_UnitTestCase
         // @todo #2087 get this to work w/o $taxonomy param
         $term = Timber::get_term($parent_id, '');
         $children = $term->children();
-        $this->assertEquals(2, count($children));
+        $this->assertSame(2, count($children));
         $this->assertEquals('Local', $children[0]->name);
     }
 

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -570,7 +570,7 @@ class TestTimberTerm extends Timber_UnitTestCase
         add_term_meta($tid, 'foo', false);
         // @todo #2087 get this to work w/o $taxonomy param
         $term = Timber::get_term($tid, '');
-        $this->assertEquals('', $term->meta('foo'));
+        $this->assertSame('', $term->meta('foo'));
     }
 
     /**

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -149,7 +149,7 @@ class TestTimberURLHelper extends Timber_UnitTestCase
         $_SERVER['HTTP_HOST'] = '';
         $_SERVER['SERVER_NAME'] = '';
         $host = Timber\URLHelper::get_host();
-        $this->assertEquals('', $host);
+        $this->assertSame('', $host);
         $_SERVER['HTTP_HOST'] = $http_host;
         $_SERVER['SERVER_NAME'] = $server_name;
     }

--- a/tests/test-timber-url-helper.php
+++ b/tests/test-timber-url-helper.php
@@ -409,7 +409,7 @@ class TestTimberURLHelper extends Timber_UnitTestCase
     {
         $_SERVER['REQUEST_URI'] = 'http://example.org/blog/post/news/2014/whatever';
         $params = Timber\URLHelper::get_params();
-        $this->assertEquals(7, count($params));
+        $this->assertSame(7, count($params));
         $whatever = Timber\URLHelper::get_params(-1);
         $blog = Timber\URLHelper::get_params(2);
         $this->assertEquals('whatever', $whatever);

--- a/tests/test-timber-wp-functions.php
+++ b/tests/test-timber-wp-functions.php
@@ -21,10 +21,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $fw2 = new FunctionWrapper('wp_footer', [], true);
         $this->assertGreaterThan(50, strlen($fw1->call()));
         //this is bunk because footer scripts will only print once
-        $this->assertEquals(0, strlen($fw2->call()));
+        $this->assertSame(0, strlen($fw2->call()));
         wp_dequeue_script('jquery');
         $wp_footer_output1 = new FunctionWrapper('wp_footer', [], true);
-        $this->assertEquals(0, strlen($wp_footer_output1));
+        $this->assertSame(0, strlen($wp_footer_output1));
     }
 
     public function testFooterAlone()

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -582,7 +582,7 @@ class TestTimberMainClass extends Timber_UnitTestCase
             'post_type' => 'post',
             'numberposts' => 17,
         ]);
-        $this->assertEquals(17, count($posts));
+        $this->assertSame(17, count($posts));
     }
 
     public function testPostsPerPage()
@@ -767,7 +767,7 @@ class TestTimberMainClass extends Timber_UnitTestCase
             'cat' => $cat,
         ]);
 
-        $this->assertEquals(2, count($posts));
+        $this->assertSame(2, count($posts));
     }
 
     /**
@@ -968,7 +968,7 @@ class TestTimberMainClass extends Timber_UnitTestCase
             // whatever
         }
 
-        $this->assertEquals(3, $the_post_count);
+        $this->assertSame(3, $the_post_count);
     }
 
     public function testGetAttachment()

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -95,7 +95,7 @@ class TestTimberMainClass extends Timber_UnitTestCase
 
         $post = Timber\Timber::get_post_by('slug', 'kill-bill-2');
 
-        $this->assertEquals(null, $post);
+        $this->assertSame(null, $post);
     }
 
     public function testGetPostByTitle()
@@ -178,7 +178,7 @@ class TestTimberMainClass extends Timber_UnitTestCase
 
         $post = Timber\Timber::get_post_by('title', 'Just a nonexistent post');
 
-        $this->assertEquals(null, $post);
+        $this->assertSame(null, $post);
     }
 
     public function testGetPostFromPostObject()


### PR DESCRIPTION
Related: 

- #2659

## Issue

While working on #2659 I found that some tests use `assertEquals`. TIL this is only a `==` comparison. For a `===` comparison, we should use `assertSame`.

Using `assertEquals` could be a problem when we want to check for empty values or explicit return values like `null` instead of `false` or empty strings in methods:

```php
// Returns true
$this->assertEquals( '', null );
```

## Solution

Use `assertSame` for the following checks:

- `true`, `false` and `null`
- Empty string checks: `""`
- Numbers / Integers

## Impact

I found several type issues by changing to `assertSame()`. In some cases, I had to update the tests, in other cases I had to make typecast some return values to make sure they are what we expect.

For examples, the dimensions for SVG images will now be returned as integers instead of strings.

## Usage Changes

None.

## Considerations

## Testing

Yes.