### PR TITLE
2.x clean init

### DIFF
--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -175,7 +175,7 @@ This example that uses a [WP_Query](http://codex.wordpress.org/Class_Reference/W
 
 ```php
 $args = [
-    'numberposts' => -1,
+    'posts_per_page' => -1,
     'post_type' => 'post',
     'meta_key' => 'color',
     'meta_value' => 'red',

--- a/docs/v2/guides/custom-integrations.md
+++ b/docs/v2/guides/custom-integrations.md
@@ -85,10 +85,10 @@ The hard part’s over. Now you need to tell Timber about your class:
 ```php
 use MyProject\MyAcfIntegration;
 
-add_filter('timber/integrations', function (array $classes): array {
-    $classes[] = MyAcfIntegration::class;
+add_filter('timber/integrations', function (array $integrations): array {
+    $integrations[] = new MyAcfIntegration();
 
-    return $classes;
+    return $integrations;
 });
 ```
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -998,7 +998,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
         if (is_array($post_type)) {
             $post_type = implode('&post_type[]=', $post_type);
         }
-        $query = 'post_parent=' . $this->ID . '&post_type[]=' . $post_type . '&numberposts=-1&orderby=menu_order title&order=ASC&post_status[]=publish';
+        $query = 'post_parent=' . $this->ID . '&post_type[]=' . $post_type . '&posts_per_page=-1&orderby=menu_order title&order=ASC&post_status[]=publish';
         if ($this->post_status === 'publish') {
             $query .= '&post_status[]=inherit';
         }

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -136,10 +136,10 @@ class Timber
     public static function init_integrations(): void
     {
         $integrations = [
-            Integration\AcfIntegration::class,
-            Integration\CoAuthorsPlusIntegration::class,
-            Integration\WpCliIntegration::class,
-            Integration\WpmlIntegration::class,
+            new Integration\AcfIntegration(),
+            new Integration\CoAuthorsPlusIntegration(),
+            new Integration\WpCliIntegration(),
+            new Integration\WpmlIntegration(),
         ];
 
         /**
@@ -147,18 +147,17 @@ class Timber
          *
          * @since 2.0.0
          *
-         * @param array $integrations An array of PHP class names. Default: array of
+         * @param IntegrationInterface[] $integrations An array of PHP class names. Default: array of
          *                            integrations that Timber initializes by default.
          */
         $integrations = apply_filters('timber/integrations', $integrations);
 
         // Integration classes must implement the IntegrationInterface.
         $integrations = array_filter($integrations, static function ($integration) {
-            return in_array(IntegrationInterface::class, class_implements($integration), true);
+            return $integration instanceof IntegrationInterface;
         });
 
-        foreach ($integrations as $integration_class) {
-            $integration = new $integration_class();
+        foreach ($integrations as $integration) {
             if (!$integration->should_init()) {
                 continue;
             }

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -449,6 +449,14 @@ class Timber
             );
         }
 
+        if (is_array($query) && isset($query['numberposts'])) {
+            Helper::doing_it_wrong(
+                'Timber::get_posts()',
+                'Using `numberposts` only works when using `get_posts()`, but not for Timber::get_posts(). Use `posts_per_page` instead.',
+                '2.0.0'
+            );
+        }
+
         /**
          * @todo Are there any more default options to support?
          */

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -528,6 +528,20 @@ class TestTimberMainClass extends Timber_UnitTestCase
         $this->assertInstanceOf(Post::class, Timber::get_post($post_id));
     }
 
+    /**
+     * @expectedIncorrectUsage Timber::get_posts()
+     */
+    public function testNumberPostsAll()
+    {
+        $this->factory->post->create_many(17);
+
+        $posts = Timber::get_posts([
+            'post_type' => 'post',
+            'numberposts' => 17,
+        ]);
+        $this->assertSame(10, count($posts));
+    }
+
     public function testPostsPerPage()
     {
         $pids = $this->factory->post->create_many(15);

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -528,34 +528,6 @@ class TestTimberMainClass extends Timber_UnitTestCase
         $this->assertInstanceOf(Post::class, Timber::get_post($post_id));
     }
 
-    /**
-     * @group wp_query_hacks
-     */
-    public function testNumberpostsFix()
-    {
-        $this->factory->post->create_many(10);
-
-        $posts = Timber::get_posts([
-            'post_type' => 'post',
-            'numberposts' => 6,
-        ]);
-        $this->assertCount(6, $posts);
-    }
-
-    /**
-     * @group wp_query_hacks
-     */
-    public function testNumberPostsAll()
-    {
-        $pids = $this->factory->post->create_many(17);
-        $query = 'post_type=post&numberposts=-1';
-        $posts = Timber::get_posts([
-            'post_type' => 'post',
-            'numberposts' => 17,
-        ]);
-        $this->assertSame(17, count($posts));
-    }
-
     public function testPostsPerPage()
     {
         $pids = $this->factory->post->create_many(15);
@@ -590,33 +562,6 @@ class TestTimberMainClass extends Timber_UnitTestCase
         ]);
 
         $this->assertCount(15, $posts);
-    }
-
-    /**
-     * @group wp_query_hacks
-     */
-    public function testGetPostsWithCategoryFix()
-    {
-        // Create several irrelevant posts that should NOT show up in our query.
-        $this->factory->post->create_many(6);
-
-        $cat = $this->factory->term->create([
-            'name' => 'News',
-            'taxonomy' => 'category',
-        ]);
-        $cats = $this->factory->post->create_many(3, [
-            'post_category' => [$cat],
-        ]);
-        $cat_post = $this->factory->post->create([
-            'post_category' => [$cat],
-        ]);
-
-        $cat_post = Timber::get_post($cat_post);
-        $this->assertEquals('News', $cat_post->category()->title());
-
-        $this->assertCount(4, Timber\Timber::get_posts([
-            'category' => $cat,
-        ]));
     }
 
     /**


### PR DESCRIPTION
## Issue

- Register admin notice on `admin_init` action
- Remove `pre_get_posts` filters, I never paid attention to those filters but I don't think this should be Timber's responsability to provide some kind of query arguments normalization. 
- Filters integrations to ensure they implement `IntegrationInterface`
- Removes `test_compatibility()` which actually does nothing

## Impact

Moving from closures to static functions (not ideal but better) provides a better way to remove those filters if needed.

## Usage Changes

None.

## Considerations

## Testing

