### PR TITLE
Update broken links in documentation

### DIFF
--- a/docs/v1/getting-started/theming.md
+++ b/docs/v1/getting-started/theming.md
@@ -151,7 +151,7 @@ This is where we are going to handle the logic that powers our index file. Let�
 $context = Timber::context();
 ```
 
-This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you’ll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/src/Timber.php) to inspect for yourself.
+This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you’ll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.
 
 ### Grab your posts
 

--- a/docs/v1/guides/cookbook-images.md
+++ b/docs/v1/guides/cookbook-images.md
@@ -137,7 +137,7 @@ You can now use all the above functions to transform your custom images in the s
 ## Limitations when working with a CDN
 
 Timber’s image functions may be somewhat limited when using a CDN.
-There are [differences between Pull CDN and Push CDN](https://cdn.net/push-vs-pull-cdn/).
+There are [differences between Pull CDN and Push CDN](https://medium.com/@ajin.sunny/push-cdn-vs-pull-cdn-a13145df5e13).
 
 ### Using a Pull CDN
 

--- a/docs/v1/guides/custom-page-templates.md
+++ b/docs/v1/guides/custom-page-templates.md
@@ -54,4 +54,4 @@ In the WordPress admin, a new entry will be added in your page’s list of avail
 ![](http://codex.wordpress.org/images/thumb/a/a3/page-templates-pulldown-screenshot.png/180px-page-templates-pulldown-screenshot.png)
 
 * Name it something like `/wp-content/themes/my-theme/template-my-custom-page.php`.
-* Do **NOT** name it something beginning with `page-` or [WordPress will get very confused](http://jespervanengelen.com/page-templates-in-wordpress-template-hierarchy/).
+* Do **NOT** prefix the filename with `page-` or WordPress will get very confused due to [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page).

--- a/docs/v1/guides/internationalization.md
+++ b/docs/v1/guides/internationalization.md
@@ -98,9 +98,3 @@ Alternatively, you can use a custom parser for Python instead. This will throw a
 #### Use Twig Gettext Extractor
 
 Another solution is [Twig Gettext Extractor](https://github.com/umpirsky/Twig-Gettext-Extractor), a special Twig parser for Poedit. The linked page contains instructions on how to set it up.
-
-### Use a gulp script
-
-You can use [a gulp script to generate POT files](https://gist.github.com/luism-s/ebca42b8b8d70e81f8917f675a784060) instead of using Poedit. The script will convert gettext functions in Twig into PHP tags and save each file as a PHP file in a cache folder. It will then iterate over these cached files (including other PHP files in your project) and generate a POT file. This approach will also consider strings in HTML attributes. 
-
-You can find installation instructions in the comments of the gulpfile in the linked gist. Basic understanding of NPM is required.

--- a/docs/v2/getting-started/a-post-archive.md
+++ b/docs/v2/getting-started/a-post-archive.md
@@ -67,7 +67,7 @@ Your teaser could look like this. We used the markup for an [Inclusive Card](htt
 There are two new things that you see here:
 
 - `{{ post.slug }}` – This property is the same as `post.post_name`, which is the version of a post’s title that is safe to use in URLs and will be used for permalinks.
-- `{{ post.excerpt }}` – This is an advanced function that pulls in the excerpt of a post, if it exists. Otherwise, it will generate an excerpt from your post’s content. Check out the documentation for [`Timber\Post::excerpt()`](https://timber.github.io/docs/reference/v2/timber-post/#excerpt) to learn more about the parameters you can control the output with.
+- `{{ post.excerpt }}` – This is an advanced function that pulls in the excerpt of a post, if it exists. Otherwise, it will generate an excerpt from your post’s content. Check out the documentation for [`Timber\Post::excerpt()`](https://timber.github.io/docs/v2/reference/timber-post/#excerpt) to learn more about the parameters you can control the output with.
 
 ## Using custom queries
 

--- a/docs/v2/getting-started/a-single-post.md
+++ b/docs/v2/getting-started/a-single-post.md
@@ -32,7 +32,7 @@ In this guide, we’re looking at a typical blog post. You can use most of the t
 
 In this example, you see that we can also use `post.author`, `post.date` and of course, `post.content` to actually display a post’s content.
 
-The `{{ post }}` variable in Twig is not an array, it’s a PHP object. More specifically, it’s an instance of [`Timber\Post`](https://timber.github.io/docs/reference/v2/timber-post/). When you look at the documentation for `Timber\Post`, you see what else you can access.
+The `{{ post }}` variable in Twig is not an array, it’s a PHP object. More specifically, it’s an instance of [`Timber\Post`](https://timber.github.io/docs/v2/reference/timber-post/). When you look at the documentation for `Timber\Post`, you see what else you can access.
 
 If you look for `title` in that post object in PHP, you will see that it’s actually not a property, but a function.
 
@@ -53,7 +53,7 @@ These are properties that a Timber post inherits from `WP_Post`. They are the ra
 
 Apart from the post title and content, we can also access the assigned author of a post through `{{ post.author }}`. The `author` is another Timber object. It’s not a post object though, but a [`Timber\User`](https://timber.github.io/docs/v2/reference/timber-user/) object. We can get the result of the `name` method through `{{ post.author.name }}`. This displays the name of the author.
 
-There’s also `{{ post.date }}`, but we won’t go into details about it here, because that’s a whole other chapter. You can read more about it in the [Date/Time Guide](https://timber.github.io/docs/guides/v2/date-time/).
+There’s also `{{ post.date }}`, but we won’t go into details about it here, because that’s a whole other chapter. You can read more about it in the [Date/Time Guide](https://timber.github.io/docs/v2/guides/date-time/).
 
 ## The featured image
 

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -144,7 +144,7 @@ External images (we call them sideloaded images) are loaded into an **external**
 ## Limitations when working with a CDN
 
 Timber’s image functions may be somewhat limited when using a CDN.
-There are [differences between Pull CDN and Push CDN](https://cdn.net/push-vs-pull-cdn/).
+There are [differences between Pull CDN and Push CDN](https://medium.com/@ajin.sunny/push-cdn-vs-pull-cdn-a13145df5e13).
 
 ### Using a Pull CDN
 

--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -3,7 +3,7 @@ title: "Custom Fields"
 order: "600"
 ---
 
-Timber tries to make it as easy as possible for you to retrieve custom meta data for Post, Term, User and Comment objects. And it works with a range of plugins that make it easier for you to create custom fields, like Advanced Custom Fields. While most of this guide applies to everything you do with custom fields, we have separate guides in the [Integrations section](https://timber.github.io/docs/v2/integrations/).
+Timber tries to make it as easy as possible for you to retrieve custom meta data for Post, Term, User and Comment objects. And it works with a range of plugins that make it easier for you to create custom fields, like Advanced Custom Fields. While most of this guide applies to everything you do with custom fields, we have a detailed guide for [ACF](https://timber.github.io/docs/v2/integrations/advanced-custom-fields/).
 
 ## Accessing custom values
 

--- a/docs/v2/guides/custom-page-templates.md
+++ b/docs/v2/guides/custom-page-templates.md
@@ -53,4 +53,4 @@ In the WordPress admin, a new entry will be added in your page’s list of avail
 ![](http://codex.wordpress.org/images/thumb/a/a3/page-templates-pulldown-screenshot.png/180px-page-templates-pulldown-screenshot.png)
 
 * Name it something like **/wp-content/themes/my-theme/template-my-custom-page.php**.
-* Do **NOT** name it something beginning with `page-` or [WordPress will get very confused](http://jespervanengelen.com/page-templates-in-wordpress-template-hierarchy/).
+* Do **NOT** prefix the filename with `page-` or WordPress will get very confused due to [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page).

--- a/docs/v2/guides/internationalization.md
+++ b/docs/v2/guides/internationalization.md
@@ -99,9 +99,3 @@ Alternatively, you can use a custom parser for Python instead. This will throw a
 #### Use Twig Gettext Extractor
 
 Another solution is [Twig Gettext Extractor](https://github.com/umpirsky/Twig-Gettext-Extractor), a special Twig parser for Poedit. The linked page contains instructions on how to set it up.
-
-### Use a gulp script
-
-You can use [a gulp script to generate POT files](https://gist.github.com/luism-s/ebca42b8b8d70e81f8917f675a784060) instead of using Poedit. The script will convert gettext functions in Twig into PHP tags and save each file as a PHP file in a cache folder. It will then iterate over these cached files (including other PHP files in your project) and generate a POT file. This approach will also consider strings in HTML attributes.
-
-You can find installation instructions in the comments of the gulpfile in the linked gist. Basic understanding of NPM is required.

--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -90,7 +90,7 @@ To initiate your new `MenuPrimary` menu that will hold `MenuItemPrimary` objects
 $menu = Timber::get_menu('primary');
 ```
 
