### PR TITLE
2.x Fix tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,7 @@ jobs:
         if: matrix.php < '8.0'
         run: |
             composer require ergebnis/composer-normalize:2.28.3
-            composer require wp-cli/wp-cli:2.7.1
+            composer require wp-cli/wp-cli:dev-main
             composer run lint-composer:fix
 
       - name: Lint composer.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
         run: |
             composer require ergebnis/composer-normalize:2.28.3
             composer require wp-cli/wp-cli:2.7.1
+            composer run lint-composer:fix
 
       - name: Lint composer.json
         run: composer run lint-composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,12 @@ jobs:
             composer update yoast/wp-test-utils -W --dev
             composer update composer/installers -W
 
+      - name: Fix WP CLI for PHP < 8.0
+        if: matrix.php < '8.0'
+        run: |
+            composer require ergebnis/composer-normalize:2.28.3
+            composer require wp-cli/wp-cli:2.7.1
+
       - name: Lint composer.json
         run: composer run lint-composer
 


### PR DESCRIPTION
## Issue

Tests seem to be broken after upgrade to WP CLI 2.8.

## Solution

Use WP CLI 2.7 as advised in https://github.com/timber/timber/pull/2760#issuecomment-1573959903.

## Impact

Fixed tests.

## Usage Changes

None.

## Considerations

None.

## Testing

Yes.