### PR TITLE
2.x Fix can_edit() permission checks for Term, User, Comment and Menu classes

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -1013,11 +1013,13 @@ The whole `Timber\Integration\Command` class was removed. Its methods were moved
 
 - `raw_meta()` – Gets a user meta value directly from the database.
 - `wp_object()` - Gets the underlying WordPress Core object.
+- `edit_link()` – Gets the edit link for a user if the current user has the correct rights.
 
 **Timber\Comment**
 
 - `raw_meta()` – Gets a comment meta value directly from the database.
 - `wp_object()` - Gets the underlying WordPress Core object.
+- `edit_link()` - Gets the edit link for a comment if the current user has the correct rights.
 
 **Timber\Menu**
 

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -501,6 +501,29 @@ class Comment extends CoreEntity
         return current_user_can('edit_comment', $this->ID);
     }
 
+    /**
+     * Gets the edit link for a comment if the current user has the correct rights.
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     * ```twig
+     * {% if comment.can_edit %}
+     * <a href="{{ comment.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return string|null The edit URL of a comment in the WordPress admin or null if the current user can’t edit the
+     *                     comment.
+     */
+    public function edit_link()
+    {
+        if (!$this->can_edit()) {
+            return null;
+        }
+
+        return get_edit_comment_link($this->ID);
+    }
+
     /* AVATAR Stuff
     ======================= */
 

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -515,7 +515,7 @@ class Comment extends CoreEntity
      * @return string|null The edit URL of a comment in the WordPress admin or null if the current user can’t edit the
      *                     comment.
      */
-    public function edit_link()
+    public function edit_link(): ?string
     {
         if (!$this->can_edit()) {
             return null;

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -491,7 +491,7 @@ class Comment extends CoreEntity
      * @example
      * ```twig
      * {% if comment.can_edit %}
-     * <a href="{{ comment.edit_link }}">Edit</a>
+     *     <a href="{{ comment.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return bool
@@ -509,7 +509,7 @@ class Comment extends CoreEntity
      * @example
      * ```twig
      * {% if comment.can_edit %}
-     * <a href="{{ comment.edit_link }}">Edit</a>
+     *     <a href="{{ comment.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return string|null The edit URL of a comment in the WordPress admin or null if the current user can’t edit the

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -484,6 +484,23 @@ class Comment extends CoreEntity
         return get_comment_reply_link($args, $this->ID, $this->post_id);
     }
 
+    /**
+     * Checks whether the current user can edit the comment.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if comment.can_edit %}
+     * <a href="{{ comment.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return current_user_can('edit_comment', $this->ID);
+    }
+
     /* AVATAR Stuff
     ======================= */
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -169,30 +169,6 @@ abstract class Core
     }
 
     /**
-     * Can you edit this post/term/user? Well good for you. You're no better than me.
-     * @example
-     * ```twig
-     * {% if post.can_edit %}
-     * <a href="{{ post.edit_link }}">Edit</a>
-     * {% endif %}
-     * ```
-     * ```html
-     * <a href="http://example.org/wp-admin/edit.php?p=242">Edit</a>
-     * ```
-     * @return bool
-     */
-    public function can_edit()
-    {
-        if (!function_exists('current_user_can')) {
-            return false;
-        }
-        if (current_user_can('edit_post', $this->ID)) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
      *
      *
      * @return array

--- a/src/CoreEntityInterface.php
+++ b/src/CoreEntityInterface.php
@@ -15,4 +15,11 @@ interface CoreEntityInterface
      * @return object|null
      */
     public function wp_object();
+
+    /**
+     * Checks whether the current user can edit the object.
+     *
+     * @return bool
+     */
+    public function can_edit(): bool;
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -573,4 +573,21 @@ class Menu extends CoreEntity
 
         return $nav_menu;
     }
