### PR TITLE
Add @api tag to Helper

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -9,6 +9,7 @@ use Timber\Factory\PostFactory;
  *
  * As the name suggests these are helpers for Timber (and you!) when developing. You can find additional
  * (mainly internally-focused helpers) in Timber\URLHelper.
+ * @api
  */
 class Helper
 {


### PR DESCRIPTION
- https://github.com/timber/timber/issues/2745

## Issue
Helper.php class is not in the current V2 docs. This seems to be caused by the missing @api tag. This also causes one of the missing links in #2745 


## Solution
Add the @api tag and deploy the new docs.

## Impact
More docs!