### PR TITLE
2.x Add note about PostsIterator and removal of timber/class/posts_iterator filter

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -219,6 +219,16 @@ By using the Factory Pattern, we refactored a lot of code and by moving logic in
 - `Timber\TermGetter`
 - `Timber\QueryIterator`
 
+## Better compatibility with plugins
+
+We updated the `Timber\PostsIterator` class for better compatibility with other WordPress plugins when looping over posts. We took great care to make sure that Timber calls the right functions and WordPress hooks in the right places when looping over posts.
+
+For this, we used [`setup()`](https://timber.github.io/docs/v2/reference/timber-post/#setup) and [`teardown()`](https://timber.github.io/docs/v2/reference/timber-post/#teardown) methods for posts. These methods can be used if you need to manipulate post objects before they are accessed in a loop.
+
+We removed the `timber/class/posts_iterator` filter hook, which you could use to use a custom post iterator. The functionality that you handled with a custom post iterator can now be handled with the `setup()` and `teardown()` methods on a post. To write custom `setup()` and `teardown()` methods, you can extend the `Timber\Post` class. [Learn more about extending Timber](https://timber.github.io/docs/v2/guides/extending-timber/) in the Extending Timber Guide.
+
+If you’ve used a custom post iterator to handle a plugin incompatibility before, it might be that you won’t need to do anything and that the issue is resolved with the existing post iterator implementation in Timber 2.0.
+
 ## Posts
 
 Before version 2.0, when you wanted to get a collection of posts, the standard way was to use `Timber::get_posts()`, and `Timber::get_post()` to get a single post. But you could also use `new Timber\Post()` or `new Timber\PostQuery()`.
@@ -1465,7 +1475,8 @@ The following filters were **removed** without a replacement:
 
 - `Timber\PostClassMap` – use the [Post Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-post-class-map) instead.
 - `timber/get_posts/mirror_wp_get_posts` – This filter was used so that `Timber::get_posts()` mimicks the behavior of WordPress’s `get_posts()` function. We removed it because `Timber::get_posts()` is the new official API. If you want the same behavior, there are [arguments that you can pass to this function](https://timber.github.io/docs/v2/guides/posts#differences-from-wp-cores-get_posts).
-- `timber_post_getter_get_posts` – Remove because the `PostGetter` class doesn’t exist anymore.
+- `timber_post_getter_get_posts` – Removed because the `Timber\PostGetter` class doesn’t exist anymore.
+- `timber/class/posts_iterator` – Removed because the `Timber\PostCollection` class doesn’t exist anymore. Use custom `Post::setup()` and `Post::teardown()` methods instead. Read more about this in the [Better compatibility with plugins section](#better-compatibility-with-plugins).
 
 ### New hooks
 


### PR DESCRIPTION
Related:

- #2834

## Issue

We didn’t mention that we removed the `timber/class/posts_iterator` filter

## Solution

Add note in documentation.

## Considerations

None.