### PR TITLE
fix: add more default arguments to PagesMenu::build method

### DIFF
--- a/src/PagesMenu.php
+++ b/src/PagesMenu.php
@@ -33,6 +33,8 @@ class PagesMenu extends Menu
          * Default arguments from wp_page_menu() function.
          *
          * @see wp_page_menu()
+         *
+         * @since 2.3.0 The 'menu' and 'theme_location' are added to provide compatibility with Polylang. See ticket #2922.
          */
         $defaults = [
             'sort_column' => 'menu_order, post_title',

--- a/src/PagesMenu.php
+++ b/src/PagesMenu.php
@@ -43,6 +43,8 @@ class PagesMenu extends Menu
             'after' => '</ul>',
             'item_spacing' => 'discard',
             'walker' => '',
+            'menu' => '',
+            'theme_location' => '',
             'menu_id' => '',
             'menu_class' => 'menu',
             'container' => 'div',

--- a/src/PagesMenu.php
+++ b/src/PagesMenu.php
@@ -34,7 +34,8 @@ class PagesMenu extends Menu
          *
          * @see wp_page_menu()
          *
-         * @since 2.3.0 The 'menu' and 'theme_location' are added to provide compatibility with Polylang. See ticket #2922.
+         * @since 2.3.0 The 'menu' and 'theme_location' are added to provide compatibility with Polylang.
+         * @see https://github.com/timber/timber/issues/2922
          */
         $defaults = [
             'sort_column' => 'menu_order, post_title',


### PR DESCRIPTION
Related:

- #2922
- Ticket 2

## Issue
Polylang pages menus assume default arguments are set, but they are not in PagesMenu.php


## Solution
Add those two default arguments.

## Impact
Better compat with Polylang.

## Usage Changes
no.

## Considerations
no.

## Testing
@lnorby and @cafesk8, are you able to test this code to see if it works as expected? You can just copy/paste the code of the changed file to your local codebase.