### PR TITLE
2.x Fix side effects with tests involving themes

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -184,7 +184,13 @@ install_wp_cli() {
     mv wp-cli.phar $WP_TESTS_DIR/
 }
 
+copy_test_themes() {
+    cp -rf ./tests/assets/themes/timber-test-theme $WP_CORE_DIR/wp-content/themes/
+    cp -rf ./tests/assets/themes/timber-test-theme-child $WP_CORE_DIR/wp-content/themes/
+}
+
 install_wp
 install_test_suite
 install_db
 install_wp_cli
+copy_test_themes

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -259,37 +259,4 @@ class Timber_UnitTestCase extends TestCase
         wp_clean_themes_cache();
         unset($GLOBALS['wp_themes']);
     }
-
-    public function setupChildTheme()
-    {
-        $dest_dir = WP_CONTENT_DIR . '/themes/fake-child-theme';
-
-        if (!file_exists($dest_dir)) {
-            mkdir($dest_dir, 0777, true);
-        }
-
-        if (!file_exists($dest_dir . '/views')) {
-            mkdir($dest_dir . '/views', 0777, true);
-        }
-
-        copy(__DIR__ . '/assets/fake-child-theme-style.css', $dest_dir . '/style.css');
-        copy(__DIR__ . '/assets/single.twig', $dest_dir . '/views/single.twig');
-
-        $this->clean_themes_cache();
-    }
-
-    public function setupParentTheme()
-    {
-        $dest_dir = WP_CONTENT_DIR . '/themes/fake-parent-theme';
-
-        if (!file_exists($dest_dir . '/views')) {
-            mkdir($dest_dir . '/views', 0777, true);
-        }
-
-        copy(__DIR__ . '/assets/fake-parent-theme-style.css', $dest_dir . '/style.css');
-        copy(__DIR__ . '/assets/single-parent.twig', $dest_dir . '/views/single.twig');
-        copy(__DIR__ . '/assets/single-parent.twig', $dest_dir . '/views/single-parent.twig');
-
-        $this->clean_themes_cache();
-    }
 }

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -9,6 +9,8 @@ class Timber_UnitTestCase extends TestCase
      */
     private $temporary_hook_removals = [];
 
+    protected $backup_wp_theme_directories;
+
     /**
      * Overload WP_UnitTestcase to ignore deprecated notices
      * thrown by use of wp_title() in Timber
@@ -246,24 +248,30 @@ class Timber_UnitTestCase extends TestCase
 
     public function restore_themes()
     {
+        if (!$this->backup_wp_theme_directories) {
+            return;
+        }
+
         global $wp_theme_directories;
 
         $wp_theme_directories = $this->backup_wp_theme_directories;
 
         wp_clean_themes_cache();
         unset($GLOBALS['wp_themes']);
-        parent::tear_down();
     }
 
     public function _setupChildTheme()
     {
         $dest_dir = WP_CONTENT_DIR . '/themes/fake-child-theme';
+
         if (!file_exists($dest_dir)) {
             mkdir($dest_dir, 0777, true);
         }
+
         if (!file_exists($dest_dir . '/views')) {
             mkdir($dest_dir . '/views', 0777, true);
         }
+
         copy(__DIR__ . '/assets/fake-child-theme-style.css', $dest_dir . '/style.css');
         copy(__DIR__ . '/assets/single.twig', $dest_dir . '/views/single.twig');
 
@@ -273,9 +281,11 @@ class Timber_UnitTestCase extends TestCase
     public function _setupParentTheme()
     {
         $dest_dir = WP_CONTENT_DIR . '/themes/fake-parent-theme';
+
         if (!file_exists($dest_dir . '/views')) {
             mkdir($dest_dir . '/views', 0777, true);
         }
+
         copy(__DIR__ . '/assets/fake-parent-theme-style.css', $dest_dir . '/style.css');
         copy(__DIR__ . '/assets/single-parent.twig', $dest_dir . '/views/single.twig');
         copy(__DIR__ . '/assets/single-parent.twig', $dest_dir . '/views/single-parent.twig');

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -260,7 +260,7 @@ class Timber_UnitTestCase extends TestCase
         unset($GLOBALS['wp_themes']);
     }
 
-    public function _setupChildTheme()
+    public function setupChildTheme()
     {
         $dest_dir = WP_CONTENT_DIR . '/themes/fake-child-theme';
 
@@ -278,7 +278,7 @@ class Timber_UnitTestCase extends TestCase
         $this->clean_themes_cache();
     }
 
-    public function _setupParentTheme()
+    public function setupParentTheme()
     {
         $dest_dir = WP_CONTENT_DIR . '/themes/fake-parent-theme';
 

--- a/tests/assets/themes/timber-test-theme-child/style.css
+++ b/tests/assets/themes/timber-test-theme-child/style.css
@@ -1,10 +1,11 @@
 /*
-Theme Name:   Fake Parent Theme
+Theme Name:   Timber Tests Child Theme
 Theme URI:    http://example.com
-Description:  Fake Parent Theme
+Description:  Child Theme
 Author:       John Doe
 Author URI:   http://example.com
+Template:     timber-test-theme
 Version:      1.0.0
 Tags:         light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready
-Text Domain:  twenty-nineteen-child
+Text Domain:  timber-tests-child
 */

