### PR TITLE
2.x Fix menu item compatibility with WPML

### DIFF
--- a/src/Integration/WpmlIntegration.php
+++ b/src/Integration/WpmlIntegration.php
@@ -19,7 +19,6 @@ class WpmlIntegration implements IntegrationInterface
         add_filter('timber/url_helper/url_to_file_system/path', [$this, 'file_system_to_url'], 10, 1);
         add_filter('timber/menu/id_from_location', [$this, 'menu_object_id_filter'], 10, 1);
         add_filter('timber/menu/items', [$this, 'menu_items_filter'], 10, 1);
-        add_filter('timber/menuitem/pre_from', [$this, 'menu_item_pre_from_filter'], 10, 1);
         add_filter('timber/image_helper/_get_file_url/home_url', [$this, 'file_system_to_url'], 10, 1);
     }
 

--- a/src/Integration/WpmlIntegration.php
+++ b/src/Integration/WpmlIntegration.php
@@ -18,7 +18,7 @@ class WpmlIntegration implements IntegrationInterface
         add_filter('timber/url_helper/get_content_subdir/home_url', [$this, 'file_system_to_url'], 10, 1);
         add_filter('timber/url_helper/url_to_file_system/path', [$this, 'file_system_to_url'], 10, 1);
         add_filter('timber/menu/id_from_location', [$this, 'menu_object_id_filter'], 10, 1);
-        add_filter('timber/menu/items', [$this, 'menu_items_filter'], 10, 1);
+        add_filter('timber/menu/item_objects', [$this, 'menu_item_objects_filter'], 10, 1);
         add_filter('timber/image_helper/_get_file_url/home_url', [$this, 'file_system_to_url'], 10, 1);
     }
 
@@ -35,7 +35,7 @@ class WpmlIntegration implements IntegrationInterface
         return wpml_object_id_filter($id, 'nav_menu');
     }
 
