### PR TITLE
chore: set proper return types

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -132,7 +132,7 @@ class Comment extends CoreEntity
      * @internal
      * @param WP_Comment $wp_comment a native WP_Comment instance
      */
-    public static function build(WP_Comment $wp_comment): self
+    public static function build(WP_Comment $wp_comment): static
     {
         $comment = new static();
         $comment->import($wp_comment);

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -122,7 +122,7 @@ class MenuItem extends CoreEntity
      * @param Menu $menu The `Menu` object the menu item is associated with.
      * @return MenuItem a new MenuItem instance
      */
-    public static function build($data, ?Menu $menu = null): self
+    public static function build($data, ?Menu $menu = null): static
     {
         return new static($data, $menu);
     }

--- a/src/Post.php
+++ b/src/Post.php
@@ -175,7 +175,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable
      * @internal
      * @return Post
      */
-    public static function build(WP_Post $wp_post): self
+    public static function build(WP_Post $wp_post): static
     {
         $post = new static();
 

--- a/src/Term.php
+++ b/src/Term.php
@@ -83,7 +83,7 @@ class Term extends CoreEntity
      * @param WP_Term      $wp_term The vanilla WordPress term object to build from.
      * @return Term
      */
-    public static function build(WP_Term $wp_term): self
+    public static function build(WP_Term $wp_term): static
     {
         $term = new static();
         $term->init($wp_term);

--- a/src/User.php
+++ b/src/User.php
@@ -106,7 +106,7 @@ class User extends CoreEntity
     /**
      * Build a new User object.
      */
-    public static function build(WP_User $wp_user): self
+    public static function build(WP_User $wp_user): static
     {
         $user = new static();
         $user->init($wp_user);


### PR DESCRIPTION
Related:

-https://github.com/timber/timber/issues/2807
- https://github.com/timber/timber/pull/2970

## Issue
The build() methods would declare the return type as the concrete class - static instead of self.


## Solution
Set proper return type now support PHP 8.0 and above

## Impact
Better code inspection hints./


## Usage Changes
no.

## Considerations
no.

## Testing
no.