### PR TITLE
Fix dynamic properties warnings

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+#[\AllowDynamicProperties]
 abstract class Core {
 
 	public $id;

--- a/lib/Integrations.php
+++ b/lib/Integrations.php
@@ -6,6 +6,7 @@ namespace Timber;
  * This is for integrating external plugins into timber
  * @package  timber
  */
+#[\AllowDynamicProperties]
 class Integrations {
 
 	var $acf;

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -6,6 +6,7 @@ namespace Timber;
  * Wrapper for the post_type object provided by WordPress
  * @since 1.0.4
 */
+#[AllowDynamicProperties]
 class PostType {
 
 	/**

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -6,7 +6,7 @@ namespace Timber;
  * Wrapper for the post_type object provided by WordPress
  * @since 1.0.4
 */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class PostType {
 
 	/**


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/issues/2793

## Issue
This removes the warnings that flood a site on newer versions of PHP


## Solution
Implement the `#[\AllowDynamicProperties]` attribute. This is not a BC break as older versions of PHP would see this as a comment and ignore it.


## Impact
None.
