### PR TITLE
2.x Fix a bug when `the_post` hook runs twice on each post in a loop

### DIFF
--- a/src/PostsIterator.php
+++ b/src/PostsIterator.php
@@ -10,6 +10,12 @@ use Timber\Factory\PostFactory;
 class PostsIterator extends \ArrayIterator
 {
     /**
+     * @var \Timber\Post The last post that was returned by the iterator. Used
+     *                   to skip the logic in `current()`.
+     */
+    protected Post $last_post;
+
+    /**
      * Prepares the state before working on a post.
      *
      * Calls the `setup()` function of the current post to setup post data. Before starting the
@@ -25,19 +31,23 @@ class PostsIterator extends \ArrayIterator
 
         // Fire action when the loop has just started.
         if (0 === $this->key()) {
+            /**
+             * The `loop_start` action is not the only thing we do to improve compatibility with
+             * WordPress. There’s more going on in the Timber\Post::setup() function. The
+             * compatibility improvements live there, because they also need to work for singular
+             * templates, where there’s no loop.
+             */
             do_action_ref_array('loop_start', [&$GLOBALS['wp_query']]);
         }
 
-        /**
-         * The `loop_start` action is not the only thing we do to improve compatibility. There’s
-         * more going on in the Timber\Post::setup() function. The compabitibility improvements live
-         * there, because they also need to work for singular templates, where there’s no loop.
-         */
         $wp_post = parent::current();
+
         // Lazily instantiate a Timber\Post instance exactly once.
         // @todo maybe improve performance by caching the instantiated post.
         $post = $factory->from($wp_post);
         $post->setup();
+
+        $this->last_post = $post;
 
         return $post;
     }
@@ -53,15 +63,20 @@ class PostsIterator extends \ArrayIterator
     public function next(): void
     {
         /**
-         * The `loop_end` action is not the only thing we do to improve compatibility. There’s
-         * more going on in the Timber\Post::teardown() function. The compabitibility improvements
-         * live there, because they also need to work for singular templates, where there’s no loop.
+         * Load from $last_post instead of $this->current(), because $this->current() would call
+         * $post->setup() again.
          */
-        $post = $this->current();
+        $post = $this->last_post;
         $post->teardown();
 
         // Fire action when the loop has ended.
         if ($this->key() === $this->count() - 1) {
+            /**
+             * The `loop_end` action is not the only thing we do to improve compatibility with
+             * WordPress. There’s more going on in the Timber\Post::teardown() function. The
+             * compatibility improvements live there, because they also need to work for singular
+             * templates, where there’s no loop.
+             */
             do_action_ref_array('loop_end', [&$GLOBALS['wp_query']]);
             wp_reset_postdata();
         }


### PR DESCRIPTION
Related:

- #2626

## Issue

While working through the todos, I found a skipped test. Upon running it, I realized that when we loop over a collection of posts, the `the_post` hook is actually called twice for each post.

This is because `PostsIterator::next()` calls `PostsIterator::current()`, which runs `Post::setup()` every time.

https://github.com/timber/timber/blob/f248f3c3e3e37a620b9af91ad0cd7602655aaa0c/src/PostsIterator.php#L60

https://github.com/timber/timber/blob/f248f3c3e3e37a620b9af91ad0cd7602655aaa0c/src/PostsIterator.php#L21-L43

https://github.com/timber/timber/blob/f248f3c3e3e37a620b9af91ad0cd7602655aaa0c/src/Post.php#L314

## Solution

I added a `$last_post` property to `PostsIterator`. It’s used to save the last post that was set up. Using `PostsIterator::current()` would lead to the same result, but because it always calls `Post::setup()`, it will call hooks that we don’t need to call.

## Impact

Less compatibility issues. More performance.

## Usage Changes

None.

## Considerations

I hope I didn’t miss a functionality that’s already baked into `ArrayIterator` that we could use for this.

## Testing

Yes.