### PR TITLE
2.x Fix implicit conversion from float to int

### DIFF
--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -121,13 +121,13 @@ class ImageDimensions
         if (file_exists($this->file_loc) && filesize($this->file_loc)) {
             if (ImageHelper::is_svg($this->file_loc)) {
                 $svg_size = $this->get_dimensions_svg($this->file_loc);
-                $this->dimensions = [$svg_size->width, $svg_size->height];
+                $this->dimensions = [(int) $svg_size->width, (int) $svg_size->height];
             } else {
                 list($width, $height) = getimagesize($this->file_loc);
 
                 $this->dimensions = [];
-                $this->dimensions[0] = $width;
-                $this->dimensions[1] = $height;
+                $this->dimensions[0] = (int) $width;
+                $this->dimensions[1] = (int) $height;
             }
 
             return $this->get_dimension_loaded($dimension);


### PR DESCRIPTION
Related:

- #2772

## Issue

We require dimensions to be int, but SVG might have float dimensions.

## Solution

Convert to int.

## Impact

No deprecation notice.

## Usage Changes

None.

## Considerations

Should we round the values before typecasting them to `int` using `round()`?

I think we also have to consider whether it might be important to get SVG dimensions as floats. For using the dimensions as `width` and `height` attributes in HTML, it has to be an integer value.

But maybe there’s a use case where you’ll want to access SVG dimensions as floats. In that case, we might somehow have to give access to `ImageDimensions::get_dimensions_svg()`, which is protected at the moment:

https://github.com/timber/timber/blob/a23d78178a3b043b888930186b7b384501d21855/src/ImageDimensions.php#L164

## Testing

No.