### PR TITLE
1.x Test and fix dynamic properties warnings

### DIFF
--- a/lib/Core.php
+++ b/lib/Core.php
@@ -2,6 +2,7 @@
 
 namespace Timber;
 
+#[\AllowDynamicProperties]
 abstract class Core {
 
 	public $id;

--- a/lib/Integrations.php
+++ b/lib/Integrations.php
@@ -6,6 +6,7 @@ namespace Timber;
  * This is for integrating external plugins into timber
  * @package  timber
  */
+#[\AllowDynamicProperties]
 class Integrations {
 
 	var $acf;

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -6,6 +6,7 @@ namespace Timber;
  * Wrapper for the post_type object provided by WordPress
  * @since 1.0.4
 */
+#[AllowDynamicProperties]
 class PostType {
 
 	/**

--- a/lib/PostType.php
+++ b/lib/PostType.php
@@ -6,7 +6,7 @@ namespace Timber;
  * Wrapper for the post_type object provided by WordPress
  * @since 1.0.4
 */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class PostType {
 
 	/**

--- a/tests/test-timber-pagination.php
+++ b/tests/test-timber-pagination.php
@@ -34,9 +34,6 @@ class TestTimberPagination extends Timber_UnitTestCase {
 		Timber::get_posts('post_type=portfolio');
 		$pagination = Timber::get_pagination();
 
-		global $timber;
-		$timber->active_query = false;
-		unset($timber->active_query);
 		$this->assertEquals(4, count($pagination['pages']));
 	}
 

--- a/tests/test-timber-site.php
+++ b/tests/test-timber-site.php
@@ -1,6 +1,7 @@
 <?php
 
 class TestTimberSite extends Timber_UnitTestCase {
+	protected $backup_wp_theme_directories;
 
 	function testStandardThemeLocation() {
 		switch_theme( 'twentyfifteen' );


### PR DESCRIPTION
Related: 

- #2860

This pull request makes sure we run tests on 8.2 to test the fixes applied in #2890. See https://github.com/timber/timber/actions/runs/7652688123/job/20852977870 to confirm that there are no Deprecation Warnings in Timber for 8.2 anymore.

@nlemoine I would appreciate a quick review on #2860 and this pull request to confirm we can release the fix in 1.24.0.