-In the same way that you [can’t instantiate post objects directly](https://timber.github.io/docs/guides/posts/#extending-timber-post), you **can’t** instantiate `Timber\Menu` or `Timber\MenuItem` objects or an object that extends this class with a constructor. Timber will use the [Menu Class Map](https://timber.github.io/docs/guides/class-maps/#the-menu-class-map) and the [MenuItem Class Map](https://timber.github.io/docs/guides/class-maps/#the-menuitem-class-map) to sort out which class it should use.
+In the same way that you [can’t instantiate post objects directly](https://timber.github.io/docs/v2/guides/posts/#extending-timber-post), you **can’t** instantiate `Timber\Menu` or `Timber\MenuItem` objects or an object that extends this class with a constructor. Timber will use the [Menu Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-menu-class-map) and the [MenuItem Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-menuitem-class-map) to sort out which class it should use.
 
 ## Pages Menu
 
@@ -111,7 +111,7 @@ class ExtendedPagesMenu extends \Timber\PagesMenu
 }
 ```
 
-There’s a special [PagesMenu Class Map](https://timber.github.io/docs/guides/class-maps/#the-pages-menu-class-map) which you can use to make Timber use your custom class.
+There’s a special [PagesMenu Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-pages-menu-class-map) which you can use to make Timber use your custom class.
 
 ## Setting up a menu globally
 

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -15,7 +15,7 @@ You can still use plugins like [W3 Total Cache](https://wordpress.org/plugins/w3
 
 ## Cache the Entire Twig File and Data
 
-When rendering, use the `$expires` argument in [`Timber::render`](https://timber.github.io/docs/v2/reference/timber/#render). For example:
+When rendering, use the `$expires` argument in [`Timber::render`](https://timber.github.io/docs/v2/reference/timber-timber/#render). For example:
 
 ```php
 $context['posts'] = Timber::get_posts();
@@ -29,7 +29,7 @@ This method is very effective, but crude - the whole template is cached. So if y
 
 ### Set cache mode
 
-As a fourth parameter for [Timber::render()](https://timber.github.io/docs/v2/reference/timber/#render), you can set the `$cache_mode`.
+As a fourth parameter for [Timber::render()](https://timber.github.io/docs/v2/reference/timber-timber/#render), you can set the `$cache_mode`.
 
 ```php
 Timber::render($filenames, $data, $expires, $cache_mode);

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -120,7 +120,7 @@ $posts = Timber::get_posts([
 ]);
 ```
 
-The `Timber::get_posts()` function accepts a second parameter with options for the query. For example, with the `merge_default` option you can tell Timber that it should merge your query parameters with the default query parameters of the current template. You can check out `merge_default` and all the other options in the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/v2/reference/timber/#get-posts).
+The `Timber::get_posts()` function accepts a second parameter with options for the query. For example, with the `merge_default` option you can tell Timber that it should merge your query parameters with the default query parameters of the current template. You can check out `merge_default` and all the other options in the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/v2/reference/timber-timber/#get_posts).
 
 ```php
 $posts = Timber::get_posts($query, $options);

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -381,7 +381,7 @@ The new `$options` parameter can be used to pass in options for the query. Check
 
 ### Post queries in Twig
 
-You can run post queries in Twig. Pass the parameters in an argument hash (in Twig, [key-value arrays are called hashes](https://mijingo.com/blog/key-value-arrays-in-twig), and you use curly braces `{}` instead of brackets `[]` for them).
+You can run post queries in Twig. Pass the parameters in an argument hash (in Twig, key-value arrays are called hashes, and you use curly braces `{}` instead of brackets `[]` for them).
 
 ```twig
 {# Hash notation #}
@@ -1527,6 +1527,6 @@ We added a couple of new guides that you may want to read through in addition to
 - [Users Guide](https://timber.github.io/docs/v2/guides/users/)
 - [Class Maps Guide](https://timber.github.io/docs/v2/guides/class-maps/)
 - [Context Guide](https://timber.github.io/docs/v2/guides/context/)
-- [Custom Fields Guide](https://timber.github.io/docs/v2/guides/custom-fields/), which is now decoupled from the [ACF Integrations Guide](https://timber.github.io/docs/integrations/advanced-custom-fields/).
+- [Custom Fields Guide](https://timber.github.io/docs/v2/guides/custom-fields/), which is now decoupled from the [ACF Integrations Guide](https://timber.github.io/docs/v2/integrations/advanced-custom-fields/).
 - [Custom Integrations Guide](https://timber.github.io/docs/v2/guides/custom-integrations/)
 - [WP CLI Guide](https://timber.github.io/docs/v2/guides/wp-cli/)

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -843,7 +843,7 @@ Up until now, there was only a representation for WordPress image attachments in
 
 - The `Timber\Image` class now extends the `Timber\Attachment` class. All your code should already be compatible with this change. But in the future, you could use the new `Timber\Attachment` class if you work with an attachment that is not an image.
 - We’ve added new methods for `Timber\Attachment`. See the [section below](https://timber.github.io/docs/v2/upgrade-guides/2.0/#new-functions).
-- To get attachments from attachment IDs in Twig, you can use `{{ get_attachment(attachment_id) }}`. Behind the curtains, Timber uses [Class Maps](https://timber.github.io/docs/v2/class-maps) to use the [`Timber\Image`](https://timber.github.io/docs/v2/reference/timber-image/) and [`Timber\Attachment`](https://timber.github.io/docs/v2/reference/timber-attachment/) classes for attachment posts.
+- To get attachments from attachment IDs in Twig, you can use `{{ get_attachment(attachment_id) }}`. Behind the curtains, Timber uses [Class Maps](https://timber.github.io/docs/v2/guides/class-maps) to use the [`Timber\Image`](https://timber.github.io/docs/v2/reference/timber-image/) and [`Timber\Attachment`](https://timber.github.io/docs/v2/reference/timber-attachment/) classes for attachment posts.
 
 ### New ExternalImage class
 


### PR DESCRIPTION
Ticket: #2742


## Issue
Link checker action found 22 broken links in the documentation.


## Solution

- Updated internal links: https://github.com/timber/timber/commit/5b8292c6d59933bb2b4ca05801dba765151875e6
- Updated 2.0 guide: https://github.com/timber/timber/commit/ff6d96772266b60c0bae354293afb0d4bf2f5647
- Added alternative for cdn guide: https://github.com/timber/timber/commit/ed2abaf81c9c2d99648b8a8afc7a2ac2dd6822d3 and https://github.com/timber/timber/commit/23bbe8a87c4b307c1b58198a28e69e16efe7a3f1
- Removed Gulp guide from translation since it is not available anymore: https://github.com/timber/timber/commit/4c808469b16cc9bcd568efeec07d418122b9502e
- Updated template hierarchy section with some explanation and an alternative link : https://github.com/timber/timber/commit/225fb104c4f5a65d1d64d5ddf4dff9c12326c4c8
- Updated integration links and text because we only have one integration guide at this time: https://github.com/timber/timber/commit/ad5b59f370bdce5b82c42f9798f097744474a41f

## Impact
With the removal of the Gulp translation guide we lose one method of translation.
