### PR TITLE
2.x Fix #2773 (send empty extension for image with no extension)

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -619,7 +619,7 @@ class ImageHelper
         $parts = PathHelper::pathinfo($tmp);
         $result['subdir'] = ($parts['dirname'] === '/') ? '' : $parts['dirname'];
         $result['filename'] = $parts['filename'];
-        $result['extension'] = \strtolower($parts['extension']);
+        $result['extension'] = (isset($parts['extension']) ? \strtolower($parts['extension']) : '');
         $result['basename'] = $parts['basename'];
 
         return $result;

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -457,8 +457,8 @@ class ImageHelper
         }
         $tmp = \download_url($file);
         \preg_match('/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file, $matches);
+
         $file_array = [];
-        $file_array['name'] = PathHelper::basename($matches[0]);
         $file_array['tmp_name'] = $tmp;
         // If error storing temporarily, do not use
         if (\is_wp_error($tmp)) {

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -57,6 +57,20 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         return $dest;
     }
 
+    public function delete_existing_sideloaded_image($file)
+    {
+        // @see \Timber\ImageHelper::sideload_image()
+        add_filter('upload_dir', [Timber\ImageHelper::class, 'set_sideload_image_upload_dir']);
+
+        $file_loc = Timber\ImageHelper::get_sideloaded_file_loc($file);
+
+        if (file_exists($file_loc)) {
+            unlink($file_loc);
+        }
+
+        remove_filter('upload_dir', [Timber\ImageHelper::class, 'set_sideload_image_upload_dir']);
+    }
+
     public function testExternalImageWithInvalidUrl()
     {
         $image = Timber::get_external_image(78);
@@ -127,6 +141,20 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
 
         $this->assertSame(
             'http://example.org/wp-content/uploads/external/634489eb6a8b95c9ef9fac9b119bd92a.jpg',
+            $image->src()
+        );
+    }
+
+    public function testExternalImageWithExternalUrlAndNoImageExtension()
+    {
+        $file = 'https://placekitten.com/222/333';
+        $filename = basename(Timber\ImageHelper::get_sideloaded_file_loc($file));
+        $this->delete_existing_sideloaded_image($file);
+
+        $image = Timber::get_external_image($file);
+
+        $this->assertSame(
+            'http://example.org/wp-content/uploads/external/' . $filename,
             $image->src()
         );
     }


### PR DESCRIPTION
Related:

- #2773
- #2774

## Issue

The pull request in #2774 was still for the 1.x branch.

## Solution

This pull request ports the changes from #2774 over to the 2.x branch. And it adds a test to make sure this works.

## Impact

No errors for image URLs without extensions.

## Usage Changes

None.

## Considerations

When no image extension is given, Timber will just assume it’s a JPG. If you know it’s another image type, there’s no way to pass that. The question is: should you be able to pass that as a parameter?

## Testing

Yes.