### PR TITLE
feat: add is_current and profile_link methods

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -201,6 +201,18 @@ class User extends CoreEntity
     }
 
     /**
+     * Check if the user object is the current user
+     *
+     * @api
+     *
+     * @return bool true if the user is the current user
+     */
+    public function is_current(): bool
+    {
+        return \get_current_user_id() === $this->ID;
+    }
+
+    /**
      * Get the name of the User
      *
      * @api
@@ -279,13 +291,13 @@ class User extends CoreEntity
     }
 
     /**
-       * Creates an associative array with user role slugs and their translated names.
-       *
-       * @internal
-       * @since 1.8.5
-       * @param array $roles user roles.
-       * @return array|null
-       */
+     * Creates an associative array with user role slugs and their translated names.
+     *
+     * @internal
+     * @since 1.8.5
+     * @param array $roles user roles.
+     * @return array|null
+     */
     protected function get_roles($roles)
     {
         if (empty($roles)) {
@@ -343,6 +355,32 @@ class User extends CoreEntity
     public function roles()
     {
         return $this->roles;
+    }
+
+    /**
+     * Gets the profile link to the user’s profile in the WordPress admin if the ID in the user object
+     * is the same as the current user’s ID.
+     *
+     * @api
+     * @since 2.1.0
+     * @example
+     *
+     * Get the profile URL for the current user:
+     *
+     * ```twig
+     * {% if user.profile_link %}
+     *     <a href="{{ user.profile_link }}">My profile</a>
+     * {% endif %}
+     * ```
+     * @return string|null The profile link for the current user.
+     */
+    public function profile_link(): ?string
+    {
+        if (!$this->is_current()) {
+            return null;
+        }
+
+        return \get_edit_profile_url($this->ID);
     }
 
     /**

--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -195,6 +195,34 @@ class TestTimberUser extends Timber_UnitTestCase
         $this->assertEquals('16th', $user->president);
     }
 
+    public function testIsCurrent()
+    {
+        $uid = $this->factory->user->create([
+            'display_name' => 'Charles vonderZwen',
+            'user_login' => 'cvanderzwen',
+        ]);
+
+        $user = Timber::get_user($uid);
+
+        wp_set_current_user($uid);
+
+        $this->assertTrue($user->is_current());
+    }
+
+    public function testProfileLink()
+    {
+        $uid = $this->factory->user->create([
+            'display_name' => 'Boaty McBoatface',
+            'user_login' => 'BMcBoatface',
+        ]);
+
+        wp_set_current_user($uid);
+
+        $user = Timber::get_user($uid);
+
+        $this->assertEquals('http://example.org/wp-admin/profile.php', $user->profile_link());
+    }
+
     public function testAvatar()
     {
         // Restore integration-free Class Map for users.


### PR DESCRIPTION
Related:

-  #2682

## Issue
> As discussed in #2676, we could add a `User::profile_link()` method that get’s the link the profile admin page if a user is logged in. This is more clear than `User::edit_link()`, where you might assume that you get URL to edit other users.

## Solution

- Add `is_current` method as an api method that checks if the current User object id is the same as the current (logged in) user.
- Use that method in the new `profile_link` method to check whether to return the profile url.


## Impact
A more clear method to get the profile url for the current user and as a bonus, a way to check if we are working with the current logged in user, which comes in handy for creating extensive front-end user profiles for example.

## Usage Changes
no.

## Considerations
Maybe we want to cache the result of the is_current method?

## Testing
Yes, tests included for both methods.
