### PR TITLE
Typo: Changing functions section references $filters instead of $functions

### DIFF
--- a/docs/v2/guides/extending-twig.md
+++ b/docs/v2/guides/extending-twig.md
@@ -69,9 +69,9 @@ add_filter('timber/twig/filters', function ($functions) {
     ];
 
     // Remove a function.
-    unset($filters['get_image']);
+    unset($functions['get_image']);
 
-    return $filters;
+    return $functions;
 });
 ```
 


### PR DESCRIPTION
## Issue
Typo in the [Changing functions](https://timber.github.io/docs/v2/guides/extending-twig/#changing-functions) section of Extending Twig docs. References `$filters` instead of `$functions`