### PR TITLE
Improve scheme detection and take advantage of WP native functions

### DIFF
--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -34,7 +34,7 @@ class URLHelper
      */
     public static function get_scheme()
     {
-        return isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+        return is_ssl() ? 'https' : 'http';
     }
 
     /**


### PR DESCRIPTION
Using `is_ssl`:
- covers more use cases than self made functions
- is already there