### PR TITLE
2.x Add `AllowDynamicProperties` attribute

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -5,6 +5,7 @@ namespace Timber;
 /**
  * Class Core
  */
+#[\AllowDynamicProperties]
 abstract class Core
 {
     public $id;

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -6,6 +6,7 @@ namespace Timber;
  * Wrapper for the post_type object provided by WordPress
  * @since 1.0.4
 */
+#[\AllowDynamicProperties]
 class PostType
 {
     /**

--- a/tests/test-timber-integration-acf.php
+++ b/tests/test-timber-integration-acf.php
@@ -48,7 +48,7 @@ class TestTimberIntegrationACF extends Timber_UnitTestCase
     public function testACFGetFieldTermCategory()
     {
         $tid = $this->factory->term->create();
-        update_field('color', 'blue', "category_${tid}");
+        update_field('color', 'blue', "category_{$tid}");
         $cat = Timber::get_term($tid);
         $this->assertEquals('blue', $cat->color);
         $str = '{{term.color}}';

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -1,5 +1,6 @@
 <?php
 
+#[AllowDynamicProperties]
 class TestTimberSite extends Timber_UnitTestCase
 {
     public function testStandardThemeLocation()


### PR DESCRIPTION
## Issue

Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

As you may have noticed in the CI logs, this generates a lot of noise both in error logs and test run logs.


## Solution

To reduce noise this pull request adds the `#[AllowDynamicProperties]` attribute to the [`Core`](src/Core.php) class.

## Considerations

Ideally, a magic `__set()` method should be added which will require adding a catch-all data property to store the non-declared fields.

```php
/**
 * Store dynamic meta fields.
 *
 * @var array<string, mixed>
 */
private $fields = [];

/**
 * Magic setter for dynamic meta fields, for convenience in Twig views.
 *
 * This method is not meant to be called directly.
 *
 * @example
 * ```php
 * $post = Timber\Post::get( get_the_ID() );
 *
 * $post->favorite_darkside_track = 'Any Colour You Like'
 * ```
 * ```twig
 * {# Since this property does not exist explicitly on the Post class,
 *    it will dynamically dispatch the magic __get() method with an argument
 *    of "favorite_darkside_track" #}
 * <span>Favorite <i>Dark Side of the Moon</i> Track: {{ post.favorite_darkside_track }}</span>
 * ```
 * @link https://secure.php.net/manual/en/language.oop5.overloading.php#object.set
 *
 * @param string $field The name of the property being mutated.
 * @param mixed $valuee The value to assign.
 *
 * @return void
 */
public function __set($field, $value)
{
    $this->fields[$field] = $value;
}
```

## Related

- [wordpress/wordpress#c033058](https://github.com/WordPress/WordPress/commit/c03305852e7e40e61cad5798eba9ebc3b961e27a)
