### PR TITLE
Update property and method docblocks in Theme.php.

### DIFF
--- a/src/Theme.php
+++ b/src/Theme.php
@@ -66,13 +66,13 @@ class Theme extends Core implements JsonSerializable
 
     /**
      * @api
-     * @var string the slug of the theme (ex: `my-super-theme`)
+     * @var string the slug of the theme (ex: `my-timber-theme`)
      */
     public $slug;
 
     /**
      * @api
-     * @var string
+     * @var string Retrieves template directory URI for the active (parent) theme. (ex: `http://example.org/wp-content/themes/my-timber-theme`).
      */
     public $uri;
 
@@ -91,7 +91,7 @@ class Theme extends Core implements JsonSerializable
      * @example
      * ```php
      * <?php
-     *     $theme = new Timber\Theme("my-theme");
+     *     $theme = new Timber\Theme("my-timber-theme");
      *     $context['theme_stuff'] = $theme;
      *     Timber::render('single.twig', $context);
      * ```
@@ -110,10 +110,10 @@ class Theme extends Core implements JsonSerializable
     }
 
     /**
-     * Initalizes the Theme object
+     * Initializes the Theme object
      *
      * @internal
-     * @param string $slug of theme (eg 'twentysixteen').
+     * @param string $slug of theme (eg 'my-timber-theme').
      */
     protected function init($slug = null)
     {
@@ -134,7 +134,7 @@ class Theme extends Core implements JsonSerializable
 
     /**
      * @api
-     * @return string the absolute path to the theme (ex: `http://example.org/wp-content/themes/my-timber-theme`)
+     * @return string Retrieves template directory URI for the active (child) theme. (ex: `http://example.org/wp-content/themes/my-timber-theme`).
      */
     public function link()
     {
@@ -143,7 +143,7 @@ class Theme extends Core implements JsonSerializable
 
     /**
      * @api
-     * @return  string the relative path to the theme (ex: `/wp-content/themes/my-timber-theme`)
+     * @return string The relative path to the theme (ex: `/wp-content/themes/my-timber-theme`).
      */
     public function path()
     {


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #1313

## Issue
When looking through the old issues, I found this issue which I ran into a long time ago as well. So I tried to clear up the docblocks.


## Solution
The changes on rule 75 and 137 are leading in this PR. The now reflect more what to expect of the property/method.

Other changes while at it:
- The changes to rule 69, 94, 116 are to give a consistent example of theme slugs. 
- 113 fixes a typo.
- 146 removes a double space and adds a capital letter.


## Impact
Hopefully a better overall understanding of the Theme class.
