### PR TITLE
docs: Fix transform_value filter with `__return_true`

### DIFF
--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -20,7 +20,7 @@ If you’ve worked with ACF before, you’re use to use `get_field( 'my_acf_fiel
 $meta = $post->meta('my_acf_field');
 ```
 
-### Transform values to Timber/PHP objects  
+### Transform values to Timber/PHP objects
 Timber by default returns all field values as is based on the return type set in your ACF field setting.
 
 But sometimes you might want to transform values directly into Timber/PHP objects. For example, if you have a relationship field, you might want to transform the values directly into `Timber\Post` objects.
@@ -29,7 +29,7 @@ You can do so using the `timber/meta/transform_value` filter:
 
 **functions.php**
 ```php
-add_filter('timber/meta/transform_value', '__return__true');
+add_filter('timber/meta/transform_value', '__return_true');
 ```
 
 Or you can use the `transform_value` parameter to transform values on a field by field basis:


### PR DESCRIPTION
Thanks for this package 🙏

I created this PR to just fix very little error in doc. I see it when I went copy/paste code from doc so I want fix that.

## Issue
<!-- Description of the problem that this code change is solving -->

The filter value contains too many `_`
https://developer.wordpress.org/reference/functions/__return_true/

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->

I have removed the underscore.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->

Nothing.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

Simplify copy/paste from doc.

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
