### PR TITLE
doc: Add drop support notice to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
 
       Please read the [migration guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) and maybe the [switch to composer guide](https://timber.github.io/docs/v2/getting-started/switch-to-composer/) if you were using the plugin version.
 
-      ** Your issue is about Timber 2.x**
+      **Your issue is about Timber 2.x**
 
       Thanks for taking the time to fill out the issue form. We can help best if you provide as much information as possible.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,6 +5,16 @@ body:
 - type: markdown
   attributes:
     value: |
+      **⚠️ Your issue about Timber 1.x**
+
+      Support for [Timber 1.x has been dropped](https://github.com/timber/timber/discussions/2804).
+
+      This means that your issue will likely not be addressed. We encourage all Timber users to migrate to Timber 2.x (currenlty RC 1).
+
+      Please read the [migration guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) and maybe the [switch to composer guide](https://timber.github.io/docs/v2/getting-started/switch-to-composer/) if you were using the plugin version.
+
+      ** Your issue is about Timber 2.x**
+
       Thanks for taking the time to fill out the issue form. We can help best if you provide as much information as possible.
 
       Is this a support or usage question? Please post it to [Discussions](https://github.com/timber/timber/discussions) or on Stack Overflow (http://stackoverflow.com/questions/tagged/timber) using the *Timber* tag.
@@ -42,6 +52,7 @@ body:
   attributes:
     label: What version of Timber are you using?
     placeholder: "Example: Timber 1.22.1"
+    description: ⚠️ Timber 1.x is no longer supported. Please [upgrade to Timber 2.x](https://timber.github.io/docs/v2/upgrade-guides/2.0/).
   validations:
     required: true
 - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
 
       Support for [Timber 1.x has been dropped](https://github.com/timber/timber/discussions/2804).
 
-      This means that your issue will likely not be addressed. We encourage all Timber users to migrate to Timber 2.x (currenlty RC 1).
+      This means that your issue will likely not be addressed. We encourage all Timber users to migrate to Timber 2.x (currently RC 1).
 
       Please read the [migration guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) and maybe the [switch to composer guide](https://timber.github.io/docs/v2/getting-started/switch-to-composer/) if you were using the plugin version.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
 
       This means that your issue will likely not be addressed. We encourage all Timber users to migrate to Timber 2.x (currently RC 1).
 
-      Please read the [migration guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) and maybe the [switch to composer guide](https://timber.github.io/docs/v2/getting-started/switch-to-composer/) if you were using the plugin version.
+      Please read the [migration guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) and maybe the [switch to Composer guide](https://timber.github.io/docs/v2/getting-started/switch-to-composer/) if you were using the plugin version.
 
       **Your issue is about Timber 2.x**
 


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #2741

Add a note about Timber 1.x being dropped so:
- we can inform and encourage users to move to Timber 2
- issues about Timber 1.x stop being added whereas they won't be adressed
