### PR TITLE
fix: Improve doing_it_wrong messages for using deprecated parameters in Timber::get_post(), Timber::get_attachment() and Timber::get_image()

### DIFF
--- a/src/Timber.php
+++ b/src/Timber.php
@@ -252,21 +252,9 @@ class Timber
      */
     public static function get_post($query = false, $options = [])
     {
-        if (\is_string($query) && !\is_numeric($query)) {
-            Helper::doing_it_wrong(
-                'Timber::get_post()',
-                'Getting a post by post slug or post name was removed from Timber::get_post() in Timber 2.0. Use Timber::get_post_by() instead.',
-                '2.0.0'
-            );
-        }
+        self::check_post_api_deprecations($query, $options, 'Timber::get_post()');
 
         if (\is_string($options)) {
-            Helper::doing_it_wrong(
-                'Timber::get_post()',
-                'The $PostClass parameter for passing in the post class to use in Timber::get_posts() was replaced with an $options array in Timber 2.0. To customize which class to instantiate for your post, use Class Maps instead: https://timber.github.io/docs/v2/guides/class-maps/',
-                '2.0.0'
-            );
-
             $options = [];
         }
 
@@ -316,6 +304,8 @@ class Timber
      */
     public static function get_attachment($query = false, $options = [])
     {
+        self::check_post_api_deprecations($query, $options, 'Timber::get_attachment()');
+
         $post = static::get_post($query, $options);
 
         // No need to instantiate a Post we're not going to use.
@@ -341,6 +331,8 @@ class Timber
      */
     public static function get_image($query = false, $options = [])
     {
+        self::check_post_api_deprecations($query, $options, 'Timber::get_image()');
+
         $post = static::get_post($query, $options);
 
         // No need to instantiate a Post we're not going to use.
@@ -377,6 +369,32 @@ class Timber
         ]);
 
         return ExternalImage::build($url, $args);
+    }
+
+    /**
+     * Checks for deprecated Timber::get_post() API usage.
+     *
+     * @param $query
+     * @param $options
+     * @param $function_name
+     */
+    private static function check_post_api_deprecations($query = false, $options = [], string $function_name = 'Timber::get_post()')
+    {
+        if (\is_string($query) && !\is_numeric($query)) {
+            Helper::doing_it_wrong(
+                $function_name,
+                'Getting a post by post slug or post name was removed from Timber::get_post() in Timber 2.0. Use Timber::get_post_by() instead.',
+                '2.0.0'
+            );
+        }
+
+        if (\is_string($options)) {
+            Helper::doing_it_wrong(
+                $function_name,
+                'The $PostClass parameter for passing in the post class to use in Timber::get_posts() was replaced with an $options array in Timber 2.0. To customize which class to instantiate for your post, use Class Maps instead: https://timber.github.io/docs/v2/guides/class-maps/',
+                '2.0.0'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Related:

- #2992

## Issue

Error messages might be confusing if you use `Timber::get_image()` with a wrong parameter. You will get error messages that say there was an error with `Timber::get_post()`.

## Solution

Use different error messages per method.

## Impact

Better understanding of error.

## Usage Changes

None.

## Considerations

This can be removed in a next major version.

## Testing

Not in particular.