### PR TITLE
Fix URI to FS parsing in ImageHelper

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -616,6 +616,14 @@ class ImageHelper
                 $tmp = URLHelper::remove_url_component($tmp, WP_CONTENT_DIR);
             }
         }
+
+        // Remove query and fragment from URL.
+        if (($i = \strpos($tmp, '?')) !== false) {
+            $tmp = \substr($tmp, 0, $i);
+        } elseif (($i = \strpos($tmp, '#')) !== false) {
+            $tmp = \substr($tmp, 0, $i);
+        }
+
         $parts = PathHelper::pathinfo($tmp);
         $result['subdir'] = ($parts['dirname'] === '/') ? '' : $parts['dirname'];
         $result['filename'] = $parts['filename'];

--- a/tests/test-timber-image-helper-internals.php
+++ b/tests/test-timber-image-helper-internals.php
@@ -61,6 +61,36 @@ class TestTimberImageHelperInternals extends TimberAttachment_UnitTestCase
         $this->assertEquals('myimage.jpg', $parts['basename']);
     }
 
+    public function testAnalyzeURLUploadsWithQuery()
+    {
+        $src = 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg?foo=A&baz=B';
+
+        $parts = Timber\ImageHelper::analyze_url($src);
+
+        $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg?foo=A&baz=B', $parts['url']);
+        $this->assertSame(true, $parts['absolute']);
+        $this->assertSame(1, $parts['base']);
+        $this->assertEquals('/2017/02', $parts['subdir']);
+        $this->assertEquals('myimage', $parts['filename']);
+        $this->assertEquals('jpg', $parts['extension']);
+        $this->assertEquals('myimage.jpg', $parts['basename']);
+    }
+
+    public function testAnalyzeURLUploadsWithFragment()
+    {
+        $src = 'http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg#foo';
+
+        $parts = Timber\ImageHelper::analyze_url($src);
+
+        $this->assertEquals('http://' . $_SERVER['HTTP_HOST'] . '/wp-content/uploads/2017/02/myimage.jpg#foo', $parts['url']);
+        $this->assertSame(true, $parts['absolute']);
+        $this->assertSame(1, $parts['base']);
+        $this->assertEquals('/2017/02', $parts['subdir']);
+        $this->assertEquals('myimage', $parts['filename']);
+        $this->assertEquals('jpg', $parts['extension']);
+        $this->assertEquals('myimage.jpg', $parts['basename']);
+    }
+
     public function testAnalyzeURLTheme()
     {
         $dest = TestExternalImage::copy_image_to_stylesheet('assets/images');


### PR DESCRIPTION
Related:

- #3024

## Issue

`ImageHelper::get_url_components()` fails to consider URI-only components when decomposing the path components which prevents Timber from finding the file on the file system.

Example of URI components that pollute decomposed path: query (`?`) and fragment (`#`).

```twig
<img src="{{ 'https://example.com/uploads/2024/07/cat.jpg?lang=fr'|resize(640) }}" />
```

```php
[
	'url'       => 'https://example.com/uploads/2024/07/cat.jpg?lang=fr',
	'absolute'  => true,
	'base'      => 1,
	'subdir'    => '/2024/07',
	'filename'  => 'cat',
	'extension' => 'jpg?lang=fr',
	'basename'  => 'cat.jpg?lang=fr',
]
```

```
[ Timber ] Error loading /var/www/example.com/uploads/2024/07/cat.jpg?lang=fr
```

## Solution

Remove query and fragment components from the URL _before_ parsing it with `PathHelper::pathinfo()`.

Alternatively, they can be removed from the parsed `basename` and `extension` _after_ parsing.

## Impact

If the target path contains a question mark or hash/number/pound sign in a directory or file name, the currently proposed solution would break.

## Usage Changes

No changes.

## Considerations

Nothing to add.

## Testing

Unit tests have been added for query and fragment components.