--- a/tests/assets/themes/timber-test-theme-child/views/single.twig
+++ b/tests/assets/themes/timber-test-theme-child/views/single.twig
@@ -1,0 +1,1 @@
+I am single.twig

--- a/tests/assets/themes/timber-test-theme/style.css
+++ b/tests/assets/themes/timber-test-theme/style.css
@@ -1,11 +1,10 @@
 /*
-Theme Name:   Fake Child Theme
+Theme Name:   Timber Tests Theme
 Theme URI:    http://example.com
-Description:  Fake Parent Child Theme
+Description:  Parent Theme
 Author:       John Doe
 Author URI:   http://example.com
-Template:     fake-parent-theme
 Version:      1.0.0
 Tags:         light, dark, two-columns, right-sidebar, responsive-layout, accessibility-ready
-Text Domain:  twenty-nineteen-child
+Text Domain:  timber-tests
 */

--- a/tests/assets/themes/timber-test-theme/views/single-course.twig
+++ b/tests/assets/themes/timber-test-theme/views/single-course.twig
@@ -1,0 +1,1 @@
+I am single course

--- a/tests/assets/themes/timber-test-theme/views/single-parent.twig
+++ b/tests/assets/themes/timber-test-theme/views/single-parent.twig
@@ -1,0 +1,1 @@
+I am single.twig in parent theme

--- a/tests/assets/themes/timber-test-theme/views/single.twig
+++ b/tests/assets/themes/timber-test-theme/views/single.twig
@@ -1,0 +1,1 @@
+I am single.twig in parent theme

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -7,8 +7,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
 {
     public function set_up()
     {
-        $this->_setupParentTheme();
-        switch_theme('fake-parent-theme');
+        switch_theme('default');
 
         parent::set_up();
     }
@@ -74,12 +73,12 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $image = Timber::get_external_image($dest);
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
             $image->src()
         );
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
             $image->src('medium')
         );
     }
@@ -90,15 +89,15 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $this->addFile($dest);
         $this->assertFileExists($dest);
 
-        $image = Timber::get_external_image('/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg');
-        $image2 = Timber::get_external_image('wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg');
+        $image = Timber::get_external_image('/wp-content/themes/default/assets/images/cardinals.jpg');
+        $image2 = Timber::get_external_image('wp-content/themes/default/assets/images/cardinals.jpg');
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
             $image->src()
         );
         $this->assertSame(
-            'http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
             $image2->src()
         );
     }
@@ -110,11 +109,11 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $this->assertFileExists($dest);
 
         $image = Timber::get_external_image(
-            'http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg'
+            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg'
         );
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
             $image->src()
         );
     }
@@ -140,7 +139,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $image = Timber::get_external_image($dest);
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/fake-parent-theme/non-existent-image.jpg',
+            'http://example.org/wp-content/themes/default/non-existent-image.jpg',
             $image->src()
         );
 
@@ -158,7 +157,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $image = Timber::get_external_image($dest);
 
         $this->assertSame(
-            'wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg',
+            'wp-content/themes/default/assets/images/cardinals.jpg',
             $image->path()
         );
     }
@@ -174,7 +173,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $result = Timber::compile_string('{{ image }}', [
             'image' => $image,
         ]);
