### PR TITLE
3059 docs better documentation on how to check for empty post collections

### DIFF
--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -487,7 +487,7 @@ You could do this in Twig and use `get_posts()` to convert your IDs to `Timber\P
 ```twig
 {% set sponsors = get_posts(post.meta('sponsors')) %}
 
-{% if sponsors %}
+{% if sponsors is not empty %}
     <h2>Many thanks to our generous sponsors</h2>
 
     <ul>

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -235,4 +235,4 @@ echo Timber\Helper::stop_timer($start);
 ```
 ## Important notes
 
-- Never use `{% spaceless %}` tags to minify your HTML output. These tags are only meant to control whitespace between html tags.
+- Never use `{% apply spaceless %}` tags to minify your HTML output. These tags are only meant to control whitespace between html tags.

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -235,4 +235,4 @@ echo Timber\Helper::stop_timer($start);
 ```
 ## Important notes
 
-- Never use `{% apply spaceless %}` tags to minify your HTML output. These tags are only meant to control whitespace between html tags.
+- Never use `{% apply spaceless %}` tags to minify your HTML output. These tags are only meant to control whitespace between HTML tags.

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -54,9 +54,14 @@ This is especially helpful if you only have an image ID and want to convert it t
 It also works if you have an array of post IDs that you want to convert to `Timber\Post` objects.
 
 ```twig
-{% for post in Post(post_ids) %}
-
-{% endfor %}
+{% set post = get_posts(post_ids) %}
+{% if posts is not empty %}
+<ul>
+    {% for post in posts %}
+        <li>{{ post.title }}</li>
+    {% endfor %}
+</ul>
+{% endif %}
 ```
 
 ## Invalid posts

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -39,16 +39,16 @@ Here’s a Twig template that received the post above in a `post` variable.
 
 ## Twig
 
-You can convert post IDs to post objects in Twig using the `Post()` function.
+You can convert a post ID to post objects in Twig using the `get_post()` function.
 
 ```twig
-{% set post = Post(post_id) %}
+{% set post = get_post(post_id) %}
 ```
 
 This is especially helpful if you only have an image ID and want to convert it to an image:
 
 ```twig
-<img src="{{ Image(attachment_id).src }}">
+<img src="{{ get_image(attachment_id).src }}">
 ```
 
 It also works if you have an array of post IDs that you want to convert to `Timber\Post` objects.

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -54,7 +54,7 @@ This is especially helpful if you only have an image ID and want to convert it t
 It also works if you have an array of post IDs that you want to convert to `Timber\Post` objects.
 
 ```twig
-{% set post = get_posts(post_ids) %}
+{% set posts = get_posts(post_ids) %}
 {% if posts is not empty %}
 <ul>
     {% for post in posts %}

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -398,13 +398,18 @@ You can run post queries in Twig. Pass the parameters in an argument hash (in Tw
 
 ```twig
 {# Hash notation #}
-{% for post in get_posts({
+{% set posts = get_posts({
     post_type: 'post',
     post_status: 'publish',
     posts_per_page: 10
 }) %}
-    <a href="{{ post.link }}">{{ post.title }}</a>
-{% endfor %}
+{% if posts is not empty %}
+    <ul>
+        {% for post in posts %}
+            <li><a href="{{ post.link }}">{{ post.title }}</a></li>
+        {% endfor %}
+    </ul>
+{% endif %}
 ```
 
 We still recommend you to run queries and prepare posts in PHP and not in Twig. But sometimes this is not possible when you don’t have access to the relevant PHP files, but only to Twig.

--- a/src/Post.php
+++ b/src/Post.php
@@ -543,16 +543,18 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
      * @example
      * ```twig
      * <section id="job-feed">
-     * {% for post in job %}
-     *     <div class="job">
-     *         <h2>{{ post.title }}</h2>
-     *         <p>{{ post.terms({
-     *             taxonomy: 'category',
-     *             orderby: 'name',
-     *             order: 'ASC'
-     *         })|join(', ') }}</p>
-     *     </div>
-     * {% endfor %}
+     * {% if jobs is not empty %}
+     *   {% for post in jobs %}
+     *       <div class="job">
+     *           <h2>{{ post.title }}</h2>
+     *           <p>{{ post.terms({
+     *               taxonomy: 'category',
+     *               orderby: 'name',
+     *               order: 'ASC'
+     *           })|join(', ') }}</p>
+     *       </div>
+     *   {% endfor %}
+     * {% endif %}
      * </section>
      * ```
      * ```html
@@ -985,7 +987,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
      * @api
      * @example
      * ```twig
-     * {% if post.children %}
+     * {% if post.children is not empty %}
      *     Here are the child pages:
      *     {% for child in post.children %}
      *         <a href="{{ child.link }}">{{ child.title }}</a>


### PR DESCRIPTION
Related:

- #3059

## Issue
Some documentation/docsblocks didn't feature the right way of checking for empty post collections yet.

## Solution
Update examples, and while at it I found a few outdated/deprecated usages as well in our guides and changed these as well at the same time.


## Impact
Better guided!
