### PR TITLE
2.0 fix deprecated filter use in transient test

### DIFF
--- a/src/Factory/CommentFactory.php
+++ b/src/Factory/CommentFactory.php
@@ -72,7 +72,32 @@ class CommentFactory
 
     protected function get_comment_class(WP_Comment $comment): string
     {
-        // Get the user-configured Class Map
+
+        /**
+         * Filters the class(es) used for comments linked to different post types.
+         *
+         * The default class is Timber\Comment. You can use this filter to provide your own comment class for specific post types.
+         *
+         * Make sure to merge in your additional classes instead of overwriting the whole Class Map.
+         *
+         * @since 2.0.0
+         * @example
+         * ```
+         * use Book;
+         *
+         * add_filter( 'timber/post/classmap', function( $classmap ) {
+         *     $custom_classmap = [
+         *         'book' => BookComment::class,
+         *     ];
+         *
+         *     return array_merge( $classmap, $custom_classmap );
+         * } );
+         * ```
+         *
+         * @param array $classmap The post class(es) to use. An associative array where the key is
+         *                        the post type and the value the name of the class to use for the comments
+         *                        of this post type or a callback that determines the class to use.
+         */
         $map = \apply_filters('timber/comment/classmap', []);
 
         $type = \get_post_type($comment->comment_post_ID);

--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -180,6 +180,16 @@ class PostFactory
         $mimes['webp'] = 'image/webp';
         $check = \wp_check_filetype(PathHelper::basename($src), $mimes);
 
+
+        /**
+         * Filters the list of image extensions that will be used to determine if an attachment is an image.
+         *
+         * You can use this filter to add or remove image extensions to the list of extensions that will be
+         * used to determine if an attachment is an image.
+         * 
+         * @param array $extensions An array of image extensions.
+         * @since 2.0.0
+         */
         $extensions = \apply_filters('timber/post/image_extensions', [
             'jpg',
             'jpeg',

--- a/src/Factory/TermFactory.php
+++ b/src/Factory/TermFactory.php
@@ -100,7 +100,27 @@ class TermFactory
 
     protected function get_term_class(WP_Term $term): string
     {
-        // Get the user-configured Class Map
+        /**
+         * Filters the class(es) used for terms of different taxonomies.
+         *
+         * The default Term Class Map will contain class names mapped to the build-in post_tag and category taxonomies.
+         *
+         * @since 2.0.0
+         * @example
+         * ```
+         * add_filter( 'timber/term/classmap', function( $classmap ) {
+         *     $custom_classmap = [
+         *         'expertise'   => ExpertiseTerm::class,
+         *     ];
+         *
+         *     return array_merge( $classmap, $custom_classmap );
+         * } );
+         * ```
+         *
+         * @param array $classmap The term class(es) to use. An associative array where the key is
+         *                        the taxonomy name and the value the name of the class to use for this
+         *                        taxonomy or a callback that determines the class to use.
+         */
         $map = \apply_filters('timber/term/classmap', [
             'post_tag' => Term::class,
             'category' => Term::class,

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -71,30 +71,34 @@ class Helper
      *
      * @internal
      *
-     * @param string     $slug
-     * @param callable     $callback
-     * @param integer      $transient_time Expiration of transients in seconds
-     * @param integer     $lock_timeout   How long (in seconds) to lock the transient to prevent race conditions
-     * @param boolean     $force          Force callback to be executed when transient is locked
+     * @param string      $slug              Unique identifier for transient
+     * @param callable    $callback          Callback that generates the data that's to be cached
+     * @param integer     $transient_time    Expiration of transients in seconds
+     * @param integer     $lock_timeout      How long (in seconds) to lock the transient to prevent race conditions
+     * @param boolean     $force             Force callback to be executed when transient is locked
      * @param boolean     $enable_transients Force callback to be executed when transient is locked
      */
     protected static function handle_transient_locking($slug, $callback, $transient_time, $lock_timeout, $force, $enable_transients)
     {
         if ($enable_transients && self::_is_transient_locked($slug)) {
             /**
-             * Filters …
+             * Whether to force a locked transients to be regenerated.
              *
-             * @todo Add summary, add description, add description for $force param
+             * If a transient is locked, it means that another process is currently generating the data.
+             * If you want to force the transient to be regenerated, during that process, you can set this
+             * filter to true.
              *
              * @since 2.0.0
-             * @param bool $force
+             * @param bool $force Whether to force a locked transient to be regenerated.
              */
             $force = \apply_filters('timber/transient/force_transients', $force);
 
             /**
-             * Filters …
+             * Whether to force a locked transients to be regenerated.
              *
-             * @todo Add summary
+             * If a transient is locked, it means that another process is currently generating the data.
+             * If you want to force the transient to be regenerated, during that process, you can set this
+             * filter to true.
              *
              * @deprecated 2.0.0, use `timber/transient/force_transients`
              */
@@ -106,27 +110,44 @@ class Helper
             );
 
             /**
-             * Filters …
+             * Whether to force a specific locked transients to be regenerated.
              *
-             * Here is a description about the filter.
-             * `$slug` The transient slug.
+             * If a transient is locked, it means that another process is currently generating the data.
+             * If you want to force the transient to be regenerated during that process, you can set this value to true.
              *
-             * @todo Add summary, add description, add description for $force param
+             * @example
+             * ```php
              *
+             * add_filter( 'timber/transient/force_transient_mycustumslug', function($force) {
+             *     if(false == something_special_has_occured()){
+             *       return false;
+             *     }
+             *
+             *     return true;
+             * }, 10 );
+             * ```
              * @since 2.0.0
              *
-             * @param bool $force
+             * @param bool $force Whether to force a locked transient to be regenerated.
              */
             $force = \apply_filters("timber/transient/force_transient_{$slug}", $force);
 
             /**
-             * Filters …
+             * Whether to force a specific locked transients to be regenerated.
              *
-             * @todo Add summary
-             *
+             * If a transient is locked, it means that another process is currently generating the data.
+             * If you want to force the transient to be regenerated, during that process, you can set this value to true.
+             * `$slug` The transient slug.
+             * 
+             * @param bool $force Whether to force a locked transient to be regenerated.
              * @deprecated 2.0.0, use `timber/transient/force_transient_{$slug}`
              */
-            $force = \apply_filters("timber_force_transient_{$slug}", $force);
+            $force = \apply_filters_deprecated(
+                "timber_force_transient_{$slug}",
+                [$force],
+                '2.0.0',
+                "timber/transient/force_transient_{$slug}"
+            );
 
             if (!$force) {
                 //the server is currently executing the process.

--- a/src/Image/Operation/Resize.php
+++ b/src/Image/Operation/Resize.php
@@ -104,7 +104,7 @@ class Resize extends ImageOperation
         $current_size = $image->get_size();
         $src_w = $current_size['width'];
         $src_h = $current_size['height'];
-        $src_ratio = $src_w / $src_h;
+        $src_ratio = $src_w / max(1, $src_h);
         if (!$h) {
             $h = \round($w / $src_ratio);
         }
@@ -124,7 +124,7 @@ class Resize extends ImageOperation
             ];
         }
         // Get ratios
-        $dest_ratio = $w / $h;
+        $dest_ratio = $w / max(1, $h);
         $src_wt = $src_h * $dest_ratio;
         $src_ht = $src_w / $dest_ratio;
         $src_x = $src_w / 2 - $src_wt / 2;

--- a/src/LocationManager.php
+++ b/src/LocationManager.php
@@ -26,20 +26,28 @@ class LocationManager
         }, $locs);
 
         /**
-         * Filters …
+         * Filters the filesystem paths to search for Twig templates.
          *
-         * @todo Add summary, description, example, parameter description
+         * @example
+         * ```
+         * add_filter( 'timber/locations', function( $locs ) {
+         *   $locs = \array_map(function ($loc) {
+         *      \array_unshift($loc, \dirname(__DIR__) . '/my-custom-dir');
+         *       return $loc;
+         *   }, $locs);
+         *
+         *     return $locs;
+         * } );
+         * ```
          *
          * @since 0.20.10
          *
-         * @param array $locs
+         * @param array $locs An array of filesystem paths to search for Twig templates.
          */
         $locs = \apply_filters('timber/locations', $locs);
 
         /**
-         * Filters …
-         *
-         * @todo Add summary
+         * Filters the filesystem paths to search for Twig templates.
          *
          * @deprecated 2.0.0, use `timber/locations`
          */

--- a/src/Post.php
+++ b/src/Post.php
@@ -721,8 +721,6 @@ class Post extends CoreEntity implements DatedInterface, Setupable
          *
          * This filter is used by the ACF Integration.
          *
-         * @todo Add example
-         *
          * @see   \Timber\Post::field_object()
          * @since 1.6.0
          *
@@ -915,7 +913,16 @@ class Post extends CoreEntity implements DatedInterface, Setupable
          *
          * This filter is used by the CoAuthorsPlus integration.
          *
-         * @todo  Add example
+         * @example
+         * ```
+         * add_filter( 'timber/post/authors', function( $author, $post ) {
+         *      foreach ($cauthors as $author) {
+         *        // do something with $author
+         *      }
+         *
+         *     return $authors;
+         * } );
+         * ```
          *
          * @see   \Timber\Post::authors()
          * @since 1.1.4

--- a/src/Term.php
+++ b/src/Term.php
@@ -401,7 +401,15 @@ class Term extends CoreEntity
         /**
          * Filters the relative link (path) to a term archive page.
          *
-         * @todo Add example
+         * ```
+         * add_filter( 'timber/term/path', function( $rel, $term ) {
+         *     if ( $term->slug === 'news' ) {
+         *        return '/category/modified-url';
+         *     }
+         *
+         *     return $rel;
+         * }, 10, 2 );
+         * ```
          *
          * @see   \Timber\Term::path()
          * @since 0.21.9

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -103,7 +103,8 @@ class Timber
      */
     public static function init()
     {
-        if (!\defined('ABSPATH')
+        if (
+            !\defined('ABSPATH')
             || !\class_exists('\WP')
             || \defined('TIMBER_LOADED')
         ) {
@@ -1454,7 +1455,7 @@ class Timber
          *
          * @since 2.0.0
          *
-         * @param string $output
+         * @param string|bool $output the compiled output.
          */
         $output = \apply_filters('timber/compile/result', $output);
 
@@ -1465,15 +1466,13 @@ class Timber
          * This action can be helpful if you need to debug Twig template
          * compilation.
          *
-         * @todo Add parameter descriptions
-         *
          * @since 2.0.0
          *
-         * @param string $output
-         * @param string $file
-         * @param array  $data
-         * @param bool   $expires
-         * @param string $cache_mode
+         * @param string            $output       The compiled output.
+         * @param string            $file         The name of the Twig template that was compiled.
+         * @param array             $data         The data that was used to compile the Twig template.        
+         * @param bool|int|array    $expires      The expiration time of the cache in seconds, or false to disable cache.
+         * @param string            $cache_mode   Any of the cache mode constants defined in Timber\Loader.
          */
         \do_action('timber/compile/done', $output, $file, $data, $expires, $cache_mode);
 

--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -172,14 +172,17 @@ class URLHelper
     }
 
     /**
-     * Takes a url and figures out its place based in the file system based on path
+     * Translates a URL to a filesystem path
+     * 
+     * Takes a url and figures out its filesystem location.
+     * 
      * NOTE: Not fool-proof, makes a lot of assumptions about the file path
      * matching the URL path
      *
      * @api
      *
-     * @param string $url
-     * @return string
+     * @param string $url The URL to translate to a filesystem path
+     * @return string The filesystem path derived from the URL
      */
     public static function url_to_file_system($url)
     {
@@ -187,15 +190,15 @@ class URLHelper
 
         /**
          * Filters the path of a parsed URL.
-         *
+         * 
+         * You can use this filter to alter the returned file system path. 
          * This filter is used by the WPML integration.
-         *
-         * @todo Add description, parameter description.
+
          *
          * @see \Timber\URLHelper::url_to_file_system()
          * @since 1.3.2
          *
-         * @param string $path
+         * @param string $path The current translated path
          */
         $url_parts['path'] = \apply_filters('timber/url_helper/url_to_file_system/path', $url_parts['path']);
 
@@ -217,43 +220,48 @@ class URLHelper
     }
 
     /**
+     * Translates a filesystem path to a URL
+     * 
+     * Takes a filesystem path and figures out its URL location.
+     * 
      * @api
-     * @param string $fs
-     * @return string
+     * @param string $fs The filesystem path to translate to a URL
+     * @return string    The URL derived from the filesystem path
      */
     public static function file_system_to_url($fs)
     {
         $relative_path = self::get_rel_path($fs);
-        $home = \home_url('/' . $relative_path);
+        $url = \home_url('/' . $relative_path);
 
         /**
-         * Filters the home URL …
-         *
+         * Filters the URL in URLHelper::file_system_to_url
+         * 
+         * You can use this filter to alter the returned URL. 
          * This filter is used by the WPML integration.
-         *
-         * @todo Complete summary, add description.
          *
          * @see \Timber\URLHelper::file_system_to_url()
          * @since 1.3.2
          *
-         * @param string $home The home URL.
+         * @param string $url The current translated url
          */
-        $home = \apply_filters('timber/url_helper/file_system_to_url', $home);
+        $url = \apply_filters('timber/url_helper/file_system_to_url', $url);
 
         /**
-         * Filters the home URL …
-         *
-         * @todo Complete summary.
-         *
+         * Filters the URL in URLHelper::file_system_to_url
+         * 
+         * You can use this filter to alter the returned URL. 
+         * This filter is used by the WPML integration.
+         * 
+         * @param string $url The current url
          * @deprecated 2.0.0, use `timber/url_helper/file_system_to_url`
          */
-        $home = \apply_filters_deprecated(
+        $url = \apply_filters_deprecated(
             'timber/URLHelper/file_system_to_url',
-            [$home],
+            [$url],
             '2.0.0',
             'timber/url_helper/file_system_to_url'
         );
-        return $home;
+        return $url;
     }
 
     /**
@@ -318,6 +326,17 @@ class URLHelper
     public static function remove_double_slashes($url)
     {
         $url = \str_replace('//', '/', $url);
+
+        /**
+         * Filters the schemes that are excluded for double slash removal.
+         * 
+         * If an url start with one of the schemes in the whitelist, 
+         * that scheme will be excluded from the double slash removal.
+         *
+         * @since 1.16.0
+         *
+         * @param array $schemes_whitelist the schemes that are excluded for double slash removal.
+         */
         $schemes_whitelist = \apply_filters('timber/url/schemes-whitelist', ['http', 'https', 's3', 'gs']);
         foreach ($schemes_whitelist as $scheme) {
             if (\strstr($url, $scheme . ':') && !\strstr($url, $scheme . '://')) {

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -179,9 +179,9 @@ class TestTimberCache extends Timber_UnitTestCase
 
         Timber\Helper::_lock_transient($transient, 30);
 
-        add_filter('timber_force_transient_' . $transient, '__return_true');
+        add_filter('timber/transient/force_transient_timber_test_transient_' . $transient, '__return_true');
         $get_transient = Timber\Helper::transient($transient, '__return_true');
-        remove_filter('timber_force_transient_' . $transient, '__return_true');
+        remove_filter('timber/transient/force_transient_timber_test_transient_' . $transient, '__return_true');
 
         $this->assertTrue($get_transient);
     }
@@ -330,8 +330,10 @@ class TestTimberCache extends Timber_UnitTestCase
         $clear = $loader->clear_cache_timber(\Timber\Loader::CACHE_OBJECT);
         $this->assertTrue($clear);
         $works = true;
-        if (isset($wp_object_cache->cache[\Timber\Loader::CACHEGROUP])
-            && !empty($wp_object_cache->cache[\Timber\Loader::CACHEGROUP])) {
+        if (
+            isset($wp_object_cache->cache[\Timber\Loader::CACHEGROUP])
+            && !empty($wp_object_cache->cache[\Timber\Loader::CACHEGROUP])
+        ) {
             $works = false;
         }
         $this->assertTrue($works);


### PR DESCRIPTION

Related:

- https://github.com/timber/timber/actions/runs/7688000757/job/20948692822?pr=2901

## Issue
Tests seem to fail due to a deprecated filter still in use in the transient tests.


## Solution
Update filter


## Impact
Tests are almost running now? 👯 


## Usage Changes
no

## Considerations
no

## Testing
Test the test
