### PR TITLE
2.x Fix Menu theme locations array to enforce string or integers

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -252,7 +252,8 @@ class Menu extends CoreEntity
         }
 
         // Set theme location if available
-        $this->theme_location = array_flip(get_nav_menu_locations())[$term->term_id] ?? null;
+        $locations = array_flip(array_filter(get_nav_menu_locations(), fn ($location) => is_string($location) || is_int($location)));
+        $this->theme_location = $locations[$term->term_id] ?? null;
         if ($this->theme_location) {
             $this->args->theme_location = $this->theme_location;
         }

--- a/tests/test-timber-menu.php
+++ b/tests/test-timber-menu.php
@@ -924,12 +924,16 @@ class TestTimberMenu extends Timber_UnitTestCase
         $this->assertEquals($parent->link(), $top->link());
     }
 
+    /**
+     * @issue https://github.com/timber/timber/issues/2576
+     */
     public function testThemeLocationProperty()
     {
         $term = self::_createTestMenu();
         $menu_id = $term['term_id'];
 
         $this->registerNavMenus([
+            'primary' => null,
             'secondary' => $menu_id,
         ]);
 


### PR DESCRIPTION
## Issue

With Timber v2 , WPML, and PHP 8, if any nav menu location happens to be `null`, this warning occurs:

```
Warning: array_flip(): Can only flip string and integer values, entry skipped in vendor/timber/timber/src/Menu.php on line 255
```

This is similar to issue #2576 where the warning was with `MenuFactory::get_menu_location()`.

## Solution

The solution is to apply the [same fix made to `MenuFactory`](https://github.com/timber/timber/commit/e4228795cf41a0e1d0c870fd70a9b969f2b44906); filter the nav menu locations array to enforce strings or integers.

## Testing

The `TestTimberMenu::testThemeLocationProperty()` method was updated to match `TestMenuFactory::testGetMenuLocation()`.