### PR TITLE
2881 confusing site api related to meta and option

### DIFF
--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -170,7 +170,7 @@ For site options, it’s also possible to access it directly through its name:
 Please be aware that using this might conflict with existing Timber methods on the `Timber\Site` object. That’s why the `option()` method is the preferred way to retrieve site options.
 
 
-You cannot fetch ACF options with `site.option()`. You will need to add the fields to the context yourself. This process is described in [Getting data from ACF](../integrations/advanced-custom-fields.md#options-page).
+You cannot fetch ACF options with `site.option()`. You will need to add the fields to the context yourself. This process is described in the [ACF integration](https://timber.github.io/docs/v2/integrations/advanced-custom-fields/#options-page) documentation.
 
 ## Query by custom field value
 

--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -169,6 +169,9 @@ For site options, it’s also possible to access it directly through its name:
 
 Please be aware that using this might conflict with existing Timber methods on the `Timber\Site` object. That’s why the `option()` method is the preferred way to retrieve site options.
 
+
+You cannot fetch ACF options with `site.option()`. You will need to add the fields to the context yourself. This process is described in [Getting data from ACF](../integrations/advanced-custom-fields.md#options-page).
+
 ## Query by custom field value
 
 This example that uses a [WP_Query](http://codex.wordpress.org/Class_Reference/WP_Query) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.


### PR DESCRIPTION
Related:

- #2881 

## Issue
The custom-fields.md doc does not mention that ACF option field have to be fetched via another way then `site.option`


## Solution
Add a mention in the documentation with a link to that ACF options section in the docs.


## Impact
Better understanding of the documentation.
