### PR TITLE
docs: update the widgets guide

### DIFF
--- a/docs/v2/guides/widgets.md
+++ b/docs/v2/guides/widgets.md
@@ -3,15 +3,39 @@ title: "Widgets"
 order: "160"
 ---
 
-Everyone loves widgets! Of course they do...
+In a Gutenberg world, widgets are getting less important. However, they are still a part of WordPress and you might need to use them. Timber can help you with that.
+
+First we will have to register the widget area in our theme. This is done in the `functions.php` file for example.
 
 ```php
-$data = [
-    'footer_widgets' => Timber::get_widgets('footer_widgets'),
-];
+function site_widgets_init() {
+  register_sidebar( array(
+        'name'          => 'Footer widgets',
+        'id'            => 'footer_widgets'
+        'description'   => 'Add widgets here to appear in your footer.',
+        'before_widget' => '<section id="%1$s" class="widget %2$s">',
+        'after_widget'  => '</section>',
+        'before_title'  => '<h3 class="widget__title">',
+        'after_title'   => '</h3>',
+  ) );
+}
+
+add_action( 'widgets_init', 'site_widgets_init' );
 ```
 
-...where `footer_widgets` is the registered name of the widgets you want to get (in twentythirteen these are called `sidebar-1` and `sidebar-2`).
+Then you can add the widgets to the global context.
+```php
+function add_to_context($context)
+{
+    // add other stuff to the context
+    $context['footer_widgets'] = Timber::get_widgets('footer_widgets');
+
+    return $context;
+}
+add_filter('timber/context', 'add_to_context');
+```
+
+...where `footer_widgets` is the registered name of the widgets you want to get.
 
 Then use it in your template:
 

--- a/docs/v2/guides/widgets.md
+++ b/docs/v2/guides/widgets.md
@@ -3,13 +3,13 @@ title: "Widgets"
 order: "160"
 ---
 
-In a Gutenberg world, widgets are getting less important. However, they are still a part of WordPress and you might need to use them. Timber can help you with that.
+In a world where the block editor is used more and more, widgets are getting less important. However, they are still a part of WordPress and you might need to use them. Timber can help you with that.
 
-First we will have to register the widget area in our theme. This is done in the `functions.php` file for example.
+First we will have to register the widget area in our theme. This is done in the **functions.php** file for example.
 
 ```php
 function site_widgets_init() {
-  register_sidebar( array(
+    register_sidebar([
         'name'          => 'Footer widgets',
         'id'            => 'footer_widgets'
         'description'   => 'Add widgets here to appear in your footer.',
@@ -17,21 +17,21 @@ function site_widgets_init() {
         'after_widget'  => '</section>',
         'before_title'  => '<h3 class="widget__title">',
         'after_title'   => '</h3>',
-  ) );
+    ]);
 }
 
-add_action( 'widgets_init', 'site_widgets_init' );
+add_action('widgets_init', 'site_widgets_init');
 ```
 
 Then you can add the widgets to the global context.
+
 ```php
-function add_to_context($context)
-{
-    // add other stuff to the context
+function add_to_context($context) {
     $context['footer_widgets'] = Timber::get_widgets('footer_widgets');
 
     return $context;
 }
+
 add_filter('timber/context', 'add_to_context');
 ```
 


### PR DESCRIPTION
Related:

- #3021

## Issue
Widget guide is a bit out of date.


## Solution
Update it.

## Impact
Better understanding of widgets, for the time they are still around.

## Usage Changes
no

## Considerations
Maybe we can include a guide as well on how to work with the new WordPress template areas as well.
