### PR TITLE
fix: Fix bug with Attachment::path() method

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -125,10 +125,7 @@ class Attachment extends Post
     public function path(): string
     {
         $src = $this->src();
-        // If src is a URL, convert it to a filesystem path first.
-        if (URLHelper::is_url($src)) {
-            $src = URLHelper::url_to_file_system($src);
-        }
+        $src = URLHelper::url_to_file_system($src);
 
         return URLHelper::get_rel_path($src);
     }

--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -124,7 +124,13 @@ class Attachment extends Post
      */
     public function path(): string
     {
-        return URLHelper::get_rel_path($this->src());
+        $src = $this->src();
+        // If src is a URL, convert it to a filesystem path first.
+        if (URLHelper::is_url($src)) {
+            $src = URLHelper::url_to_file_system($src);
+        }
+
+        return URLHelper::get_rel_path($src);
     }
 
     /**

--- a/tests/test-timber-attachment.php
+++ b/tests/test-timber-attachment.php
@@ -270,6 +270,14 @@ class TestTimberAttachment extends TimberAttachment_UnitTestCase
         $this->assertSame(16555, $attachment->size());
     }
 
+    public function testFilePath()
+    {
+        $pid = $this->factory->post->create();
+        $iid = self::get_attachment($pid, 'dummy-pdf.pdf');
+        $attachment = Timber::get_post($iid);
+        $this->assertEquals('wp-content/uploads/' . date('Y/m') . '/dummy-pdf.pdf', $attachment->path());
+    }
+
     public function testFileSizeMissingInMetadata()
     {
         $pid = $this->factory->post->create();


### PR DESCRIPTION
Related:

- #3072

Solution was provided by @mrfsrf

## Issue
When `'Timber\Attachment::path()`; is requested, the Path ends up being a mix of a path and a URL.


## Solution
If we are working with a URL, the convert the path first to a filesystem path before getting the relative path.

## Impact
A method that works again.


## Usage Changes
No.

## Considerations
Do we need to run the is_url check first since we are probably working with a URL anyway?


## Testing
Yes, test added.
