### PR TITLE
docs: Mark Helper::convert_wp_object as API method

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -282,7 +282,6 @@ class Helper
      * Output a value (string, array, object, etc.) to the error log
      *
      * @api
-     * @param mixed $error The error that you want to error_log().
      * @return void
      */
     public static function error_log(mixed $error)
@@ -707,7 +706,8 @@ class Helper
      *
      * If no match is found the function will return the initial argument.
      *
-     * @param mixed $obj WP Object
+     * @api
+     * @param mixed $obj WP Object to convert
      * @return mixed Instance of equivalent Timber object, or the argument if no match is found
      */
     public static function convert_wp_object(mixed $obj)


### PR DESCRIPTION
Related:

- #3004

## Issue
`Timber\Helper::convert_wp_object` is not listed as an API function


## Solution
Mark as API function and rebuild docs.


## Impact
More functions documentated


## Usage Changes
No

## Considerations
When taking a look at the Helper methods, they are sparsely documented. We could improve on that.

When trying to commit, `Rector` was being a pain in the butt since it wanted to remove the mixed parameters from methods, including our API functions.

@nlemoine , could we remove that conversion like so? I can make a separate PR for that. This would make the life of of other contributors a lot easier.

![image](https://github.com/timber/timber/assets/17764157/f57f220d-f2e6-4f74-9f98-6376ebbdf9dd)

## Testing
already tested