### PR TITLE
Ensure Twig 3.x is not installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=7.2.5 || ^8.0",
-    "twig/twig": ">=1.44.7 || ^2.10",
+    "twig/twig": "^1.44.7 || ^2.10",
     "upstatement/routes": "^0.9",
     "composer/installers": "^1.0 || ^2.0",
     "twig/cache-extension": "^1.5"

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,10 @@ _Twig is the template language powering Timber; if you need a little background 
 
 **Fixes and improvements**
 
+= 1.22.1 =
+
+* Fixed a bug when Twig version 3 was accidentally installed when installing Timber through Composer, by @rmens in https://github.com/timber/timber/pull/2679.
+
 = 1.22.0 =
 
 * Fixed included Twig version. In the plugin version 1.21.0 of Timber, Twig version 2.15.3 was accidentally included instead of Twig version 1.44.7.


### PR DESCRIPTION

**Ticket**: https://github.com/timber/timber/issues/2672

## Issue
There was an error with versioning in the composer.json file allowing Twig 3.4.3 to be installed. This introduces breaking changes like a missing `filter` tag.

## Solution
Make version selector more strict.

## Impact
This pull request fixes the errors that people are seeing in https://github.com/timber/timber/issues/2672 because we will revert to Twig 1.44.7 or 2.15.3.

## Usage Changes
None.

## Considerations
This is a small hotfix and might be considered version 1.22.1?

## Testing
Yes.