### PR TITLE
fix: Attachment size doc block

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -209,26 +209,25 @@ class Attachment extends Post
     }
 
     /**
-     * Gets filesize in a human readable format.
+     * Gets the raw filesize in bytes.
      *
-     * This can be useful if you want to display the human readable filesize for a file. It’s
-     * easier to read «16 KB» than «16555 bytes» or «1 MB» than «1048576 bytes».
+     * Use the `size_format` filter to format the raw size into a human readable size («1 MB» intead of «1048576»)
      *
      * @api
      * @since 2.0.0
      * @example
+     * @see https://developer.wordpress.org/reference/functions/size_format/
      *
      * Use filesize information in a link that downloads a file:
      *
      * ```twig
      * <a class="download" href="{{ attachment.src }}" download="{{ attachment.title }}">
      *     <span class="download-title">{{ attachment.title }}</span>
-     *     <span class="download-info">(Download, {{ attachment.size }})</span>
+     *     <span class="download-info">(Download, {{ attachment.size|size_format }})</span>
      * </a>
      * ```
      *
-     * @return int|null The filesize string in a human-readable format or null if the
-     *                     filesize can’t be read.
+     * @return int|null The raw filesize or null if it could not be read.
      */
     public function size(): ?int
     {


### PR DESCRIPTION
Related:

- #2819 

## Issue

The doc block was wrong here.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->


## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.

Alternatively, you’re very welcome to directly edit the readme.txt file with:
- A quick summary, including your GitHub handle.
- A list of changes for Theme Developers (under the "Changes for Theme Developers" label).
- New usage instructions, possibly with a short code example.
-->


## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
