### PR TITLE
fix: initialize typed properties correctly in ExternalImage::build()

### DIFF
--- a/src/ExternalImage.php
+++ b/src/ExternalImage.php
@@ -143,17 +143,13 @@ class ExternalImage implements ImageInterface
 
         $args = \wp_parse_args($args, [
             'alt' => '',
+            'caption' => '',
         ]);
 
         $external_image = new static();
 
-        if (!empty($args['alt'])) {
-            $external_image->alt_text = (string) $args['alt'];
-        }
-
-        if (!empty($args['caption'])) {
-            $external_image->caption = (string) $args['caption'];
-        }
+        $external_image->alt_text = (string) $args['alt'];
+        $external_image->caption = (string) $args['caption'];
 
         if (\str_contains($url, '://')) {
             // Assume URL.

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -243,6 +243,9 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $this->addFile($dest);
         $this->assertFileExists($dest);
 
+        $image = Timber::get_external_image($dest);
+        $this->assertSame('', $image->alt());
+
         $image = Timber::get_external_image($dest, [
             'alt' => 'Cardinals logo',
         ]);
@@ -257,6 +260,9 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         $dest = self::copy_image_to_stylesheet('assets/images');
         $this->addFile($dest);
         $this->assertFileExists($dest);
+
+        $image = Timber::get_external_image($dest);
+        $this->assertSame('', $image->caption());
 
         $image = Timber::get_external_image($dest, [
             'caption' => 'Cardinals logo',


### PR DESCRIPTION
Related:

- Ticket #2817

## Issue
The (protected) typed properties of `ExternalImage`, `$alt_text` and `$caption`, were not initialized properly in the static `build()` method, causing errors when accessing them later (`must not be accessed before initialization`). The error only occurred in PHP >= 7.4, when this behavior (not initializing typed properties) was introduced.

## Solution
The calling method (`Timber::get_external_image()`) provides empty strings as default arguments for `alt` and `caption` when calling the build() method. Also, within the build method, there was a default for at least the `alt` parameter. But as these default parameters were empty strings, they were not used to initialize the properties properly. I did two things:
1. Ensure that also `caption` has a default value (empty string) defined within `build()`
2. Initialize properties even if the parameters are empty strings.

## Impact
No negative impact expected, as typed properties did not even exist before PHP 7.4, so that version is required for Timber 2.0. 

## Usage Changes
None

## Considerations
One could argue that null values would be even more appropriate as default initialization values for the respective properties, if they are not specifically defined by the user. That would allow to separate between "there is no alt value" and "there is an alt value, the empty string". 

## Testing
I enhanced the unit test for the `ExternalImage` class to cover  the case where a user does NOT specify an alt-text or a caption when creating the `ExternalImage` with `Timber::get_external-image()`. These test cases fail for the original code but succeed when the patch is applied.
