### PR TITLE
2.x Add doing_it_wrong not for `numberposts` in Timber::get_posts()

### DIFF
--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -175,7 +175,7 @@ This example that uses a [WP_Query](http://codex.wordpress.org/Class_Reference/W
 
 ```php
 $args = [
-    'numberposts' => -1,
+    'posts_per_page' => -1,
     'post_type' => 'post',
     'meta_key' => 'color',
     'meta_value' => 'red',

--- a/src/Post.php
+++ b/src/Post.php
@@ -998,7 +998,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
         if (is_array($post_type)) {
             $post_type = implode('&post_type[]=', $post_type);
         }
-        $query = 'post_parent=' . $this->ID . '&post_type[]=' . $post_type . '&numberposts=-1&orderby=menu_order title&order=ASC&post_status[]=publish';
+        $query = 'post_parent=' . $this->ID . '&post_type[]=' . $post_type . '&posts_per_page=-1&orderby=menu_order title&order=ASC&post_status[]=publish';
         if ($this->post_status === 'publish') {
             $query .= '&post_status[]=inherit';
         }

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -449,6 +449,14 @@ class Timber
             );
         }
 
+        if (is_array($query) && isset($query['numberposts'])) {
+            Helper::doing_it_wrong(
+                'Timber::get_posts()',
+                'Using `numberposts` only works when using `get_posts()`, but not for Timber::get_posts(). Use `posts_per_page` instead.',
+                '2.0.0'
+            );
+        }
+
         /**
          * @todo Are there any more default options to support?
          */

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -533,6 +533,8 @@ class TestTimberMainClass extends Timber_UnitTestCase
      */
     public function testNumberPostsAll()
     {
+        $this->factory->post->create_many(17);
+
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'numberposts' => 17,

--- a/tests/test-timber.php
+++ b/tests/test-timber.php
@@ -528,6 +528,18 @@ class TestTimberMainClass extends Timber_UnitTestCase
         $this->assertInstanceOf(Post::class, Timber::get_post($post_id));
     }
 
+    /**
+     * @expectedIncorrectUsage Timber::get_posts()
+     */
+    public function testNumberPostsAll()
+    {
+        $posts = Timber::get_posts([
+            'post_type' => 'post',
+            'numberposts' => 17,
+        ]);
+        $this->assertSame(10, count($posts));
+    }
+
     public function testPostsPerPage()
     {
         $pids = $this->factory->post->create_many(15);


### PR DESCRIPTION
Related:

- #2714

## Issue

The `numberposts` parameter is only supported when using `get_posts()`, but not when using `Timber::get_posts()`.


## Solution

Add a doing-it-wrong notice.

## Impact

Better guidance for developers migrating to v2.

## Usage Changes

Use `posts_per_page` instead.

## Considerations

Can be removed in the next major Timber version.

## Testing

Yes.