### PR TITLE
updated guternberg docs to reflect ACF Block >v6

### DIFF
--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -8,29 +8,28 @@ order: "1550"
 Timber works with the Block Editor (also called Gutenberg) out of the box. If you use `{{ post.content }}`, Timber will render all the Gutenberg blocks.
 
 ## ACF Blocks
-
-### What are ACF Blocks?
-
 ACF Blocks are an alternative way to create content blocks without advanced JavaScript knowledge. If you want to learn more about them, read the article on [advancedcustomfields.com](https://www.advancedcustomfields.com/resources/blocks/).
 
-### How to use ACF Blocks with Timber
+### Concept
+A (ACF) block is an individual element that can be added to a page or post. It can be a simple text block, a gallery, a call to action, or a complex layout. Blocks are the building blocks of your website. In this tutorial, we will show you how to create a simple block with ACF and Timber.
+
+### Prerequisites
 
 Before you can start using ACF Blocks, you must install the Advanced Custom Fields Pro 6.0 or later.
 
 #### Add Blocks Directory Structure
 
-First, we will create a blocks directory in our theme folder. This directory will house the individual block.json files that will provide the settings for each respective block.
+First, we will create a `blocks` directory in our theme folder. This directory will house folders for each of our custom blocks. Inside each block directory, we will have a block.json file, a CSS file and a Twig template. 
 
-1. Create a **blocks** directory in the root of your theme: 
+1. Create a `blocks` directory in the root of your theme: 
 2. Add a directory with the block name of your choice. Example: **my-block**
 3. Within your custom block directory, create a block.json file. 
 4. Also within your custom block directory, add a css file to reference in the settings. 
-    * Note: this is optional. You can reference CSS from any directory or rely on sitewide styling to get applied to your block on production. For purposes of this tutorial
+    * Note: this is optional. You can reference CSS from any directory or rely on sitewide styling to get applied to your block on production.
 
-Your blocks directory shoud look like this: 
+Your theme structure should look like this: 
 
 ```
-.
 |--...
 |-- wp-content
 |   |-- themes 
@@ -43,8 +42,9 @@ Your blocks directory shoud look like this:
 ```
 
 #### Write the Block Settings file: block.json
+The block.json file is a configuration file that contains the settings for your block. It is used to define the block's name, title, description, category among many other settings.
 
-[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use renderCallback instead of renderTemplate so we can set a function callback to render all our blocks instead of creating a function for each individual block.
+[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
 
 Example contents of the block.json
 ```json
@@ -63,11 +63,11 @@ Example contents of the block.json
     } 
 }
 ```
-Important note on the `name` property: You are not required to use `acf ` as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example you could also name them `my-project/block-name`. Keep in mind that we recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
+Important note on the `name` property: You are not required to use `acf` as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example you could also name them `my-project/block-name`. Keep in mind that we recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
 
 #### Register the Block
 
-Your theme needs to know the block exists on `init` so we will use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function within our functions.php file and trigger the function on the  `init` action. 
+Your theme needs to know the block exists on `init` so we will use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function within our functions.php file and trigger the function on the `init` action. 
 
 The straight forward way to do this is shown below: 
 
@@ -94,20 +94,33 @@ add_action( 'init', 'register_acf_blocks' ); //trigger the register function on 
 
 #### Render Block
 
-Next, add the following function to your functions.php file:  
+Now that we have our block registered, we need to create a function to render our blocks. We will create a function called `my_acf_block_render_callback` that will be used to render all our blocks. In this function we will prepaire the context for our block and render the block using Timber.
 
 ```php
-function my_acf_block_render_callback( $block ) {
+/**
+ * Render callback to prepare and display a registered block using Timber.
+ *
+ * @param    array    $attributes The block attributes.
+ * @param    string   $content The block content.
+ * @param    bool     $is_preview Whether or not the block is being rendered for editing preview.
+ * @param    int      $post_id The current post being edited or viewed.
+ * @param    WP_Block $wp_block The block instance (since WP 5.5).
+ * @return   void
+ */
+function my_acf_block_render_callback($attributes, $content = '', $is_preview = false, $post_id = 0, $wp_block = null) {
     // Create the slug of the block using the name property in the block.json. 
 	$slug = str_replace( 'acf/', '', $block['name'] );
 
 	$context = Timber::context();
 
-	// Store block values. 
-	$context['block'] = $block;
+	// Store block attributes. 
+	$context['attributes'] = $attributes;
 
 	// Store field values. These are the fields from your ACF field group for the block. 
 	$context['fields'] = get_fields(); 
+
+    // Store whether the block is being rendered in the editor or on the frontend.
+    $context['is_preview'] = $is_preview;
 
 	// Render the block.
 	Timber::render(
@@ -116,7 +129,7 @@ function my_acf_block_render_callback( $block ) {
 	);
 }
 ```
-We call this function in the renderCallback object in block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory. 
+We call this function in the `renderCallback` object in block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory. 
 
 #### Create fields in ACF
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -145,7 +145,7 @@ Url: {{ fields.group.url }}
 
 #### Render Block
 
-Finally, Add the following function to your template to your functions.php file:  
+Finally, Add the following function to your functions.php file:  
 
 ```php
 //functions.php 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -8,93 +8,112 @@ order: "1550"
 Timber works with the Block Editor (also called Gutenberg) out of the box. If you use `{{ post.content }}`, Timber will render all the Gutenberg blocks.
 
 ## ACF Blocks
-ACF Blocks are an alternative way to create content blocks without advanced JavaScript knowledge. If you want to learn more about them, read the article on [advancedcustomfields.com](https://www.advancedcustomfields.com/resources/blocks/).
+
+[ACF Blocks](https://www.advancedcustomfields.com/resources/blocks/) are an alternative way to create content blocks without advanced JavaScript knowledge.
 
 ### Concept
+
 A (ACF) block is an individual element that can be added to a page or post. It can be a simple text block, a gallery, a call to action, or a complex layout. Blocks are the building blocks of your website. In this tutorial, we will show you how to create a simple block with ACF and Timber.
 
 ### Prerequisites
 
-Before you can start using ACF Blocks, you must install the Advanced Custom Fields Pro 6.0 or later.
+Before you can start using ACF Blocks, you must install Advanced Custom Fields Pro 6.0 or later.
 
 #### Add Blocks Directory Structure
 
-First, we will create a `blocks` directory in our theme folder. This directory will house folders for each of our custom blocks. Inside each block directory, we will have a block.json file, a CSS file and a Twig template. 
+First, we will create a `blocks` directory in our theme folder. This directory will house folders for each of our custom blocks. Inside each block directory, we will have a block.json file, a CSS file and a Twig template.
 
-1. Create a `blocks` directory in the root of your theme: 
-2. Add a directory with the block name of your choice. Example: **my-block**
-3. Within your custom block directory, create a block.json file. 
-4. Also within your custom block directory, add a css file to reference in the settings. 
+1. Create a `blocks` directory in the root of your theme.
+2. Add a directory with the block name of your choice. Example: **my-block**.
+3. Within your custom block directory, create a block.json file.
+4. Also within your custom block directory, add a CSS file to reference in the settings.
     * Note: this is optional. You can reference CSS from any directory or rely on sitewide styling to get applied to your block on production.
 
-Your theme structure should look like this: 
+Your theme structure should look like this:
 
 ```
 |--...
 |-- wp-content
-|   |-- themes 
-|       |-- your-theme # your theme directory
-|           |-- blocks # your blocks directory
-|               |-- my-block # your block
-|                   |-- block.json # your block settings 
-|                   |-- my-block.css # styles for your block
-|                   |-- my-block.twig # your block template
+|   |-- themes
+|       |-- your-theme                  # Your theme directory
+|           |-- blocks                  # Your blocks directory
+|               |-- my-block            # Your block
+|                   |-- block.json      # Your block settings
+|                   |-- my-block.css    # Styles for your block
+|                   |-- my-block.twig   # Your block template
 ```
 
-#### Write the Block Settings file: block.json
-The block.json file is a configuration file that contains the settings for your block. It is used to define the block's name, title, description, category among many other settings.
+#### The block settings file: block.json
 
-[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
+The block.json file is a configuration file that contains the settings for your block. It is used to define the block’s name, title, description, category among many other settings.
+
+[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we’ll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
 
 Example contents of the block.json
+
 ```json
 {
-    "name": "acf/my-block", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name
-    "title": "My Block", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title
-    "description": "Description for my block", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#description
-    "style": [ "file:./my-block.css" ], // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category,
-    
-    "category": "formatting", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#category
-    "icon": "format-aside", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#icon
-    "keywords": ["my", "block"], // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#keywords
-    "acf": { 
-        "mode": "preview", // https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson
-        "renderCallback": "my_acf_block_render_callback" // the function that will render the block we'll add later on
-    } 
+    "name": "acf/my-block",
+    "title": "My Block",
+    "description": "Description for my block",
+    "style": [ "file:./my-block.css" ],
+    "category": "formatting",
+    "icon": "format-aside",
+    "keywords": ["my", "block"],
+    "acf": {
+        "mode": "preview",
+        "renderCallback": "my_acf_block_render_callback"
+    }
 }
 ```
-Important note on the `name` property: You are not required to use `acf` as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example you could also name them `my-project/block-name`. Keep in mind that we recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
+
+**Notes:**
+
+- Learn more about the different entries in the block.json file in the [WordPress documentation](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata).
+- For the entries under `acf`, learn more in the [ACF documentation](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson).
+- For the `name` property, you are not required to use `acf` as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example: you could also name them `my-project/block-name`. We recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
 
 #### Register the Block
 
-Your theme needs to know the block exists on `init` so we will use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function within our functions.php file and trigger the function on the `init` action. 
+Your theme needs to know the block exists on `init` so we will use the [register_block_type()](https://developer.wordpress.org/reference/functions/register_block_type/) function and trigger the function on the `init` action.
 
-The straight forward way to do this is shown below: 
+Here’s the straight-forward way to do this.
+
+**functions.php**
 
 ```php
 function register_acf_blocks() {
-    register_block_type( __DIR__ . '/blocks/my-block' ); //register_block_type will look in the current directory and register the block you specify
-    //add additional register_block_type functions for each of your custom blocks
+    // The register_block_type() function will look in the current directory and
+    // register the block you specify. Add additional register_block_type()
+    // functions for each of your custom blocks.
+    register_block_type( __DIR__ . '/blocks/my-block' );
 }
-add_action( 'init', 'register_acf_blocks' ); //trigger the register function on init
+
+add_action( 'init', 'register_acf_blocks' );
 ```
 
 Alternatively, you can dynamically register each block. This will keep our code DRY and prevent you from having to register each individual block every time you create a new one.
 
 ```php
 function register_acf_blocks() {
-	foreach ( $blocks = new DirectoryIterator( __DIR__ . '/blocks' ) as $item ) {
-        if ( $item -> isDir() && !$item -> isDot() ) //check for the directory
-		if ( file_exists( $item -> getPathname() . '/block.json' ) ) //check if the block.json exists
-		register_block_type( $item -> getPathname() );  //register the block given the directory name within the blocks directory
-	}
+    foreach ($blocks = new DirectoryIterator( __DIR__ . '/blocks' ) as $item) {
+        // Check if block.json file exists in each subfolder.
+        if ($item->isDir() && !$item->isDot()
+            && file_exists($item->getPathname() . '/block.json')
+        ) {
+            // Register the block given the directory name within the blocks
+            // directory.
+            register_block_type($item -> getPathname());
+        }
+    }
 }
-add_action( 'init', 'register_acf_blocks' ); //trigger the register function on init
+
+add_action('init', 'register_acf_blocks');
 ```
 
-#### Render Block
+#### Render block
 
-Now that we have our block registered, we need to create a function to render our blocks. We will create a function called `my_acf_block_render_callback` that will be used to render all our blocks. In this function we will prepaire the context for our block and render the block using Timber.
+Now that we have our block registered, we need to create a function to render our blocks. We will create a function called `my_acf_block_render_callback()` that will be used to render all our blocks. In this function, we will prepare the context for our block and render the block using Timber.
 
 ```php
 /**
@@ -108,44 +127,46 @@ Now that we have our block registered, we need to create a function to render ou
  * @return   void
  */
 function my_acf_block_render_callback($attributes, $content = '', $is_preview = false, $post_id = 0, $wp_block = null) {
-    // Create the slug of the block using the name property in the block.json. 
-	$slug = str_replace( 'acf/', '', $block['name'] );
+    // Create the slug of the block using the name property in the block.json.
+    $slug = str_replace( 'acf/', '', $block['name'] );
 
-	$context = Timber::context();
+    $context = Timber::context();
 
-	// Store block attributes. 
-	$context['attributes'] = $attributes;
+    // Store block attributes.
+    $context['attributes'] = $attributes;
 
-	// Store field values. These are the fields from your ACF field group for the block. 
-	$context['fields'] = get_fields(); 
+    // Store field values. These are the fields from your ACF field group for the block.
+    $context['fields'] = get_fields();
 
     // Store whether the block is being rendered in the editor or on the frontend.
     $context['is_preview'] = $is_preview;
 
-	// Render the block.
-	Timber::render(
-			'blocks/' . $slug . '/' . $slug . '.twig',
-			$context
-	);
+    // Render the block.
+    Timber::render(
+        'blocks/' . $slug . '/' . $slug . '.twig',
+        $context
+    );
 }
 ```
-We call this function in the `renderCallback` object in block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory. 
+We call this function in the `renderCallback` object in the block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory.
 
 #### Create fields in ACF
 
-[ACF has precise guidance](https://www.advancedcustomfields.com/resources/create-your-first-acf-block/#create-the-testimonial-field-group) on how to create the fields for your block. The important thing is to make sure the field group is enabled for your specific block: 
-    Show field group if: Block  
-    Operator: is equal to  
-    Selector: My Block  
-    
+[ACF has precise guidance](https://www.advancedcustomfields.com/resources/create-your-first-acf-block/#create-the-testimonial-field-group) on how to create the fields for your block. The important thing is to make sure the field group is enabled for your specific block:
+
+- **Show field group if:** Block
+- **Operator:** is equal to
+- **Selector:** My Block
 
 #### Block Template
-Now that we have our block directory and settings, we need the a twig template for our block that will be used to display our block. 
 
-Within our new Twig template, we will call each of the fields we created in ACF for our block. Each field we define for this block in ACF will be prepended with the fields key. Here is a simple example: 
+Now that we have our block directory and settings, we need the a Twig template for our block that will be used to display our block.
+
+Within our new Twig template, we will call each of the fields we created in ACF for our block. Each field we define for this block in ACF will be prepended with the fields key. Here is a simple example:
+
+**my-block.twig**
 
 ```twig
-{# my-block.twig #}
 <div>
     <h2>{{ fields.title }}</h2>
     <p>{{ fields.text }}</p>
@@ -154,7 +175,7 @@ Within our new Twig template, we will call each of the fields we created in ACF 
 
 ##### Using repeaters
 
-```
+```twig
 {% for field in fields.repeater %}
     Title: {{ field.title }} <br/>
     Url: {{ field.url }}
@@ -163,9 +184,7 @@ Within our new Twig template, we will call each of the fields we created in ACF 
 
 ##### Using groups
 
-```
+```twig
 Title: {{ fields.group.title }} <br/>
 Url: {{ fields.group.url }}
 ```
-
-

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -23,7 +23,7 @@ First, we will create a blocks directory in our theme folder. This directory wil
 
 1. Create a **blocks** directory in the root of your theme: 
 2. Add a directory with the block name of your choice. Example: **my-block**
-3. Within your custom block directory, add the block.json file. 
+3. Within your custom block directory, create a block.json file. 
 4. Also within your custom block directory, add a css file to reference in the settings. 
     * Note: this is optional. You can reference CSS from any directory or rely on sitewide styling to get applied to your block on production. For purposes of this tutorial
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -168,7 +168,7 @@ function my_acf_block_render_callback( $block ) {
 	);
 }
 ```
-We call this function in the renderCallback object in block.json file of our block. This function will work for all blocks so long as we follow the nameing convertion of acf/[block name] for the name property in the block.json and name the template [block name].twig in the blocks folder of the views directory. 
+We call this function in the renderCallback object in block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory. 
 
 
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -15,7 +15,7 @@ ACF Blocks are an alternative way to create content blocks without advanced Java
 
 ### How to use ACF Blocks with Timber
 
-Before you can start using ACF Blocks, you must install the Advanced Custom Fields 6.2.5 version or later.
+Before you can start using ACF Blocks, you must install the Advanced Custom Fields Pro 6.0 or later.
 
 #### Add Blocks Directory Structure
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -44,7 +44,7 @@ Your blocks directory shoud look like this:
 #### Write the Block Settings file: block.json
 
 [WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use renderCallback instead of renderTemplate so we can set a function callback to render all our blocks instead of creating a function for each individual block.
-
+Example contents of the block.json
 ```json
 //block.json
 {

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -66,7 +66,7 @@ Important note on the name property: You are not required to use acf as the name
 
 #### Register the Block
 
-Your site will need to know the block exists on init so we will employ the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function witin our functions.php file and trigger the function on init. 
+Your theme needs to know the block exists on `init` so we will use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function within our functions.php file and trigger the function on the  `init` action. 
 
 The straight forward way to do this is posted below: 
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -63,7 +63,7 @@ Example contents of the block.json
     } 
 }
 ```
-Important note on the `name` property: You are not required to use acf as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example you could also name them `my-project/block-name`. Keep in mind that we recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
+Important note on the `name` property: You are not required to use `acf ` as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example you could also name them `my-project/block-name`. Keep in mind that we recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
 
 #### Register the Block
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -117,7 +117,7 @@ Now that we have our block directory and settings, we need the block template th
 |                   |-- my-block.twig # your block template 
 ```
 
-Within our new template, we will call each of the fields we created in ACF for our block. Each field we define for this block in ACF will be prepended with the fields key. Here is a simple example: 
+Within our new Twig template, we will call each of the fields we created in ACF for our block. Each field we define for this block in ACF will be prepended with the fields key. Here is a simple example: 
 
 ```twig
 {# my-block.twig #}

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -153,7 +153,7 @@ function my_acf_block_render_callback( $block ) {
     // Create the slug of the block using the name property in the block.json. 
 	$slug = str_replace( 'acf/', '', $block['name'] );
 
-	$context = Timber::get_context();
+	$context = Timber::context();
 
 	// Store block values. 
 	$context['block'] = $block;

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -43,7 +43,7 @@ Your blocks directory shoud look like this:
 
 #### Write the Block Settings file: block.json
 
-[Wordpress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal fields plus the acf property. We will use renderCallback instead of renderTemplate so we can set a formula to render our blocks instead of rednering them one by one in our code. 
+[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use renderCallback instead of renderTemplate so we can set a function callback to render all our blocks instead of creating a function for each individual block.
 
 ```json
 //block.json

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -46,7 +46,6 @@ Your blocks directory shoud look like this:
 [WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use renderCallback instead of renderTemplate so we can set a function callback to render all our blocks instead of creating a function for each individual block.
 Example contents of the block.json
 ```json
-//block.json
 {
     "name": "acf/my-block", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#name
     "title": "My Block", // https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#title

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -61,7 +61,7 @@ Example contents of the block.json
     } 
 }
 ```
-Important note on the name property: You are not required to use acf as the namespace in the naming convention `namespace/block-name`, but you still need a value. The block-name will need to match your template name for when we render the block later on. 
+Important note on the `name` property: You are not required to use acf as the namespace in the naming convention `namespace/block-name`, but you do have to provide one. For example you could also name them `my-project/block-name`. Keep in mind that we recommend using the same namespace throughout your blocks and that, in the case you use another namespace then `acf`, you need to change the render callback as well to omit your chosen namespace.
 
 #### Register the Block
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -45,6 +45,7 @@ Your blocks directory shoud look like this:
 #### Write the Block Settings file: block.json
 
 [WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use renderCallback instead of renderTemplate so we can set a function callback to render all our blocks instead of creating a function for each individual block.
+
 Example contents of the block.json
 ```json
 {

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -68,7 +68,7 @@ Important note on the name property: You are not required to use acf as the name
 
 Your theme needs to know the block exists on `init` so we will use the [register_block_type](https://developer.wordpress.org/reference/functions/register_block_type/) function within our functions.php file and trigger the function on the  `init` action. 
 
-The straight forward way to do this is posted below: 
+The straight forward way to do this is shown below: 
 
 ```php
 function register_acf_blocks() {

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -99,7 +99,7 @@ add_action( 'init', 'register_acf_blocks' ); //trigger the register function on 
     
 
 #### Block Template
-Now that we have our block directory and settings, we need the block template that our site will render. We will create a blocks directory within our view directory to keep things organized and add the template file to that blocks directory: 
+Now that we have our block directory and settings, we need the a twig template for our block that will be used to display our block. We will create a blocks directory within our view directory to keep things organized and add the template file to that blocks directory: 
 
 ```
 .

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -78,7 +78,7 @@ function register_acf_blocks() {
 add_action( 'init', 'register_acf_blocks' ); //trigger the register function on init
 ```
 
-Alternatively, you can dynamically register each block. This will keep our code DRY and prevent you from having to register each inidivual block every time you create a new one. 
+Alternatively, you can dynamically register each block. This will keep our code DRY and prevent you from having to register each individual block every time you create a new one.
 
 ```php
 function register_acf_blocks() {

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -39,6 +39,7 @@ Your blocks directory shoud look like this:
 |               |-- my-block # your block
 |                   |-- block.json # your block settings 
 |                   |-- my-block.css # styles for your block
+|                   |-- my-block.twig # your block template
 ```
 
 #### Write the Block Settings file: block.json
@@ -90,6 +91,32 @@ function register_acf_blocks() {
 add_action( 'init', 'register_acf_blocks' ); //trigger the register function on init
 ```
 
+#### Render Block
+
+Next, add the following function to your functions.php file:  
+
+```php
+function my_acf_block_render_callback( $block ) {
+    // Create the slug of the block using the name property in the block.json. 
+	$slug = str_replace( 'acf/', '', $block['name'] );
+
+	$context = Timber::context();
+
+	// Store block values. 
+	$context['block'] = $block;
+
+	// Store field values. These are the fields from your ACF field group for the block. 
+	$context['fields'] = get_fields(); 
+
+	// Render the block.
+	Timber::render(
+			'blocks/' . $slug . '/' . $slug . '.twig',
+			$context
+	);
+}
+```
+We call this function in the renderCallback object in block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory. 
+
 #### Create fields in ACF
 
 [ACF has precise guidance](https://www.advancedcustomfields.com/resources/create-your-first-acf-block/#create-the-testimonial-field-group) on how to create the fields for your block. The important thing is to make sure the field group is enabled for your specific block: 
@@ -99,22 +126,7 @@ add_action( 'init', 'register_acf_blocks' ); //trigger the register function on 
     
 
 #### Block Template
-Now that we have our block directory and settings, we need the a twig template for our block that will be used to display our block. We will create a blocks directory within our view directory to keep things organized and add the template file to that blocks directory: 
-
-```
-.
-|--...
-|-- wp-content
-|   |-- themes 
-|       |-- your-theme # your theme directory
-|           |-- blocks # your blocks directory
-|               |-- my-block # your block
-|                   |-- block.json # your block settings 
-|                   |-- my-block.css # styles for your block
-|           |-- views # your views directory
-|               |-- blocks # your block templates directory
-|                   |-- my-block.twig # your block template 
-```
+Now that we have our block directory and settings, we need the a twig template for our block that will be used to display our block. 
 
 Within our new Twig template, we will call each of the fields we created in ACF for our block. Each field we define for this block in ACF will be prepended with the fields key. Here is a simple example: 
 
@@ -141,33 +153,5 @@ Within our new Twig template, we will call each of the fields we created in ACF 
 Title: {{ fields.group.title }} <br/>
 Url: {{ fields.group.url }}
 ```
-
-#### Render Block
-
-Finally, Add the following function to your functions.php file:  
-
-```php
-//functions.php 
-function my_acf_block_render_callback( $block ) {
-    // Create the slug of the block using the name property in the block.json. 
-	$slug = str_replace( 'acf/', '', $block['name'] );
-
-	$context = Timber::context();
-
-	// Store block values. 
-	$context['block'] = $block;
-
-	// Store field values. These are the fields from your ACF field group for the block. 
-	$context['fields'] = get_fields(); 
-
-	// Render the block.
-	Timber::render(
-			'blocks/' . $slug . '.twig',
-			$context
-	);
-}
-```
-We call this function in the renderCallback object in block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the blocks folder inside the views directory. 
-
 
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -11,7 +11,7 @@ Timber works with the Block Editor (also called Gutenberg) out of the box. If yo
 
 ### What are ACF Blocks?
 
-ACF Blocks are an alternative way to create content blocks without advanced JavaScript knowledge. If you want to learn more about them, read the article on [advancedcustomfields.com](https://www.advancedcustomfields.com/resources/blocks/). 
+ACF Blocks are an alternative way to create content blocks without advanced JavaScript knowledge. If you want to learn more about them, read the article on [advancedcustomfields.com](https://www.advancedcustomfields.com/resources/blocks/).
 
 ### How to use ACF Blocks with Timber
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -19,7 +19,7 @@ Before you can start using ACF Blocks, you must install the Advanced Custom Fiel
 
 #### Add Blocks Directory Structure
 
-First, we will create a blocks directory in our theme file. This directory will house the individual block.json files that will provide the settings for each respective block.
+First, we will create a blocks directory in our theme folder. This directory will house the individual block.json files that will provide the settings for each respective block.
 
 1. Create a **blocks** directory in the root of your theme: 
 2. Add a directory with the block name of your choice. Example: **my-block**


### PR DESCRIPTION
Related:
- #2916

## Issue
Updates to ACF Blocks documentation to reflect the use of block.json in ACF v6 


## Solution
Wrote very descriptive docs on how to add blocks to a Timber theme. 


## Impact
No impact on code, just less frustrated devs. 


## Usage Changes
none

## Considerations
n/a


## Testing
n/a
