### PR TITLE
2.x Fix bug with nextpage block

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -1170,22 +1170,47 @@ class Post extends CoreEntity implements DatedInterface, Setupable
         if ($len == -1 && $page == 0 && $this->___content) {
             return $this->___content;
         }
+
         $content = $this->post_content;
+
         if ($len > 0) {
             $content = wp_trim_words($content, $len);
         }
-        if ($page) {
-            $contents = explode('<!--nextpage-->', $content);
+
+        /**
+         * Page content split by <!--nextpage-->.
+         *
+         * @see WP_Query::generate_postdata()
+         */
+        if ($page && false !== strpos($content, '<!--nextpage-->')) {
+            $content = str_replace("\n<!--nextpage-->\n", '<!--nextpage-->', $content);
+            $content = str_replace("\n<!--nextpage-->", '<!--nextpage-->', $content);
+            $content = str_replace("<!--nextpage-->\n", '<!--nextpage-->', $content);
+
+            // Remove the nextpage block delimiters, to avoid invalid block structures in the split content.
+            $content = str_replace('<!-- wp:nextpage -->', '', $content);
+            $content = str_replace('<!-- /wp:nextpage -->', '', $content);
+
+            // Ignore nextpage at the beginning of the content.
+            if (0 === strpos($content, '<!--nextpage-->')) {
+                $content = substr($content, 15);
+            }
+
+            $pages = explode('<!--nextpage-->', $content);
             $page--;
-            if (count($contents) > $page) {
-                $content = $contents[$page];
+
+            if (count($pages) > $page) {
+                $content = $pages[$page];
             }
         }
+
         $content = $this->content_handle_no_teaser_block($content);
         $content = apply_filters('the_content', ($content));
+
         if ($len == -1 && $page == 0) {
             $this->___content = $content;
         }
+
         return $content;
     }
 

--- a/tests/test-timber-post-content.php
+++ b/tests/test-timber-post-content.php
@@ -56,6 +56,55 @@ class TestTimberPostContent extends Timber_UnitTestCase
         $this->assertEquals($page2, trim(strip_tags($post->paged_content())));
     }
 
+    public function testPagedContentWithBlocks()
+    {
+        $paged_content = /** @lang text */
+'<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Paged Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:nextpage -->
+<!--nextpage-->
+<!-- /wp:nextpage -->
+
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Paged Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->'
+        ;
+
+        $post_id = $this->factory->post->create([
+            'post_title' => 'Paged content',
+            'post_content' => $paged_content,
+            'post_type' => 'post',
+        ]);
+
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+
+        $post = Timber::get_post();
+        $post->setup();
+
+        $paged_content = '<div class="is-layout-flow wp-block-group"><div class="wp-block-group__inner-container">
+<p>Paged Content</p>
+</div></div>';
+
+        $this->assertEquals($paged_content, trim($post->paged_content()));
+
+        // Go to next page.
+        $pagination = $post->pagination();
+        $this->go_to($pagination['pages'][1]['link']);
+        setup_postdata(get_post($post_id));
+
+        $post = Timber::get_post();
+        $post->setup();
+
+        $this->assertEquals($paged_content, trim($post->paged_content()));
+    }
+
     /**
      * @ticket 2218
      */

--- a/tests/test-timber-post-content.php
+++ b/tests/test-timber-post-content.php
@@ -105,6 +105,59 @@ class TestTimberPostContent extends Timber_UnitTestCase
         $this->assertEquals($paged_content, trim($post->paged_content()));
     }
 
+    public function testPagedContentWithBlocksAndNextPageAtBeginning()
+    {
+        $paged_content = /** @lang text */
+'<!-- wp:nextpage -->
+<!--nextpage-->
+<!-- /wp:nextpage -->
+
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Paged Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:nextpage -->
+<!--nextpage-->
+<!-- /wp:nextpage -->
+
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Paged Content</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->'
+        ;
+
+        $post_id = $this->factory->post->create([
+            'post_title' => 'Paged content',
+            'post_content' => $paged_content,
+            'post_type' => 'post',
+        ]);
+
+        $this->go_to(get_permalink($post_id));
+        setup_postdata(get_post($post_id));
+
+        $post = Timber::get_post();
+        $post->setup();
+
+        $paged_content = '<div class="is-layout-flow wp-block-group"><div class="wp-block-group__inner-container">
+<p>Paged Content</p>
+</div></div>';
+
+        $this->assertEquals($paged_content, trim($post->paged_content()));
+
+        // Go to next page.
+        $pagination = $post->pagination();
+        $this->go_to($pagination['pages'][1]['link']);
+        setup_postdata(get_post($post_id));
+
+        $post = Timber::get_post();
+        $post->setup();
+
+        $this->assertEquals($paged_content, trim($post->paged_content()));
+    }
+
     /**
      * @ticket 2218
      */

--- a/tests/test-timber-post-content.php
+++ b/tests/test-timber-post-content.php
@@ -88,9 +88,13 @@ class TestTimberPostContent extends Timber_UnitTestCase
         $post = Timber::get_post();
         $post->setup();
 
-        $paged_content = '<div class="is-layout-flow wp-block-group"><div class="wp-block-group__inner-container">
+        $paged_content = trim(do_blocks(/** @lang text */
+            '<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
 <p>Paged Content</p>
-</div></div>';
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->'
+        ));
 
         $this->assertEquals($paged_content, trim($post->paged_content()));
 
@@ -141,9 +145,13 @@ class TestTimberPostContent extends Timber_UnitTestCase
         $post = Timber::get_post();
         $post->setup();
 
-        $paged_content = '<div class="is-layout-flow wp-block-group"><div class="wp-block-group__inner-container">
+        $paged_content = trim(do_blocks(/** @lang text */
+            '<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:paragraph -->
 <p>Paged Content</p>
-</div></div>';
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->'
+        ));
 
         $this->assertEquals($paged_content, trim($post->paged_content()));
 


### PR DESCRIPTION
Resolves:

- #2589

## Issue

When the nextpage block was used, Timber doesn’t correctly split the content. The block on the second and subsequent pages are not properly converted, because there’s a stray `<!-- /wp:nextpage -->` block closer when we explode only on `<!--nextpage-->`.

A nextpage block looks like this:

```html
<!-- wp:nextpage -->
<!--nextpage-->
<!-- /wp:nextpage -->
```

## Solution

Take nextpage logic from WordPress to make it work with `<!--nextpage-->` only as well as nextpage blocks.

## Impact

Should be backwards compatible.

## Usage Changes

None.

## Considerations

WordPress ignores `<!--nextpage-->` if it’s at the beginning of a block. I added a test for this behavior as well.

## Testing

Yes.