### PR TITLE
2.x Remove unused param from `Timber\Term::build()`

### DIFF
--- a/src/Term.php
+++ b/src/Term.php
@@ -83,7 +83,7 @@ class Term extends CoreEntity
      * @param \WP_Term the vanilla WP term object to build from
      * @return \Timber\Term
      */
-    public static function build(WP_Term $wp_term, array $_options = []): self
+    public static function build(WP_Term $wp_term): self
     {
         $term = new static();
         $term->init($wp_term);


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/pull/2668#pullrequestreview-1435474737

## Issue

There is an unused property in `Timber\Term::build()`. The `$_options` parameter was introduced in https://github.com/timber/timber/commit/21445a1f5b50606fb3f8789c981f698a0437b2b9, where it was still needed. At that time, `Timber\Menu` still extended `Timber\Term`. So `Timber\Term::build()` had to use that optional parameter to be compatible.

Now, `Timber\Term` only extends `Timber\CoreEntity`. 

## Solution

We can safely remove that unused parameter.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

None needed.