### PR TITLE
ci: Update GitHub Actions workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 indent_style = spaces
 indent_size = 4
 
-[*.json]
+[*.{json,yml}]
 indent_size = 2
 
 [*.txt]

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,38 @@
+name: 'Setup PHP & Composer'
+description: 'Setup PHP & installs composer dependencies'
+inputs:
+  PHP_VERSION:
+    description: PHP version
+    default: "8.1"
+    required: false
+    type: string
+  PHP_TOOLS:
+    description: PHP version
+    default: ""
+    required: false
+    type: string
+  COMPOSER_ARGS:
+    description: Set of arguments passed to Composer.
+    default: '--prefer-dist --no-scripts'
+    required: false
+    type: string
+  INSTALL_DEPS:
+    description: Whether to install dependencies or not.
+    default: true
+    required: false
+    type: boolean
+
+runs:
+  using: composite
+  steps:
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.PHP_VERSION }}
+        tools: ${{ format('composer,{0}', inputs.PHP_TOOLS) }}
+
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@v2
+      if: ${{ inputs.INSTALL_DEPS }}
+      with:
+        composer-options: ${{ inputs.COMPOSER_ARGS }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,7 +32,7 @@ runs:
         tools: ${{ format('composer,{0}', inputs.PHP_TOOLS) }}
 
     - name: Install Composer dependencies
+      if: ${{ inputs.INSTALL_DEPS == 'true' }}
       uses: ramsey/composer-install@v2
-      if: ${{ inputs.INSTALL_DEPS }}
       with:
         composer-options: ${{ inputs.COMPOSER_ARGS }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -2,11 +2,15 @@ name: Lint composer
 
 on:
   push:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**composer.json'
-    branches:
-      - '*'
   pull_request:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**composer.json'
     types:

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -1,0 +1,37 @@
+name: Lint composer
+
+on:
+  push:
+    paths:
+      - '**composer.json'
+    branches:
+      - '*'
+  pull_request:
+    paths:
+      - '**composer.json'
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  composer-lint:
+    name: Composer lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+        with:
+          PHP_TOOLS: 'composer-normalize'
+          INSTALL_DEPS: false
+
+      - name: Lint composer
+        run: |
+          composer validate --strict
+          composer-normalize --dry-run --no-check-lock

--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -3,16 +3,16 @@ name: Docs links checker
 on: [workflow_dispatch]
 
 jobs:
-  linkChecker:
+  links-check:
+    name: Link Checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
             ref: 2.x
 
-      - name: Link Checker
+      - uses: lycheeverse/lychee-action@v1.8.0
         id: lychee
-        uses: lycheeverse/lychee-action@v1.8.0
         with:
             args: --verbose './docs/**/*.md' --max-concurrency 1 --max-retries 0 --accept 200,429 --cache
         env:

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -1,0 +1,39 @@
+name: PHP coding standards
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - '**composer.json'
+    branches:
+      - '*'
+  pull_request:
+    paths:
+      - '**.php'
+      - '**composer.json'
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-cs:
+    name: PHP coding standards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+
+      - name: Run coding standards
+        if: steps.changed-files.outputs.all_changed_files != ''
+        run: ./vendor/bin/ecs check ${{ steps.changed-files.outputs.files }}

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -2,12 +2,16 @@ name: PHP coding standards
 
 on:
   push:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**.php'
       - '**composer.json'
-    branches:
-      - '*'
   pull_request:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**.php'
       - '**composer.json'

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,42 @@
+name: PHP lint
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - '**composer.json'
+    branches:
+      - '*'
+  pull_request:
+    paths:
+      - '**.php'
+      - '**composer.json'
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-lint:
+    name: PHP lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+        with:
+          PHP_TOOLS: 'parallel-lint,cs2pr'
+          INSTALL_DEPS: false
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+
+      - name: Run PHP lint
+        if: steps.changed-files.outputs.all_changed_files != ''
+        run: parallel-lint --exclude .git --exclude vendor --checkstyle ${{ join(steps.changed-files.outputs.all_changed_files, ' ') }} | cs2pr

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -2,12 +2,16 @@ name: PHP lint
 
 on:
   push:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**.php'
       - '**composer.json'
-    branches:
-      - '*'
   pull_request:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**.php'
       - '**composer.json'

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -1,0 +1,41 @@
+name: PHP static analysis
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - '**composer.json'
+    branches:
+      - '*'
+  pull_request:
+    paths:
+      - '**.php'
+      - '**composer.json'
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-static-analysis:
+    name: PHP static analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+        with:
+          PHP_TOOLS: cs2pr
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v39
+
+      - name: Run static analysis
+        if: steps.changed-files.outputs.all_changed_files != ''
+        run: ./vendor/bin/phpstan analyse --memory-limit=-1 --error-format=checkstyle ${{ join(steps.changed-files.outputs.all_changed_files, ' ') }} | cs2pr

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -2,12 +2,16 @@ name: PHP static analysis
 
 on:
   push:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**.php'
       - '**composer.json'
-    branches:
-      - '*'
   pull_request:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**.php'
       - '**composer.json'

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -2,14 +2,18 @@ name: PHP unit tests
 
 on:
   push:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**workflows/php-unit-tests.yml'
       - '**.php'
       - '**composer.json'
       - '**phpunit.xml'
-    branches:
-      - '*'
   pull_request:
+    branches:
+      - master
+      - 2.x
     paths:
       - '**workflows/php-unit-tests.yml'
       - '**.php'

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -1,26 +1,32 @@
-name: Timber Tests
+name: PHP unit tests
 
 on:
   push:
+    paths:
+      - '**workflows/php-unit-tests.yml'
+      - '**.php'
+      - '**composer.json'
+      - '**phpunit.xml'
     branches:
       - '*'
   pull_request:
+    paths:
+      - '**workflows/php-unit-tests.yml'
+      - '**.php'
+      - '**composer.json'
+      - '**phpunit.xml'
     types:
       - opened
       - synchronize
       - ready_for_review
 
-# Cancel previous workflow run groups that have not completed.
 concurrency:
-  # Group workflow runs by workflow name, along with the head branch ref of the pull request
-  # or otherwise the branch or tag ref.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  phpunit:
+  php-unit-tests:
     runs-on: ubuntu-latest
-
     services:
       mysql:
         image: mariadb:latest
@@ -32,7 +38,6 @@ jobs:
         ports:
           - 3306
         options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
-
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -111,8 +116,7 @@ jobs:
     name: PHP ${{ matrix.php }} ${{ matrix.extensions == 'imagick' && ' (Imagick)' || '' }}${{ matrix.coverage && ' (with coverage)' || '' }} ${{ matrix.webp && ' (webp)' || '' }} | WP ${{ matrix.wp }}${{ matrix.multisite == 1 && ' (MS)' || '' }} | ${{ matrix.dependency-version }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -140,23 +144,13 @@ jobs:
 
       - uses: ramsey/composer-install@v2
         with:
-            dependency-versions: ${{ matrix.dependency-version }}
+          dependency-versions: ${{ matrix.dependency-version }}
 
       - name: Upgrade dev dependencies when lowest
         if: matrix.dependency-version == 'lowest'
         run: |
             composer update yoast/wp-test-utils -W --dev
             composer update composer/installers -W
-
-      - name: Lint composer.json
-        run: composer run lint-composer
-
-      - name: Lint PHP
-        run: composer run lint
-
-      - name: Check CS
-        if: ${{ matrix.dependency-version == 'highest' || matrix.dependency-version == 'prefer-stable' }}
-        run: composer run cs
 
       - name: Downgrade PHPUnit to ^7.5 when WP < 5.9
         if: matrix.wp < '5.9'
@@ -169,11 +163,6 @@ jobs:
       - name: Install tests
         run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true
 
-      # - name: Setup PCOV
-      #   if: ${{ matrix.coverage == true }}
-      #   run: |
-      #     composer require --dev --ignore-platform-reqs pcov/clobber
-      #     vendor/bin/pcov clobber
 
       - name: Run tests
         if: ${{ !matrix.webp }}

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.7",
     "squizlabs/php_codesniffer": "^3.0",
-    "symplify/easy-coding-standard": "^11.0",
+    "symplify/easy-coding-standard": "^12.0",
     "szepeviktor/phpstan-wordpress": "^1.1",
     "twig/cache-extra": "^3.3",
     "wpackagist-plugin/advanced-custom-fields": "^5.0 || ^6.0",


### PR DESCRIPTION
## Issue

- Split each job into its own file
- Filter paths so Actions runs only when necessary (no need to run composer lint when it has not been modified)
- Add cs2pr to provide PR author direct feedback
- Add dependabot for GA
- Bump easy-coding-standards to ^12

## Solution

We should have much faster/accurate CI tests and cleaner UI view. 

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
