### PR TITLE
Add documentation and plugin notice about the end of the plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,10 @@ By
 [![WordPress Rating](https://img.shields.io/wordpress/plugin/r/timber-library.svg?style=flat-square)](https://wordpress.org/support/plugin/timber-library/reviews/)
 [![!Financial Contributors](https://opencollective.com/timber/tiers/badge.svg)](https://opencollective.com/timber/)
 
-> ⚠️ **Important information about the Timber plugin**
-> With the upcoming release of Timber 2.0, we will stop releasing Timber as a plugin. We advise everyone to **[switch to the Composer based install of Timber 1 as a first step](https://timber.github.io/docs/getting-started/switch-to-composer/)** as soon as possible. If you need PHP 8.2 support you will have to switch to Timber 2.0.
+### ⚠️ Important information about the Timber plugin ⚠️ 
+> With the release of Timber 2.0, Composer is the only supported install method. We are unable to continue releasing or supporting Timber as a plugin on WordPress.org. We advise everyone to **[switch to the Composer based install of Timber 1 as a first step](https://timber.github.io/docs/getting-started/switch-to-composer/)** as soon as possible. If you need PHP 8.2 support you will have to switch to Timber 2.0.
 
-
-Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
-* Announcement: [Dropping support for the plugin version of Timber](https://github.com/timber/timber/discussions/2804)
-* Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
-* Backstory: [Why we are dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
-* Github issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)
+For more information and a list of additional resources, please visit this [discussion](https://github.com/timber/timber/discussions/2804).
 
 ### Because WordPress is awesome, but the_loop isn't
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](https://twig.symfony.com/) separate from your PHP files.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By
 
 
 Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
-
+* Announcement: [Dropping support for the plugin version of Timber](https://github.com/timber/timber/discussions/2804)
 * Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
 * Backstory: [Why we are dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
 * Github issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ By
 [![WordPress Rating](https://img.shields.io/wordpress/plugin/r/timber-library.svg?style=flat-square)](https://wordpress.org/support/plugin/timber-library/reviews/)
 [![!Financial Contributors](https://opencollective.com/timber/tiers/badge.svg)](https://opencollective.com/timber/)
 
+> ⚠️ **Important information about the Timber plugin**
+> With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advice everyone to switch to the composer based install as soon as possible.
+
+Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
+
+* Guide: [How do I switch over from the plugin version to the composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
+* Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
+* Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
+
 ### Because WordPress is awesome, but the_loop isn't
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](https://twig.symfony.com/) separate from your PHP files.
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ By
 [![!Financial Contributors](https://opencollective.com/timber/tiers/badge.svg)](https://opencollective.com/timber/)
 
 > ⚠️ **Important information about the Timber plugin**
-> With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advice everyone to switch to the composer based install as soon as possible.
+> With the upcoming release of Timber 2.0, we will stop releasing Timber as a plugin. We advise everyone to **[switch to the Composer based install of Timber 1 as a first step](https://timber.github.io/docs/getting-started/switch-to-composer/)** as soon as possible. If you need PHP 8.2 support you will have to switch to Timber 2.0.
+
 
 Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
 
-* Guide: [How do I switch over from the plugin version to the composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
-* Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
-* Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
+* Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
+* Backstory: [Why we are dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
+* Github issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)
 
 ### Because WordPress is awesome, but the_loop isn't
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](https://twig.symfony.com/) separate from your PHP files.

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -7,12 +7,20 @@ menu:
 ---
 
 ## Installation
+> ⚠️ **Important information**
+> With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advice everyone to switch to the composer based install as soon as possible.
 
-### Via WordPress.org (easy)
+Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
+
+* Guide: [How do I switch over from the plugin version to the composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
+* Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
+* Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
+
+### ~~Via WordPress.org (easy)~~
 
 You can grab the all-things-included plugin at [WordPress.org](http://wordpress.org/plugins/timber-library/) either through the WordPress site or through the Plugins menu in the backend. Then skip ahead to [using the starter theme](#use-the-starter-theme).
 
-### Via GitHub (for developers)
+### Via Composer (recommended)
 
 The GitHub version of Timber requires [Composer](https://getcomposer.org/download/). If you'd prefer one-click installation, you should use the [WordPress.org](https://wordpress.org/plugins/timber-library/) version.
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -8,7 +8,7 @@ menu:
 
 ## Installation
 > ⚠️ **Important information about the Timber plugin**
-> With the upcoming release of Timber 2.0, we will stop releasing Timber as a plugin. We advise everyone to **[switch to the Composer based install of Timber 1 as a first step](https://timber.github.io/docs/getting-started/switch-to-composer/)** as soon as possible. If you need PHP 8.2 support you will have to switch to Timber 2.0.
+> With the release of Timber 2.0, Composer is the only supported install method. We are unable to continue releasing or supporting Timber as a plugin on WordPress.org. We advise everyone to **[switch to the Composer based install of Timber 1 as a first step](https://timber.github.io/docs/getting-started/switch-to-composer/)** as soon as possible. If you need PHP 8.2 support you will have to switch to Timber 2.0.
 
 Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -7,8 +7,8 @@ menu:
 ---
 
 ## Installation
-> ⚠️ **Important information**
-> With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advice everyone to switch to the composer based install as soon as possible.
+> ⚠️ **Important information about the Timber plugin**
+> With the upcoming release of Timber 2.0, we will stop releasing Timber as a plugin. We advise everyone to **[switch to the Composer based install of Timber 1 as a first step](https://timber.github.io/docs/getting-started/switch-to-composer/)** as soon as possible. If you need PHP 8.2 support you will have to switch to Timber 2.0.
 
 Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
 
@@ -18,11 +18,11 @@ Underneath this text you will find an extensive list with guides and the reasons
 
 ### ~~Via WordPress.org (easy)~~
 
-You can grab the all-things-included plugin at [WordPress.org](http://wordpress.org/plugins/timber-library/) either through the WordPress site or through the Plugins menu in the backend. Then skip ahead to [using the starter theme](#use-the-starter-theme).
+~~You can grab the all-things-included plugin at [WordPress.org](http://wordpress.org/plugins/timber-library/) either through the WordPress site or through the Plugins menu in the backend. Then skip ahead to [using the starter theme](#use-the-starter-theme).~~
 
 ### Via Composer (recommended)
 
-The GitHub version of Timber requires [Composer](https://getcomposer.org/download/). If you'd prefer one-click installation, you should use the [WordPress.org](https://wordpress.org/plugins/timber-library/) version.
+The GitHub version of Timber requires [Composer](https://getcomposer.org/download/).
 
 Run the following Composer command from within your theme's root directory:
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -13,7 +13,7 @@ menu:
 Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
 
 * Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
-* Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
+* Backstory: [Why we are dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
 * Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
 
 ### ~~Via WordPress.org (easy)~~

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -12,7 +12,7 @@ menu:
 
 Underneath this text you will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
 
-* Guide: [How do I switch over from the plugin version to the composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
+* Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
 * Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
 * Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
 

--- a/docs/getting-started/switch-to-composer.md
+++ b/docs/getting-started/switch-to-composer.md
@@ -12,13 +12,14 @@ With the upcoming release of Timber 2, we will stop releasing Timber as a plugin
 
 1. Get a local development version of your website up and running.
 2. Check if you are running the latest version of the Timber plugin. If not, update it and check if your website still runs as expected.
-
+3. Disable the Timber plugin
 4. Install the latest 1.x version of Timber via Composer
 5. Load the Composer autoloader and initialize Timber
-5. Load the composer autoloader and initialize Timber 
 6. Check if your website still runs as expected
 7. Deploy your changes to your live website
 
+
+### 1. Get a local development version of your website up and running
 We highly recommend doing these steps on a local development version of your website. If you don’t have one yet, you could use [Local by Flywheel](https://localbyflywheel.com/) to get one up and running in a few minutes.
 
 #### 1.1 How to install Composer
@@ -30,6 +31,8 @@ We want to make sure that you are running the latest version of the Timber plugi
 
 ### 3. Disable the Timber plugin
 Once you are sure that you are running the latest version of the Timber plugin, you can disable it. This will make sure that the plugin is not loaded anymore and does not interfere with the Composer based version of Timber.
+
+Please note that you website will throw erros at this point, as there is no Timber available. This will be fixed in the next two steps.
 
 ### 4. Install the latest 1.x version of Timber via Composer
 Now that the plugin is disabled, you can install the latest 1.x version of Timber via Composer. You can do this by navigating to your site's active theme folder inside your terminal and then running the following command:
@@ -50,15 +53,10 @@ it is safe to answer `y` to this question and press enter.
 Now that we have Timber installed via Composer, we need to load the Composer autoloader and initialize Timber. You can do this by adding the following code at the top of your **functions.php** file:
 
 ```php
-/**
- * If you are installing Timber as a Composer dependency in your theme, you'll need this block
- * to load your dependencies and initialize Timber.
- */
-$composer_autoload = __DIR__ . '/vendor/autoload.php';
-if ( file_exists( $composer_autoload ) ) {
-	require_once $composer_autoload;
-	$timber = new Timber\Timber();
-}
+// Load Composer dependencies.
+require_once __DIR__ . '/vendor/autoload.php';
+
+$timber = new Timber\Timber();
 ```
 
 ### 6. Check if your website still runs as expected

--- a/docs/getting-started/switch-to-composer.md
+++ b/docs/getting-started/switch-to-composer.md
@@ -6,7 +6,7 @@ menu:
     parent: "getting-started"
 ---
 
-With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advise everyone to switch to the Composer based install of Timber 1 as soon as possible as a first step towards upgrading to Timber 2.
+With the release of Timber 2.0, Composer is the only supported install method. We are unable to continue releasing or supporting Timber as a plugin on WordPress.org. We advise everyone to switch to the Composer based install of Timber 1 as soon as possible as a first step towards upgrading to Timber 2.
 
 ## Recommended upgrade path
 

--- a/docs/getting-started/switch-to-composer.md
+++ b/docs/getting-started/switch-to-composer.md
@@ -1,0 +1,65 @@
+---
+title: "Switch to Composer"
+description: "How to switch your plugin based Timber theme over to the composer based version."
+menu:
+  main:
+    parent: "getting-started"
+---
+
+With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advice everyone to switch to the composer based install as soon as possible.
+
+## Recommended upgrade path
+
+1. Get a local development version of your website up and running.
+2. Check if you are running the latest version of the Timber plugin, if not, update it and check if your website still runs as expected
+3. Disable the Timber plugin
+4. Install the latest 1.x version of Timber via composer
+5. Load the composer autoloader and initialize Timber 
+6. Check if your website still runs as expected
+7. Deploy your changes to your live website
+
+### 1. Get a local development version of your website up and running
+We highly recommend doing these steps on a local development version of your website. If you don't have one yet, you can use [Local by Flywheel](https://localbyflywheel.com/) to get one up and running in a few minutes.
+
+#### 1.1 How to install Composer
+If you don't have Composer installed yet, you can follow the [official installation guide](https://getcomposer.org/doc/00-intro.md).
+
+
+### 2. Check if you are running the latest version of the Timber plugin
+We want to make sure that you are running the latest version of the Timber plugin before we start the upgrade process. This way we can be sure that any issues that might occur are not caused by an outdated version of the plugin.
+
+### 3. Disable the Timber plugin
+Once you are sure that you are running the latest version of the Timber plugin, you can disable it. This will make sure that the plugin is not loaded anymore and does not interfere with the composer based version of Timber.
+
+### 4. Install the latest 1.x version of Timber via composer
+Now that the plugin is disabled, you can install the latest 1.x version of Timber via composer. You can do this by navigating to your site's active theme folder inside your terminal and then running the following commands:
+
+```shell
+composer init
+```
+This will start the composer initialization process. You can just press enter on all the questions that are asked. This will create a `composer.json` file in your theme folder. After that we can require the latest 1.x version of Timber by running the following command:
+
+```shell
+composer require timber/timber:^1.0
+```
+
+### 5. Load the composer autoloader and initialize Timber
+Now that we have Timber installed via composer, we need to load the composer autoloader and initialize Timber. You can do this by adding the following code at the top of your `functions.php` file:
+
+```php
+/**
+ * If you are installing Timber as a Composer dependency in your theme, you'll need this block
+ * to load your dependencies and initialize Timber.
+ */
+$composer_autoload = __DIR__ . '/vendor/autoload.php';
+if ( file_exists( $composer_autoload ) ) {
+	require_once $composer_autoload;
+	$timber = new Timber\Timber();
+}
+```
+
+### 6. Check if your website still runs as expected
+Now that you have Timber installed via composer, you can check if your website still runs as expected. If you run into any issues, please try to solve them yourself by activating WordPress debugging and checking the error logs.
+
+### 7. Deploy your changes to your live website
+When you are 100% sure that you have succesfully upgraded your website to the composer based version of Timber, you can disable the Timber plugin, deploy your theme changes to your live website. If you are using a deployment pipeline, you can commit your changes and push them to your live website and make sure that the new `vendor` folder inside your theme gets deployed as well. If you are not using a version control system, you can use FTP to upload your changes to your theme. As a last step you can remove the Timber plugin from your website.

--- a/docs/getting-started/switch-to-composer.md
+++ b/docs/getting-started/switch-to-composer.md
@@ -1,6 +1,6 @@
 ---
 title: "Switch to Composer"
-description: "How to switch your plugin based Timber theme over to the composer based version."
+description: "How to switch your plugin based Timber theme over to the Composer based version."
 menu:
   main:
     parent: "getting-started"

--- a/docs/getting-started/switch-to-composer.md
+++ b/docs/getting-started/switch-to-composer.md
@@ -6,45 +6,48 @@ menu:
     parent: "getting-started"
 ---
 
-With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advice everyone to switch to the composer based install as soon as possible.
+With the upcoming release of Timber 2, we will stop releasing Timber as a plugin. We advise everyone to switch to the Composer based install of Timber 1 as soon as possible as a first step towards upgrading to Timber 2.
 
 ## Recommended upgrade path
 
 1. Get a local development version of your website up and running.
-2. Check if you are running the latest version of the Timber plugin, if not, update it and check if your website still runs as expected
-3. Disable the Timber plugin
-4. Install the latest 1.x version of Timber via composer
+2. Check if you are running the latest version of the Timber plugin. If not, update it and check if your website still runs as expected.
+
+4. Install the latest 1.x version of Timber via Composer
+5. Load the Composer autoloader and initialize Timber
 5. Load the composer autoloader and initialize Timber 
 6. Check if your website still runs as expected
 7. Deploy your changes to your live website
 
-### 1. Get a local development version of your website up and running
-We highly recommend doing these steps on a local development version of your website. If you don't have one yet, you can use [Local by Flywheel](https://localbyflywheel.com/) to get one up and running in a few minutes.
+We highly recommend doing these steps on a local development version of your website. If you don’t have one yet, you could use [Local by Flywheel](https://localbyflywheel.com/) to get one up and running in a few minutes.
 
 #### 1.1 How to install Composer
-If you don't have Composer installed yet, you can follow the [official installation guide](https://getcomposer.org/doc/00-intro.md).
+If you don’t have Composer installed yet, you can follow the [official installation guide](https://getcomposer.org/doc/00-intro.md).
 
 
 ### 2. Check if you are running the latest version of the Timber plugin
 We want to make sure that you are running the latest version of the Timber plugin before we start the upgrade process. This way we can be sure that any issues that might occur are not caused by an outdated version of the plugin.
 
 ### 3. Disable the Timber plugin
-Once you are sure that you are running the latest version of the Timber plugin, you can disable it. This will make sure that the plugin is not loaded anymore and does not interfere with the composer based version of Timber.
+Once you are sure that you are running the latest version of the Timber plugin, you can disable it. This will make sure that the plugin is not loaded anymore and does not interfere with the Composer based version of Timber.
 
-### 4. Install the latest 1.x version of Timber via composer
-Now that the plugin is disabled, you can install the latest 1.x version of Timber via composer. You can do this by navigating to your site's active theme folder inside your terminal and then running the following commands:
-
-```shell
-composer init
-```
-This will start the composer initialization process. You can just press enter on all the questions that are asked. This will create a `composer.json` file in your theme folder. After that we can require the latest 1.x version of Timber by running the following command:
+### 4. Install the latest 1.x version of Timber via Composer
+Now that the plugin is disabled, you can install the latest 1.x version of Timber via Composer. You can do this by navigating to your site's active theme folder inside your terminal and then running the following command:
 
 ```shell
 composer require timber/timber:^1.0
 ```
 
-### 5. Load the composer autoloader and initialize Timber
-Now that we have Timber installed via composer, we need to load the composer autoloader and initialize Timber. You can do this by adding the following code at the top of your `functions.php` file:
+If Composer gives you the following notice:
+
+```shell
+composer/installers contains a Composer plugin [...] (writes "allow-plugins" to composer.json)
+```
+it is safe to answer `y` to this question and press enter.
+
+
+### 5. Load the Composer autoloader and initialize Timber
+Now that we have Timber installed via Composer, we need to load the Composer autoloader and initialize Timber. You can do this by adding the following code at the top of your **functions.php** file:
 
 ```php
 /**
@@ -59,7 +62,15 @@ if ( file_exists( $composer_autoload ) ) {
 ```
 
 ### 6. Check if your website still runs as expected
-Now that you have Timber installed via composer, you can check if your website still runs as expected. If you run into any issues, please try to solve them yourself by activating WordPress debugging and checking the error logs.
+Now that you have Timber installed via Composer, you can check if your website still runs as expected. If you run into any issues, please try to solve them yourself by activating [WordPress debugging](https://wordpress.org/documentation/article/debugging-in-wordpress/) and checking the error logs.
 
 ### 7. Deploy your changes to your live website
-When you are 100% sure that you have succesfully upgraded your website to the composer based version of Timber, you can disable the Timber plugin, deploy your theme changes to your live website. If you are using a deployment pipeline, you can commit your changes and push them to your live website and make sure that the new `vendor` folder inside your theme gets deployed as well. If you are not using a version control system, you can use FTP to upload your changes to your theme. As a last step you can remove the Timber plugin from your website.
+When you are 100% sure that you have successfully upgraded your theme in the development website to the Composer based version of Timber, you can deploy your theme changes to your live website.
+
+Make sure that the new **vendor** folder inside your theme gets deployed as well. If you are using a deployment pipeline, you can commit your changes and push to your live website.
+
+If you are not using a version control system, you can use FTP or SCP to upload your changes to your theme.
+
+As a last step, you should disable and then remove the Timber v1 plugin from your live website.
+
+Congrats - you successfully moved to the Composer-based install and are prepared to later [upgrade to Timber v2](https://timber.github.io/docs/v2/upgrade-guides/2.0/).

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -6,11 +6,23 @@ class Admin {
 
 	public static function init() {
 		$filter = add_filter('plugin_row_meta', array(__CLASS__, 'meta_links'), 10, 2);
+		$action = add_action('after_plugin_row_timber-library/timber.php', array(__CLASS__, 'show_deprecation_warning'), 10, 3);
 		$action = add_action('in_plugin_update_message-timber-library/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
 		$action = add_action('in_plugin_update_message-timber/timber.php', array(__CLASS__, 'in_plugin_update_message'), 10, 2);
 		if ( $filter && $action ) {
 			return true;
 		}
+	}
+
+	/**
+	 * show additional information about the plugin deprecation.
+	 *
+	 * @param string  $file
+	 * @param array   $plugin
+	 */
+	public static function show_deprecation_warning($file, $plugin, $status)
+	{
+		echo '<td colspan="3" class="plugin-update colspanchange"><div class="update-message notice-error notice inline notice-warning notice-alt"><p>We recommend <a target="_blank" href="#">switching to the Composer based version of Timber</a>. <a href="#" target="_blank">Why you need to switch.</a></p></div></td>';
 	}
 
 	/**

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -22,7 +22,7 @@ class Admin {
 	 */
 	public static function show_deprecation_warning($file, $plugin, $status)
 	{
-		echo '<td colspan="3" class="plugin-update colspanchange"><div class="update-message notice-error notice inline notice-warning notice-alt"><p>We recommend <a target="_blank" href="#">switching to the Composer based version of Timber</a>. <a href="#" target="_blank">Why you need to switch.</a></p></div></td>';
+		echo '<td colspan="3" class="plugin-update colspanchange"><div class="update-message notice-error notice inline notice-warning notice-alt"><p>We recommend <a target="_blank" href="https://timber.github.io/docs/getting-started/switch-to-composer/">switching to the Composer based version</a> of Timber. <a href="#" target="_blank">Why you need to switch.</a></p></div></td>';
 	}
 
 	/**

--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -22,7 +22,7 @@ class Admin {
 	 */
 	public static function show_deprecation_warning($file, $plugin, $status)
 	{
-		echo '<td colspan="3" class="plugin-update colspanchange"><div class="update-message notice-error notice inline notice-warning notice-alt"><p>We recommend <a target="_blank" href="https://timber.github.io/docs/getting-started/switch-to-composer/">switching to the Composer based version</a> of Timber. <a href="#" target="_blank">Why you need to switch.</a></p></div></td>';
+		echo '<td colspan="3" class="plugin-update colspanchange"><div class="update-message notice-error notice inline notice-warning notice-alt"><p>We recommend <a target="_blank" href="https://timber.github.io/docs/getting-started/switch-to-composer/">switching to the Composer based version</a> of Timber. <a href="https://github.com/timber/timber/discussions/2804" target="_blank">Why you need to switch.</a></p></div></td>';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Helps you create themes faster with sustainable code. With Timber, you write HTM
 With the upcoming release of Timber 2.0, we will not release a 2.0 version and beyond as a plugin, but only as a Composer package. We advise everyone to switch to the Composer based install as soon as possible.
 You will find an extensive list with guides and the reasons why we are not going to release Timber 2.0 as a plugin anymore.
 
-### Switching to the composer based version
+### Switching to the Composer based version
 * Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
 * Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
 * GitHub issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)

--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,14 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Helps you create themes faster with sustainable code. With Timber, you write HTML using Twig Templates http://www.upstatement.com/timber/
 
 == Description ==
+With the upcoming release of Timber 2, we will not release a 2.0 version and beyond  in plugin form. We advice everyone to switch to the composer based install as soon as possible.
+You will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
+
+### Switching to the composer based version
+* Guide: [How do I switch over from the plugin version to the composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
+* Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
+* Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
+
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](http://twig.sensiolabs.org/) separate from your PHP files. This cleans up your theme code so, for example, your PHP file can focus on being the data/logic, while your Twig file can focus 100% on the HTML and display.
 
 Once Timber is installed and activated in your plugin directory, it gives any WordPress theme the ability to take advantage of the power of Twig and other Timber features.

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,7 @@ With the upcoming release of Timber 2.0, we will not release a 2.0 version and b
 You will find an extensive list with guides and the reasons why we are not going to release Timber 2.0 as a plugin anymore.
 
 ### Switching to the Composer based version
+* Announcement: [Dropping support for the plugin version of Timber](https://github.com/timber/timber/discussions/2804)
 * Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
 * Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
 * GitHub issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)

--- a/readme.txt
+++ b/readme.txt
@@ -11,13 +11,13 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Helps you create themes faster with sustainable code. With Timber, you write HTML using Twig Templates http://www.upstatement.com/timber/
 
 == Description ==
-With the upcoming release of Timber 2, we will not release a 2.0 version and beyond  in plugin form. We advice everyone to switch to the composer based install as soon as possible.
-You will find an extensive list with guides and the reasons why we are not going to release Timber 2 in plugin version anymore.
+With the upcoming release of Timber 2.0, we will not release a 2.0 version and beyond as a plugin, but only as a Composer package. We advise everyone to switch to the Composer based install as soon as possible.
+You will find an extensive list with guides and the reasons why we are not going to release Timber 2.0 as a plugin anymore.
 
 ### Switching to the composer based version
-* Guide: [How do I switch over from the plugin version to the composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
+* Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
 * Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
-* Github issue: [Road to Timber 2.0](https://github.com/timber/timber/issues/2741)
+* GitHub issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)
 
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](http://twig.sensiolabs.org/) separate from your PHP files. This cleans up your theme code so, for example, your PHP file can focus on being the data/logic, while your Twig file can focus 100% on the HTML and display.
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,7 @@ You will find an extensive list with guides and the reasons why we are not going
 ### Switching to the Composer based version
 * Announcement: [Dropping support for the plugin version of Timber](https://github.com/timber/timber/discussions/2804)
 * Guide: [How do I switch over from the plugin version to the Composer based version of Timber?](https://timber.github.io/docs/getting-started/switch-to-composer/)
-* Backstory: [Why are we dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
+* Backstory: [Why we are dropping support for the plugin in the first place](https://github.com/timber/timber/pull/2005)
 * GitHub issue: [Roadmap for Timber 2.0](https://github.com/timber/timber/issues/2741)
 
 Timber helps you create fully-customized WordPress themes faster with more sustainable code. With Timber, you write your HTML using the [Twig Template Engine](http://twig.sensiolabs.org/) separate from your PHP files. This cleans up your theme code so, for example, your PHP file can focus on being the data/logic, while your Twig file can focus 100% on the HTML and display.


### PR DESCRIPTION
Related:

- #2794

## Work in progress
This is a first version of this PR where I would like to have input from the core team: @gchtr , @nlemoine and @jarednova . Could you have a look at the wording of the notices in the .txt, .md file? Is that what we want to communicate? Please change/complete my suggested texts and notifications where necessary so that we can release this.

**Example of the plugin notice as currently commited**
![afbeelding](https://github.com/timber/timber/assets/17764157/1f3b558d-0eb2-45b4-aace-1c18aae67fad)


### TODO's

- [x] Fill the links in the code changes
- [x] test the upgrade guide with a minimal theme and latest WordPress version
- [x] [Release a plugin version with the new code changes.](https://github.com/timber/timber/issues/2820)


## Issue
We are not going to release a plugin version of Timber anymore. We think that a lot of people will be stuck on the plugin version of Timber 1. With a install base of 50.000+ installations we are talking about a lot of people.


## Solution
Let's inform Timber users about the upcoming end of the Timber plugin and help them with extra guides on how to switch to the Composer based (1.x) version.


## Impact
Minimal on the codebase. This PR adds an inline plugin notification as the only code change.


## Usage Changes
See the whole guide :)


## Considerations

- I made a docs/getting-started/switch-to-composer.md guide. Is this the proper location?
- See the plugin notification I currently created. Is this the way we want to notify the plugin users about this change
- Is the switch-to-composer guide good enough?



## Testing
No
