### PR TITLE
fix: fixes image operation artifacts by rounding

### DIFF
--- a/src/Image/Operation/Letterbox.php
+++ b/src/Image/Operation/Letterbox.php
@@ -16,6 +16,7 @@ use Timber\PathHelper;
  * - height of new image
  * - color of padding
  */
+
 class Letterbox extends ImageOperation
 {
     /**
@@ -93,15 +94,16 @@ class Letterbox extends ImageOperation
                 $y = 0;
                 $x = $w / 2 - $owt / 2;
                 $oht = $h;
-                $image->crop(0, 0, $ow, $oh, $owt, $oht);
             } else {
                 $w_scale = $w / $ow;
                 $oht = $oh * $w_scale;
                 $x = 0;
                 $y = $h / 2 - $oht / 2;
                 $owt = $w;
-                $image->crop(0, 0, $ow, $oh, $owt, $oht);
             }
+
+            $image->crop(0, 0, \round($ow), \round($oh), \round($owt), \round($oht));
+
             $result = $image->save($save_filename);
             $func = 'imagecreatefromjpeg';
             $save_func = 'imagejpeg';

--- a/src/Image/Operation/Resize.php
+++ b/src/Image/Operation/Resize.php
@@ -204,12 +204,12 @@ class Resize extends ImageOperation
 
             $crop = $this->get_target_sizes($image);
             $image->crop(
-                (int) $crop['x'],
-                (int) $crop['y'],
-                (int) $crop['src_w'],
-                (int) $crop['src_h'],
-                (int) $crop['target_w'],
-                (int) $crop['target_h']
+                (int) \round($crop['x']),
+                (int) \round($crop['y']),
+                (int) \round($crop['src_w']),
+                (int) \round($crop['src_h']),
+                (int) \round($crop['target_w']),
+                (int) \round($crop['target_h'])
             );
             $quality = \apply_filters('wp_editor_set_quality', 82, 'image/jpeg');
             $image->set_quality($quality);

--- a/src/Image/Operation/Retina.php
+++ b/src/Image/Operation/Retina.php
@@ -63,8 +63,8 @@ class Retina extends ImageOperation
             $src_w = $current_size['width'];
             $src_h = $current_size['height'];
             // Get ratios
-            $w = $src_w * $this->factor;
-            $h = $src_h * $this->factor;
+            $w = \round($src_w * $this->factor);
+            $h = \round($src_h * $this->factor);
             $image->crop(0, 0, $src_w, $src_h, $w, $h);
             $result = $image->save($save_filename);
             if (\is_wp_error($result)) {


### PR DESCRIPTION
Related:

- #3039

## Issue
In some cases image operations would lead to strange artifacts. This was because of non rounded numbers. In the 1.x branch these rounding functions where used. This PR restores that to the 2.x branch.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->


## Impact
Better image generation.

## Usage Changes
no

## Testing
Already covered by tests