### PR TITLE
cli: update ramsey/composer-install to v3

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -33,6 +33,6 @@ runs:
 
     - name: Install Composer dependencies
       if: ${{ inputs.INSTALL_DEPS == 'true' }}
-      uses: ramsey/composer-install@v2
+      uses: ramsey/composer-install@v3
       with:
         composer-options: ${{ inputs.COMPOSER_ARGS }}


### PR DESCRIPTION

Related:

- #2941

## Issue
Dependabot missed this older version.


## Solution
Update that as well to use the latest version to get rid of the node 16 errors.


## Impact
Better tests!

## Usage Changes
none
