### PR TITLE
docs: Add `\Twig\` to TwigFilter and TwigFunction examples

### DIFF
--- a/docs/v2/guides/extending-twig.md
+++ b/docs/v2/guides/extending-twig.md
@@ -153,15 +153,15 @@ Here’s the same functions and filters that we add above. But instead of using 
 ```php
 add_filter( 'timber/twig', function( \Twig\Environment $twig ) {
     $twig->addFunction(
-        new TwigFunction( 'edit_post_link', 'edit_post_link' )
+        new \Twig\TwigFunction( 'edit_post_link', 'edit_post_link' )
     );
 
     $twig->addFilter(
-        new TwigFilter( 'price', 'format_price' )
+        new \Twig\TwigFilter( 'price', 'format_price' )
     );
 
     $twig->addFilter(
-        new TwigFilter( 'slugify', 'sanitize_title' )
+        new \Twig\TwigFilter( 'slugify', 'sanitize_title' )
     ];
 
     return $twig;


### PR DESCRIPTION
Previous format was giving Class "TwigFunction" not found so I think this is how it should be written in docs, following starter-theme example on adding filters which I got working (https://github.com/timber/starter-theme/blob/c116aea47525f2412d54430088c81fa93b0f045b/src/StarterSite.php#L135).