### PR TITLE
Remove string helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "composer/installers": "^1.0 || ^2.0",
+    "symfony/polyfill-php80": "^1.27",
     "twig/twig": "^2.15.3 || ^3.0"
   },
   "require-dev": {

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -1034,6 +1034,11 @@ The following functions and properties were **removed from the codebase**, eithe
 - `get_current_url()` – use `Timber\URLHelper::get_current_url()` instead
 - `filter_array()` – use `array_filter()` or `Timber\Helper::wp_list_filter()` instead.
 
+### Timber\TextHelper
+
+- `starts_with()` - use `str_starts_with()` instead.
+- `ends_with()` - use `str_ends_with()` instead.
+
 ### Timber\Integration\Command
 
 The whole `Timber\Integration\Command` class was removed. Its methods were moved over to the `Timber\Cache\Cleaner` class.

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -173,7 +173,7 @@ class ImageHelper
             return false;
         }
 
-        if (TextHelper::ends_with(strtolower($file_path), '.svg')) {
+        if (str_ends_with(strtolower($file_path), '.svg')) {
             return true;
         }
 
@@ -537,14 +537,14 @@ class ImageHelper
         ];
         $upload_dir = wp_upload_dir();
         $tmp = $url;
-        if (TextHelper::starts_with($tmp, ABSPATH) || TextHelper::starts_with($tmp, '/srv/www/')) {
+        if (str_starts_with($tmp, ABSPATH) || str_starts_with($tmp, '/srv/www/')) {
             // we've been given a dir, not an url
             $result['absolute'] = true;
-            if (TextHelper::starts_with($tmp, $upload_dir['basedir'])) {
+            if (str_starts_with($tmp, $upload_dir['basedir'])) {
                 $result['base'] = self::BASE_UPLOADS; // upload based
                 $tmp = URLHelper::remove_url_component($tmp, $upload_dir['basedir']);
             }
-            if (TextHelper::starts_with($tmp, WP_CONTENT_DIR)) {
+            if (str_starts_with($tmp, WP_CONTENT_DIR)) {
                 $result['base'] = self::BASE_CONTENT; // content based
                 $tmp = URLHelper::remove_url_component($tmp, WP_CONTENT_DIR);
             }

--- a/src/Post.php
+++ b/src/Post.php
@@ -1907,7 +1907,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
         $audio = false;
 
         // Only get audio from the content if a playlist isn’t present.
-        if (false === strpos($this->content(), 'wp-playlist-script')) {
+        if (!str_contains($this->content(), 'wp-playlist-script')) {
             $audio = get_media_embedded_in_content($this->content(), ['audio']);
         }
 
@@ -1929,7 +1929,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
         $video = false;
 
         // Only get video from the content if a playlist isn't present.
-        if (false === strpos($this->content(), 'wp-playlist-script')) {
+        if (!str_contains($this->content(), 'wp-playlist-script')) {
             $video = get_media_embedded_in_content($this->content(), ['video', 'object', 'embed', 'iframe']);
         }
 

--- a/src/TextHelper.php
+++ b/src/TextHelper.php
@@ -107,33 +107,6 @@ class TextHelper
     }
 
     /**
-     * @api
-     * @param string $haystack
-     * @param string $needle
-     * @return boolean
-     */
-    public static function starts_with($haystack, $needle)
-    {
-        if (0 === strpos($haystack, $needle)) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * @api
-     * Does the string in question (haystack)
-     * end with the substring in question (needle)?
-     * @param string $haystack
-     * @param string $needle
-     * @return boolean
-     */
-    public static function ends_with($haystack, $needle)
-    {
-        return (substr($haystack, strlen($haystack) - strlen($needle)) == $needle);
-    }
-
-    /**
      *
      *
      * @param string  $html

--- a/tests/test-timber-text-helper.php
+++ b/tests/test-timber-text-helper.php
@@ -6,13 +6,13 @@ class TestTimberTextHelper extends Timber_UnitTestCase
 
     public function testStartsWith()
     {
-        $maybe_starts_with = Timber\TextHelper::starts_with($this->gettysburg, 'Four score');
+        $maybe_starts_with = str_starts_with($this->gettysburg, 'Four score');
         $this->assertTrue($maybe_starts_with);
     }
 
     public function testDontStartWith()
     {
-        $maybe_starts_with = Timber\TextHelper::starts_with($this->gettysburg, "Can't get enough of that SugarCrisp");
+        $maybe_starts_with = str_starts_with($this->gettysburg, "Can't get enough of that SugarCrisp");
         $this->assertFalse($maybe_starts_with);
     }
 


### PR DESCRIPTION
This is handled by PHP 8 and can easily be polyfilled. 

Timber is full of helpers that already exists either in WordPress or PHP (and can easily be polyfilled).
