### PR TITLE
Add workflow to check docs links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,29 @@
+name: Docs links checker
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * SUN"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.7.0
+        with:
+            args: --max-concurrency=32
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: docs


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/pull/2732

## Issue

It may be hard to keep all links in docs up to date. 

## Solution

As suggested in PR above, setup a workflow to spot them.

It will check every week docs links and create an issue if bad links are found. 
