### PR TITLE
ci: add PHP 8.2/8.3 and update test matrix

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
+        php: ['7.4', '8.0', '8.1', '8.2']
         wp: ['latest', '5.3']
         multisite: ['0', '1']
         dependency-version: ['highest', 'lowest']
@@ -59,58 +59,30 @@ jobs:
               php: '8.0'
             - wp: '5.3'
               php: '8.1'
+            - wp: '5.3'
+              php: '8.2'
         include:
-          # WP Trunk
-          - php: '7.4'
-            wp: 'trunk'
-            dependency-version: 'highest'
-            multisite: '0'
-            experimental: true
-          # PHP 8.0
-          - php: '8.0'
-            wp: 'latest'
-            dependency-version: 'prefer-stable'
-            multisite: '0'
-            experimental: false
-          # PHP 8.0 / Lowest dependencies
-          - php: '8.0'
-            wp: 'latest'
-            dependency-version: 'prefer-lowest'
-            multisite: '0'
-            experimental: false
-          # PHP 8.1
-          - php: '8.1'
-            wp: 'latest'
-            dependency-version: 'prefer-stable'
-            multisite: '0'
-            experimental: false
-          # PHP 8.1 / Lowest dependencies
-          - php: '8.1'
-            wp: 'latest'
-            dependency-version: 'prefer-lowest'
-            multisite: '0'
-            experimental: false
-          # PHP 8.1 / experimental
-          - php: '8.1'
-            wp: 'trunk'
-            dependency-version: 'highest'
-            multisite: '0'
-            experimental: true
           # PHP 8.2 / experimental
           - php: '8.2'
             wp: 'trunk'
             dependency-version: 'highest'
             multisite: '0'
             experimental: true
+          # PHP 8.3 / experimental
+          - php: '8.3'
+            wp: 'trunk'
+            dependency-version: 'highest'
+            multisite: '0'
+            experimental: true
           # PHP with Imagick
-          - php: '7.4'
+          - php: '8.1'
             wp: 'latest'
             dependency-version: 'highest'
             multisite: '0'
             extensions: 'imagick'
             experimental: false
           # Coverage
-          - php: '7.4'
+          - php: '8.1'
             wp: 'latest'
             dependency-version: 'highest'
             multisite: '0'


### PR DESCRIPTION
Time to update those tests and run them against more recent versions.

PHP 8.3 should not be experimental IMHO.

We can add it we'll get rid of WP 5.3 (2.1 ?)