### PR TITLE
Fix typo on Users guide docs

### DIFF
--- a/docs/v2/guides/users.md
+++ b/docs/v2/guides/users.md
@@ -153,7 +153,7 @@ So, how does Timber know about your `User` class? Timber will use the [User Clas
 
 ## Querying Users
 
-If you want to get an array of users, you can use `Timber::get_user()`.
+If you want to get an array of users, you can use `Timber::get_users()`.
 
 ```php
 $users = Timber::get_users($query);


### PR DESCRIPTION
A fix to update `Timber::get_user()` to `Timber::get_users()` located here: https://timber.github.io/docs/v2/guides/users/#querying-users