### PR TITLE
2.x Fix a bug when `|time_ago` didn’t consider timezones correctly

### DIFF
--- a/docs/v2/guides/date-time.md
+++ b/docs/v2/guides/date-time.md
@@ -262,7 +262,7 @@ DateTimeHelper::time_ago($post->date());
 **Twig**
 
 ```twig
-{{ post.date|time_ago }}
+{{ post.date('U')|time_ago }}
 ```
 
 **HTML**

--- a/src/DateTimeHelper.php
+++ b/src/DateTimeHelper.php
@@ -54,11 +54,18 @@ class DateTimeHelper
      *
      * Differentiates between past and future dates.
      *
+     * @api
      * @see \human_time_diff()
+     * @example
+     * ```twig
+     * {{ post.date('U')|time_ago }}
+     * {{ post.date('Y-m-d H:i:s')|time_ago }}
+     * {{ post.date(constant('DATE_ATOM'))|time_ago }}
+     * ```
      *
      * @param int|string $from          Base date as a timestamp or a date string.
      * @param int|string $to            Optional. Date to calculate difference to as a timestamp or
-     *                                  a date string. Default to current time.
+     *                                  a date string. Default current time.
      * @param string     $format_past   Optional. String to use for past dates. To be used with
      *                                  `sprintf()`. Default `%s ago`.
      * @param string     $format_future Optional. String to use for future dates. To be used with
@@ -78,14 +85,18 @@ class DateTimeHelper
             $format_future = __('%s from now');
         }
 
-        $to = $to === null ? time() : $to;
-        $to = is_int($to) ? $to : strtotime($to);
-        $from = is_int($from) ? $from : strtotime($from);
+        $to = $to ?? time();
+        $to = is_numeric($to)
+            ? new \DateTimeImmutable('@' . $to, wp_timezone())
+            : new \DateTimeImmutable($to, wp_timezone());
+        $from = is_numeric($from)
+            ? new \DateTimeImmutable('@' . $from, wp_timezone())
+            : new \DateTimeImmutable($from, wp_timezone());
 
         if ($from < $to) {
-            return sprintf($format_past, human_time_diff($from, $to));
+            return sprintf($format_past, human_time_diff($from->getTimestamp(), $to->getTimestamp()));
         } else {
-            return sprintf($format_future, human_time_diff($to, $from));
+            return sprintf($format_future, human_time_diff($to->getTimestamp(), $from->getTimestamp()));
         }
     }
 }

--- a/src/Post.php
+++ b/src/Post.php
@@ -1307,6 +1307,9 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * [`get_the_date`](https://developer.wordpress.org/reference/hooks/get_the_date/) filter to the
      * output.
      *
+     * If you use {{ post.date }} with the |time_ago filter, then make sure that you use a time
+     * format including the full time and not just the date.
+     *
      * @api
      * @example
      * ```twig
@@ -1314,12 +1317,18 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * Published on {{ post.date }}
      * OR
      * Published on {{ post.date('F jS') }}
+     * which was
+     * {{ post.date('U')|time_ago }}
+     * {{ post.date('Y-m-d H:i:s')|time_ago }}
+     * {{ post.date(constant('DATE_ATOM'))|time_ago }}
      * ```
      *
      * ```html
      * Published on January 12, 2015
      * OR
      * Published on Jan 12th
+     * which was
+     * 8 years ago
      * ```
      *
      * @param string|null $date_format Optional. PHP date format. Will use the `date_format` option


### PR DESCRIPTION
Related:

- #2737

## Issue

The `|time_ago` filter doesn’t work correctly when timezone is set to Australia.

## Solution

- Don’t use `strtotime()`, but create DateTime objects with their corresponding timezone.
- Update some documentation entries for correct usage with `{{ post.date }}`. It’s important to use a time string including the time.

## Impact

The `|time_ago` filter should work more reliably.

## Usage Changes

None.

## Considerations

None.

## Testing

Yes.