### PR TITLE
fix: Fix deprecation notice since twig 3.10 to now use EscaperRuntime…

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -10,6 +10,8 @@ use Timber\Factory\PostFactory;
 use Timber\Factory\TermFactory;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
+use Twig\Extension\EscaperExtension;
+use Twig\Runtime\EscaperRuntime;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
@@ -553,13 +555,20 @@ class Twig
             return \esc_js($string);
         };
 
-        if (\class_exists('Twig\Extension\EscaperExtension')) {
-            $escaper_extension = $twig->getExtension('Twig\Extension\EscaperExtension');
+        if (\class_exists(EscaperRuntime::class)) {
+            $escaper_extension = $twig->getRuntime(EscaperRuntime::class);
+            $escaper_extension->setEscaper('esc_url', '\esc_url');
+            $escaper_extension->setEscaper('wp_kses_post', '\wp_kses_post');
+            $escaper_extension->setEscaper('esc_html', '\esc_html');
+            $escaper_extension->setEscaper('esc_js', '\esc_js');
+        } elseif ($twig->hasExtension(EscaperExtension::class)) {
+            $escaper_extension = $twig->getExtension(EscaperExtension::class);
             $escaper_extension->setEscaper('esc_url', $esc_url);
             $escaper_extension->setEscaper('wp_kses_post', $wp_kses_post);
             $escaper_extension->setEscaper('esc_html', $esc_html);
             $escaper_extension->setEscaper('esc_js', $esc_js);
         }
+
         return $twig;
     }
 

--- a/tests/test-timber-escapers.php
+++ b/tests/test-timber-escapers.php
@@ -74,4 +74,23 @@ class TestTimberFilterEscapers extends Timber_UnitTestCase
 
         $this->assertEquals($native, $result);
     }
+
+    public function testOldEscaper()
+    {
+        $dirty_url = 'https://example.com/?foo=1&bar=2';
+        $other_protocol_url = 'ftp://example.com/?foo=1&bar=2';
+
+        $native = esc_url($dirty_url);
+        $other_protocol_native = esc_url($other_protocol_url);
+        $result = Timber::compile_string('<a href="{{ url|e("esc_url") }}">', [
+            'url' => $dirty_url,
+        ]);
+
+        $other_protocol_result = Timber::compile_string('{{ url|e("esc_url") }}', [
+            'url' => $other_protocol_url,
+        ]);
+
+        $this->assertEquals('<a href="' . $native . '">', $result);
+        $this->assertEquals($other_protocol_native, $other_protocol_result);
+    }
 }


### PR DESCRIPTION
Related:

- #2993

## Issue
Since Twig 3.10 the old methods of adding additional escapers is deprecated.

## Solution
Use the new escaping extension instead with a fallback to use the old escapers. Since we support twig from version 3.5 and onward.

I took the if/else setup from here: https://github.com/symfony/ux/blob/796dd587827f2bb849064c33cc4e053c39e0a0e9/src/TwigComponent/src/Twig/TwigEnvironmentConfigurator.php
## Impact
No more deprecation notices.

## Usage Changes
No.

## Considerations
No.

## Testing
Yes. I added a test to test one of the old escaper methods so we can test that functionality as long as we support that.
