### PR TITLE
Update 2.0.md - fix 404 link to setup guide

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -19,7 +19,7 @@ We upgraded Timber to work with more modern PHP and functionalities that only we
 
 ## No more plugin support
 
-As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/v2/getting-started/setup/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
+As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/v2/installation/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
 
 ## Initializing Timber
 


### PR DESCRIPTION
Reviewer may want to change "Setup Guide" to "Installation Guide" or "Installation Page" or something else if it's more accurate.

## Issue
Link to Setup Guide in Upgrading to 2.0 docs 404s.

## Solution
Inferred that this should probably be the Installation docs.

## Impact
Fix regression, no other impact.

## Considerations
A CI step could be added which checks for broken links in markdown documents.