### PR TITLE
ci: Use draft release for release please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "php",
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
-      "draft": false,
+      "draft": true,
       "prerelease": false
     }
   },


### PR DESCRIPTION
When creating a new release with Release Please, it would be released as is.

I’d rather have it released as a draft first, so we can polish the notes a bit and make use of the GitHub feature that auto-generates release notes.

Once we get used to Release Please and feel more confident, we could switch this back.

