### PR TITLE
test: Fix avatar test

### DIFF
--- a/tests/test-timber-user.php
+++ b/tests/test-timber-user.php
@@ -237,8 +237,8 @@ class TestTimberUser extends Timber_UnitTestCase
             'user_email' => 'm.palmowski@spiders.agency',
         ]);
         $user = Timber::get_user($uid);
-        $this->assertEquals('http://2.gravatar.com/avatar/b2965625410b81a2b25ef02b54493ce0?s=96&d=mm&r=g', $user->avatar());
-        $this->assertEquals('http://2.gravatar.com/avatar/b2965625410b81a2b25ef02b54493ce0?s=120&d=mm&r=g', $user->avatar([
+        $this->assertStringEndsWith('gravatar.com/avatar/b2965625410b81a2b25ef02b54493ce0?s=96&d=mm&r=g', $user->avatar());
+        $this->assertStringEndsWith('gravatar.com/avatar/b2965625410b81a2b25ef02b54493ce0?s=120&d=mm&r=g', $user->avatar([
             'size' => 120,
         ]));
     }


### PR DESCRIPTION
Fix pesky avatar test by not checking the whole URL but only the last part of the string by using `assertStringEndsWith`. Should be good enough then 👍 