-        $this->assertSame('http://example.org/wp-content/themes/fake-parent-theme/assets/images/cardinals.jpg', $result);
+        $this->assertSame('http://example.org/wp-content/themes/default/assets/images/cardinals.jpg', $result);
     }
 
     public function testExternalImageSize()

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -7,15 +7,13 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
 {
     public function set_up()
     {
-        switch_theme('default');
+        switch_theme('timber-test-theme');
 
         parent::set_up();
     }
 
     public function tear_down()
     {
-        switch_theme('default');
-
         $img_dir = get_stylesheet_directory_uri() . '/images';
 
         if (file_exists($img_dir)) {
@@ -30,6 +28,8 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
                 unlink($file);
             }
         }
+
+        switch_theme('default');
 
         parent::tear_down();
     }
@@ -73,12 +73,12 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $image = Timber::get_external_image($dest);
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg',
             $image->src()
         );
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg',
             $image->src('medium')
         );
     }
@@ -89,15 +89,15 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $this->addFile($dest);
         $this->assertFileExists($dest);
 
-        $image = Timber::get_external_image('/wp-content/themes/default/assets/images/cardinals.jpg');
-        $image2 = Timber::get_external_image('wp-content/themes/default/assets/images/cardinals.jpg');
+        $image = Timber::get_external_image('/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg');
+        $image2 = Timber::get_external_image('wp-content/themes/timber-test-theme/assets/images/cardinals.jpg');
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg',
             $image->src()
         );
         $this->assertSame(
-            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg',
             $image2->src()
         );
     }
@@ -109,11 +109,11 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $this->assertFileExists($dest);
 
         $image = Timber::get_external_image(
-            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg'
+            'http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg'
         );
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/default/assets/images/cardinals.jpg',
+            'http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg',
             $image->src()
         );
     }
@@ -139,7 +139,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $image = Timber::get_external_image($dest);
 
         $this->assertSame(
-            'http://example.org/wp-content/themes/default/non-existent-image.jpg',
+            'http://example.org/wp-content/themes/timber-test-theme/non-existent-image.jpg',
             $image->src()
         );
 
@@ -157,7 +157,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $image = Timber::get_external_image($dest);
 
         $this->assertSame(
-            'wp-content/themes/default/assets/images/cardinals.jpg',
+            'wp-content/themes/timber-test-theme/assets/images/cardinals.jpg',
             $image->path()
         );
     }
@@ -173,7 +173,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $result = Timber::compile_string('{{ image }}', [
             'image' => $image,
         ]);
