### PR TITLE
Fix PHPDoc typo

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -516,8 +516,8 @@ class Helper {
 	 *
 	 * If no match is found the function will return the inital argument.
 	 *
-	 * @param mix $obj WP Object
-	 * @return mix Instance of equivalent Timber object, or the argument if no match is found
+	 * @param mixed $obj WP Object
+	 * @return mixed Instance of equivalent Timber object, or the argument if no match is found
 	 */
 	public static function convert_wp_object( $obj ) {
 		if ( $obj instanceof \WP_Post ) {


### PR DESCRIPTION
due to reported (issue)[https://github.com/timber/timber/issues/2706]

(issue)[https://github.com/timber/timber/issues/2706]

## Issue
Looks like a typo in PHPDoc
mix -> mixed
Warning:(154, 54) Expected parameter of type 'Timber\mix', 'array|WP_Post' provided


## Solution
mix => mixed


## Impact
almost zero