-    public function menu_items_filter(array $items)
+    public function menu_item_objects_filter(array $items)
     {
         return array_map(
             fn ($item) => ($item instanceof WPML_LS_Menu_Item ? new WP_Post($item) : $item),

--- a/src/Integration/WpmlIntegration.php
+++ b/src/Integration/WpmlIntegration.php
@@ -2,6 +2,9 @@
 
 namespace Timber\Integration;
 
+use WP_Post;
+use WPML_LS_Menu_Item;
+
 class WpmlIntegration implements IntegrationInterface
 {
     public function should_init(): bool
@@ -15,6 +18,8 @@ class WpmlIntegration implements IntegrationInterface
         add_filter('timber/url_helper/get_content_subdir/home_url', [$this, 'file_system_to_url'], 10, 1);
         add_filter('timber/url_helper/url_to_file_system/path', [$this, 'file_system_to_url'], 10, 1);
         add_filter('timber/menu/id_from_location', [$this, 'menu_object_id_filter'], 10, 1);
+        add_filter('timber/menu/items', [$this, 'menu_items_filter'], 10, 1);
+        add_filter('timber/menuitem/pre_from', [$this, 'menu_item_pre_from_filter'], 10, 1);
         add_filter('timber/image_helper/_get_file_url/home_url', [$this, 'file_system_to_url'], 10, 1);
     }
 
@@ -29,5 +34,13 @@ class WpmlIntegration implements IntegrationInterface
     public function menu_object_id_filter($id)
     {
         return wpml_object_id_filter($id, 'nav_menu');
+    }
+
+    public function menu_items_filter(array $items)
+    {
+        return array_map(
+            fn ($item) => ($item instanceof WPML_LS_Menu_Item ? new WP_Post($item) : $item),
+            $items
+        );
     }
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -205,6 +205,28 @@ class Menu extends CoreEntity
          */
         $sorted_menu_items = apply_filters('wp_nav_menu_objects', $sorted_menu_items, $args);
 
+        /**
+         * Filters the sorted list of menu item objects before creating the Menu object.
+         *
+         * @since 2.0.0
+         * @example
+         * ```
+         * add_filter( 'timber/menu/items', function ( $items ) {
+         *     return array_map(function ($item) {
+         *         if ( is_object( $item ) && ! ( $item instanceof \WP_Post ) ) {
+         *             return new \WP_Post( get_object_vars( $item ) );
+         *         }
+         *
+         *         return $item;
+         *     }, $items);
+         * } );
+         * ```
+         *
+         * @param array<mixed> $item
+         * @param WP_Term $menu
+         */
+        $sorted_menu_items = apply_filters('timber/menu/items', $sorted_menu_items, $menu);
+
         // Create Menu object
         $nav_menu = new static($menu, (array) $args);
         $nav_menu->sorted_menu_items = $sorted_menu_items;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -211,7 +211,7 @@ class Menu extends CoreEntity
          * @since 2.0.0
          * @example
          * ```
-         * add_filter( 'timber/menu/items', function ( $items ) {
+         * add_filter( 'timber/menu/item_objects', function ( $items ) {
          *     return array_map(function ($item) {
          *         if ( is_object( $item ) && ! ( $item instanceof \WP_Post ) ) {
          *             return new \WP_Post( get_object_vars( $item ) );
@@ -225,7 +225,7 @@ class Menu extends CoreEntity
          * @param array<mixed> $item
          * @param WP_Term $menu
          */
-        $sorted_menu_items = apply_filters('timber/menu/items', $sorted_menu_items, $menu);
+        $sorted_menu_items = apply_filters('timber/menu/item_objects', $sorted_menu_items, $menu);
 
         // Create Menu object
         $nav_menu = new static($menu, (array) $args);

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -486,7 +486,7 @@ class TestTimberMenu extends Timber_UnitTestCase
             }, $items);
         };
 
-        $this->add_filter_temporarily('timber/menu/items', $filter, 10, 2);
+        $this->add_filter_temporarily('timber/menu/item_objects', $filter, 10, 2);
 
         $menu = Timber::get_menu($menu_id);
         $items = $menu->get_items();

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -474,6 +474,28 @@ class TestTimberMenu extends Timber_UnitTestCase
         ]);
     }
 
+    public function testMenuItemsFilter()
+    {
+        $term = self::_createTestMenu();
+        $menu_id = $term['term_id'];
+
+        $filter = function (array $items, WP_Term $menu) {
+            return array_map(function ($item) {
+                $item->classes[] = "test_{$item->ID}";
+                return $item;
+            }, $items);
+        };
+
+        $this->add_filter_temporarily('timber/menu/items', $filter, 10, 2);
+
+        $menu = Timber::get_menu($menu_id);
+        $items = $menu->get_items();
+
+        foreach ($items as $item) {
+            $this->assertContains("test_{$item->ID}", $item->classes);
+        }
+    }
+
     public function testMenuItemIsTargetBlank()
     {
         $menu_arr = self::_createTestMenu();


### PR DESCRIPTION
## Issue

WPML uses a custom nav menu item class: `WPML_LS_Menu_Item`.

When this menu item is passed to `MenuItemFactory::from()`, the method ignores it and returns `null` which violates the return type of the array map closure in `Menu::convert_menu_items()` leading to a fatal error:

```
PHP Fatal error:  Uncaught TypeError: Timber\Menu::Timber\{closure}(): Return value must be of type Timber\MenuItem, null returned in vendor/timber/timber/src/Menu.php:289
Stack trace:
#0 [internal function]: Timber\Menu->Timber\{closure}(Object(WPML_LS_Menu_Item))
#1 vendor/timber/timber/src/Menu.php(288): array_map(Object(Closure), Array)
#2 vendor/timber/timber/src/Menu.php(213): Timber\Menu->convert_menu_items(Array)
#3 vendor/timber/timber/src/Factory/MenuFactory.php(276): Timber\Menu::build(Object(WP_Term), Object(stdClass))
#4 vendor/timber/timber/src/Factory/MenuFactory.php(101): Timber\Factory\MenuFactory->build(Object(WP_Term), Array)
#5 vendor/timber/timber/src/Factory/MenuFactory.php(47): Timber\Factory\MenuFactory->from_location('site-header...', Array)
#6 vendor/timber/timber/src/Timber.php(986): Timber\Factory\MenuFactory->from('site-header...', Array)
#7 web/app/themes/foobar/includes/Site.php(966): Timber\Timber::get_menu('site-header...')
#8 web/app/themes/foobar/includes/Site.php(296): App\Theme\Site->get_timber_menus()
#9 web/wp/wp-includes/class-wp-hook.php(308): App\Theme\Site->filter_timber_context(Array)
#10 web/wp/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#11 vendor/timber/timber/src/Timber.php(1278): apply_filters('timber/context', Array)
#12 vendor/timber/timber/src/Timber.php(1169): Timber\Timber::context_global()
#13 vendor/locomotivemtl/wp-lib-theme/inc/Template/AbstractTemplate.php(40): Timber\Timber::context()
#14 web/app/themes/foobar/includes/Template/BaseTemplate.php(19): App\Theme\Template\AbstractTemplate->__construct()
#15 web/app/themes/foobar/theme/404.php(9): App\Theme\Template\BaseTemplate->__construct()
#16 web/wp/wp-includes/template-loader.php(106): include('...')
#17 web/wp/wp-blog-header.php(19): require_once('...')
#18 web/index.php(18): require('...')
#19 {main}
  thrown in vendor/timber/timber/src/Menu.php on line 289
```

## Solution

Added a filter `timber/menu/items` to `Menu::build()`, as [proposed](https://github.com/timber/timber/pull/2705#issuecomment-1439520248) by @gchtr, to allow one to filter all menu items. In turn, `WpmlIntegration` hooks into this filter to replace any occurrences of `WPML_LS_Menu_Item` with `WP_Post`.

<details>
<summary>Initial Solution</summary>

I propose adding a hook to `MenuItemFactory::from()` to allow integrations to convert any non-standard menu item into an acceptable menu item: `WP_Post`.

In `WpmlIntegration`, I've added a callback on this new hook to convert WPML's `WPML_LS_Menu_Item` into `WP_Post`.

The hook is named `timber/menuitem/pre_from` but the suffix, `pre_from`, is not my favourite name. I'm open to suggestions.

</details>

## Impact

Adding an extra hook could affect performance but I should be minor.


## Considerations

Alternatively, a filter to convert non-standard menu items could be applied to a late-callback on `wp_get_nav_menu_items` but that risks affecting any logic elsewhere that expects that custom menu item.


## Testing

A unit test for the filter has been added: `TestTimberMenu::testMenuItemsFilter()`.