### PR TITLE
V2 site overwrite magic __call method

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -34,7 +34,7 @@ abstract class Core
     }
 
     /**
-     * Magic method dispatcher for meta fields, for convience in Twig views.
+     * Magic method dispatcher for meta fields, for convenience in Twig views.
      *
      * Called when explicitly invoking non-existent methods on a Core object. This method is not
      * meant to be called directly.

--- a/src/Site.php
+++ b/src/Site.php
@@ -174,6 +174,39 @@ class Site extends Core implements CoreInterface
     }
 
     /**
+     * Magic method dispatcher for site option fields, for convenience in Twig views.
+     *
+     * Called when explicitly invoking non-existent methods on the Site object. This method is not
+     * meant to be called directly.
+     *
+     * @example
+     * The following example will dynamically dispatch the magic __call() method with an argument
+     * of "users_can_register" #}
+     *
+     * ```twig
+     * {% if site.users_can_register %}
+     *   {# Show a notification and link to the register form #}
+     * {% endif %}
+     * @link https://secure.php.net/manual/en/language.oop5.overloading.php#object.call
+     * @link https://github.com/twigphp/Twig/issues/2
+     * @api
+     *
+     * @param string $option     The name of the method being called.
+     * @param array  $arguments Enumerated array containing the parameters passed to the function.
+     *                          Not used.
+     *
+     * @return mixed The value of the option field named `$field` if truthy, `false` otherwise.
+     */
+    public function __call($option, $arguments)
+    {
+        if (\method_exists($this, 'option') && $meta_value = $this->option($option)) {
+            return $meta_value;
+        }
+
+        return false;
+    }
+
+    /**
      * Gets the underlying WordPress Core object.
      *
      * @since 2.0.0

--- a/src/Site.php
+++ b/src/Site.php
@@ -199,11 +199,7 @@ class Site extends Core implements CoreInterface
      */
     public function __call($option, $arguments)
     {
-        if (\method_exists($this, 'option') && $meta_value = $this->option($option)) {
-            return $meta_value;
-        }
-
-        return false;
+        return $this->option($option);
     }
 
     /**

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -91,6 +91,18 @@ class TestTimberSite extends Timber_UnitTestCase
         $this->assertEquals('bar', $site->foo);
     }
 
+    public function testSiteCall()
+    {
+        update_option('foo', 'barr');
+        $site = new Timber\Site();
+
+        $twig_string = '{{site.foo}}';
+        $result = Timber\Timber::compile_string($twig_string, [
+            'site' => $site,
+        ]);
+        $this->assertEquals('barr', $result);
+    }
+
     /**
      * @expectedDeprecated {{ site.meta() }}
      */


### PR DESCRIPTION
Related:

- [Overwrite __call method](https://github.com/timber/timber/issues/2741#issuecomment-1713435871_)
- https://github.com/timber/timber/pull/1700

## Issue
When calling a site option that does not have it's own method, like `site.home`. Timber would use the magic `__call` method from the Core class. This magic method by defaults calls the `meta()` method. Since the `meta()` method was deprecated in the site class (https://github.com/timber/timber/pull/1700) the magic `__call `method throws a deprecation notice.


## Solution
Overwrite the __call method in Site.php and call the appropriate `option()` method instead.


## Impact
Less questions on why deprecation notices are thrown.


## Usage Changes
None.


## Considerations
Sometimes it's hard to wrap your head around what are actual instantiated data in Timber and what is called via these magic methods. I always thought that `{{ site.home }}` was a valid method, but when digging deeper I found out that you should call` {{ site.link }}`

I would be in favor of deprecating these magic methods in the future as well so people (including myself) will learn the difference.

## Testing
No, should it be tested?
