### PR TITLE
2.x Update descriptions for compile and render methods

### DIFF
--- a/src/Timber.php
+++ b/src/Timber.php
@@ -1260,10 +1260,10 @@ class Timber
     }
 
     /**
-     * Compile a Twig file.
+     * Compiles a Twig file.
      *
-     * Passes data to a Twig file and returns the output.
-     * If the template file doesn't exist it will throw a warning when WP_DEBUG is enabled.
+     * Passes data to a Twig file and returns the output. If the template file doesn't exist it will throw a warning
+     * when WP_DEBUG is enabled.
      *
      * @api
      * @example
@@ -1276,8 +1276,8 @@ class Timber
      *
      * $team_member = Timber::compile( 'team-member.twig', $data );
      * ```
-     * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, Timber will
-     *                                 render the first file that exists.
+     * @param array|string $filenames  Name or full path of the Twig file to compile. If this is an array of file
+     *                                 names or paths, Timber will compile the first file that exists.
      * @param array        $data       Optional. An array of data to use in Twig template.
      * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
      *                                 array, the first value is used for non-logged in visitors, the second for users.
@@ -1523,7 +1523,7 @@ class Timber
     }
 
     /**
-     * Render function.
+     * Renders a Twig file.
      *
      * Passes data to a Twig file and echoes the output.
      *
@@ -1534,8 +1534,8 @@ class Timber
      *
      * Timber::render( 'index.twig', $context );
      * ```
-     * @param array|string $filenames  Name of the Twig file to render. If this is an array of files, Timber will
-     *                                 render the first file that exists.
+     * @param array|string $filenames  Name or full path of the Twig file to render. If this is an array of file
+     *                                 names or paths, Timber will render the first file that exists.
      * @param array        $data       Optional. An array of data to use in Twig template.
      * @param bool|int     $expires    Optional. In seconds. Use false to disable cache altogether. When passed an
      *                                 array, the first value is used for non-logged in visitors, the second for users.

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -529,6 +529,12 @@ class TestTimberMainClass extends Timber_UnitTestCase
         $this->assertEquals('I am single course', $str);
     }
 
+    public function testCompileAbsolutePath()
+    {
+        $str = Timber::compile(__DIR__ . '/assets/single.twig', null);
+        $this->assertEquals('I am single.twig', trim($str));
+    }
+
     /**
        * @ticket 1660
        */


### PR DESCRIPTION
Resolves:

- #2509

## Issue

`Timber::render()` and `Timber::compile()` allow full file paths. This isn’t mentioned in the DocBlock.

## Solution

Improves the description for the `$filenames` parameters and add a quick test.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

Yes.