### PR TITLE
fix: delete resized images at separate directory

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -321,7 +321,7 @@ class ImageHelper
             $local_file = URLHelper::url_to_file_system($local_file);
         }
         $info = PathHelper::pathinfo($local_file);
-        $dir = $info['dirname'];
+        $dir = \apply_filters('timber/image/new_path', $info['dirname']);
         $ext = $info['extension'];
         $filename = $info['filename'];
         self::process_delete_generated_files($filename, $ext, $dir, '-[0-9999999]*', '-[0-9]*x[0-9]*-c-[a-z]*.');


### PR DESCRIPTION
## Issue
Resized images are not getting deleted when deleting an attachment if images are generated by Timber in a separate directory using the filter [timber/image/new_path](https://timber.github.io/docs/v2/hooks/filters/#timber/image/new_path).

## Solution
Apply the filter inside the [delete_generated_files](https://github.com/timohubois/timber/blob/6a6605df9e63b4c08025b664346386261e6bd914/src/ImageHelper.php#L324) function.