### PR TITLE
Prevent division by zero errors

### DIFF
--- a/lib/Image/Operation/Resize.php
+++ b/lib/Image/Operation/Resize.php
@@ -99,7 +99,7 @@ class Resize extends ImageOperation {
 		$current_size = $image->get_size();
 		$src_w = $current_size['width'];
 		$src_h = $current_size['height'];
-		$src_ratio = $src_w / $src_h;
+		$src_ratio = $src_w / max(1, $src_h);
 		if ( !$h ) {
 			$h = round($w / $src_ratio);
 		}
@@ -115,7 +115,7 @@ class Resize extends ImageOperation {
 			);
 		}
 		// Get ratios
-		$dest_ratio = $w / $h;
+		$dest_ratio = $w / max(1, $h);
 		$src_wt = $src_h * $dest_ratio;
 		$src_ht = $src_w / $dest_ratio;
 		$src_x = $src_w / 2 - $src_wt / 2;


### PR DESCRIPTION
Prevent division by zero errors for rare cases when images are not correctly uploaded to Wordpress.

## Issue
I had an error with images that reported a height of 0, and that led to a division by zero error white screen of death.

## Solution
Use max() to prevent division by zero.


## Impact
This shouldn't have much impact on anything.


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.

Alternatively, you’re very welcome to directly edit the readme.txt file with:
- A quick summary, including your GitHub handle.
- A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
- New usage instructions, possibly with a short code example.
-->


## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
