### PR TITLE
fix: Fix failing tests for WP 6.4

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
         - vendor/php-stubs/acf-pro-stubs/acf-pro-stubs.php
     excludePaths:
         - tests/*
+        - docs/*
     ignoreErrors:
         - '#Instantiated class Twig\\CacheExtension\\CacheStrategy\\GenerationalCacheStrategy not found.#'
         - '#Instantiated class Twig\\CacheExtension\\Extension not found.#'

--- a/tests/test-timber-wp-functions.php
+++ b/tests/test-timber-wp-functions.php
@@ -12,6 +12,9 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertEquals('jared sez hi', $output);
     }
 
+    /**
+     * @expectedDeprecated the_block_template_skip_link
+     */
     public function testFooterOnFooterFW()
     {
         global $wp_scripts;
@@ -27,6 +30,9 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertSame(0, strlen($wp_footer_output1));
     }
 
+    /**
+     * @expectedDeprecated the_block_template_skip_link
+     */
     public function testFooterAlone()
     {
         global $wp_scripts;
@@ -47,6 +53,9 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertEquals('bar', $fw1->call());
     }
 
+    /**
+     * @expectedDeprecated the_block_template_skip_link
+     */
     public function testDoubleActionWPFooter()
     {
         global $wp_scripts;
@@ -60,6 +69,9 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         remove_action('wp_footer', 'echo_junk');
     }
 
+    /**
+     * @expectedDeprecated the_block_template_skip_link
+     */
     public function testInTwig()
     {
         global $wp_scripts;
@@ -70,6 +82,9 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertGreaterThan(-1, $pos);
     }
 
+    /**
+     * @expectedDeprecated the_block_template_skip_link
+     */
     public function testInTwigString()
     {
         global $wp_scripts;
@@ -80,6 +95,9 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertGreaterThan(-1, $pos);
     }
 
+    /**
+     * @expectedDeprecated the_block_template_skip_link
+     */
     public function testAgainstFooterFunctionOutput()
     {
         global $wp_scripts;


### PR DESCRIPTION
## Issue

With the release of WordPress 6.4, we’re running into lots of errors.

## Solution

Turns out that WordPress [still always calls `the_block_template_skip_link()`](https://github.com/WordPress/WordPress/blob/6.4/wp-includes/default-filters.php#L720), which always causes [a `_deprecated_function()` notice](https://github.com/WordPress/WordPress/blob/6.4/wp-includes/deprecated.php#L6138). My solution is to add `@expectedDeprecated` calls.

I also excluded the `docs/` folder from the PHPStan checks.

@nlemoine Can we also ignore the docs for the **PHP Lint** workflow? We’re getting errors there, too: https://github.com/timber/timber/actions/runs/6808609995/job/18513339121?pr=1617.

## Impact

Less noise in tests.

## Usage Changes

None.

## Considerations

Maybe.

## Testing

Yes.