### PR TITLE
[Docs] Use recommended method to get meta in ACF Integration sample code

### DIFF
--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -77,8 +77,8 @@ This is where we’ll start in PHP.
 ```php
 $post = Timber::get_post();
 
-if (isset($post->hero_image) && strlen($post->hero_image)) {
-    $post->hero_image = Timber::get_image($post->hero_image);
+if (isset($post->meta('hero_image')) && strlen($post->meta('hero_image'))) {
+    $post->meta('hero_image') = Timber::get_image($post->meta('hero_image'));
 }
 
 $context = Timber::context([
@@ -93,7 +93,7 @@ Timber::render('single.twig', $context);
 You can now use all the above functions to transform your custom images in the same way, the format will be:
 
 ```twig
-<img src="{{ post.hero_image.src | resize(500, 300) }}" />
+<img src="{{ post.meta('hero_image').src | resize(500, 300) }}" />
 ```
 
 ## Gallery Field
@@ -124,7 +124,7 @@ or
 The post data returned from a relationship field will not contain the Timber methods needed for easy handling inside of your Twig file. To get these, you’ll need to convert them into proper `Timber\Post` objects using `get_posts()`:
 
 ```twig
-{% for item in get_posts(post.relationship_field) %}
+{% for item in get_posts(post.meta('relationship_field')) %}
    {{ item.title }}
    {# Do something with item #}
 {% endfor %}

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -77,10 +77,6 @@ This is where we’ll start in PHP.
 ```php
 $post = Timber::get_post();
 
-if (isset($post->meta('hero_image')) && strlen($post->meta('hero_image'))) {
-    $post->hero_image = Timber::get_image($post->meta('hero_image'));
-}
-
 $context = Timber::context([
     'post' => $post,
 ]);
@@ -93,7 +89,9 @@ Timber::render('single.twig', $context);
 You can now use all the above functions to transform your custom images in the same way, the format will be:
 
 ```twig
-<img src="{{ post.meta('hero_image').src | resize(500, 300) }}" />
+{% if post.meta('hero_image') %}
+    <img src="{{ get_image(post.meta('hero_image')).src | resize(500, 300) }}" />
+{% endif %}
 ```
 
 ## Gallery Field

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -78,7 +78,7 @@ This is where we’ll start in PHP.
 $post = Timber::get_post();
 
 if (isset($post->meta('hero_image')) && strlen($post->meta('hero_image'))) {
-    $post->meta('hero_image') = Timber::get_image($post->meta('hero_image'));
+    $post->hero_image = Timber::get_image($post->meta('hero_image'));
 }
 
 $context = Timber::context([


### PR DESCRIPTION
## Issue
In ACF Integration docs, sample code directly accesses to meta fields as properties of the `post` object itself.

## Solution
Use the recommended approach (`meta` method) to access such fields.

## Impact
Better code samples
