### PR TITLE
fix: fix get location by id in Timber::get_menu_location()

### DIFF
--- a/src/Timber.php
+++ b/src/Timber.php
@@ -1076,7 +1076,7 @@ class Timber
         }
 
         $locations = \array_flip(static::get_menu_locations());
-        return $locations[$term->term_id] ?? null;
+        return $locations[$term_id] ?? null;
     }
 
     /**

--- a/tests/test-menu-factory.php
+++ b/tests/test-menu-factory.php
@@ -218,5 +218,8 @@ class TestMenuFactory extends Timber_UnitTestCase
         $factory = new MenuFactory();
         $location = Timber::get_menu_location(get_term($id));
         $this->assertSame('primary', $location);
+
+        $location = Timber::get_menu_location($id);
+        $this->assertSame('primary', $location);
     }
 }


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/pull/2733

## Issue
When reviewing https://github.com/timber/timber/issues/3062 I found this bug that I missed during the review of @mcaskill PR.


## Solution
Fix the bug and support menu's by ID as well.


## Impact
Better functionality of this method.


## Usage Changes
no.

## Considerations
no

## Testing
Added a test for getting the menu by ID as well.