### PR TITLE
docs: updated plugin support part

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -19,7 +19,10 @@ We upgraded Timber to work with more modern PHP and functionalities that only we
 
 ## No more plugin support
 
-As of version 2.0, you can’t install Timber as a plugin. You need to install it through Composer. Follow the [Setup Guide](https://timber.github.io/docs/v2/installation/) for how to install Timber. Timber will continue to exist as a WordPress plugin in version 1.x.
+As of version 2.0, [We will stop releasing Timber as a plugin](https://github.com/timber/timber/discussions/2804). You need to install it through Composer. 
+
+If you are currently using Timber as a **plugin**, you can follow this guide to [switch from the plugin to Timber 1.x](https://timber.github.io/docs/getting-started/switch-to-composer/).
+After that, you can follow the [Upgrade to 2.0 guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) to switch from (Composer-based) Timber 1.x to Timber 2.0.
 
 ## Initializing Timber
 


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/pull/2800

## Issue
In the v2 guide there is no link/information about how to switch from the plugin version to the Composer-based installation.


## Solution
After we merged #2800 and deployed the new docs we can merge this PR to refer in the 2.0 guide to the _Switch from the plugin to Composer_ guide.

## Impact
Better information when you end up directly in the 2.0 upgrade guide.

## Usage Changes
no.


## Considerations
Cross-reference this 2.0 guide as the next step in the guide created in #2800? 

## Testing
no.
