### PR TITLE
Fix for infinite loops in post.excerpt in specific cases

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -1279,7 +1279,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
          */
         $remove_blocks = (bool) \apply_filters('timber/post/content/remove_blocks', $remove_blocks);
 
-        if ($remove_blocks && \function_exists('excerpt_remove_blocks')) {
+        if ($remove_blocks) {
             $content = \excerpt_remove_blocks($content);
         }
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -1215,26 +1215,26 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      *
      * @param int $page Optional. The page to show if the content of the post is split into multiple
      *                  pages. Read more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-within-a-post). Default `0`.
-     * @param int $num_words Optional. The number of words to show. Default `-1` (show all).
+     * @param int $len Optional. The number of words to show. Default `-1` (show all).
      * @param bool $remove_blocks Optional. Whether to remove blocks. Defaults to false. True when called from the $post->excerpt() method.
      * @return string The content of the post.
      */
-    public function content($page = 0, $num_words = -1, $remove_blocks = false)
+    public function content($page = 0, $len = -1, $remove_blocks = false)
     {
-        if ($rd = $this->get_revised_data_from_method('content', [$page, $num_words])) {
+        if ($rd = $this->get_revised_data_from_method('content', [$page, $len])) {
             return $rd;
         }
         if ($form = $this->maybe_show_password_form()) {
             return $form;
         }
-        if ($num_words == -1 && $page == 0 && $this->___content) {
+        if ($len == -1 && $page == 0 && $this->___content) {
             return $this->___content;
         }
 
         $content = $this->post_content;
 
-        if ($num_words > 0) {
-            $content = \wp_trim_words($content, $num_words);
+        if ($len > 0) {
+            $content = \wp_trim_words($content, $len);
         }
 
         /**
@@ -1286,7 +1286,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
         $content = $this->content_handle_no_teaser_block($content);
         $content = \apply_filters('the_content', ($content));
 
-        if ($num_words == -1 && $page == 0) {
+        if ($len == -1 && $page == 0) {
             $this->___content = $content;
         }
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -1215,25 +1215,26 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      *
      * @param int $page Optional. The page to show if the content of the post is split into multiple
      *                  pages. Read more about this in the [Pagination Guide](https://timber.github.io/docs/v2/guides/pagination/#paged-content-within-a-post). Default `0`.
-     *
-     * @return string
+     * @param int $num_words Optional. The number of words to show. Default `-1` (show all).
+     * @param bool $remove_blocks Optional. Whether to remove blocks. Defaults to false. True when called from the $post->excerpt() method.
+     * @return string The content of the post.
      */
-    public function content($page = 0, $len = -1)
+    public function content($page = 0, $num_words = -1, $remove_blocks = false)
     {
-        if ($rd = $this->get_revised_data_from_method('content', [$page, $len])) {
+        if ($rd = $this->get_revised_data_from_method('content', [$page, $num_words])) {
             return $rd;
         }
         if ($form = $this->maybe_show_password_form()) {
             return $form;
         }
-        if ($len == -1 && $page == 0 && $this->___content) {
+        if ($num_words == -1 && $page == 0 && $this->___content) {
             return $this->___content;
         }
 
         $content = $this->post_content;
 
-        if ($len > 0) {
-            $content = \wp_trim_words($content, $len);
+        if ($num_words > 0) {
+            $content = \wp_trim_words($content, $num_words);
         }
 
         /**
@@ -1263,10 +1264,29 @@ class Post extends CoreEntity implements DatedInterface, Setupable
             }
         }
 
+        /**
+         * Filters whether the content produced by block editor blocks should be removed or not from the content.
+         *
+         * If truthy then block whose content does not belong in the excerpt, will be removed.
+         * This removal is done using WordPress Core `excerpt_remove_blocks` function.
+         *
+         * @since 2.1.1
+         *
+         * @param bool $remove_blocks Whether blocks whose content should not be part of the excerpt should be removed
+         *                            or not from the excerpt.
+         *
+         * @see   excerpt_remove_blocks() The WordPress Core function that will handle the block removal from the excerpt.
+         */
+        $remove_blocks = (bool) \apply_filters('timber/post/content/remove_blocks', $remove_blocks);
+
+        if ($remove_blocks && \function_exists('excerpt_remove_blocks')) {
+            $content = \excerpt_remove_blocks($content);
+        }
+
         $content = $this->content_handle_no_teaser_block($content);
         $content = \apply_filters('the_content', ($content));
 
-        if ($len == -1 && $page == 0) {
+        if ($num_words == -1 && $page == 0) {
             $this->___content = $content;
         }
 

--- a/src/PostExcerpt.php
+++ b/src/PostExcerpt.php
@@ -497,7 +497,7 @@ class PostExcerpt
 
         // Build an excerpt text from the post’s content.
         if (empty($text)) {
-            $text = $this->post->content();
+            $text = $this->post->content(0, -1, true);
             $text = TextHelper::remove_tags($text, $this->destroy_tags);
             $text_before_trim = \trim($text);
             $text_before_char_trim = '';

--- a/tests/assets/block-tests/block-register.php
+++ b/tests/assets/block-tests/block-register.php
@@ -1,0 +1,20 @@
+<?php
+
+register_block_type('timber/test-block', [
+    'render_callback' => 'render_block_example',
+    'api_version' => 3,
+    'attributes' => [
+        'post_id' => [
+            'type' => 'integer',
+        ],
+    ],
+]);
+
+function render_block_example($attributes, $content = '', $wp_block = null)
+{
+    // get the dynamically set post ID from the block attributes. We do it this way because get_the_ID() doesn't work in the block context during phpUnit tests.
+    return Timber::compile('block-template.twig', [
+        'post' => Timber::get_post($attributes['post_id']),
+        'attributes' => $attributes,
+    ]);
+}

--- a/tests/assets/block-tests/block-template.twig
+++ b/tests/assets/block-tests/block-template.twig
@@ -1,0 +1,6 @@
+{{ post.excerpt({
+      words: 100,
+      read_more: false
+   })
+}}
+<p>What is love</p>

--- a/tests/test-timber-post-excerpt.php
+++ b/tests/test-timber-post-excerpt.php
@@ -356,4 +356,33 @@ class TestTimberPostExcerpt extends Timber_UnitTestCase
 
         $this->assertEquals('Let this be the content, albeit a very short one!&hellip;', (string) $excerpt);
     }
+
+    /**
+     * Checks if the excerpt is correctly generated when the content contains a block.
+     * Prior to this fix, the excerpt would cause infinite loops (which show up as a segmentation fault in PHPunit).
+     *
+     * @ticket https://github.com/timber/timber/issues/2041
+     *
+     * @return void
+     */
+    public function testExcerptWithCustomBlock()
+    {
+        require_once 'assets/block-tests/block-register.php';
+
+        // Create an empty post
+        $post_id = $this->factory->post->create([
+            'post_excerpt' => '',
+            'post_content' => '',
+        ]);
+
+        // Update the post with a block and pass the post ID to the block
+        $this->factory->post->update_object($post_id, [
+            'post_excerpt' => '',
+            'post_content' => '<!-- wp:timber/test-block { "post_id": ' . $post_id . '} /--> Some other content',
+        ]);
+
+        $post = Timber::get_post($post_id);
+
+        $this->assertEquals('Some other content', (string) $post->excerpt());
+    }
 }


### PR DESCRIPTION
Related:

- #2041

## Issue
When you render a post preview in a dynamic block this will cause an infinite loop. 

## Solution
When fetching the content from the excerpt method, run the `excerpt_remove_blocks ` function inside the `content()` method.

## Impact
Post previews will probably render faster since now we are not parsing blocks anymore.

## Usage Changes
I added a third parameter to the  `content()` method but this is optional.

## Considerations
Nothing I can think about right now.

## Testing
Test and additional assets added to register a block, render the block via a render callback and then run a post.preview inside it. if you remove the suggested changes in Post.php and run the test it will cause a timeout which shows up in PHPunit as a segmentation fault.
