### PR TITLE
fix: fix regression where crops with the default crop setting would s…

### DIFF
--- a/src/Image/Operation/Resize.php
+++ b/src/Image/Operation/Resize.php
@@ -210,12 +210,12 @@ class Resize extends ImageOperation
 
             $crop = $this->get_target_sizes($image);
             $image->crop(
-                $crop['x'],
-                $crop['y'],
-                $crop['src_w'],
-                $crop['src_h'],
-                $crop['target_w'],
-                $crop['target_h']
+                (int) $crop['x'],
+                (int) $crop['y'],
+                (int) $crop['src_w'],
+                (int) $crop['src_h'],
+                (int) $crop['target_w'],
+                (int) $crop['target_h']
             );
             $quality = \apply_filters('wp_editor_set_quality', 82, 'image/jpeg');
             $image->set_quality($quality);

--- a/src/Image/Operation/Resize.php
+++ b/src/Image/Operation/Resize.php
@@ -113,7 +113,7 @@ class Resize extends ImageOperation
             $w = \round($h * $src_ratio);
         }
 
-        if (!$crop || $crop === 'default') {
+        if (!$crop) {
             return [
                 'x' => 0,
                 'y' => 0,


### PR DESCRIPTION
Related:

- #2986

## Issue
In https://github.com/timber/timber/commit/18bf3586322a7bf829d5a246449a2c794f1e7862 a bug was introduced where the default crop parameter would lead to squeezing the image inside a confined space. instead of cropping into the image.


## Solution
Revert that if statement to the way it was in 1.x

## Impact
Working crops!

## Usage Changes
No.

## Considerations
[See ](https://github.com/timber/timber/issues/2866)

## Testing
no.
