### PR TITLE
fix: add a wrapper around wp_kses_post() function to allow for null

### DIFF
--- a/docs/v2/guides/escaping.md
+++ b/docs/v2/guides/escaping.md
@@ -37,13 +37,13 @@ You can read more about the basics of [theme security](https://developer.wordpre
 
 Twig offers a variety of [escaping functions](https://twig.symfony.com/doc/filters/escape.html) out of the box. They are intended to escape a string for safe insertion into the final output.
 
-In addition to these standard escaping functions, Timber comes with some valuable custom escapers for your WordPress theme. To use the escaper (see documentation link above), you pipe your content through a function `e` and if you want to use a custom escaper, you would supply an argument to the function, e.g. `e('wp_kses_post')`.
+In addition to these standard escaping functions, Timber comes with some valuable custom escapers for your WordPress theme.
 
 ## wp_kses_post
 
 KSES is a recursive acronym for `KSES Kills Evil Scripts`. It’s goal is to ensure only "allowed" HTML element names, attribute names and attribute values plus only sane HTML entities in the string. Allowed means based on a configuration.
 
-The `wp_kses_post` escaper uses the internal WordPress function [`wp_kses_post()`](https://developer.wordpress.org/reference/functions/wp_kses_post/) that sanitizes content for allowed HTML tags for the post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );`.
+The `wp_kses_post` escaper uses the internal WordPress function [`wp_kses_post()`](https://developer.wordpress.org/reference/functions/wp_kses_post/) that sanitizes content for allowed HTML tags for the post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );`. We pipe the `wp_kses_post()` function through the `Timber\Twig::kses_allow_null` method to allow for null values.
 
 **Twig**
 

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -440,7 +440,7 @@ class Twig
                 'callable' => 'wp_kses',
             ],
             'wp_kses_post' => [
-                'callable' => 'wp_kses_post',
+                'callable' => [$this, 'kses_allow_null'],
             ],
             'esc_attr' => [
                 'callable' => 'esc_attr',
@@ -486,6 +486,23 @@ class Twig
         $escaper_filters = \apply_filters('timber/twig/escapers', $escaper_filters);
 
         return $escaper_filters;
+    }
+
+    /**
+     * Wrapper for `wp_kses_post` that allows `null` values.
+     *
+     * @since 2.3.0
+     * @internal This method is used to provide a workaround for the `wp_kses_post` function that does not allow `null` values.
+     * @param mixed $content The content to sanitize.
+     * @return null|string The sanitized content or `null` if the input was `null`.
+     */
+    public function kses_allow_null(mixed $content)
+    {
+        if (\is_null($content)) {
+            return null;
+        }
+
+        return \wp_kses_post($content);
     }
 
     /**

--- a/tests/test-timber-escapers.php
+++ b/tests/test-timber-escapers.php
@@ -75,6 +75,16 @@ class TestTimberFilterEscapers extends Timber_UnitTestCase
         $this->assertEquals($native, $result);
     }
 
+    public function testKsesEscaperAllowNull()
+    {
+
+        $result = Timber::compile_string('{{ text|wp_kses_post(null) }}', [
+            'text' => null,
+        ]);
+
+        $this->assertEquals(null, $result);
+    }
+
     public function testOldEscaper()
     {
         $dirty_url = 'https://example.com/?foo=1&bar=2';


### PR DESCRIPTION
Related:

- #3008

## Issue
`wp_kses_post()` function does not allow null values.

## Solution
Wrap the function in  a method to bail early before escaping

## Impact
Better escaping

## Usage Changes
No.

## Considerations
There might be a better way to achieve this? If so, let me know

## Testing
Yes