+
+    /**
+     * Checks whether the current user can edit the menu.
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     * ```twig
+     * {% if menu.can_edit %}
+     * {% endif %}
+     * ```
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return current_user_can('edit_term', $this->ID);
+    }
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -579,15 +579,10 @@ class Menu extends CoreEntity
      *
      * @api
      * @since 2.0.0
-     * @example
-     * ```twig
-     * {% if menu.can_edit %}
-     * {% endif %}
-     * ```
      * @return bool
      */
     public function can_edit(): bool
     {
-        return current_user_can('edit_term', $this->ID);
+        return current_user_can('edit_theme_options');
     }
 }

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -588,15 +588,10 @@ class MenuItem extends CoreEntity
      *
      * @api
      * @since 2.0.0
-     * @example
-     * ```twig
-     * {% if post.can_edit %}
-     * {% endif %}
-     * ```
      * @return bool
      */
     public function can_edit(): bool
     {
-        return current_user_can('edit_post', $this->ID);
+        return current_user_can('edit_theme_options');
     }
 }

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -582,4 +582,21 @@ class MenuItem extends CoreEntity
         $title = apply_filters('nav_menu_item_title', $this->title, $this->wp_object, $this->menu->args ? $this->menu->args : new \stdClass(), $this->level);
         return $title;
     }
