### PR TITLE
Prevent unneeded blog switching in multisite env.

### DIFF
--- a/src/Site.php
+++ b/src/Site.php
@@ -188,17 +188,31 @@ class Site extends Core implements CoreInterface
     /**
      * Switches to the blog requested in the request
      *
-     * @param string|integer|null $site_name_or_id
+     * @param string|integer|null $blog_identifier The name or ID of the blog to switch to. If `null`, the current blog.
      * @return integer with the ID of the new blog
      */
-    protected static function switch_to_blog($site_name_or_id)
+    protected static function switch_to_blog($blog_identifier)
     {
-        if ($site_name_or_id === null) {
-            $site_name_or_id = \get_current_blog_id();
+        $current_id = \gget_current_blog_id();
+
+        if ($blog_identifier === null) {
+            $blog_identifier = $current_id;
         }
-        $info = \get_blog_details($site_name_or_id);
-        \switch_to_blog($info->blog_id);
-        return $info->blog_id;
+
+        $info = \gget_blog_details($blog_identifier);
+
+        if (false === $info) {
+            Helper::error_log('Timber\Site::switch_to_blog() could not find a blog with the identifier "' . $blog_identifier . '"');
+            return $current_id;
+        }
+
+        $blog_identifier = $info->blog_id;
+
+        if ($current_id !== $blog_identifier) {
+            \gswitch_to_blog($blog_identifier);
+        }
+
+        return $blog_identifier;
     }
 
     /**

--- a/src/Site.php
+++ b/src/Site.php
@@ -193,13 +193,13 @@ class Site extends Core implements CoreInterface
      */
     protected static function switch_to_blog($blog_identifier)
     {
-        $current_id = \gget_current_blog_id();
+        $current_id = \get_current_blog_id();
 
         if ($blog_identifier === null) {
             $blog_identifier = $current_id;
         }
 
-        $info = \gget_blog_details($blog_identifier);
+        $info = \get_blog_details($blog_identifier);
 
         if (false === $info) {
             Helper::error_log('Timber\Site::switch_to_blog() could not find a blog with the identifier "' . $blog_identifier . '"');
@@ -209,7 +209,7 @@ class Site extends Core implements CoreInterface
         $blog_identifier = $info->blog_id;
 
         if ($current_id !== $blog_identifier) {
-            \gswitch_to_blog($blog_identifier);
+            \switch_to_blog($blog_identifier);
         }
 
         return $blog_identifier;

--- a/src/Site.php
+++ b/src/Site.php
@@ -199,7 +199,7 @@ class Site extends Core implements CoreInterface
             $blog_identifier = $current_id;
         }
 
-        $info = \get_blog_details($blog_identifier);
+        $info = \get_blog_details($blog_identifier, false);
 
         if (false === $info) {
             return $current_id;

--- a/src/Site.php
+++ b/src/Site.php
@@ -207,7 +207,7 @@ class Site extends Core implements CoreInterface
 
         $blog_identifier = $info->blog_id;
 
-        if ($current_id !== (int) $blog_identifier) {
+        if ((int) $current_id !== (int) $blog_identifier) {
             \switch_to_blog($blog_identifier);
         }
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -202,7 +202,6 @@ class Site extends Core implements CoreInterface
         $info = \get_blog_details($blog_identifier);
 
         if (false === $info) {
-            Helper::error_log('Timber\Site::switch_to_blog() could not find a blog with the identifier "' . $blog_identifier . '"');
             return $current_id;
         }
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -205,7 +205,7 @@ class Site extends Core implements CoreInterface
             return $current_id;
         }
 
-        (int) $blog_identifier = $info->blog_id;
+        $blog_identifier = $info->blog_id;
 
         if ($current_id !== (int) $blog_identifier) {
             \switch_to_blog($blog_identifier);

--- a/src/Site.php
+++ b/src/Site.php
@@ -191,7 +191,7 @@ class Site extends Core implements CoreInterface
      * @param string|integer|null $blog_identifier The name or ID of the blog to switch to. If `null`, the current blog.
      * @return integer with the ID of the new blog
      */
-    protected static function switch_to_blog($blog_identifier)
+    protected static function switch_to_blog($blog_identifier = null): int
     {
         $current_id = \get_current_blog_id();
 
@@ -205,13 +205,13 @@ class Site extends Core implements CoreInterface
             return $current_id;
         }
 
-        $blog_identifier = $info->blog_id;
+        (int) $blog_identifier = $info->blog_id;
 
-        if ($current_id !== $blog_identifier) {
+        if ($current_id !== (int) $blog_identifier) {
             \switch_to_blog($blog_identifier);
         }
 
-        return $blog_identifier;
+        return (int) $blog_identifier;
     }
 
     /**

--- a/tests/test-timber-multisite.php
+++ b/tests/test-timber-multisite.php
@@ -53,6 +53,7 @@ class TestTimberMultisite extends Timber_UnitTestCase
             $this->factory->post->create([
                 'post_title' => array_pop($post_titles),
             ]);
+            restore_current_blog();
         }
 
         $timber_posts = [];
@@ -108,6 +109,7 @@ class TestTimberMultisite extends Timber_UnitTestCase
             $this->factory->post->create([
                 'post_title' => 'Zebras are good on site ID = ' . $site_id,
             ]);
+            restore_current_blog();
         }
         $this->go_to('/');
         $timber_posts = [];
@@ -144,8 +146,11 @@ class TestTimberMultisite extends Timber_UnitTestCase
             return;
         }
         $site_ids[] = self::createSubDomainSite('foo.example.org', 'My Foo');
+        restore_current_blog();
         $site_ids[] = self::createSubDomainSite('quack.example.org', "Ducks R Us");
+        restore_current_blog();
         $site_ids[] = self::createSubDomainSite('duck.example.org', "More Ducks R Us");
+        restore_current_blog();
 
         $post_titles = ["I don't like zebras", "Zebra and a half", "Have a zebra of a time"];
         $others = $this->factory->post->create_many(8);
@@ -154,6 +159,7 @@ class TestTimberMultisite extends Timber_UnitTestCase
             $this->factory->post->create([
                 'post_title' => array_pop($post_titles),
             ]);
+            restore_current_blog();
         }
 
         $timber_posts = [];


### PR DESCRIPTION
To get some further experience with PRs I wanted to tackle an older issue.

Related:

- #1180

## Issue
switch_to_blog() was used when not needed in multisite environments, resulting in unneeded globals being set.

## Solution
Only use switch_to_blog() when the ID is different from the current id blog id. While at it, I changed some internal variables to reflect the new internal working and updated the docblock as well. I also added a fallback when get_blog_details() returns null instead of a site object.


## Impact
Less globals set in the form of $GLOBALS['_wp_switched_stack'] and $GLOBALS['switched']

## Testing
Current tests are covering it.
