### PR TITLE
fix: Fix a bug with URL check for avatars

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -588,6 +588,7 @@ class Comment extends CoreEntity
                 $default = $avatar_default;
             }
         }
+
         if ('mystery' == $default) {
             $default = $host . '/avatar/ad516503a11cd5ca435acc9bb6523536?s=' . $size;
             // ad516503a11cd5ca435acc9bb6523536 == md5('unknown@gravatar.com')
@@ -597,7 +598,7 @@ class Comment extends CoreEntity
             $default = '';
         } elseif ('gravatar_default' == $default) {
             $default = $host . '/avatar/?s=' . $size;
-        } elseif (empty($email) && !\strstr($default, 'https://')) {
+        } elseif (empty($email) && !\preg_match('/^https?:\/\//', $default)) {
             $default = $host . '/avatar/?d=' . $default . '&amp;s=' . $size;
         }
         return $default;

--- a/tests/test-timber-comment-avatar.php
+++ b/tests/test-timber-comment-avatar.php
@@ -148,8 +148,9 @@ class TestTimberCommentAvatar extends Timber_UnitTestCase
             # you get back the default in the avatar url?
             $this->assertEquals($params, "d=$default_url&amp;s=32");
         }
-        # you get back url?
-        $this->assertTrue(substr($avatar, 0, 6) == "https:");
+
+        // Check if we get back an URL (either http:// or https:).
+        $this->assertMatchesRegularExpression("/^https?::", $avatar);
     }
 
     public function crawl($url)

--- a/tests/test-timber-comment-avatar.php
+++ b/tests/test-timber-comment-avatar.php
@@ -124,7 +124,7 @@ class TestTimberCommentAvatar extends Timber_UnitTestCase
         # pass custom url on different domain. can't check by crawling as
         # i get a 302 regardless of default url
         # so just check it comes back with it in the url
-        $this->valid_avatar($comment, "https://upload.wikimedia.org/wikipedia/en/b/bc/Wiki.png");
+        $this->valid_avatar($comment, 'https://upload.wikimedia.org/wikipedia/en/b/bc/Wiki.png');
 
         # same domain.
         $this->valid_avatar($comment, $theme_url . "/images/default.png");
@@ -150,7 +150,7 @@ class TestTimberCommentAvatar extends Timber_UnitTestCase
         }
 
         // Check if we get back an URL (either http:// or https:).
-        $this->assertMatchesRegularExpression("/^https?::", $avatar);
+        $this->assertMatchesRegularExpression("/^https?:.*/", $avatar);
     }
 
     public function crawl($url)


### PR DESCRIPTION
Related:

- #2947

## Issue

A possible error was introduced in #2947 when checking for a http(s):// protocol.

## Solution

Improve the check to allow both protocols.

## Impact

None.

## Usage Changes

None.

## Considerations

None.

## Testing

No.