### PR TITLE
fix: Allow overwrite of default avatar in comments.

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -252,6 +252,10 @@ class Comment extends CoreEntity
             return $args['url'];
         }
 
+        if (isset($args['default'])) {
+            $default = $args['default'];
+        }
+
         $email_hash = '';
         if (!empty($email)) {
             $email_hash = \md5(\strtolower(\trim($email)));
@@ -609,11 +613,23 @@ class Comment extends CoreEntity
      */
     protected function avatar_out($default, $host, $email_hash, $size)
     {
-        $out = $host . '/avatar/' . $email_hash . '?s=' . $size . '&amp;d=' . \urlencode($default);
+        $out = $host . '/avatar/' . $email_hash;
         $rating = \get_option('avatar_rating');
+
+        $url_args = [
+            's' => $size,
+            'd' => $default,
+        ];
+
         if (!empty($rating)) {
-            $out .= '&amp;r=' . $rating;
+            $url_args['r'] = $rating;
         }
+
+        $out = \add_query_arg(
+            \rawurlencode_deep(\array_filter($url_args)),
+            $out
+        );
+
         return \str_replace('&#038;', '&amp;', \esc_url($out));
     }
 }


### PR DESCRIPTION


Related:

- #2468

## Issue
Default avatar overrides could not be overwritten by the pre_get_avatar_data filter. 


## Solution
Set `default ` arg as well, while at it, add arguments more the WordPress way in `avatar_out`


## Impact
None, this only affects sites that override the default avatar.


## Usage Changes
none

## Considerations
The new default url is fed into Gravatar and then returned. Ideally you would like to check if an avatar returned by gravatar is a default one and if so, overwriting the resulting url with the default url, thus not resulting in a url like:

http://0.gravatar.com/avatar/a5f7937f4bc10cfe01abb42fe5504da9?s=92&d=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fthumb%2F1%2F15%2FCat_August_2010-4.jpg%2F1920px-Cat_August_2010-4.jpg&r=X

where the d arguments holds the overwritten default. This would lead to less dependance on Gravatar as a whole but I did not found a good way to do that.

## Testing
no
