### PR TITLE
Fix iterable case

### DIFF
--- a/src/Factory/CommentFactory.php
+++ b/src/Factory/CommentFactory.php
@@ -64,7 +64,7 @@ class CommentFactory
         ));
     }
 
-    protected function from_wp_comment_query(WP_Comment_Query $query): Iterable
+    protected function from_wp_comment_query(WP_Comment_Query $query): iterable
     {
         return array_map([$this, 'build'], $query->get_comments());
     }

--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -75,7 +75,7 @@ class PostFactory
         ));
     }
 
-    protected function from_wp_query(WP_Query $query): Iterable
+    protected function from_wp_query(WP_Query $query): iterable
     {
         return new PostQuery($query);
     }

--- a/src/Factory/TermFactory.php
+++ b/src/Factory/TermFactory.php
@@ -59,7 +59,7 @@ class TermFactory
         return $this->build($wp_term);
     }
 
-    protected function from_wp_term_query(WP_Term_Query $query): Iterable
+    protected function from_wp_term_query(WP_Term_Query $query): iterable
     {
         return array_map([$this, 'build'], $query->get_terms());
     }

--- a/src/Factory/UserFactory.php
+++ b/src/Factory/UserFactory.php
@@ -87,7 +87,7 @@ class UserFactory
     }
 
     // @todo return a UserCollection instance?
-    protected function from_wp_user_query(WP_User_Query $query): Iterable
+    protected function from_wp_user_query(WP_User_Query $query): iterable
     {
         return array_map([$this, 'build'], $query->get_results());
     }

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -736,9 +736,9 @@ class Timber
      *                              taxonomies.
      * @param array        $options Optional. None are currently supported. Default empty array.
      *
-     * @return Iterable
+     * @return iterable
      */
-    public static function get_terms($args = null, array $options = []): Iterable
+    public static function get_terms($args = null, array $options = []): iterable
     {
         // default to all queryable taxonomies
         $args = $args ?? [
@@ -875,9 +875,9 @@ class Timber
      *                       parameter exists to prevent future breaking changes. Default empty
      *                       array `[]`.
      *
-     * @return \Iterable An array of users objects. Will be empty if no users were found.
+     * @return iterable An array of users objects. Will be empty if no users were found.
      */
-    public static function get_users(array $query = [], array $options = []): Iterable
+    public static function get_users(array $query = [], array $options = []): iterable
     {
         $factory = new UserFactory();
         // TODO return a Collection type?
@@ -1088,7 +1088,7 @@ class Timber
      * @param array   $options optional; none are currently supported
      * @return mixed
      */
-    public static function get_comments(array $query = [], array $options = []): Iterable
+    public static function get_comments(array $query = [], array $options = []): iterable
     {
         $factory = new CommentFactory();
         // TODO return a Collection type?


### PR DESCRIPTION
`Iterable` with capital `i` might let you think that it's a native class whereas it's a pseudo type

## Issue
Not really an issue but I think iterable return types might lead to confusion. Proof is one them was backslashed in a PHPDoc block.

## Solution
Lower case all of them. 

## Impact
None.

## Usage Changes
None.

## Considerations

Using iterables on every `get_{objects}` (terms, users, comments) is bit annoying. While it's legitimate on `posts` because we return true collection objects, all the other ones just return simple arrays.

But since the return type is `iterable`:
- you're discouraged to use `array_*` functions (outside of Twig) which are often very useful (map, filter, etc.), although it will work in the current implementation for users, terms and comments
- when using `array_*` functions, my IDE (and PHPStan) complaints about it ("Expected type 'array'. Found 'iterable'.") and they're right to
- you can't use [`iterator_to_array`](https://github.com/bpolaszek/php-iterable-functions/blob/7136af22d8f7165f173cbd04cfa224443ffacdb0/README.md?plain=1#L25-L27) if already an array

In the end, all these "iterables" are [converted to arrays in Twig](https://github.com/twigphp/Twig/blob/78c18ad58e48d3fff2f7812bb60b6176ee52689a/src/Extension/CoreExtension.php#L723-L727). 

So the underlying question is: do we really need `iterable`? I guess these types have been introduced to be future proof in case we might implement collections for WP objects. But will we for such object object types (terms/users/comments)?