-        $this->assertSame('http://example.org/wp-content/themes/default/assets/images/cardinals.jpg', $result);
+        $this->assertSame('http://example.org/wp-content/themes/timber-test-theme/assets/images/cardinals.jpg', $result);
     }
 
     public function testExternalImageSize()

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -99,8 +99,8 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromChildTheme()
     {
-        $this->_setupParentTheme();
-        $this->_setupChildTheme();
+        $this->setupParentTheme();
+        $this->setupChildTheme();
         $this->assertFileExists(WP_CONTENT_DIR . '/themes/fake-child-theme/style.css');
         switch_theme('fake-child-theme');
         $child_theme = get_stylesheet_directory_uri();
@@ -112,8 +112,8 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromParentTheme()
     {
-        $this->_setupParentTheme();
-        $this->_setupChildTheme();
+        $this->setupParentTheme();
+        $this->setupChildTheme();
         switch_theme('fake-child-theme');
         $templates = ['single-parent.twig'];
         $str = Timber::compile($templates, []);
@@ -159,7 +159,7 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirName()
     {
-        $this->_setupParentTheme();
+        $this->setupParentTheme();
         switch_theme('fake-parent-theme');
 
         Timber::$dirname = [
@@ -175,7 +175,7 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirNameWithoutNamespace()
     {
-        $this->_setupParentTheme();
+        $this->setupParentTheme();
         switch_theme('fake-parent-theme');
 
         Timber::$dirname = [['foo', 'views']];
@@ -189,7 +189,7 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirNameWithoutNamespaceAndSimpleArray()
     {
-        $this->_setupParentTheme();
+        $this->setupParentTheme();
         switch_theme('fake-parent-theme');
 
         Timber::$dirname = ['foo', 'views'];
@@ -244,7 +244,7 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromLocationWithAndWithoutNamespacesAndDirs()
     {
-        $this->_setupParentTheme();
+        $this->setupParentTheme();
         switch_theme('fake-parent-theme');
 
         Timber::$dirname = [

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -159,6 +159,9 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirName()
     {
+        $this->_setupParentTheme();
+        switch_theme('fake-parent-theme');
+
         Timber::$dirname = [
             \Timber\Loader::MAIN_NAMESPACE => ['foo', 'views'],
         ];
@@ -172,6 +175,9 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirNameWithoutNamespace()
     {
+        $this->_setupParentTheme();
+        switch_theme('fake-parent-theme');
+
         Timber::$dirname = [['foo', 'views']];
         if (!file_exists(get_template_directory() . '/foo')) {
             mkdir(get_template_directory() . '/foo', 0777, true);
@@ -183,6 +189,9 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirNameWithoutNamespaceAndSimpleArray()
     {
+        $this->_setupParentTheme();
+        switch_theme('fake-parent-theme');
+
         Timber::$dirname = ['foo', 'views'];
         if (!file_exists(get_template_directory() . '/foo')) {
             mkdir(get_template_directory() . '/foo', 0777, true);
@@ -235,6 +244,9 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromLocationWithAndWithoutNamespacesAndDirs()
     {
+        $this->_setupParentTheme();
+        switch_theme('fake-parent-theme');
+
         Timber::$dirname = [
             \Timber\Loader::MAIN_NAMESPACE => ['foo', 'views'],
         ];

--- a/tests/test-timber-loader.php
+++ b/tests/test-timber-loader.php
@@ -73,17 +73,22 @@ class TestTimberLoader extends Timber_UnitTestCase
      */
     public function testTwigPathFilter()
     {
+        switch_theme('timber-test-theme-child');
+
         $php_unit = $this;
+
         add_filter('timber/loader/paths', function ($paths) use ($php_unit) {
             $paths = call_user_func_array('array_merge', array_values($paths));
-            $count = count($paths);
-            $php_unit->assertEquals(3, count($paths));
+            $php_unit->assertEquals(6, count($paths));
             $pos = array_search('/', $paths);
             unset($paths[$pos]);
-            $php_unit->assertEquals(2, count($paths));
+            $php_unit->assertEquals(5, count($paths));
             return $paths;
         });
-        $str = Timber::compile('assets/single.twig', []);
+
+        Timber::compile('assets/single.twig', []);
+
+        switch_theme('default');
     }
 
     public function testTimberLocationsFilterAdded()
@@ -99,25 +104,23 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromChildTheme()
     {
-        $this->setupParentTheme();
-        $this->setupChildTheme();
-        $this->assertFileExists(WP_CONTENT_DIR . '/themes/fake-child-theme/style.css');
-        switch_theme('fake-child-theme');
+        $this->assertFileExists(WP_CONTENT_DIR . '/themes/timber-test-theme-child/style.css');
+        switch_theme('timber-test-theme-child');
         $child_theme = get_stylesheet_directory_uri();
-        $this->assertEquals(WP_CONTENT_URL . '/themes/fake-child-theme', $child_theme);
+        $this->assertEquals(WP_CONTENT_URL . '/themes/timber-test-theme-child', $child_theme);
         $context = [];
         $str = Timber::compile('single.twig', $context);
         $this->assertEquals('I am single.twig', trim($str));
+        switch_theme('default');
     }
 
     public function testTwigLoadsFromParentTheme()
     {
-        $this->setupParentTheme();
-        $this->setupChildTheme();
-        switch_theme('fake-child-theme');
+        switch_theme('timber-test-theme-child');
         $templates = ['single-parent.twig'];
         $str = Timber::compile($templates, []);
         $this->assertEquals('I am single.twig in parent theme', trim($str));
+        switch_theme('default');
     }
 
     public function _setupRelativeViews()
@@ -159,8 +162,7 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromAlternateDirName()
     {
-        $this->setupParentTheme();
-        switch_theme('fake-parent-theme');
+        switch_theme('timber-test-theme');
 
         Timber::$dirname = [
             \Timber\Loader::MAIN_NAMESPACE => ['foo', 'views'],
@@ -171,12 +173,13 @@ class TestTimberLoader extends Timber_UnitTestCase
         copy(__DIR__ . '/assets/single-foo.twig', get_template_directory() . '/foo/single-foo.twig');
         $str = Timber::compile('single-foo.twig');
         $this->assertEquals('I am single-foo', trim($str));
+
+        switch_theme('default');
     }
 
     public function testTwigLoadsFromAlternateDirNameWithoutNamespace()
     {
-        $this->setupParentTheme();
-        switch_theme('fake-parent-theme');
+        switch_theme('timber-test-theme');
 
         Timber::$dirname = [['foo', 'views']];
         if (!file_exists(get_template_directory() . '/foo')) {
@@ -185,12 +188,13 @@ class TestTimberLoader extends Timber_UnitTestCase
         copy(__DIR__ . '/assets/single-foo.twig', get_template_directory() . '/foo/single-foo.twig');
         $str = Timber::compile('single-foo.twig');
         $this->assertEquals('I am single-foo', trim($str));
+
+        switch_theme('default');
     }
 
     public function testTwigLoadsFromAlternateDirNameWithoutNamespaceAndSimpleArray()
     {
-        $this->setupParentTheme();
-        switch_theme('fake-parent-theme');
+        switch_theme('timber-test-theme');
 
         Timber::$dirname = ['foo', 'views'];
         if (!file_exists(get_template_directory() . '/foo')) {
@@ -199,6 +203,8 @@ class TestTimberLoader extends Timber_UnitTestCase
         copy(__DIR__ . '/assets/single-foo.twig', get_template_directory() . '/foo/single-foo.twig');
         $str = Timber::compile('single-foo.twig');
         $this->assertEquals('I am single-foo', trim($str));
+
+        switch_theme('default');
     }
 
     public function testTwigLoadsFromLocation()
@@ -244,8 +250,7 @@ class TestTimberLoader extends Timber_UnitTestCase
 
     public function testTwigLoadsFromLocationWithAndWithoutNamespacesAndDirs()
     {
-        $this->setupParentTheme();
-        switch_theme('fake-parent-theme');
+        switch_theme('timber-test-theme');
 
         Timber::$dirname = [
             \Timber\Loader::MAIN_NAMESPACE => ['foo', 'views'],
@@ -271,6 +276,8 @@ class TestTimberLoader extends Timber_UnitTestCase
         // Dir
         $str = Timber::compile('single-foo.twig');
         $this->assertEquals('I am single-foo', trim($str));
+
+        switch_theme('default');
     }
 
     public function testTwigLoadsFromMultipleLocationsWithNamespace()

--- a/tests/test-timber-parent-child.php
+++ b/tests/test-timber-parent-child.php
@@ -7,8 +7,8 @@ class TestTimberParentChild extends Timber_UnitTestCase
 {
     public function testParentChildGeneral()
     {
-        $this->_setupParentTheme();
-        $this->_setupChildTheme();
+        $this->setupParentTheme();
+        $this->setupChildTheme();
         switch_theme('fake-child-theme');
         register_post_type('course');
 

--- a/tests/test-timber-parent-child.php
+++ b/tests/test-timber-parent-child.php
@@ -7,14 +7,8 @@ class TestTimberParentChild extends Timber_UnitTestCase
 {
     public function testParentChildGeneral()
     {
-        $this->setupParentTheme();
-        $this->setupChildTheme();
-        switch_theme('fake-child-theme');
+        switch_theme('timber-test-theme-child');
         register_post_type('course');
-
-        //copy a specific file to the PARENT directory
-        $dest_dir = WP_CONTENT_DIR . '/themes/fake-parent-theme';
-        copy(__DIR__ . '/assets/single-course.twig', $dest_dir . '/views/single-course.twig');
 
         $pid = $this->factory->post->create();
         $post = Timber::get_post($pid);
@@ -22,5 +16,7 @@ class TestTimberParentChild extends Timber_UnitTestCase
             'post' => $post,
         ]);
         $this->assertEquals('I am single course', $str);
+
+        switch_theme('default');
     }
 }

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -20,8 +20,8 @@ class TestTimberSite extends Timber_UnitTestCase
 
     public function testChildParentThemeLocation()
     {
-        $this->_setupParentTheme();
-        $this->_setupChildTheme();
+        $this->setupParentTheme();
+        $this->setupChildTheme();
         $content_subdir = Timber\URLHelper::get_content_subdir();
         $this->assertFileExists(WP_CONTENT_DIR . '/themes/fake-child-theme/style.css');
         switch_theme('fake-child-theme');

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -20,14 +20,14 @@ class TestTimberSite extends Timber_UnitTestCase
 
     public function testChildParentThemeLocation()
     {
-        $this->setupParentTheme();
-        $this->setupChildTheme();
         $content_subdir = Timber\URLHelper::get_content_subdir();
-        $this->assertFileExists(WP_CONTENT_DIR . '/themes/fake-child-theme/style.css');
-        switch_theme('fake-child-theme');
+        $this->assertFileExists(WP_CONTENT_DIR . '/themes/timber-test-theme-child/style.css');
+        switch_theme('timber-test-theme-child');
         $site = new Timber\Site();
-        $this->assertEquals($content_subdir . '/themes/fake-child-theme', $site->theme->path);
-        $this->assertEquals($content_subdir . '/themes/fake-parent-theme', $site->theme->parent->path);
+        $this->assertEquals($content_subdir . '/themes/timber-test-theme-child', $site->theme->path);
+        $this->assertEquals($content_subdir . '/themes/timber-test-theme', $site->theme->parent->path);
+
+        switch_theme('default');
     }
 
     public function testThemeFromContext()

--- a/tests/test-timber-theme.php
+++ b/tests/test-timber-theme.php
@@ -2,8 +2,6 @@
 
 class TestTimberTheme extends Timber_UnitTestCase
 {
-    protected $backup_wp_theme_directories;
-
     public $theme_slug = 'twentythirty';
 
     public function testThemeVersion()
@@ -109,15 +107,9 @@ class TestTimberTheme extends Timber_UnitTestCase
 
     public function set_up()
     {
-        global $wp_theme_directories;
-
         parent::set_up();
 
-        $this->backup_wp_theme_directories = $wp_theme_directories;
-        $wp_theme_directories = [WP_CONTENT_DIR . '/themes'];
-
-        wp_clean_themes_cache();
-        unset($GLOBALS['wp_themes']);
+        $this->clean_themes_cache();
 
         $theme = wp_get_theme($this->theme_slug);
         if (!$theme->exists()) {
@@ -127,12 +119,7 @@ class TestTimberTheme extends Timber_UnitTestCase
 
     public function tear_down()
     {
-        global $wp_theme_directories;
-
-        $wp_theme_directories = $this->backup_wp_theme_directories;
-
-        wp_clean_themes_cache();
-        unset($GLOBALS['wp_themes']);
+        $this->restore_themes();
         parent::tear_down();
     }
 }

--- a/tests/test-timber-widgets.php
+++ b/tests/test-timber-widgets.php
@@ -7,9 +7,7 @@ class TestTimberWidgets extends Timber_UnitTestCase
      */
     public function testHTML()
     {
-        // replace this with some actual testing code
-        $widgets = wp_get_sidebars_widgets();
-        $data = [];
+        // Replace this with some actual testing code
         $content = Timber::get_widgets('sidebar-1');
         $content = trim($content);
         $this->assertEquals('<', substr($content, 0, 1));
@@ -20,6 +18,9 @@ class TestTimberWidgets extends Timber_UnitTestCase
      */
     public function testManySidebars()
     {
+        // $this->_setupParentTheme();
+        // switch_theme('fake-parent-theme');
+
         $widgets = wp_get_sidebars_widgets();
         $sidebar1 = Timber::get_widgets('sidebar-1');
         $sidebar2 = Timber::get_widgets('sidebar-2');

--- a/tests/test-timber-widgets.php
+++ b/tests/test-timber-widgets.php
@@ -18,10 +18,6 @@ class TestTimberWidgets extends Timber_UnitTestCase
      */
     public function testManySidebars()
     {
-        // $this->_setupParentTheme();
-        // switch_theme('fake-parent-theme');
-
-        $widgets = wp_get_sidebars_widgets();
         $sidebar1 = Timber::get_widgets('sidebar-1');
         $sidebar2 = Timber::get_widgets('sidebar-2');
         $this->assertGreaterThan(0, strlen($sidebar1));


### PR DESCRIPTION
**Ticket**: #2695

## Issue

Uuugh, it took me so long to figure out why tests were sometimes working and sometimes not (in #2695), depending on whether it’s a fresh test installation or not or running singular tests.

The issue that arises is when other tests install a theme or switch to a theme while other tests use the default theme as a baseline.

## Solution

This pull request should solve a lot of testing side-effects by 

- preparing a Timber test theme as well as a child theme that should be used for all tests
- installs these themes while bootstrapping the tests instead of installing various themes during the tests
- switches back to the `default` theme after tests

## Impact

Less side effects.

## Usage Changes

We should use the `timber-test-theme` and the `timber-test-theme-child` to run tests instead of various `twentyxx` themes that might not be available with different WordPress versions.

## Considerations

None.

## Testing

Yes.

After this pull request is merged, we can update #2675. That should fix the tests there as well.