+
+    /**
+     * Checks whether the current user can edit the menu item.
+     *
+     * @api
+     * @since 2.0.0
+     * @example
+     * ```twig
+     * {% if post.can_edit %}
+     * {% endif %}
+     * ```
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return current_user_can('edit_post', $this->ID);
+    }
 }

--- a/src/Post.php
+++ b/src/Post.php
@@ -1483,7 +1483,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * @example
      * ```twig
      * {% if post.can_edit %}
-     * <a href="{{ post.edit_link }}">Edit</a>
+     *     <a href="{{ post.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return bool
@@ -1500,7 +1500,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * @example
      * ```twig
      * {% if post.can_edit %}
-     * <a href="{{ post.edit_link }}">Edit</a>
+     *     <a href="{{ post.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return string|null The edit URL of a post in the WordPress admin or null if the current user can’t edit the

--- a/src/Post.php
+++ b/src/Post.php
@@ -1477,10 +1477,21 @@ class Post extends CoreEntity implements DatedInterface, Setupable
     }
 
     /**
-     * Returns the edit URL of a post if the user has access to it
+     * Checks whether the current user can edit the post.
      *
      * @api
-     * @return bool|string the edit URL of a post in the WordPress admin
+     * @example
+     * ```twig
+     * {% if post.can_edit %}
+     * <a href="{{ post.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return current_user_can('edit_post', $this->ID);
+    }
      */
     public function edit_link()
     {

--- a/src/Post.php
+++ b/src/Post.php
@@ -1492,12 +1492,27 @@ class Post extends CoreEntity implements DatedInterface, Setupable
     {
         return current_user_can('edit_post', $this->ID);
     }
+
+    /**
+     * Gets the edit link for a post if the current user has the correct rights.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if post.can_edit %}
+     * <a href="{{ post.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return string|null The edit URL of a post in the WordPress admin or null if the current user can’t edit the
+     *                     post.
      */
     public function edit_link()
     {
-        if ($this->can_edit()) {
-            return get_edit_post_link($this->ID);
+        if (!$this->can_edit()) {
+            return null;
         }
+
+        return get_edit_post_link($this->ID);
     }
 
     /**

--- a/src/Post.php
+++ b/src/Post.php
@@ -1506,7 +1506,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * @return string|null The edit URL of a post in the WordPress admin or null if the current user can’t edit the
      *                     post.
      */
-    public function edit_link()
+    public function edit_link(): ?string
     {
         if (!$this->can_edit()) {
             return null;

--- a/src/Term.php
+++ b/src/Term.php
@@ -307,7 +307,7 @@ class Term extends CoreEntity
      * @example
      * ```twig
      * {% if term.can_edit %}
-     * <a href="{{ term.edit_link }}">Edit</a>
+     *     <a href="{{ term.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return bool
@@ -324,7 +324,7 @@ class Term extends CoreEntity
      * @example
      * ```twig
      * {% if term.can_edit %}
-     * <a href="{{ term.edit_link }}">Edit</a>
+     *    <a href="{{ term.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return string|null The edit URL of a term in the WordPress admin or null if the current user can’t edit the

--- a/src/Term.php
+++ b/src/Term.php
@@ -316,9 +316,26 @@ class Term extends CoreEntity
     {
         return current_user_can('edit_term', $this->ID);
     }
+
+    /**
+     * Gets the edit link for a term if the current user has the correct rights.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if term.can_edit %}
+     * <a href="{{ term.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return string|null The edit URL of a term in the WordPress admin or null if the current user can’t edit the
+     *                     term.
      */
     public function edit_link()
     {
+        if (!$this->can_edit()) {
+            return null;
+        }
+
         return get_edit_term_link($this->ID, $this->taxonomy);
     }
 

--- a/src/Term.php
+++ b/src/Term.php
@@ -301,8 +301,21 @@ class Term extends CoreEntity
     }
 
     /**
+     * Checks whether the current user can edit the term.
+     *
      * @api
-     * @return string
+     * @example
+     * ```twig
+     * {% if term.can_edit %}
+     * <a href="{{ term.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return current_user_can('edit_term', $this->ID);
+    }
      */
     public function edit_link()
     {

--- a/src/Term.php
+++ b/src/Term.php
@@ -330,7 +330,7 @@ class Term extends CoreEntity
      * @return string|null The edit URL of a term in the WordPress admin or null if the current user can’t edit the
      *                     term.
      */
-    public function edit_link()
+    public function edit_link(): ?string
     {
         if (!$this->can_edit()) {
             return null;

--- a/src/User.php
+++ b/src/User.php
@@ -413,6 +413,23 @@ class User extends CoreEntity
     }
 
     /**
+     * Checks whether the current user can edit the post.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if user.can_edit %}
+     * <a href="{{ user.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return current_user_can('edit_user', $this->ID);
+    }
+
+    /**
      * Gets a user’s avatar URL.
      *
      * @api

--- a/src/User.php
+++ b/src/User.php
@@ -430,6 +430,29 @@ class User extends CoreEntity
     }
 
     /**
+     * Gets the edit link for a user if the current user has the correct rights.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if user.can_edit %}
+     * <a href="{{ user.edit_link }}">Edit</a>
+     * {% endif %}
+     * ```
+     * @since 2.0.0
+     * @return string|null The edit URL of a user in the WordPress admin or null if the current user can’t edit the
+     *                     post.
+     */
+    public function edit_link()
+    {
+        if (!$this->can_edit()) {
+            return null;
+        }
+
+        return get_edit_user_link($this->ID);
+    }
+
+    /**
      * Gets a user’s avatar URL.
      *
      * @api

--- a/src/User.php
+++ b/src/User.php
@@ -419,7 +419,7 @@ class User extends CoreEntity
      * @example
      * ```twig
      * {% if user.can_edit %}
-     * <a href="{{ user.edit_link }}">Edit</a>
+     *     <a href="{{ user.edit_link }}">Edit</a>
      * {% endif %}
      * ```
      * @return bool
@@ -430,18 +430,28 @@ class User extends CoreEntity
     }
 
     /**
-     * Gets the edit link for a user if the current user has the correct rights.
+     * Gets the edit link for a user if the current user has the correct rights or the profile link for the current
+     * user.
      *
      * @api
+     * @since 2.0.0
      * @example
      * ```twig
      * {% if user.can_edit %}
-     * <a href="{{ user.edit_link }}">Edit</a>
+     *     <a href="{{ user.edit_link }}">Edit</a>
      * {% endif %}
      * ```
-     * @since 2.0.0
-     * @return string|null The edit URL of a user in the WordPress admin or null if the current user can’t edit the
-     *                     post.
+     *
+     * Get the profile URL for the current user:
+     *
+     * ```twig
+     * {# Assuming user is the current user. #}
+     * {% if user %}
+     *     <a href="{{ user.edit_link }}">My profile</a>
+     * {% endif %}
+     * ```
+     * @return string|null The edit URL of a user in the WordPress admin or the profile link if the user object is for
+     *                     the current user. Null if the current user can’t edit the user.
      */
     public function edit_link()
     {

--- a/src/User.php
+++ b/src/User.php
@@ -453,7 +453,7 @@ class User extends CoreEntity
      * @return string|null The edit URL of a user in the WordPress admin or the profile link if the user object is for
      *                     the current user. Null if the current user can’t edit the user.
      */
-    public function edit_link()
+    public function edit_link(): ?string
     {
         if (!$this->can_edit()) {
             return null;

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -294,6 +294,33 @@ class TestTimberComment extends Timber_UnitTestCase
         $this->assertEquals('Kramer, Elaine Benes, J. Peterman, ', $compiled);
     }
 
+    public function testCanEdit()
+    {
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        $post_id = $this->factory->post->create();
+        $comment_id = $this->factory->comment->create([
+            'comment_post_ID' => $post_id,
+            'comment_content' => 'What a week!',
+            'comment_date' => '2021-05-16 09:01:00',
+        ]);
+
+        // Test admin role.
+        wp_set_current_user(1);
+        $comment = Timber::get_comment($comment_id);
+        $this->assertTrue($comment->can_edit());
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertFalse($comment->can_edit());
+
+        wp_set_current_user(0);
+    }
+
     public function testWPObject()
     {
         $comment_id = $this->factory->comment->create();

--- a/tests/test-timber-comment.php
+++ b/tests/test-timber-comment.php
@@ -308,15 +308,46 @@ class TestTimberComment extends Timber_UnitTestCase
             'comment_content' => 'What a week!',
             'comment_date' => '2021-05-16 09:01:00',
         ]);
+        $comment = Timber::get_comment($comment_id);
 
         // Test admin role.
         wp_set_current_user(1);
-        $comment = Timber::get_comment($comment_id);
         $this->assertTrue($comment->can_edit());
 
         // Test subscriber role.
         wp_set_current_user($subscriber_id);
         $this->assertFalse($comment->can_edit());
+
+        wp_set_current_user(0);
+    }
+
+    public function testEditLink()
+    {
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        $post_id = $this->factory->post->create();
+        $comment_id = $this->factory->comment->create([
+            'comment_post_ID' => $post_id,
+            'comment_content' => 'What a week!',
+            'comment_date' => '2021-05-16 09:01:00',
+        ]);
+
+        $comment = Timber::get_comment($comment_id);
+
+        // Test admin role.
+        wp_set_current_user(1);
+        $this->assertEquals(
+            'http://example.org/wp-admin/comment.php?action=editcomment&amp;c=' . $comment_id,
+            $comment->edit_link()
+        );
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertNull($comment->edit_link());
 
         wp_set_current_user(0);
     }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -1078,6 +1078,53 @@ class TestTimberMenu extends Timber_UnitTestCase
         $this->assertStringContainsString('id="my-unique-container-id"', $nav_menu_timber);
     }
 
+    public function testMenuCanEdit()
+    {
+        self::_createTestMenu();
+
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        $menu = Timber::get_menu('Menu One');
+
+        // Test admin role.
+        wp_set_current_user(1);
+        $this->assertTrue($menu->can_edit());
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertFalse($menu->can_edit());
+
+        wp_set_current_user(0);
+    }
+
+    public function testMenuItemCanEdit()
+    {
+        self::_createTestMenu();
+
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        $menu = Timber::get_menu('Menu One');
+        $menu_items = $menu->get_items();
+
+        // Test admin role.
+        wp_set_current_user(1);
+        $this->assertTrue($menu_items[0]->can_edit());
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertFalse($menu_items[0]->can_edit());
+
+        wp_set_current_user(0);
+    }
+
     public function testWPObject()
     {
         $menu_id = self::_createTestMenu()['term_id'];

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -312,12 +312,24 @@ class TestTimberPost extends Timber_UnitTestCase
 
     public function testCanEdit()
     {
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        // Test admin role.
         wp_set_current_user(1);
         $post_id = $this->factory->post->create([
             'post_author' => 1,
         ]);
         $post = Timber::get_post($post_id);
         $this->assertTrue($post->can_edit());
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertFalse($post->can_edit());
+
         wp_set_current_user(0);
     }
 

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -1170,10 +1170,7 @@ class TestTimberPost extends Timber_UnitTestCase
         update_option('home', 'http://example.org', true);
     }
 
-    /**
-     * @group failing
-     */
-    public function testEditUrl()
+    public function testEditLink()
     {
         ini_set("log_errors", 1);
         ini_set("error_log", "/tmp/php-error.log");

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -162,6 +162,26 @@ class TestTimberTerm extends Timber_UnitTestCase
         $this->assertFalse(strstr($term->path(), 'http://'));
     }
 
+    public function testCanEdit()
+    {
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        // Test admin role.
+        wp_set_current_user(1);
+        $term_id = $this->factory->term->create();
+        $term = Timber::get_term($term_id);
+        $this->assertTrue($term->can_edit());
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertFalse($term->can_edit());
+
+        wp_set_current_user(0);
+    }
 
     /*
      * Term::posts() tests

--- a/tests/test-timber-term.php
+++ b/tests/test-timber-term.php
@@ -626,7 +626,7 @@ class TestTimberTerm extends Timber_UnitTestCase
         $this->assertNotTrue($term->meta('foo'));
     }
 
-    public function testTermEditLink()
+    public function testEditLink()
     {
         wp_set_current_user(1);
         $tid = $this->factory->term->create([

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -183,6 +183,42 @@ class TestTimberUser extends Timber_UnitTestCase
         ]));
     }
 
+    public function testEditLink()
+    {
+        $subscriber_id = $this->factory->user->create([
+            'display_name' => 'Subscriber Sam',
+            'user_login' => 'subsam',
+            'role' => 'subscriber',
+        ]);
+
+        $editor_id = $this->factory->user->create([
+            'display_name' => 'Emilia Editore',
+            'user_login' => 'eeditore',
+            'role' => 'editor',
+        ]);
+
+        $subscriber = Timber::get_user($subscriber_id);
+        $editor = Timber::get_user($editor_id);
+        $admin = Timber::get_user(1);
+
+        // Test admin role.
+        wp_set_current_user(1);
+        $this->assertEquals(
+            'http://example.org/wp-admin/user-edit.php?user_id=' . $subscriber_id,
+            $subscriber->edit_link()
+        );
+        $this->assertEquals('http://example.org/wp-admin/user-edit.php?user_id=' . $editor_id, $editor->edit_link());
+        $this->assertEquals('http://example.org/wp-admin/profile.php', $admin->edit_link());
+
+        // Test subscriber role.
+        wp_set_current_user($subscriber_id);
+        $this->assertEquals('http://example.org/wp-admin/profile.php', $subscriber->edit_link());
+        $this->assertNull($editor->edit_link());
+        $this->assertNull($admin->edit_link());
+
+        wp_set_current_user(0);
+    }
+
     public function testWPObject()
     {
         $user_id = $this->factory()->user->create();

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -68,13 +68,13 @@ class TestTimberUser extends Timber_UnitTestCase
 
     public function testUserCapability()
     {
-        $uid = $this->factory->user->create([
+        $this->factory->user->create([
             'display_name' => 'Tito Bottitta',
             'user_login' => 'mbottitta',
             'role' => 'editor',
         ]);
 
-        $subscriber_uid = $this->factory->user->create([
+        $this->factory->user->create([
             'display_name' => 'Baberaham Lincoln',
             'user_login' => 'blincoln',
             'role' => 'subscriber',


### PR DESCRIPTION
Resolves:

- #2645

## Issue

When using `{{ term.can_edit }}`, Timber should use the correct permission check for a term. The same goes for other core objects like comment and users.

## Solution

This pull request

- Moves `can_edit()` to the specific Timber object classes.
- Adds `can_edit()` to the `CoreEntity` interface.
- Adds new `edit_link()` functions to `Comment` and `User` class.

## Impact

Accurate capability checks.

## Usage Changes

None.

## Considerations

Checking the permissions on the `Menu` and `MenuItem` feels a bit weird first. They can’t be edited through the usual edit screens and need a check for the `edit_theme_options` capability. The question now is: Does it make sense to have the `can_edit()` check for the menu and menu items? Otherwise, we would have to remove the interface.

By adding `User::edit_link()`, it’s possible to get the profile URL for the current user, which is nice! I wonder whether we should add a `User::profile_link()` method as well. This would only return a link if the user object is the current user.

## Testing

Yes.