### PR TITLE
2.x Revert final constructors

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -19,7 +19,7 @@ We upgraded Timber to work with more modern PHP and functionalities that only we
 
 ## No more plugin support
 
-As of version 2.0, [We will stop releasing Timber as a plugin](https://github.com/timber/timber/discussions/2804). You need to install it through Composer. 
+As of version 2.0, [We will stop releasing Timber as a plugin](https://github.com/timber/timber/discussions/2804). You need to install it through Composer.
 
 If you are currently using Timber as a **plugin**, you can follow this guide to [switch from the plugin to Timber 1.x](https://timber.github.io/docs/getting-started/switch-to-composer/).
 After that, you can follow the [Upgrade to 2.0 guide](https://timber.github.io/docs/v2/upgrade-guides/2.0/) to switch from (Composer-based) Timber 1.x to Timber 2.0.
@@ -218,19 +218,6 @@ By using the Factory Pattern, we refactored a lot of code and by moving logic in
 - `Timber\PostGetter`
 - `Timber\TermGetter`
 - `Timber\QueryIterator`
-
-### Object constructors are now final
-
-To lock down the API and make it easier for us to add changes in the future, we made the constructors of the following classes `final`.
-
-- `Timber\Post`
-- `Timber\Term`
-- `Timber\Comment`
-- `Timber\User`
-- `Timber\Menu`
-- `Timber\MenuItem`
-
-This means that you can’t overwrite the `__construct()` function anymore when you extend a Timber object. Use a custom method instead to add changes to your object.
 
 ## Posts
 
@@ -1138,29 +1125,8 @@ The whole `Timber\Integration\Command` class was removed. Its methods were moved
 
 **Timber\Post**
 
-- `__construct()` – The constructor is now `final`. You can’t overwrite it. Use a custom method to overwrite something in the object instead.
 - `children()` – We removed the `$child_post_class` parameter in this function. Use [Class Maps](https://timber.github.io/docs/v2/guides/class-maps/) instead to control which class to instantiate child posts with.
 - `comments()` – We removed the `$CommentClass` parameter in this function. Use [Class Maps](https://timber.github.io/docs/v2/guides/class-maps/) instead to control which class to instantiate child posts with.
-
-**Timber\Term**
-
-- `__construct()` – The constructor is now `final`. You can’t overwrite it. Use a custom method to overwrite something in the object instead.
-
-**Timber\User**
-
-- `__construct()` – The constructor is now `final`. You can’t overwrite it. Use a custom method to overwrite something in the object instead.
-
-**Timber\Menu**
-
-- `__construct()` – The constructor is now `final`. You can’t overwrite it. Use a custom method to overwrite something in the object instead.
-
-**Timber\MenuItem**
-
-- `__construct()` – The constructor is now `final`. You can’t overwrite it. Use a custom method to overwrite something in the object instead.
-
-**Timber\Comment**
-
-- `__construct()` – The constructor is now `final`. You can’t overwrite it. Use a custom method to overwrite something in the object instead.
 
 **Timber\Cache\Cleaner**
 

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -122,7 +122,7 @@ class Comment extends CoreEntity
      *
      * @internal
      */
-    final protected function __construct()
+    protected function __construct()
     {
     }
 

--- a/src/ExternalImage.php
+++ b/src/ExternalImage.php
@@ -124,7 +124,7 @@ class ExternalImage implements ImageInterface
      */
     protected ?ImageDimensions $image_dimensions;
 
-    final protected function __construct()
+    protected function __construct()
     {
     }
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -278,7 +278,7 @@ class Menu extends CoreEntity
      *                            many levels of hierarchy should be included in the menu. Default
      *                            `0`, which is all levels.
      */
-    final protected function __construct(?WP_term $term, array $args = [])
+    protected function __construct(?WP_term $term, array $args = [])
     {
         // For future enhancements?
         $this->raw_args = $args;

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -132,7 +132,7 @@ class MenuItem extends CoreEntity
      * @param WP_Post $data
      * @param \Timber\Menu $menu The `Timber\Menu` object the menu item is associated with.
      */
-    final protected function __construct(WP_Post $data, $menu = null)
+    protected function __construct(WP_Post $data, $menu = null)
     {
         $this->wp_object = $data;
         $this->menu = $menu;

--- a/src/Post.php
+++ b/src/Post.php
@@ -210,7 +210,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      *
      * @internal
      */
-    final protected function __construct()
+    protected function __construct()
     {
     }
 

--- a/src/Term.php
+++ b/src/Term.php
@@ -74,7 +74,7 @@ class Term extends CoreEntity
     /**
      * @internal
      */
-    final protected function __construct()
+    protected function __construct()
     {
     }
 

--- a/src/User.php
+++ b/src/User.php
@@ -99,7 +99,7 @@ class User extends CoreEntity
      *
      * @internal
      */
-    final protected function __construct()
+    protected function __construct()
     {
     }
 


### PR DESCRIPTION
Related:

- #2813
- #2660

## Issue

The final constructors prevent advanced use cases as described in #2813. We don’t want to make it so hard to work around it. But we first need to figure out a proper solution for this.

## Solution

Revert that pull request for 2.x and figure out a better solution in a future release.

## Impact

Less trouble to incorporate advanced coding patterns with Timber.

## Usage Changes

None.

## Considerations

None.

## Testing

No.