### PR TITLE
docs: Documented transform_value filter/parameter

### DIFF
--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -20,15 +20,15 @@ If you’ve worked with ACF before, you’re use to use `get_field( 'my_acf_fiel
 $meta = $post->meta('my_acf_field');
 ```
 
-### Transform  values to Timber/PHP objects
+### Transform values to Timber/PHP objects  
 Timber by default returns all field values as is based on the return type set in your ACF field setting.
 
-But sometimes you might want to transform values directly into Timber/PHP objects. For example, if you have a relationship field, you might want to transform the values in `Timber\Post` objects.
+But sometimes you might want to transform values directly into Timber/PHP objects. For example, if you have a relationship field, you might want to transform the values directly into `Timber\Post` objects.
 
 You can do so using the `timber/meta/transform_value` filter:
 
+**functions.php**
 ```php
-// in your functions.php
 add_filter('timber/meta/transform_value', '__return__true');
 ```
 
@@ -48,20 +48,19 @@ $meta = $post->meta('my_meta_field', ['transform_value' => true]);
 
 You can also use both the filter and parameter options at the same time to globally transform values and then opt-out on a field by field basis by setting `transform_value` to `false`.
 
-The values of the following field types can be transformed into Timber/PHP objects:
+The values of the following field types will be transformed into Timber/PHP objects when using transforms:
 
-
-|Field type | Returns  |
+| Field type | Returns  |
 |---------|---------|
-|file    | `Timber::get_attachment`         |
-|image    | `Timber::get_image`         |
-|gallery    | `Timber::get_posts`         |
-|date picker     |  `DateTimeImmutable`       |
-|date time picker     |  `DateTimeImmutable`       |
-|post object     | `Timber::get_posts`         |
-|relationship     | `Timber::get_posts`         |
-|taxonomy     | `Timber::get_terms`         |
-|user     | `Timber::get_users`         |
+| File    | `Timber\Attachment`         |
+| Image    | `Timber\Image`         |
+| Gallery    | array of `Timber\Post` objects         |
+| Date picker     |  `DateTimeImmutable`       |
+| Date time picker     |  `DateTimeImmutable`       |
+| Post object     | array of `Timber\Post` objects         |
+| Relationship     | array of `Timber\Post` objects         |
+| Taxonomy     | array of `Timber\Term` objects         |
+| User     | array of `Timber\User` objects         |
 
 
 

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -21,7 +21,11 @@ $meta = $post->meta('my_acf_field');
 ```
 
 ### Transform  values to Timber/PHP objects
-Timber does not automatically transform meta values to Timber/PHP objects by default. If you want to transform values to Timber/PHP objects, you can use the `timber/meta/transform_value` filter to do so globally:
+Timber by default returns all field values as is based on the return type set in your ACF field setting.
+
+But sometimes you might want to transform values directly into Timber/PHP objects. For example, if you have a relationship field, you might want to transform the values in `Timber\Post` objects.
+
+You can do so using the `timber/meta/transform_value` filter:
 
 ```php
 // in your functions.php
@@ -43,6 +47,23 @@ $meta = $post->meta('my_meta_field', ['transform_value' => true]);
 ```
 
 You can also use both the filter and parameter options at the same time to globally transform values and then opt-out on a field by field basis by setting `transform_value` to `false`.
+
+The values of the following field types can be transformed into Timber/PHP objects:
+
+
+|Field type | Returns  |
+|---------|---------|
+|file    | `Timber::get_attachment`         |
+|image    | `Timber::get_image`         |
+|gallery    | `Timber::get_posts`         |
+|date picker     |  `DateTimeImmutable`       |
+|date time picker     |  `DateTimeImmutable`       |
+|post object     | `Timber::get_posts`         |
+|relationship     | `Timber::get_posts`         |
+|taxonomy     | `Timber::get_terms`         |
+|user     | `Timber::get_users`         |
+
+
 
 
 ### Unformatted values

--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -20,6 +20,31 @@ If you’ve worked with ACF before, you’re use to use `get_field( 'my_acf_fiel
 $meta = $post->meta('my_acf_field');
 ```
 
+### Transform  values to Timber/PHP objects
+Timber does not automatically transform meta values to Timber/PHP objects by default. If you want to transform values to Timber/PHP objects, you can use the `timber/meta/transform_value` filter to do so globally:
+
+```php
+// in your functions.php
+add_filter('timber/meta/transform_value', '__return__true');
+```
+
+Or you can use the `transform_value` parameter to transform values on a field by field basis:
+
+**Twig**
+
+```twig
+{{ post.meta('my_acf_field', { transform_value: true }) }}
+```
+
+**PHP**
+
+```php
+$meta = $post->meta('my_meta_field', ['transform_value' => true]);
+```
+
+You can also use both the filter and parameter options at the same time to globally transform values and then opt-out on a field by field basis by setting `transform_value` to `false`.
+
+
 ### Unformatted values
 
 In ACF, all values are filtered. If you want to use unfiltered, raw values from the database, you’re probably used to using the third parameter for `get_field()`, which is called `$format_value`. This defaults to true. In Timber, you’d pass it like so:


### PR DESCRIPTION
Related:

- #2811

## Issue
The new default behavior to not transform meta values to Timber objects anymore was not documented. 


## Solution
Update the ACF documentation on how to opt-in to this behavior globally or on a field-by-field basis

## Impact
Better understanding of the internal workings of field value transforms.

## Usage Changes
no

## Considerations
I think this behavior was default in v1 right? Shouldn't we add this to the Upgrade to 2.0 guide as well under meta?

## Testing
no
