### PR TITLE
feat: Add support for avif image format #3015

### DIFF
--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -194,6 +194,7 @@ class PostFactory
             'png',
             'svg',
             'webp',
+            'avif',
         ]);
 
         return \in_array($check['ext'], $extensions);


### PR DESCRIPTION
Related: #3015 

## Issue
Now that WordPress widely supports Avif Format Twig should add support to the avif image format.
Browsers also widely support this image format : https://caniuse.com/avif

## Solution
Adds avif support in the extension list.

## Impact

## Usage Changes

## Considerations

## Testing
