### PR TITLE
feat: remove functionality that disabled updates via the dashboard fo…

### DIFF
--- a/lib/Admin.php
+++ b/lib/Admin.php
@@ -73,9 +73,6 @@ class Admin {
 	 */
 	protected static function update_message_major() {
 		$m = '<br><b>Warning:</b> This new version of Timber introduces some major new features which might have unknown effects on your site.';
-
-
-		$m .= self::disable_update();
 		return $m;
 	}
 
@@ -118,16 +115,16 @@ class Admin {
 		$upgrade_magnitude = self::get_upgrade_magnitude($current_version, $new_version);
 		if ( $upgrade_magnitude == 'milestone' ) {
 			$message = self::update_message_milestone();
-			echo '<br />'.sprintf($message);
+			echo '<br />' . ($message);
 			return;
 		} elseif ( $upgrade_magnitude == 'major' ) {
 			//major version
 			$message = self::update_message_major();
-			echo '<br />'.sprintf($message);
+			echo '<br />' . ($message);
 			return;
 		}
 		$message = self::update_message_minor();
-		echo '<br />'.($message);
+		echo '<br />' . ($message);
 		return;
 
 	}

--- a/tests/Timber_UnitTestCase.php
+++ b/tests/Timber_UnitTestCase.php
@@ -219,4 +219,16 @@ class Timber_UnitTestCase extends TestCase
         $method->setAccessible(true);
         return $method->invokeArgs($obj, $args);
     }
+
+	public function isWordPressVersion(string $version, string $operator = '=')
+    {
+        return version_compare($GLOBALS['wp_version'], $version, $operator);
+    }
+
+    public function skipForWordpressVersion(string $version, string $operator = '<')
+    {
+        if ($this->isWordPressVersion($version, $operator)) {
+            $this->markTestSkipped("This test requires WordPress version $version or higher.");
+        }
+    }
 }

--- a/tests/test-timber-wp-functions.php
+++ b/tests/test-timber-wp-functions.php
@@ -12,6 +12,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase {
 		}
 
 		function testFooterOnFooterFW(){
+			if ($this->isWordPressVersion('6.4', '>=')) {
+				$this->setExpectedDeprecated('the_block_template_skip_link');
+			}
+
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'jquery', false, array(), false, true );
@@ -26,6 +30,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase {
 		}
 
 		function testFooterAlone(){
+			if ($this->isWordPressVersion('6.4', '>=')) {
+				$this->setExpectedDeprecated('the_block_template_skip_link');
+			}
+
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'jquery', false, array(), false, true );
@@ -44,6 +52,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase {
 		}
 
 		function testDoubleActionWPFooter(){
+			if ($this->isWordPressVersion('6.4', '>=')) {
+				$this->setExpectedDeprecated('the_block_template_skip_link');
+			}
+
 			global $wp_scripts;
 			$wp_scripts = null;
 			add_action('wp_footer', 'echo_junk');
@@ -55,6 +67,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase {
 		}
 
 		function testInTwig(){
+			if ($this->isWordPressVersion('6.4', '>=')) {
+				$this->setExpectedDeprecated('the_block_template_skip_link');
+			}
+
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'jquery', false, array(), false, true );
@@ -63,6 +79,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase {
 		}
 
 		function testInTwigString(){
+			if ($this->isWordPressVersion('6.4', '>=')) {
+				$this->setExpectedDeprecated('the_block_template_skip_link');
+			}
+
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'jquery', false, array(), false, true );
@@ -71,6 +91,10 @@ class TestTimberWPFunctions extends Timber_UnitTestCase {
 		}
 
 		function testAgainstFooterFunctionOutput(){
+			if ($this->isWordPressVersion('6.4', '>=')) {
+				$this->setExpectedDeprecated('the_block_template_skip_link');
+			}
+
 			global $wp_scripts;
 			$wp_scripts = null;
 			wp_enqueue_script( 'colorpicker', false, array(), false, true);


### PR DESCRIPTION
## Issue
Updates via the admin dashboard were disabled for a while. Since we only going to ship (security)fixes in the future for the 1.x branch when the need occurs, we don't need this logic anymore.


## Solution
Remove logic and update the wording a bit. (screenshot was made while faking the version)

![afbeelding](https://github.com/timber/timber/assets/17764157/2258dfa1-bdc9-45e3-bf38-ff0816556af7)


## Impact
Easier updates for folks that still run Timber plugin version from version 1.23.1 and 1.25.x 

## Usage Changes
No
