### PR TITLE
ACFIntegration: Empty Datepickerfield returns "" instead of null

### DIFF
--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -153,7 +153,7 @@ class AcfIntegration implements IntegrationInterface
     public static function transform_date_picker($value, $id, $field)
     {
         if (!$value) {
-            return $value;
+            return null;
         }
         return new DateTimeImmutable(\acf_format_date($value, 'Y-m-d H:i:s'));
     }


### PR DESCRIPTION
# Problem

If you have an empty `DatePicker` field in ACF:

- `$post->raw_meta('empty_date_field')` returns `null`
- `$post->meta('empty_date_field')` returns `""`

# Solution

We return `null`, if `!$value` instead of `$value`.

### Alternative

Maybe it's more in the spirit of the ACF to return `false`, but 😕 
`null` though allows you to chain easily `$post->meta('empty_date_field')?->format('d. F Y')`. 
