### PR TITLE
chore: Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,13 @@
 # Security Policy
 
 ## Reporting a Vulnerability
-If you discover a security vulnerability within Timber, please subit your report via the link below. Please be mindful of the fact that the maintainers are working on Timber in their free time, so the initial response can take some time.
+If you discover a security vulnerability within Timber, please submit your report via the link below. Please be mindful of the fact that the maintainers are working on Timber in their free time, so the initial response can take some time.
 
 ### Disclosure Policy
 Please do not discuss any vulnerabilities (even resolved ones) without express consent.
 
 ### Submit your report
-When you've found a security issue that abides by the rules and scope of this project, please submit the report to us via [Github](https://github.com/timber/timber/security/advisories/new). In your report, make sure to include:
-
-- the calculation of the CVSS (using the [CVSS calculator](https://www.first.org/cvss/calculator/3.0));
-- the impact of the issue;
-- a detailed guide on how to reproduce the issue;
+When you've found a security issue that abides by the rules and scope of this project, please submit the report to us via [Github](https://github.com/timber/timber/security/advisories/new). In your report, make sure to include a detailed guide on how to reproduce the issue.
 
 ### After your submission
 We will make a best effort to meet the following response targets for security reports:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+If you discover a security vulnerability within Timber, please subit your report via the link below. Please be mindful of the fact that the maintainers are working on Timber in their free time, so the initial response can take some time.
+
+### Disclosure Policy
+Please do not discuss any vulnerabilities (even resolved ones) without express consent.
+
+### Submit your report
+When you've found a security issue that abides by the rules and scope of this project, please submit the report to us via [Github](https://github.com/timber/timber/security/advisories/new). In your report, make sure to include:
+
+- the calculation of the CVSS (using the [CVSS calculator](https://www.first.org/cvss/calculator/3.0));
+- the impact of the issue;
+- a detailed guide on how to reproduce the issue;
+
+### After your submission
+We will make a best effort to meet the following response targets for security reports:
+
+- Time to first response (from report submit) - 5 business days
+- Time to triage (from report submit) - 10 business days
+- Time to fix (from triage) - 15 business days


### PR DESCRIPTION
Related:

- #2938

## Issue
We don't have a security policy to inform how to disclose vulnerabilities.

## Solution
Create a policy based on other open source WP projects.

## Impact
Better security disclosures as they occur.

## Usage Changes
none

## Considerations
We might want to link to this as well from the readme.md
