### PR TITLE
fix:  exclude tests from PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,8 @@ parameters:
     scanFiles:
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
         - vendor/php-stubs/acf-pro-stubs/acf-pro-stubs.php
+    excludePaths:
+        - tests/*
     ignoreErrors:
         - '#Instantiated class Twig\\CacheExtension\\CacheStrategy\\GenerationalCacheStrategy not found.#'
         - '#Instantiated class Twig\\CacheExtension\\Extension not found.#'


### PR DESCRIPTION
## Issue

PHPStan is  running on tests folder.


## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

Exclude tests folder.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

Maybe allow PHPStan on tests later.


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
