### PR TITLE
fix: tests failing since Twig 3.8.0

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -92,7 +92,7 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -262,4 +262,16 @@ class Timber_UnitTestCase extends TestCase
         wp_clean_themes_cache();
         unset($GLOBALS['wp_themes']);
     }
+
+    public function isWordPressVersion(string $version, string $operator = '=')
+    {
+        return version_compare($GLOBALS['wp_version'], $version, $operator);
+    }
+
+    public function skipForWordpressVersion(string $version, string $operator = '<')
+    {
+        if ($this->isWordPressVersion($version, $operator)) {
+            $this->markTestSkipped("This test requires WordPress version $version or higher.");
+        }
+    }
 }

--- a/tests/test-timber-meta.php
+++ b/tests/test-timber-meta.php
@@ -2,6 +2,8 @@
 
 use Timber\Integration\AcfIntegration;
 use Timber\Timber;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
 
 /**
  * Class TestTimberMeta
@@ -618,7 +620,17 @@ class TestTimberMeta extends Timber_UnitTestCase
      */
     public function testPostMetaDirectAccessMethodWithRequiredParametersConflict()
     {
-        $this->expectException(\ArgumentCountError::class);
+        /**
+         * Twig 3.8 changed the way some exception are handled and a different exception is thrown.
+         *
+         * @see https://github.com/twigphp/Twig/commit/85bf01b4abd4b4ee6f6d1aca19af74189c939d69
+         */
+        if (version_compare(Environment::VERSION, '3.8.0', '>=')) {
+            $this->expectException(RuntimeError::class);
+        } else {
+            $this->expectException(\ArgumentCountError::class);
+        }
+
         $post_id = $this->factory->post->create();
 
         update_post_meta($post_id, 'public_method_with_args', 'I am a meta value');
@@ -641,7 +653,17 @@ class TestTimberMeta extends Timber_UnitTestCase
      */
     public function testTermMetaDirectAccessMethodWithRequiredParametersConflict()
     {
-        $this->expectException(\ArgumentCountError::class);
+        /**
+         * Twig 3.8 changed the way some exceptions are handled and a different exception is thrown.
+         *
+         * @see https://github.com/twigphp/Twig/commit/85bf01b4abd4b4ee6f6d1aca19af74189c939d69
+         */
+        if (version_compare(Environment::VERSION, '3.8.0', '>=')) {
+            $this->expectException(RuntimeError::class);
+        } else {
+            $this->expectException(\ArgumentCountError::class);
+        }
+
         $term_id = $this->factory->term->create();
 
         update_term_meta($term_id, 'public_method_with_args', 'I am a meta value');
@@ -666,7 +688,16 @@ class TestTimberMeta extends Timber_UnitTestCase
      */
     public function testUserMetaDirectAccessMethodWithRequiredParametersConflict()
     {
-        $this->expectException(\ArgumentCountError::class);
+        /**
+         * Twig 3.8 changed the way some exceptions are handled and a different exception is thrown.
+         *
+         * @see https://github.com/twigphp/Twig/commit/85bf01b4abd4b4ee6f6d1aca19af74189c939d69
+         */
+        if (version_compare(Environment::VERSION, '3.8.0', '>=')) {
+            $this->expectException(RuntimeError::class);
+        } else {
+            $this->expectException(\ArgumentCountError::class);
+        }
 
         $user_id = $this->factory->user->create();
 
@@ -693,7 +724,16 @@ class TestTimberMeta extends Timber_UnitTestCase
      */
     public function testCommentMetaDirectAccessMethodWithRequiredParametersConflict()
     {
-        $this->expectException(\ArgumentCountError::class);
+        /**
+         * Twig 3.8 changed the way some exceptions are handled and a different exception is thrown.
+         *
+         * @see https://github.com/twigphp/Twig/commit/85bf01b4abd4b4ee6f6d1aca19af74189c939d69
+         */
+        if (version_compare(Environment::VERSION, '3.8.0', '>=')) {
+            $this->expectException(RuntimeError::class);
+        } else {
+            $this->expectException(\ArgumentCountError::class);
+        }
 
         $post_id = $this->factory->post->create();
         $comment_id = $this->factory->comment->create([

--- a/tests/test-timber-wp-functions.php
+++ b/tests/test-timber-wp-functions.php
@@ -12,11 +12,12 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertEquals('jared sez hi', $output);
     }
 
-    /**
-     * @expectedDeprecated the_block_template_skip_link
-     */
     public function testFooterOnFooterFW()
     {
+        if ($this->isWordPressVersion('6.4', '>=')) {
+            $this->setExpectedDeprecated('the_block_template_skip_link');
+        }
+
         global $wp_scripts;
         $wp_scripts = null;
         wp_enqueue_script('jquery', false, [], false, true);
@@ -30,11 +31,11 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertSame(0, strlen($wp_footer_output1));
     }
 
-    /**
-     * @expectedDeprecated the_block_template_skip_link
-     */
     public function testFooterAlone()
     {
+        if ($this->isWordPressVersion('6.4', '>=')) {
+            $this->setExpectedDeprecated('the_block_template_skip_link');
+        }
         global $wp_scripts;
         $wp_scripts = null;
         wp_enqueue_script('jquery', false, [], false, true);
@@ -53,11 +54,11 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertEquals('bar', $fw1->call());
     }
 
-    /**
-     * @expectedDeprecated the_block_template_skip_link
-     */
     public function testDoubleActionWPFooter()
     {
+        if ($this->isWordPressVersion('6.4', '>=')) {
+            $this->setExpectedDeprecated('the_block_template_skip_link');
+        }
         global $wp_scripts;
         $wp_scripts = null;
         add_action('wp_footer', 'echo_junk');
@@ -69,11 +70,11 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         remove_action('wp_footer', 'echo_junk');
     }
 
-    /**
-     * @expectedDeprecated the_block_template_skip_link
-     */
     public function testInTwig()
     {
+        if ($this->isWordPressVersion('6.4', '>=')) {
+            $this->setExpectedDeprecated('the_block_template_skip_link');
+        }
         global $wp_scripts;
         $wp_scripts = null;
         wp_enqueue_script('jquery', false, [], false, true);
@@ -82,11 +83,11 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertGreaterThan(-1, $pos);
     }
 
-    /**
-     * @expectedDeprecated the_block_template_skip_link
-     */
     public function testInTwigString()
     {
+        if ($this->isWordPressVersion('6.4', '>=')) {
+            $this->setExpectedDeprecated('the_block_template_skip_link');
+        }
         global $wp_scripts;
         $wp_scripts = null;
         wp_enqueue_script('jquery', false, [], false, true);
@@ -95,11 +96,11 @@ class TestTimberWPFunctions extends Timber_UnitTestCase
         $this->assertGreaterThan(-1, $pos);
     }
 
-    /**
-     * @expectedDeprecated the_block_template_skip_link
-     */
     public function testAgainstFooterFunctionOutput()
     {
+        if ($this->isWordPressVersion('6.4', '>=')) {
+            $this->setExpectedDeprecated('the_block_template_skip_link');
+        }
         global $wp_scripts;
         $wp_scripts = null;
         wp_enqueue_script('colorpicker', false, [], false, true);


### PR DESCRIPTION
Twig recently changed the way exceptions are thrown during template rendering. Depending on the version, different types of execption can be thrown.

See: https://github.com/twigphp/Twig/commit/85bf01b4abd4b4ee6f6d1aca19af74189c939d69

