### PR TITLE
Fix User entity

### DIFF
--- a/docs/v2/guides/users.md
+++ b/docs/v2/guides/users.md
@@ -93,6 +93,44 @@ This allows you to check for a login state with an if statement.
 {% endif %}
 ```
 
+## User data
+
+If you need to access user data like the first and the last name, you can either load them from the properties set on user or with `{{ user.meta }}` for user values that are saved as meta values.
+
+Here’s a little cheat sheet:
+
+```twig
+{# Display name #}
+{{ user.name }}
+{{ user.display_name }}
+
+{# Nice name #}
+{{ user.slug }}
+{{ user.user_nicename }}
+
+{# Email #}
+{{ user.user_email }}
+
+{# Website #}
+{{ user.user_url }}
+
+{# Values loaded from user meta. #}
+{{ user.meta('first_name') }}
+{{ user.meta('last_name') }}
+{{ user.meta('description') }}
+
+{# Contact info #}
+{{ user.meta('facebook') }}
+{{ user.meta('instagram') }}
+{{ user.meta('linkedin') }}
+{{ user.meta('pinterest') }}
+{{ user.meta('soundcloud') }}
+{{ user.meta('tumblr') }}
+{{ user.meta('twitter') }}
+{{ user.meta('youtube') }}
+{{ user.meta('wikipedia') }}
+```
+
 ## Extending `Timber\User`
 
 If you need additional functionality that the `Timber\User` class doesn’t provide or if you want to have cleaner Twig templates, you can extend the `Timber\User` class with your own classes:

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -964,6 +964,9 @@ The following functions and properties were **removed from the codebase**, eithe
 ### Timber\User
 
 - `$name` property – use `name()` method instead. You can still use `{{ user.name }}` in Twig.
+- `$first_name` property – use `{{ user.meta('first_name') }}` instead.
+- `$last_name` property – use `{{ user.meta('last_name') }}` instead.
+- `$description` property – use `{{ user.meta('description') }}` instead.
 
 ### Timber\Helper
 

--- a/src/User.php
+++ b/src/User.php
@@ -65,30 +65,6 @@ class User extends CoreEntity
 
     /**
      * @api
-     * @var string The description from WordPress
-     */
-    public $description;
-
-    /**
-     * @api
-     * @var string
-     */
-    public $display_name = '';
-
-    /**
-     * @api
-     * @var string The first name of the user
-     */
-    public $first_name;
-
-    /**
-     * @api
-     * @var string The last name of the user
-     */
-    public $last_name;
-
-    /**
-     * @api
      * @var int The ID from WordPress
      */
     public $id;

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -123,10 +123,42 @@ class TestTimberUser extends Timber_UnitTestCase
             'post_author' => $uid,
         ]);
         $post = Timber::get_post($pid);
-        $str = Timber::compile_string("{{post.author.description}}", [
+        $str = Timber::compile_string("{{ post.author.description }}", [
             'post' => $post,
         ]);
         $this->assertEquals('Sixteenth President', $str);
+    }
+
+    public function testUserData()
+    {
+        $user_id = $this->factory->user->create([
+            'display_name' => 'Baberaham Lincoln',
+            'user_login' => 'blincoln',
+            'user_email' => 'babe@exmample.org',
+        ]);
+        $user = Timber::get_user($user_id);
+
+        update_user_meta($user_id, 'first_name', 'Baberaham');
+        update_user_meta($user_id, 'last_name', 'Lincoln');
+        update_user_meta($user_id, 'description', 'Sixteenth President');
+
+        $result = Timber::compile_string(
+            '{{ user.first_name }}, {{ user.last_name }}, {{ user.user_nicename }}, {{ user.display_name }}, {{ user.user_email }}, {{ user.description }}',
+            [
+                'user' => $user,
+            ]
+        );
+
+        $this->assertEquals('Baberaham, Lincoln, blincoln, Baberaham Lincoln, babe@exmample.org, Sixteenth President', $result);
+
+        $result = Timber::compile_string(
+            "{{ user.meta('first_name') }}, {{ user.meta('last_name') }}, {{ user.user_nicename }}, {{ user.display_name }}, {{ user.user_email }}, {{ user.meta('description') }}",
+            [
+                'user' => $user,
+            ]
+        );
+
+        $this->assertEquals('Baberaham, Lincoln, blincoln, Baberaham Lincoln, babe@exmample.org, Sixteenth President', $result);
     }
 
     public function testInitShouldUnsetPassword()

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -123,7 +123,7 @@ class TestTimberUser extends Timber_UnitTestCase
             'post_author' => $uid,
         ]);
         $post = Timber::get_post($pid);
-        $str = Timber::compile_string("{{post.author.meta('description')}}", [
+        $str = Timber::compile_string("{{post.author.description}}", [
             'post' => $post,
         ]);
         $this->assertEquals('Sixteenth President', $str);


### PR DESCRIPTION
## Issue

Setting public properties for user meta fields results in `{{ user.first_name }}` to return null. Because those properties are not `WP_User` properties and thus not imported.

Since those properties are declared, Twig will not retrieve them either: https://twig.symfony.com/doc/3.x/templates.html#variables

## Solution

Remove public properties matching user meta so `__call` in `Timber\Core` is actually called.

## Impact

None.

## Usage Changes

You can now do `{{ user.first_name }}`, `{{ user.last_name }}`, etc.

## Testing

Just changed the test with description to ensure this works fine.