### PR TITLE
feat: Add WP escapers via Twig filters

### DIFF
--- a/docs/v2/guides/escaping.md
+++ b/docs/v2/guides/escaping.md
@@ -48,7 +48,7 @@ The `wp_kses_post` escaper uses the internal WordPress function [`wp_kses_post()
 **Twig**
 
 ```twig
-<p class="intro">{{ post.post_content|e('wp_kses_post') }}</p>
+<p class="intro">{{ post.post_content|wp_kses_post }}</p>
 ```
 
 In this example, `post.post_content` contains the following string:
@@ -70,7 +70,7 @@ Uses WordPress’ internal [`esc_url`](https://codex.wordpress.org/Function_Refe
 **Twig**
 
 ```twig
-<a href="{{ post.meta('custom_link')|e('esc_url') }}"></a>
+<a href="{{ post.meta('custom_link')|esc_url }}"></a>
 ```
 
 **Output**
@@ -88,7 +88,7 @@ This is for plain old text. If your content has HTML markup, you should not use 
 **Twig**
 
 ```twig
-<div class="equation">{{ post.meta('equation')|e('esc_html') }}</div>
+<div class="equation">{{ post.meta('equation')|esc_html }}</div>
 ```
 
 **Output**
@@ -104,7 +104,7 @@ Escapes text strings for echoing in JavaScript. It is intended to be used for in
 **Twig**
 
 ```twig
-<script>var bar = '{{ post.meta('name')|e('esc_js') }}';</script>
+<script>var bar = '{{ post.meta('name')|esc_js }}';</script>
 ```
 
 **Output**

--- a/docs/v2/guides/escaping.md
+++ b/docs/v2/guides/escaping.md
@@ -43,7 +43,7 @@ In addition to these standard escaping functions, Timber comes with some valuabl
 
 KSES is a recursive acronym for `KSES Kills Evil Scripts`. It’s goal is to ensure only "allowed" HTML element names, attribute names and attribute values plus only sane HTML entities in the string. Allowed means based on a configuration.
 
-The `wp_kses_post` escaper uses the internal WordPress function [`wp_kses_post()`](https://codex.wordpress.org/Function_Reference/wp_kses_post) that sanitizes content for allowed HTML tags for the post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );`.
+The `wp_kses_post` escaper uses the internal WordPress function [`wp_kses_post()`](https://developer.wordpress.org/reference/functions/wp_kses_post/) that sanitizes content for allowed HTML tags for the post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );`.
 
 **Twig**
 
@@ -65,7 +65,7 @@ In this example, `post.post_content` contains the following string:
 
 ## esc_url
 
-Uses WordPress’ internal [`esc_url`](https://codex.wordpress.org/Function_Reference/esc_url) function on a text. This should be used to sanitize URLs.
+Uses WordPress’ internal [`esc_url`](https://developer.wordpress.org/reference/functions/esc_url/) function on a text. This should be used to sanitize URLs.
 
 **Twig**
 
@@ -81,7 +81,7 @@ Uses WordPress’ internal [`esc_url`](https://codex.wordpress.org/Function_Refe
 
 ## esc_html
 
-Escaping for HTML blocks. converts any potentially conflicting HTML entities to their encoded equivalent to prevent them from being rendered as markup by the browser, e.g. converts `<` to `&lt;` and double quotes `"` to `$quot;`.
+Escaping for HTML blocks. Converts any potentially conflicting HTML entities to their encoded equivalent to prevent them from being rendered as markup by the browser, e.g. converts `<` to `&lt;` and double quotes `"` to `$quot;`.
 
 This is for plain old text. If your content has HTML markup, you should not use `esc_html`, which will render the HTML as it looks in your code editor. To preserve the HTML you will want to use `wp_kses_post`.
 
@@ -95,6 +95,23 @@ This is for plain old text. If your content has HTML markup, you should not use 
 
 ```html
 <div class="equation">is x &lt; y?</div>
+```
+
+## esc_attr
+
+Escaping for HTML attributes. Encodes the <, >, &, ” and ‘ (less than, greater than, ampersand, double quote and single quote) characters. Will never double encode entities.
+Always use when escaping HTML attributes (especially form values) such as alt, value, title, etc.
+
+**Twig**
+
+```twig
+<input type="text" name="name" value="{{ user.name|esc_attr }}">
+```
+
+**Output**
+
+```html
+<input type="text" name="name" value="Han Solo">
 ```
 
 ## esc_js

--- a/src/Post.php
+++ b/src/Post.php
@@ -1674,11 +1674,11 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * Using simple links to the next an previous page.
      * ```twig
      * {% if post.pagination.next is not empty %}
-     *     <a href="{{ post.pagination.next.link|e('esc_url') }}">Go to next page</a>
+     *     <a href="{{ post.pagination.next.link|esc_url }}">Go to next page</a>
      * {% endif %}
      *
      * {% if post.pagination.prev is not empty %}
-     *     <a href="{{ post.pagination.prev.link|e('esc_url') }}">Go to previous page</a>
+     *     <a href="{{ post.pagination.prev.link|esc_url }}">Go to previous page</a>
      * {% endif %}
      * ```
      * Using a pagination for all pages.
@@ -1691,7 +1691,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      *                    {% if page.current %}
      *                        <span aria-current="page">Page {{ page.title }}</span>
      *                    {% else %}
-     *                        <a href="{{ page.link|e('esc_url') }}">Page {{ page.title }}</a>
+     *                        <a href="{{ page.link|esc_ur }}">Page {{ page.title }}</a>
      *                    {% endif %}
      *                </li>
      *            {% endfor %}

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -29,8 +29,8 @@ class Twig
 
         \add_filter('timber/twig', [$self, 'add_timber_functions']);
         \add_filter('timber/twig', [$self, 'add_timber_filters']);
+        \add_filter('timber/twig', [$self, 'add_timber_escaper_filters']);
         \add_filter('timber/twig', [$self, 'add_timber_escapers']);
-
         \add_filter('timber/loader/twig', [$self, 'set_defaults']);
     }
 
@@ -428,6 +428,73 @@ class Twig
     }
 
     /**
+     * Get Timber default filters
+     *
+     * @return array Default Timber filters
+     */
+    public function get_timber_escaper_filters()
+    {
+        $escaper_filters = [
+            /* image filters */
+            'esc_url' => [
+                'callable' => 'esc_url',
+            ],
+            'esc_url_raw' => [
+                'callable' => 'esc_url_raw',
+            ],
+            'wp_kses' => [
+                'callable' => 'wp_kses',
+            ],
+            'wp_kses_post' => [
+                'callable' => 'wp_kses_post',
+            ],
+            'esc_attr' => [
+                'callable' => 'esc_attr',
+            ],
+            'esc_html' => [
+                'callable' => 'esc_html',
+            ],
+            'esc_js' => [
+                'callable' => 'esc_js',
+            ],
+        ];
+
+        /**
+         * Filters the filters that are added to Twig.
+         *
+         * The `$escaper_filters` array is an associative array with the filter name as a key and an
+         * arguments array as the value. In the arguments array, you pass the function to call with
+         * a `callable` entry.
+         *
+         *
+         * @api
+         * @since 2.1.0
+         * @example
+         * ```php
+         * add_filter( 'timber/twig/escapers', function( $escaper_filters ) {
+         *     // Add your own filter.
+         *     $filters['esc_xml'] = [
+         *         'callable' => 'esc_xml',
+         *          'options' => [
+         *             'is_safe' => ['html'],
+         *          ],
+         *     ];
+         *
+         *     // Remove a filter.
+         *     unset( $filters['esc_js'] );
+         *
+         *     return $filters;
+         * } );
+         * ```
+         *
+         * @param array $escaper_filters
+         */
+        $escaper_filters = \apply_filters('timber/twig/escapers', $escaper_filters);
+
+        return $escaper_filters;
+    }
+
+    /**
      * Adds filters to Twig.
      *
      * @param Environment $twig The Twig Environment.
@@ -442,6 +509,23 @@ class Twig
                     $name,
                     $function['callable'],
                     $function['options'] ?? []
+                )
+            );
+        }
+
+        return $twig;
+    }
+
+    public function add_timber_escaper_filters($twig)
+    {
+        foreach ($this->get_timber_escaper_filters() as $name => $function) {
+            $twig->addFilter(
+                new TwigFilter(
+                    $name,
+                    $function['callable'],
+                    $function['options'] ?? [
+                        'is_safe' => ['html'],
+                    ]
                 )
             );
         }

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -439,9 +439,6 @@ class Twig
             'esc_url' => [
                 'callable' => 'esc_url',
             ],
-            'esc_url_raw' => [
-                'callable' => 'esc_url_raw',
-            ],
             'wp_kses' => [
                 'callable' => 'wp_kses',
             ],
@@ -460,7 +457,7 @@ class Twig
         ];
 
         /**
-         * Filters the filters that are added to Twig.
+         * Filters the escaping filters that are added to Twig.
          *
          * The `$escaper_filters` array is an associative array with the filter name as a key and an
          * arguments array as the value. In the arguments array, you pass the function to call with

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -435,7 +435,6 @@ class Twig
     public function get_timber_escaper_filters()
     {
         $escaper_filters = [
-            /* image filters */
             'esc_url' => [
                 'callable' => 'esc_url',
             ],

--- a/tests/test-timber-cache.php
+++ b/tests/test-timber-cache.php
@@ -552,7 +552,7 @@ class TestTimberCache extends Timber_UnitTestCase
         add_filter('timber/cache/transient_key', $filter);
 
         $loader = new Timber\Loader();
-        $loader->set_cache('test', 'foobar', \Timber\Loader::CACHE_TRANSIENT);
+        $loader->set_cache('test', 'foobar', Timber\Loader::CACHE_TRANSIENT);
 
         remove_filter('timber/cache/transient_key', $filter);
 

--- a/tests/test-timber-escapers.php
+++ b/tests/test-timber-escapers.php
@@ -1,0 +1,77 @@
+<?php
+
+class TestTimberFilterEscapers extends Timber_UnitTestCase
+{
+    public function testEscAttributeFilter()
+    {
+        $string = 'foo & bar';
+        $native = esc_attr($string);
+
+        $result = Timber::compile_string('{{ text|esc_attr }}', [
+            'text' => $string,
+        ]);
+
+        $this->assertEquals($native, $result);
+    }
+
+    public function testEscJSFilter()
+    {
+        // make onlclick string
+        $javascript_string = 'alert("Hello World");';
+        $native = esc_js($javascript_string);
+
+        $this->add_filter_temporarily('timber/twig/environment/options', function ($options) {
+            $options['autoescape'] = 'html';
+            return $options;
+        });
+
+        $result = Timber::compile_string('{{ text|esc_js }}', [
+            'text' => $javascript_string,
+        ]);
+
+        $this->assertEquals($native, $result);
+    }
+
+    public function testEscUrlFilter()
+    {
+        $dirty_url = 'https://example.com/?foo=1&bar=2';
+        $other_protocol_url = 'ftp://example.com/?foo=1&bar=2';
+
+        $native = esc_url($dirty_url);
+        $other_protocol_native = esc_url($other_protocol_url);
+
+        $this->add_filter_temporarily('timber/twig/environment/options', function ($options) {
+            $options['autoescape'] = 'html';
+            return $options;
+        });
+
+        $result = Timber::compile_string('<a href="{{ url|esc_url }}">', [
+            'url' => $dirty_url,
+        ]);
+
+        $other_protocol_result = Timber::compile_string('{{ url|esc_url }}', [
+            'url' => $other_protocol_url,
+        ]);
+
+        $this->assertEquals('<a href="' . $native . '">', $result);
+        $this->assertEquals($other_protocol_native, $other_protocol_result);
+    }
+
+    // Tests case as stated by https://github.com/timber/timber/issues/1848#issue-381346333
+    public function testDoubleEscaper()
+    {
+        $string = '<p>foo & bar</p>';
+        $native = wp_kses_post($string);
+
+        $this->add_filter_temporarily('timber/twig/environment/options', function ($options) {
+            $options['autoescape'] = 'html';
+            return $options;
+        });
+
+        $result = Timber::compile_string('{{ text|wp_kses_post }}', [
+            'text' => $string,
+        ]);
+
+        $this->assertEquals($native, $result);
+    }
+}


### PR DESCRIPTION
Related:

- #1848
- #1787

## Issue
Looking at the old issues I found this particular one. With escaping getting ever more important I wanted to take a shot at this.
Escaping currently in Timber is a bit cumbersome since you have to do things like this:

```twig
{{ my_content|e('esc_attr') }}
```
or even twig when setting the default Twig escaper already on in the environment. The |raw filter makes sure that the string is not double escaped.

```twig
{{ my_content|e('wp_kses_post')|raw }}
```

## Solution
Make escaping functions available via filters. 

- in `get_timber_escaper_filters` I add most of the default escapers that come with WP
- in `add_timber_escaper_filters` I have a simular function as `add_timber_filters` but add the following options by default:
```php
options' => [
  " 'is_safe' => ['html'],
],
```

## Impact
A better way of applying escapers

## Usage Changes
So instead of running `{{ my_content|e('esc_attr') }}` we can now run {{ my_content|esc_attr }} and it does not matter if the global escaping is on or off.

## Considerations
I did not spend much time on the docs at this time, but this is needed. We also might want to deprecate the old way of adding filters in the future, so this would be the recommended way.

If we want to implement this, we also need to take a look at  #1787 on updating the existing escaping examples in the PHP files.

## Testing
Yes. there were no escaper tests at this time so I added them and run some of them with global escaping on to test #1848