### PR TITLE
Fix phpstan tests

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,7 @@ parameters:
     paths:
         - src/
     scanFiles:
+        - tests/phpstan/bootstrap.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
         - vendor/php-stubs/acf-pro-stubs/acf-pro-stubs.php
     excludePaths:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
         - tests/*
         - docs/*
     ignoreErrors:
+        - '#Result of function acf_get_field_type \(void\) is used.#'
         - '#Instantiated class Twig\\CacheExtension\\CacheStrategy\\GenerationalCacheStrategy not found.#'
         - '#Instantiated class Twig\\CacheExtension\\Extension not found.#'
         - '#Method Timber\\Loader::_get_cache_extension\(\) has invalid return type Twig\\CacheExtension\\Extension.#'

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -140,7 +140,7 @@ class MenuItem extends CoreEntity
         /**
          * @property string $title The nav menu item title.
          */
-        $this->title = $data->title;
+        $this->title = $data->post_title;
 
         $this->import($data);
         $this->import_classes($data);

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -140,7 +140,7 @@ class MenuItem extends CoreEntity
         /**
          * @property string $title The nav menu item title.
          */
-        $this->title = $data->post_title;
+        $this->title = $data->title;
 
         $this->import($data);
         $this->import_classes($data);


### PR DESCRIPTION

## Issue
Lately some tests fail. This PR focusses on getting the phpstan tests running again while also tackeling two other phpstan errors I got locally.


## Solution
Include a file to discover symbols, changing a property name and ignore an ACF function error.


## Impact
PHPSTAN tests that run again.

## Usage Changes
no

## Considerations
I got 20 more errors when running phpstan, mostly the unsafe use of new static(), we might want to ignore that as well? Other errors are also some other missing symbols. Let me know if we want to look into those as well.


