### PR TITLE
docs: incorrect anchor from upgrade 2.0 guide to get_posts

### DIFF
--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -390,7 +390,7 @@ $latest_books_collection = Timber::get_posts($args);
 $latest_books_array = Timber::get_posts($args)->to_array();
 ```
 
-The new `$options` parameter can be used to pass in options for the query. Check out the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/v2/reference/timber-timber/#get_post) to see all options.
+The new `$options` parameter can be used to pass in options for the query. Check out the documentation for [`Timber::get_posts()`](https://timber.github.io/docs/v2/reference/timber-timber/#get_posts) to see all options.
 
 ### Post queries in Twig
 


### PR DESCRIPTION
Hello,

This is a simple doc fix.


## Issue
A link inside the upgrade v2 docs is incorrect, the anchor targets to the `get_post` instead of the `get_posts` function.

## Solution
Link updated inside the markdown doc.


