### PR TITLE
3063 timberget menu0 returns alphabetically first menu instead of nothing

### DIFF
--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -166,14 +166,9 @@ add_filter('timber/context', 'add_to_context');
 function add_to_context($context)
 {
     // Set all nav menus in context.
-    foreach (array_keys(get_registered_nav_menus()) as $location) {
-        // Set all nav menus in context.
-        foreach (array_keys(get_registered_nav_menus()) as $location) {
-            $menu = Timber::get_menu($location);
-            $context[$location] = $menu;
-        }
-
-        return $context;
+    foreach (array_keys(get_nav_menu_locations()) as $location) {
+        $menu = Timber::get_menu($location);
+        $context[$location] = $menu;
     }
 
     return $context;

--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -167,14 +167,13 @@ function add_to_context($context)
 {
     // Set all nav menus in context.
     foreach (array_keys(get_registered_nav_menus()) as $location) {
-        // Bail out if menu has no location.
-        if (!has_nav_menu($location)) {
-            continue;
+        // Set all nav menus in context.
+        foreach (array_keys(get_registered_nav_menus()) as $location) {
+            $menu = Timber::get_menu($location);
+            $context[$location] = $menu;
         }
 
-        $menu = Timber::get_menu($location);
-
-        $context[$location] = $menu;
+        return $context;
     }
 
     return $context;

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -105,6 +105,10 @@ class MenuFactory
      */
     public function from_id(int $id, array $args = []): ?Menu
     {
+        if (0 === $id) {
+            return null;
+        }
+
         $term = \get_term_by('id', $id, 'nav_menu');
 
         if (!$term) {


### PR DESCRIPTION
Related:

- #3063


## Issue
Menus are retrievable by `0`. It returns the alphabetically first menu. This is not what we want. 👯 

## Solution
In the case of using the get_menu method in combination with a  `0`, return `null`.

While at it, update the documentation as well with a new example.

## Impact
Less strange edge cases and a better example.

## Usage Changes
no

## Considerations
no

## Testing
no, should we?
