### PR TITLE
2.x Fix `get_term_link()` compatibility in `Timber\Term`

### DIFF
--- a/src/Term.php
+++ b/src/Term.php
@@ -322,7 +322,7 @@ class Term extends CoreEntity
      */
     public function link()
     {
-        $link = get_term_link($this);
+        $link = get_term_link($this->wp_object);
 
         /**
          * Filters the link to the term archive page.


### PR DESCRIPTION
**Ticket**: #2699

## Issue

A hook on [`pre_term_link`](https://developer.wordpress.org/reference/hooks/pre_term_link/) or [`term_link`](https://developer.wordpress.org/reference/hooks/term_link/) expects to receive [`WP_Term`](https://developer.wordpress.org/reference/classes/wp_term/) but receives [`Timber\Term`](src/Term.php).

## Solution

In [`Term::link()`](src/Term.php#L323-L326), pass `WP_Term` instead of `Timber\Term`.

## Impact

This is a breaking change.

Any implementation that hooks into `get_term_link()` expecting `Timber\Term` will be receive `WP_Term` (the type documented by WordPress).