### PR TITLE
2873 bug cannot use timberpostfactory when extending post class as the method is private

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -999,35 +999,21 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      */
     public function children($args = 'any')
     {
-        $post_type = 'any';
-        if (\is_string($args)) {
-            $post_type = $args;
-        } elseif (\array_values($args) === $args) {
-            $post_type = $args;
-        } elseif (\is_array($args)) {
-            $additional_args = $args;
+        if (\is_string($args) || \array_values($args) === $args) {
+            $args = [
+                'post_type' => 'parent' === $args ? $this->post_type : $args,
+            ];
         }
 
-        if ($post_type === 'parent') {
-            $post_type = $this->post_type;
-        }
-
-        $args = [
+        $args = \wp_parse_args($args, [
             'post_parent' => $this->ID,
-            'post_type' => $post_type,
+            'post_type' => 'any',
             'posts_per_page' => -1,
             'orderby' => 'menu_order title',
             'order' => 'ASC',
-            'post_status' => 'publish',
-        ];
+            'post_status' => 'publish' === $this->post_status ? ['publish', 'inherit'] : 'publish',
+        ]);
 
-        if ($this->post_status === 'publish') {
-            $args['post_status'] = ['publish', 'inherit'];
-        }
-
-        if (isset($additional_args)) {
-            $args = \array_merge($args, $additional_args);
-        }
         /**
          * Filters the arguments for the query used to get the children of a post.
          *

--- a/tests/test-timber-post.php
+++ b/tests/test-timber-post.php
@@ -686,6 +686,27 @@ class TestTimberPost extends Timber_UnitTestCase
         $this->assertSame(12, count($parent->children(['foo', 'bar'])));
     }
 
+    public function testPostChildrenWithArguments()
+    {
+        $parent_id = $this->factory->post->create([
+            'post_type' => 'foo',
+        ]);
+        $children = $this->factory->post->create_many(4, [
+            'post_parent' => $parent_id,
+            'post_type' => 'foo',
+            'post_status' => 'private',
+        ]);
+        $children = $this->factory->post->create_many(8, [
+            'post_parent' => $parent_id,
+            'post_type' => 'foo',
+        ]);
+        $parent = Timber::get_post($parent_id);
+        $this->assertSame(4, count($parent->children([
+            'post_type' => 'foo',
+            'post_status' => 'private',
+        ])));
+    }
+
     public function testPostNoConstructorArgument()
     {
         $pid = $this->factory->post->create();


### PR DESCRIPTION
Related:

- #2873

## Issue
The Timber\Post::factory() is private and thus cannot be overwritten. So there was no way to alter the query to get the children.


## Solution
Added two new ways to alter the query:

1. added a filter to change the arguments
2. Add a new functionality to overload the children() parameter with query arguments.

I came up with the second approach later because that might be easier for most people. You could just change the arguments in your `children` call or make a separate children method in your custom class that calls the parent::children method with these additional arguments.

## Impact
No negative impact since loading the argument with a string or a non-indexed array still works.

## Usage Changes
No

## Considerations
Maybe one of these methods is enough. Not sure if adding the full argument list is a bit too much for this method. 

## Testing
Yes! First unit test I've ever written 👯 