### PR TITLE
feat: add filter for sideloaded images basename

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -408,7 +408,7 @@ class ImageHelper
          * @param string $basename Current basename for the sideloaded file.
          * @param array $path_parts Array with path info for the sideloaded file.
          */
-        $basename = \apply_filters('timber/image_helper/sideload_image/basename', $basename, $path_parts);
+        $basename = \apply_filters('timber/sideload_image/basename', $basename, $path_parts);
 
         $ext = 'jpg';
         if (isset($path_parts['extension'])) {

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -400,7 +400,7 @@ class ImageHelper
          * @example
          * ```php
          * // Change the basename used for sideloaded images.
-         * add_filter( 'timber/image_helper/sideload_image/basename', function ($basename, $path_parts) {
+         * add_filter( 'timber/sideload_image/basename', function ($basename, $path_parts) {
          *     return $path_parts['filename'] . '-' . substr($basename, 0, 6);
          * }, 10, 2)
          * ```

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -393,6 +393,23 @@ class ImageHelper
         $file = \parse_url($file);
         $path_parts = PathHelper::pathinfo($file['path']);
         $basename = \md5($filename);
+
+        /**
+         * Filters basename for sideloaded files.
+         * @since 2.0.1
+         * @example
+         * ```php
+         * // Change the basename used for sideloaded images.
+         * add_filter( 'timber/image_helper/sideload_image/basename', function ($basename, $path_parts) {
+         *     return $path_parts['filename'] . '-' . substr($basename, 0, 6);
+         * }, 10, 2)
+         * ```
+         *
+         * @param string $basename Current basename for the sideloaded file.
+         * @param array $path_parts Array with path info for the sideloaded file.
+         */
+        $basename = \apply_filters('timber/image_helper/sideload_image/basename', $basename, $path_parts);
+
         $ext = 'jpg';
         if (isset($path_parts['extension'])) {
             $ext = $path_parts['extension'];


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/issues/2508

## Issue
Basename of sideloaded images could not be configured,


## Solution
Introduce filter as described in the original ticket to handle this.


## Impact
More control over sideload images filenames

## Considerations
When looking for a proper name for the filter I found an odd named filter. We might want to take a look at this one as well and provide consistent name? https://github.com/timber/timber/blob/e4ff72f451e11b05887179086e4bb5a82d799184/src/ImageHelper.php#L515

## Testing
no
