### PR TITLE
fix: consider 'fields' value when returning terms from query

### DIFF
--- a/src/Factory/TermFactory.php
+++ b/src/Factory/TermFactory.php
@@ -60,9 +60,16 @@ class TermFactory
         return $this->build($wp_term);
     }
 
-    protected function from_wp_term_query(WP_Term_Query $query): iterable
+    protected function from_wp_term_query(WP_Term_Query $query)
     {
-        return \array_map([$this, 'build'], $query->get_terms());
+        $terms = $query->get_terms();
+
+        $fields = $query->query_vars['fields'];
+        if ('all' === $fields || 'all_with_object_id' === $fields) {
+            return \array_map([$this, 'build'], $terms);
+        }
+
+        return $terms;
     }
 
     protected function from_term_object(object $obj): CoreInterface


### PR DESCRIPTION
Related:

- Ticket #2802 

## Issue
A `fields` argument other than `all`or `all_with_object_id` lead to a fatal error, as `TermFactory::from_wp_term_query()` did expect the result of a query to always be of type `WP_term[]` 

## Solution
In `TermFactory::from_wp_term_query()` call `TermFactory::build()` only if `fields` is `all` or `all_with_object_id`, otherwise, return plain result of `WP_Term_Query::get_terms()` (i.e., `int[]|string[]|string`)

## Considerations
One could - instead of examining the `fields` argument - check if the object returned from `WP_Term_Query::get_terms()` actually is a `WP_Term[]`. That would be future proof (if there are `fields` values added for which the query also returns an array of `WP_Term`) - but might have some impact on performance, so I decided to solve it this way.

## Testing
No specific
