### PR TITLE
Fix: Use correct deprecation_info for Twig callables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "require": {
     "php": "^8.1",
-    "twig/twig": "^3.5"
+    "twig/twig": "^3.16"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.28",

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -14,6 +14,7 @@ use Twig\Extension\EscaperExtension;
 use Twig\Runtime\EscaperRuntime;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\DeprecatedCallableInfo;
 
 /**
  * Class Twig
@@ -100,7 +101,13 @@ class Twig
                     return $post_factory->from($post_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_post() }} or {{ get_posts() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'TimberPost' => [
@@ -109,7 +116,13 @@ class Twig
                     return $post_factory->from($post_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_post() }} or {{ get_posts() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'Image' => [
@@ -118,7 +131,13 @@ class Twig
                     return $post_factory->from($post_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_image() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'TimberImage' => [
@@ -127,7 +146,13 @@ class Twig
                     return $post_factory->from($post_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_image() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'Term' => [
@@ -136,7 +161,13 @@ class Twig
                     return $termFactory->from($term_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_term() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'TimberTerm' => [
@@ -145,7 +176,13 @@ class Twig
                     return $termFactory->from($term_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_term() }} or {{ get_terms() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'User' => [
@@ -154,7 +191,13 @@ class Twig
                     return Timber::get_user($user_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_user() }} or {{ get_users() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'TimberUser' => [
@@ -163,7 +206,13 @@ class Twig
                     return Timber::get_user($user_id);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ get_user() }} or {{ get_users() }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'shortcode' => [
@@ -299,7 +348,13 @@ class Twig
                     return $obj::class;
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: "{{ function('get_class', my_object) }}",
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
             'print_r' => [
@@ -308,7 +363,13 @@ class Twig
                     return \print_r($arr, true);
                 },
                 'options' => [
-                    'deprecated' => true,
+                    'deprecation_info' => new DeprecatedCallableInfo(
+                        package: 'timber/timber',
+                        version: '2.0.0',
+                        altName: '{{ dump(my_object) }}',
+                        altPackage: null,
+                        altVersion: null
+                    ),
                 ],
             ],
 


### PR DESCRIPTION
## Issue
<!-- Description of the problem that this code change is solving -->
Twig v.3.15. introduced some nice features. Testing it with Timber v.2.x. works fine. However, there is this annoying deprecation warning:
```
'twig/twig', '3.15', 'Using the "deprecated", "deprecating_package", and "alternative" options is deprecated, pass a "deprecation_info" one instead.')
```

`$options['deprecated']` is deprecated since Twig 3.15. 
From Changelog:
[ * Improve the way one can deprecate a Twig callable (use `deprecation_info` instead of the other callable options)
](https://github.com/twigphp/Twig/blob/709fc6abcef276d40581be663c120307ccf0f2ce/CHANGELOG#L41) 
https://github.com/twigphp/Twig/blob/709fc6abcef276d40581be663c120307ccf0f2ce/src/AbstractTwigCallable.php#L46

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
updates Timber to use the new deprecation_info option introduced in Twig 3.15 for handling deprecated features.
Question:
Why was the deprecated option used to signal Twig in the first place when Timber already provides the Helper::deprecated() function to handle deprecation warnings? This seems redundant, as Helper::deprecated() outputs its own warning messages. Or am I missing something?

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
