### PR TITLE
Add filter to $output before it is cached

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -396,7 +396,7 @@ class ImageHelper
 
         /**
          * Filters basename for sideloaded files.
-         * @since 2.0.1
+         * @since 2.1.0
          * @example
          * ```php
          * // Change the basename used for sideloaded images.

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -176,6 +176,17 @@ class Loader
 
             $template = $twig->load($file);
             $output = $template->render($data);
+
+            /**
+             * Filters $output before it is cached.
+             *
+             * @since 2.0.1
+             *
+             * @param string $output
+             * @param array  $data
+             * @param string $file
+             */
+            $output = \apply_filters('timber/output/pre-cache', $output, $data, $file);
         }
 
         if (false !== $output && false !== $expires && null !== $key) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -180,7 +180,7 @@ class Loader
             /**
              * Filters $output before it is cached.
              *
-             * @since 2.0.1
+             * @since 2.1.0
              *
              * @param string $output
              * @param array  $data

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -329,7 +329,7 @@ class TestTimberCache extends Timber_UnitTestCase
         $clear = $loader->clear_cache_timber(Timber\Loader::CACHE_OBJECT);
         $this->assertTrue($clear);
         $works = true;
-      
+
         if (isset($wp_object_cache->cache[Timber\Loader::CACHEGROUP])
             && !empty($wp_object_cache->cache[Timber\Loader::CACHEGROUP])) {
             $works = false;


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

Related:
- #2908 

## Issue
When filtering $output with `timber/output` the result is not cached. This is inefficient if the filter being applied is deterministic based on $output content, because the filter results could also be cached rather than being run every time.


## Solution
This pull request adds another filter, `timber/output/pre-cache`, immediately after the template is rendered and before the $output is cached. If this filter is used, then its results will be cached.

## Impact
This pull request is backwards compatible, and does not break any existing uses of `timber/output`. The `apply_filters` call may add a tiny bit of overhead to each render (not including the actual filter, if any are added) , but overall this could be considered negligible.


## Usage Changes
No changes to how Timber is used, other than an additional filter.

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
No tests needed.
