### PR TITLE
test: Replace missing svn in GitHub Actions when installing WordPress

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        wp: ['latest', '6.2']
+        wp: ['6.6.2', '6.2']
         multisite: ['0', '1']
         dependency-version: ['highest', 'lowest']
         webp: [false]

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2']
-        wp: ['6.6.2', '6.2']
+        wp: ['latest', '6.2']
         multisite: ['0', '1']
         dependency-version: ['highest', 'lowest']
         webp: [false]

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -65,8 +65,8 @@ install_wp() {
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 		mkdir -p $TMPDIR/wordpress-trunk
 		rm -rf $TMPDIR/wordpress-trunk/*
-		git clone git://develop.git.wordpress.org/ $TMPDIR/wordpress-trunk/wordpress
-		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+		git clone --depth 1 git://develop.git.wordpress.org/ $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/src/* $WP_CORE_DIR
 	else
 		if [ $WP_VERSION == 'latest' ]; then
 			local ARCHIVE_NAME='latest'

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -65,7 +65,7 @@ install_wp() {
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 		mkdir -p $TMPDIR/wordpress-trunk
 		rm -rf $TMPDIR/wordpress-trunk/*
-		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		git clone git://develop.git.wordpress.org/ $TMPDIR/wordpress-trunk/wordpress
 		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
 	else
 		if [ $WP_VERSION == 'latest' ]; then
@@ -109,8 +109,9 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		rm -rf $WP_TESTS_DIR/{includes,data}
-		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+        git clone --depth 1 --branch $WP_VERSION git://develop.git.wordpress.org/ $TMPDIR/wordpress-develop/wordpress
+        cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/includes $WP_TESTS_DIR/includes
+        cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/data $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -109,9 +109,17 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		rm -rf $WP_TESTS_DIR/{includes,data}
-        git clone --depth 1 --branch $WP_VERSION git://develop.git.wordpress.org/ $TMPDIR/wordpress-develop/wordpress
-        cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/includes $WP_TESTS_DIR/includes
-        cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/data $WP_TESTS_DIR/data
+
+		if [ $WP_VERSION == 'latest' ]; then
+			 echo "Using latest version ${LATEST_VERSION} of WordPress for testing."
+			 BRANCH=$LATEST_VERSION
+		else
+			 BRANCH=$WP_VERSION
+		fi
+		
+		git clone --depth 1 --branch $BRANCH git://develop.git.wordpress.org/ $TMPDIR/wordpress-develop/wordpress
+		cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/includes $WP_TESTS_DIR/includes
+		cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/data $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then


### PR DESCRIPTION
Tests have all failed recently. Apparently, GitHub has removed support for `svn` in GitHub Actions (https://github.blog/news-insights/product-news/sunsetting-subversion-support/).

This PR replaces the `svn` commands in **bin/install-wp-tests.sh** with other commands.

The only thing that doesn’t work now is when we use `latest` or `trunk` for the WordPress version. That’s why some tests are still failing.

Any idea on how to solve that without throwing a lot of code at the bash script?