### PR TITLE
feat: upgrade Timber requirements (PHP 8.1/WP 6.0/Twig 3.5)

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        wp: ['latest', '6.1']
+        wp: ['latest', '6.2']
         multisite: ['0', '1']
         dependency-version: ['highest', 'lowest']
         webp: [false]

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -46,21 +46,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2']
-        wp: ['latest', '5.3']
+        php: ['8.1', '8.2']
+        wp: ['latest', '6.0']
         multisite: ['0', '1']
         dependency-version: ['highest', 'lowest']
         webp: [false]
         coverage: [false]
         extensions: ['gd']
         experimental: [false]
-        exclude:
-            - wp: '5.3'
-              php: '8.0'
-            - wp: '5.3'
-              php: '8.1'
-            - wp: '5.3'
-              php: '8.2'
         include:
           # PHP 8.2 / experimental
           - php: '8.2'
@@ -121,20 +114,6 @@ jobs:
       - uses: ramsey/composer-install@v3
         with:
           dependency-versions: ${{ matrix.dependency-version }}
-
-      - name: Upgrade dev dependencies when lowest
-        if: matrix.dependency-version == 'lowest'
-        run: |
-            composer update yoast/wp-test-utils -W --dev
-            composer update composer/installers -W
-
-      - name: Downgrade PHPUnit to ^7.5 when WP < 5.9
-        if: matrix.wp < '5.9'
-        run: composer req phpunit/phpunit:^7.5 yoast/wp-test-utils:^1.0 -W --dev
-
-      - name: Upgrade PHPUnit to ^9.0 when prefer lowest and PHP 8.0+
-        if: ${{ matrix.dependency-version == 'prefer-lowest' && matrix.php >= '8.0' }}
-        run: composer req phpunit/phpunit:^9.0 yoast/wp-test-utils:^1.0 -W --dev
 
       - name: Install tests
         run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        wp: ['latest', '6.0']
+        wp: ['latest', '6.1']
         multisite: ['0', '1']
         dependency-version: ['highest', 'lowest']
         webp: [false]

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,8 @@
     "twig/cache-extra": "^3.3",
     "wpackagist-plugin/advanced-custom-fields": "^5.0 || ^6.0",
     "wpackagist-plugin/co-authors-plus": "^3.3",
-    "yoast/wp-test-utils": "^1.0",
-    "phpunit/phpunit": "^9.6"
+    "yoast/wp-test-utils": "^1.2",
+    "phpunit/phpunit": "^9.0"
   },
   "suggest": {
     "php-coveralls/php-coveralls": "^2.0 for code coverage",

--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,9 @@
     "docs": "https://timber.github.io/docs/"
   },
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.1",
     "composer/installers": "^1.0 || ^2.0",
-    "symfony/polyfill-php80": "^1.27",
-    "twig/twig": "^2.15.3 || ^3.0"
+    "twig/twig": "^3.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.28",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "require": {
     "php": "^8.1",
-    "twig/twig": "^3.0"
+    "twig/twig": "^3.5"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.28",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
   },
   "require": {
     "php": "^8.1",
-    "composer/installers": "^1.0 || ^2.0",
     "twig/twig": "^3.0"
   },
   "require-dev": {
@@ -52,7 +51,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "php-stubs/acf-pro-stubs": "^6.0",
     "php-stubs/wp-cli-stubs": "^2.0",
-    "phpro/grumphp": "^1.12",
+    "phpro/grumphp": "^2.0",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.7",
     "squizlabs/php_codesniffer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -54,14 +54,14 @@
     "phpro/grumphp": "^2.0",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.7",
+    "phpunit/phpunit": "^9.0",
     "squizlabs/php_codesniffer": "^3.0",
     "symplify/easy-coding-standard": "^12.0",
     "szepeviktor/phpstan-wordpress": "^1.1",
     "twig/cache-extra": "^3.3",
     "wpackagist-plugin/advanced-custom-fields": "^6.0",
     "wpackagist-plugin/co-authors-plus": "^3.6",
-    "yoast/wp-test-utils": "^1.2",
-    "phpunit/phpunit": "^9.0"
+    "yoast/wp-test-utils": "^1.2"
   },
   "suggest": {
     "php-coveralls/php-coveralls": "^2.0 for code coverage",
@@ -100,7 +100,8 @@
       "ergebnis/composer-normalize": true,
       "phpro/grumphp": true,
       "phpstan/extension-installer": true
-    }
+    },
+    "sort-packages": true
   },
   "scripts": {
     "analyze": "phpstan analyse --memory-limit=1G",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "twig/cache-extra": "^3.3",
     "wpackagist-plugin/advanced-custom-fields": "^5.0 || ^6.0",
     "wpackagist-plugin/co-authors-plus": "^3.3",
-    "yoast/wp-test-utils": "^1.0"
+    "yoast/wp-test-utils": "^1.0",
+    "phpunit/phpunit": "^9.6"
   },
   "suggest": {
     "php-coveralls/php-coveralls": "^2.0 for code coverage",

--- a/composer.json
+++ b/composer.json
@@ -58,8 +58,8 @@
     "symplify/easy-coding-standard": "^12.0",
     "szepeviktor/phpstan-wordpress": "^1.1",
     "twig/cache-extra": "^3.3",
-    "wpackagist-plugin/advanced-custom-fields": "^5.0 || ^6.0",
-    "wpackagist-plugin/co-authors-plus": "^3.3",
+    "wpackagist-plugin/advanced-custom-fields": "^6.0",
+    "wpackagist-plugin/co-authors-plus": "^3.6",
     "yoast/wp-test-utils": "^1.2",
     "phpunit/phpunit": "^9.0"
   },

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,6 +96,8 @@ require_once __DIR__ . '/WpCliLogger.php';
 
 WP_CLI::set_logger(new WpCliLogger(false));
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
 /*
  * Bootstrap WordPress. This will also load the Composer autoload file, the PHPUnit Polyfills
  * and the custom autoloader for the TestCase and the mock object classes.


### PR DESCRIPTION
- PHP >=8.1
- WP >=6.0
- Twig >= 3.5
- Remove symfony/polyfill-php80
- Update workflow matrix accordingly

<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

## Issue

As previously discussed, Timber >=2.1 will drop support for PHP <= 8.1 and WP <= 6.0.

[Packagist stats](https://packagist.org/packages/timber/timber/php-stats#2) shows pretty wide 8.1+ adoption and we should encourage users to move forward.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->


## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations

Twig <= 3.5 has security issues, so I bumped directly to Twig 3.5:

![Capture d’écran 2024-04-10 à 21 28 06](https://github.com/timber/timber/assets/2526939/e2a62419-d71f-4383-9ae4-9ae57acdd19e)


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
