### PR TITLE
Refactor WebP conversion: add cwebp and imagick engines

### DIFF
--- a/src/Image/Converter/CWebPConverter.php
+++ b/src/Image/Converter/CWebPConverter.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Timber\Image\Converter;
+
+use Timber\Helper;
+
+/**
+ * cwebp CLI implementation
+ */
+class CWebPConverter implements IConverter
+{
+    private $binary_path;
+
+    public function __construct(
+        private $quality
+    ) {
+        $this->binary_path = \apply_filters('webp_cwebp_path', '/usr/local/bin/cwebp');
+    }
+
+    public function convert($load_filename, $save_filename)
+    {
+        if (!\file_exists($this->binary_path)) {
+            Helper::error_log('cwebp binary not found at: ' . $this->binary_path);
+            return false;
+        }
+
+        $command = \sprintf(
+            '%s -q %d %s -o %s 2>&1',
+            \escapeshellcmd($this->binary_path),
+            $this->quality,
+            \escapeshellarg((string) $load_filename),
+            \escapeshellarg((string) $save_filename)
+        );
+
+        \exec($command, $output, $return_var);
+
+        if ($return_var !== 0) {
+            Helper::error_log('cwebp conversion failed: ' . \implode(' ', $output));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Image/Converter/GDConverter.php
+++ b/src/Image/Converter/GDConverter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Timber\Image\Converter;
+
+use Timber\Helper;
+
+/**
+ * Original GD implementation
+ */
+class GDConverter implements IConverter
+{
+    public function __construct(
+        private $quality
+    ) {
+    }
+
+    public function convert($load_filename, $save_filename)
+    {
+        $ext = \wp_check_filetype($load_filename);
+        if (isset($ext['ext'])) {
+            $ext = $ext['ext'];
+        }
+        $ext = \strtolower((string) $ext);
+        $ext = \str_replace('jpg', 'jpeg', $ext);
+
+        $imagecreate_function = 'imagecreatefrom' . $ext;
+        if (!\function_exists($imagecreate_function)) {
+            return false;
+        }
+
+        $input = $imagecreate_function($load_filename);
+
+        if ($input === false) {
+            return false;
+        }
+
+        if (!\imageistruecolor($input)) {
+            \imagepalettetotruecolor($input);
+        }
+
+        if (!\function_exists('imagewebp')) {
+            Helper::error_log('The function imagewebp does not exist on this server to convert image to ' . $save_filename . '.');
+            return false;
+        }
+
+        return \imagewebp($input, $save_filename, $this->quality);
+    }
+}

--- a/src/Image/Converter/IConverter.php
+++ b/src/Image/Converter/IConverter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Timber\Image\Converter;
+
+/**
+ * Interface for WebP converters
+ */
+interface IConverter
+{
+    public function convert($load_filename, $save_filename);
+}

--- a/src/Image/Converter/ImagickConverter.php
+++ b/src/Image/Converter/ImagickConverter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Timber\Image\Converter;
+
+use Exception;
+use Imagick;
+use Timber\Helper;
+
+/**
+ * ImageMagick implementation
+ */
+class ImagickConverter implements IConverter
+{
+    public function __construct(
+        private $quality
+    ) {
+    }
+
+    public function convert($load_filename, $save_filename)
+    {
+        if (!\class_exists('Imagick')) {
+            Helper::error_log('Imagick is not installed on this server.');
+            return false;
+        }
+
+        try {
+            $image = new Imagick($load_filename);
+            $image->setImageFormat('webp');
+            $image->setImageCompressionQuality($this->quality);
+            return $image->writeImage($save_filename);
+        } catch (Exception $e) {
+            Helper::error_log('Imagick conversion failed: ' . $e->getMessage());
+            return false;
+        }
+    }
+}

--- a/src/Image/Operation/ToWebp.php
+++ b/src/Image/Operation/ToWebp.php
@@ -4,8 +4,8 @@ namespace Timber\Image\Operation;
 
 use Timber\Image\Converter\CWebPConverter;
 use Timber\Image\Converter\GDConverter;
-use Timber\Image\Converter\ImagickConverter;
 use Timber\Image\Converter\IConverter;
+use Timber\Image\Converter\ImagickConverter;
 use Timber\Image\Operation as ImageOperation;
 use Timber\ImageHelper;
 

--- a/src/Image/Operation/ToWebp.php
+++ b/src/Image/Operation/ToWebp.php
@@ -5,6 +5,7 @@ namespace Timber\Image\Operation;
 use Timber\Image\Converter\CWebPConverter;
 use Timber\Image\Converter\GDConverter;
 use Timber\Image\Converter\ImagickConverter;
+use Timber\Image\Converter\IConverter;
 use Timber\Image\Operation as ImageOperation;
 use Timber\ImageHelper;
 

--- a/tests/test-timber-image-towebp.php
+++ b/tests/test-timber-image-towebp.php
@@ -24,6 +24,11 @@ class TestTimberImageToWEBP extends Timber_UnitTestCase
 
     public function testCwebpTIFtoWEB()
     {
+        $binary_path = '/opt/homebrew/bin/cwebp';
+        if (!file_exists($binary_path)) {
+            $this->markTestSkipped('cwebp binary not available at ' . $binary_path);
+        }
+
         add_filter('webp_converter_engine', fn ($engine) => 'cwebp');
         add_filter('webp_cwebp_path', fn ($path) => '/opt/homebrew/bin/cwebp');
 


### PR DESCRIPTION

## Issue
<!-- Description of the problem that this code change is solving -->
Currently, WebP image conversion is limited to PHP's GD library. This has limitations:
- Lack of TIFF support
- Limited control over conversion quality
- No alternative for servers with ImageMagick or cwebp installed

This change introduces multiple converter engines (GD, ImageMagick, cwebp), allowing:
- Better image quality through specialized converters
- Support for converting TIFF files to WebP
- Flexibility to choose the best converter based on server capabilities

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
- Extract WebP conversion logic into separate converter classes
- Add CWebPConverter using cwebp binary for high-quality conversion
- Add ImagickConverter for servers with ImageMagick support
- Keep GDConverter as default fallback option

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
None.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Yes
