### PR TITLE
Fix `PostFactory::is_image` incorrectly using `wp_check_filetype`

### DIFF
--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -172,7 +172,7 @@ class PostFactory
 
     protected function is_image(WP_Post $post)
     {
-        $src = wp_get_attachment_url($post->ID);
+        $src = get_attached_file($post->ID);
         $mimes = wp_get_mime_types();
         // Add mime types that Timber recongizes as images, regardless of config
         $mimes['svg'] = 'image/svg+xml';


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #2444

## Issue
<!-- Description of the problem that this code change is solving -->

Images with query params are not correctly identified as images.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

The current way to detect an image is to use `wp_attachment_is_image` and use that with `wp_check_filetype` to detect if the file has an expected extension.

However, `wp_check_filetype` is not meant to be used with an URL but with a path instead. So this check fails currently if the URL has query params for example.

The fix is to use `get_attached_file` to get the actual file path instead of the URL matching what `wp_attachment_is_image` is doing.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->

I don't think there are any performance or BC changes since this is a bug fix IMHO.


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.

Alternatively, you’re very welcome to directly edit the readme.txt file with:
- A quick summary, including your GitHub handle.
- A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
- New usage instructions, possibly with a short code example.
-->

No.

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

Ideally `wp_attachment_is_image` would been used, but seeing there are custom filters in place this is (no longer) a viable solution so mimicking what `wp_attachment_is_image` is doing seems like the best choice at the moment.

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->

I have to see if I can figure it out, this code path seems untested at the moment and setting up a local dev environment requires a little more time then I can invest right now.