### PR TITLE
2.x Fix MariaDB in automatic tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:latest
+        image: mariadb:10
         env:
           MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       mysql:
         image: mariadb:latest
         env:
+          MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_ROOT_PASSWORD: ''
           MYSQL_DATABASE: wordpress_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:10
+        image: mariadb:latest
         env:
           MYSQL_USER: root
           MYSQL_ALLOW_EMPTY_PASSWORD: true
@@ -31,7 +31,7 @@ jobs:
           MYSQL_DATABASE: wordpress_test
         ports:
           - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
 
     continue-on-error: ${{ matrix.experimental }}
     strategy:


### PR DESCRIPTION
## Issue

Tests don’t run after automatic update to MariaDB v11.

## Solution

As a first measure: downgrade to MariaDB v10.

Then, we can start to find out what went wrong. I read the Upgrade Guide for the 11 release (https://mariadb.com/kb/en/upgrading-from-mariadb-10-11-to-mariadb-11-0/), but I don’t know MariaDB or MySQL well enough to see what we would need to change.

@nlemoine Do you know what to do here?

## Impact

Fixes automatic tests.

## Usage Changes

None.

## Considerations

None.