### PR TITLE
Fix adding classes in `MenuItem`

### DIFF
--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -180,7 +180,7 @@ class MenuItem extends CoreEntity
     public function add_class(string $class_name)
     {
         // Class name is already there
-        if (!\in_array($class_name, $this->classes, true)) {
+        if (\in_array($class_name, $this->classes, true)) {
             return;
         }
         $this->classes[] = $class_name;


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

N/A

## Issue
<!-- Description of the problem that this code change is solving -->

In Timber V1 `MenuItem` would have classes with their own ID e.g. `menu-item-123`.
In Timber V2 this was missing.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

Upon investigation I found that `add_class` had an inverted boolean check for `in_array`.
Correcting this fixes the issue.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->

This changes improves backwards compat with V1.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

N/A

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

N/A

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->

I assume that tests are missing or incorrect for this feature because it is a boolean flip.
Might be best if someone increased coverage.