### PR TITLE
Fix: allow Timber\PostExcerpt::read_more to accept bool value

### DIFF
--- a/src/PostExcerpt.php
+++ b/src/PostExcerpt.php
@@ -87,7 +87,7 @@ class PostExcerpt
     /**
      * Read more text.
      *
-     * @var string
+     * @var string|bool
      */
     protected $read_more = 'Read More';
 
@@ -299,7 +299,7 @@ class PostExcerpt
      * <p>{{ post.excerpt.read_more('Learn more') }}</p>
      * ```
      *
-     * @param string $text Text for the link. Default 'Read More'.
+     * @param string|bool $readmore Text for the link. Default 'Read More'.
      *
      * @return PostExcerpt
      */

--- a/src/PostExcerpt.php
+++ b/src/PostExcerpt.php
@@ -299,7 +299,7 @@ class PostExcerpt
      * <p>{{ post.excerpt.read_more('Learn more') }}</p>
      * ```
      *
-     * @param string|bool $readmore Text for the link. Default 'Read More'.
+     * @param string|bool $text Text for the link. Default 'Read More'.
      *
      * @return PostExcerpt
      */


### PR DESCRIPTION
Related:

- #2578

## Issue

```
The [Timber\PostPreview::read_more](https://timber.github.io/docs/reference/timber-postpreview/#read_more) docs say:

    Set this to false to not add a "Read More" link.

But Timber\PostPreview::read_more doesn't actually accept a boolean value, it only accepts a string value type. 😬
```

## Solution
Port changes of #2578 to v2.


## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
No

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
Already covered by tests in `TestTimberPostExcerptObject::testExcerptConstructorWithWords`
