### PR TITLE
fix: update twig/twig dependency to version 3.17 to fix unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "require": {
     "php": "^8.1",
-    "twig/twig": "^3.16"
+    "twig/twig": "^3.17"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.28",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "squizlabs/php_codesniffer": "^3.0",
     "symplify/easy-coding-standard": "^12.2",
     "szepeviktor/phpstan-wordpress": "^1.1",
-    "twig/cache-extra": "^3.3",
+    "twig/cache-extra": "^3.17",
     "wpackagist-plugin/advanced-custom-fields": "^6.0",
     "wpackagist-plugin/co-authors-plus": "^3.6",
     "yoast/wp-test-utils": "^1.2"


### PR DESCRIPTION
## Issue
Unit tests fail because of Twig bug.


## Solution
Bump Twig.

## Impact
Unit tests!


