### PR TITLE
Fix: LocationManager returns wrong locations in child themes

### DIFF
--- a/src/LocationManager.php
+++ b/src/LocationManager.php
@@ -15,6 +15,7 @@ class LocationManager
         $locs = \array_merge_recursive($locs, self::get_locations_user());
         $locs = \array_merge_recursive($locs, self::get_locations_caller($caller));
         //remove themes from caller
+		$locs = \array_diff($locs, self::get_locations_theme());
         $locs = \array_merge_recursive($locs, self::get_locations_theme());
         $locs = \array_merge_recursive($locs, self::get_locations_caller($caller));
         $locs = \array_merge_recursive($locs, self::get_locations_open_basedir());


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #2843

## Issue
<!-- Description of the problem that this code change is solving -->
- Child theme not able to override templates of the parent theme due to wrong locations array.
## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
- This solution was proposed in #2843 by @palttamas but I could not find PR related to it so creating this


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->
- None