### PR TITLE
2.x Add note about installing the release candidate

### DIFF
--- a/docs/v2/installation/installation.md
+++ b/docs/v2/installation/installation.md
@@ -15,6 +15,12 @@ To install Timber, you can use the following command:
 composer require timber/timber
 ```
 
+While Timber version 2 is still released as a release candidate, you should use the following command:
+
+```bash
+composer require timber/timber:2.0.0-rc.1
+```
+
 Now in which folder do you run that command?
 
 You can choose yourself where in your project you want to include Timber.


### PR DESCRIPTION
Related:

- #2741

## Issue

When we mention how to [install Timber in the documentation](https://timber.github.io/docs/v2/installation/#install-timber-into-an-existing-project), it might not be clear how to install the release candidate.

## Solution

Add a section about the release candidate that we can later remove again.

## Impact

Less confusion.

## Usage Changes

None.

## Considerations

None.

## Testing

No.