### PR TITLE
Opt-In Advanced Deletion for Generated Image Variants (tojpg/towebp & scaled)

### DIFF
--- a/src/Image/Operation/ToJpg.php
+++ b/src/Image/Operation/ToJpg.php
@@ -21,13 +21,27 @@ class ToJpg extends ImageOperation
     }
 
     /**
-     * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
-     * @param   string    $src_extension    ignored
-     * @return  string    the final filename to be used (ex: my-awesome-pic.jpg)
+     * Returns the final filename to be used.
+     *
+     * If the advanced file naming feature is enabled (via the filter
+     * `timber/image/advanced_file_names`), the output filename will include
+     * the "-tojpg" suffix (e.g. my-awesome-pic-tojpg.jpg). Otherwise, it returns
+     * the legacy filename (e.g. my-awesome-pic.jpg).
+     *
+     * @param   string $src_filename  The basename of the file (ex: my-awesome-pic).
+     * @param   string $src_extension Ignored.
+     * @return  string The final filename.
      */
     public function filename($src_filename, $src_extension = 'jpg')
     {
-        $new_name = $src_filename . '.jpg';
+        $advanced = \apply_filters('timber/image/advanced_file_names', false);
+
+        if ($advanced) {
+            $new_name = $src_filename . '-tojpg.jpg';
+        } else {
+            $new_name = $src_filename . '.jpg';
+        }
+
         return $new_name;
     }
 

--- a/src/Image/Operation/ToWebp.php
+++ b/src/Image/Operation/ToWebp.php
@@ -22,13 +22,27 @@ class ToWebp extends ImageOperation
     }
 
     /**
-     * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
-     * @param   string    $src_extension    ignored
-     * @return  string    the final filename to be used (ex: my-awesome-pic.webp)
+     * Returns the final filename to be used.
+     *
+     * If the advanced file naming feature is enabled (via the filter
+     * `timber/image/advanced_file_names`), the output filename will include
+     * the "-towebp" suffix (e.g. my-awesome-pic-towebp.webp). Otherwise, it returns
+     * the legacy filename (e.g. my-awesome-pic.webp).
+     *
+     * @param   string $src_filename  The basename of the file (ex: my-awesome-pic).
+     * @param   string $src_extension Ignored.
+     * @return  string The final filename.
      */
     public function filename($src_filename, $src_extension = 'webp')
     {
-        $new_name = $src_filename . '.webp';
+        $advanced = \apply_filters('timber/image/advanced_file_names', false);
+
+        if ($advanced) {
+            $new_name = $src_filename . '-towebp.webp';
+        } else {
+            $new_name = $src_filename . '.webp';
+        }
+
         return $new_name;
     }
 

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -321,25 +321,40 @@ class ImageHelper
             $local_file = URLHelper::url_to_file_system($local_file);
         }
         $info = PathHelper::pathinfo($local_file);
-        $dir = $info['dirname'];
+        $original_dir = $info['dirname'];
         $ext = $info['extension'];
         $filename = $info['filename'];
-        self::process_delete_generated_files($filename, $ext, $dir, '-[0-9999999]*', '-[0-9]*x[0-9]*-c-[a-z]*.');
-        self::process_delete_generated_files($filename, $ext, $dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.');
-        self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg.*');
-        self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg-[0-9999999]*');
+
+        // Re-analyze the URL to see if a generated folder is configured.
+        $au = self::analyze_url($local_file);
+        $generated_folder = \apply_filters('timber/image/generated_folder', false, $au);
+        if ($generated_folder && $au['base'] == self::BASE_UPLOADS) {
+            // If the source has a year/month subfolder, preserve that structure.
+            if (\preg_match('#^/\d{4}/\d{2}$#', (string) $au['subdir'])) {
+                $dest_subdir = '/' . \trim($generated_folder, '/') . $au['subdir'];
+            } else {
+                $dest_subdir = '/' . \trim($generated_folder, '/');
+            }
+            $upload_dir = \wp_upload_dir();
+            $dest_dir = $upload_dir['basedir'] . $dest_subdir;
+        } else {
+            $dest_dir = $original_dir;
+        }
+
+        // Now run deletion logic in the destination directory.
+        self::process_delete_generated_files($filename, $ext, $dest_dir, '-[0-9999999]*', '-[0-9]*x[0-9]*-c-[a-z]*.');
+        self::process_delete_generated_files($filename, $ext, $dest_dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.');
+        self::process_delete_generated_files($filename, 'jpg', $dest_dir, '-tojpg.*');
+        self::process_delete_generated_files($filename, 'jpg', $dest_dir, '-tojpg-[0-9999999]*');
 
         $advanced = \apply_filters('timber/image/advanced_file_names', false);
-
         if ($advanced) {
-            self::process_delete_generated_files_advanced($filename, 'jpg', $dir);
-            self::process_delete_generated_files_advanced($filename, 'webp', $dir);
-
-            // Delete the original generated files if it is a scaled image.
+            self::process_delete_generated_files_advanced($filename, 'jpg', $dest_dir);
+            self::process_delete_generated_files_advanced($filename, 'webp', $dest_dir);
             $filename_without_scaled = \str_replace('-scaled', '', $filename);
             if ($filename_without_scaled !== $filename) {
-                self::process_delete_generated_files_advanced($filename_without_scaled, 'jpg', $dir);
-                self::process_delete_generated_files_advanced($filename_without_scaled, 'webp', $dir);
+                self::process_delete_generated_files_advanced($filename_without_scaled, 'jpg', $dest_dir);
+                self::process_delete_generated_files_advanced($filename_without_scaled, 'webp', $dest_dir);
             }
         }
     }
@@ -866,22 +881,44 @@ class ImageHelper
 
         // break down URL into components
         $au = self::analyze_url($src);
+        $original_subdir = $au['subdir'];
+
+        // Override subdirectory for generated images if a folder is configured.
+        $generated_folder = \apply_filters('timber/image/generated_folder', false, $au);
+
+        if ($generated_folder && $au['base'] == self::BASE_UPLOADS) {
+            if (\preg_match('#^/\d{4}/\d{2}$#', (string) $au['subdir'])) {
+                $au['subdir'] = '/' . \trim($generated_folder, '/') . $au['subdir'];
+            } else {
+                $au['subdir'] = '/' . \trim($generated_folder, '/');
+            }
+            // Ensure the destination directory exists.
+            $upload_dir = \wp_upload_dir();
+            $dest_dir = $upload_dir['basedir'] . $au['subdir'];
+            if (!\file_exists($dest_dir)) {
+                \mkdir($dest_dir, 0755, true);
+            }
+        }
+        $dest_subdir = $au['subdir']; // new subdir for generated image
 
         // build URL and filenames
         $new_url = self::_get_file_url(
             $au['base'],
-            $au['subdir'],
+            $dest_subdir,
             $op->filename($au['filename'], $au['extension']),
             $au['absolute']
         );
         $destination_path = self::_get_file_path(
             $au['base'],
-            $au['subdir'],
-            $op->filename($au['filename'], $au['extension'])
+            $dest_subdir,
+            $op->filename(
+                $au['filename'],
+                $au['extension']
+            )
         );
         $source_path = self::_get_file_path(
             $au['base'],
-            $au['subdir'],
+            $original_subdir,
             $au['basename']
         );
 

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -328,25 +328,49 @@ class ImageHelper
         self::process_delete_generated_files($filename, $ext, $dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.');
         self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg.*');
         self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg-[0-9999999]*');
+
+        $advanced = \apply_filters('timber/image/advanced_file_names', false);
+
+        if ($advanced) {
+            self::process_delete_generated_files($filename, 'jpg', $dir, '', '', true);
+            self::process_delete_generated_files($filename, 'webp', $dir, '', '', true);
+
+            $filename_without_scaled = \str_replace('-scaled', '', $filename);
+            if ($filename_without_scaled !== $filename) {
+                self::process_delete_generated_files($filename_without_scaled, 'jpg', $dir, '', '', true);
+                self::process_delete_generated_files($filename_without_scaled, 'webp', $dir, '', '', true);
+            }
+        }
     }
 
     /**
      * Deletes resized versions of the supplied file name.
      *
-     * If passed a value like my-pic.jpg, this function will delete my-pic-500x200-c-left.jpg, my-pic-400x400-c-default.jpg, etc.
-     *
-     * Keeping these here so I know what the hell we’re matching
-     * $match = preg_match("/\/srv\/www\/wordpress-develop\/src\/wp-content\/uploads\/2014\/05\/$filename-[0-9]*x[0-9]*-c-[a-z]*.jpg/", $found_file);
-     * $match = preg_match("/\/srv\/www\/wordpress-develop\/src\/wp-content\/uploads\/2014\/05\/arch-[0-9]*x[0-9]*-c-[a-z]*.jpg/", $filename);
+     * If passed a value like my-pic.jpg, this function will delete my-pic-500x200-c-left.jpg,
+     * my-pic-400x400-c-default.jpg, etc.
      *
      * @param string  $filename       ex: my-pic.
      * @param string  $ext            ex: jpg.
      * @param string  $dir            var/www/wp-content/uploads/2015/.
      * @param string  $search_pattern Pattern of files to pluck from.
      * @param string  $match_pattern  Pattern of files to go forth and delete.
+     * @param bool    $advanced       Optional. If true, ignore $search_pattern and $match_pattern and simply delete any file starting with "$filename-".
      */
-    protected static function process_delete_generated_files($filename, $ext, $dir, $search_pattern, $match_pattern = null)
+    protected static function process_delete_generated_files($filename, $ext, $dir, $search_pattern, $match_pattern = null, $advanced = false)
     {
+        if ($advanced) {
+            $pattern = $dir . '/' . $filename . '-*.' . $ext;
+            $files = \glob($pattern);
+            if ($files && \is_array($files)) {
+                foreach ($files as $file) {
+                    if (\basename($file) !== $filename . '.' . $ext) {
+                        @\unlink($file);
+                    }
+                }
+            }
+            return;
+        }
+
         $searcher = '/' . $filename . $search_pattern;
         $files = \glob($dir . $searcher);
         if ($files === false || empty($files)) {

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -332,13 +332,13 @@ class ImageHelper
         $advanced = \apply_filters('timber/image/advanced_file_names', false);
 
         if ($advanced) {
-            self::process_delete_generated_files($filename, 'jpg', $dir, '', '', true);
-            self::process_delete_generated_files($filename, 'webp', $dir, '', '', true);
+            self::process_delete_generated_files_advanced($filename, 'jpg', $dir);
+            self::process_delete_generated_files_advanced($filename, 'webp', $dir);
 
             $filename_without_scaled = \str_replace('-scaled', '', $filename);
             if ($filename_without_scaled !== $filename) {
-                self::process_delete_generated_files($filename_without_scaled, 'jpg', $dir, '', '', true);
-                self::process_delete_generated_files($filename_without_scaled, 'webp', $dir, '', '', true);
+                self::process_delete_generated_files_advanced($filename_without_scaled, 'jpg', $dir);
+                self::process_delete_generated_files_advanced($filename_without_scaled, 'webp', $dir);
             }
         }
     }
@@ -349,28 +349,14 @@ class ImageHelper
      * If passed a value like my-pic.jpg, this function will delete my-pic-500x200-c-left.jpg,
      * my-pic-400x400-c-default.jpg, etc.
      *
-     * @param string  $filename       ex: my-pic.
-     * @param string  $ext            ex: jpg.
+     * @param string  $filename       Example: my-pic.
+     * @param string  $ext            Example: jpg.
      * @param string  $dir            var/www/wp-content/uploads/2015/.
      * @param string  $search_pattern Pattern of files to pluck from.
      * @param string  $match_pattern  Pattern of files to go forth and delete.
-     * @param bool    $advanced       Optional. If true, ignore $search_pattern and $match_pattern and simply delete any file starting with "$filename-".
      */
-    protected static function process_delete_generated_files($filename, $ext, $dir, $search_pattern, $match_pattern = null, $advanced = false)
+    protected static function process_delete_generated_files($filename, $ext, $dir, $search_pattern, $match_pattern = null)
     {
-        if ($advanced) {
-            $pattern = $dir . '/' . $filename . '-*.' . $ext;
-            $files = \glob($pattern);
-            if ($files && \is_array($files)) {
-                foreach ($files as $file) {
-                    if (\basename($file) !== $filename . '.' . $ext) {
-                        @\unlink($file);
-                    }
-                }
-            }
-            return;
-        }
-
         $searcher = '/' . $filename . $search_pattern;
         $files = \glob($dir . $searcher);
         if ($files === false || empty($files)) {
@@ -381,6 +367,32 @@ class ImageHelper
             $match = \preg_match($pattern, $found_file);
             if (!$match_pattern || $match) {
                 \unlink($found_file);
+            }
+        }
+    }
+
+    /**
+     * Deletes any files starting with "$filename-".
+     *
+     * If passed a value like my-pic.jpg, this function will delete my-pic-500x200-c-left.jpg,
+     * my-pic-400x400-c-default.jpg, etc.
+     *
+     * @param string  $filename Example: my-pic.
+     * @param string  $ext      Example: jpg.
+     * @param string  $dir      var/www/wp-content/uploads/2015/.
+     */
+    protected static function process_delete_generated_files_advanced($filename, $ext, $dir)
+    {
+        $pattern = $dir . '/' . $filename . '-*.' . $ext;
+        $files = \glob($pattern);
+
+        if (!$files || !\is_array($files)) {
+            return;
+        }
+
+        foreach ($files as $file) {
+            if (\basename($file) !== $filename . '.' . $ext) {
+                @\unlink($file);
             }
         }
     }

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -335,6 +335,7 @@ class ImageHelper
             self::process_delete_generated_files_advanced($filename, 'jpg', $dir);
             self::process_delete_generated_files_advanced($filename, 'webp', $dir);
 
+            // Delete the original generated files if it is a scaled image.
             $filename_without_scaled = \str_replace('-scaled', '', $filename);
             if ($filename_without_scaled !== $filename) {
                 self::process_delete_generated_files_advanced($filename_without_scaled, 'jpg', $dir);

--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Integration with Advanced Custom Fields (ACF)
  *

--- a/src/PostCollectionInterface.php
+++ b/src/PostCollectionInterface.php
@@ -28,7 +28,7 @@ interface PostCollectionInterface extends Traversable, Countable, ArrayAccess
      * Get this collection as a numeric array of \Timber\Post objects.
      *
      * @api
-     * @return \Timber\Post[]
+     * @return Post[]
      */
     public function to_array(): array;
 }

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -8,13 +8,13 @@ use DateTimeInterface;
 use Exception;
 use Timber\Factory\PostFactory;
 use Timber\Factory\TermFactory;
+use Twig\DeprecatedCallableInfo;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
 use Twig\Extension\EscaperExtension;
 use Twig\Runtime\EscaperRuntime;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
-use Twig\DeprecatedCallableInfo;
 
 /**
  * Class Twig

--- a/tests/assets/image-test.twig
+++ b/tests/assets/image-test.twig
@@ -1,1 +1,1 @@
-<img src="{{test_image|resize(size.width, size.height, crop ? crop)}}" />
+<img src="{{ test_image|resize(size.width, size.height, crop ? crop) }}" />

--- a/tests/test-timber-image-advanced-file-names.php
+++ b/tests/test-timber-image-advanced-file-names.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @group image
+ */
+class TestTimberImageAdvancedFileNames extends TimberAttachment_UnitTestCase
+{
+    public function testAdvancedFileNamesToJpeg()
+    {
+        $this->add_filter_temporarily('timber/image/advanced_file_names', '__return_true');
+
+        $file = self::copyTestAttachment('city-museum.jpg');
+        $src = Timber::compile_string('{{ file|tojpg }}', [
+            'file' => $file,
+        ]);
+        $path = Timber\ImageHelper::get_server_location($src);
+
+        $this->assertFileExists($path);
+        $this->assertStringEndsWith('-tojpg.jpg', $path);
+
+        Timber\ImageHelper::delete_generated_files($file);
+
+        $this->assertFileDoesNotExist($path);
+    }
+
+    public function testAdvancedFileNamesToJpegResized()
+    {
+        $this->add_filter_temporarily('timber/image/advanced_file_names', '__return_true');
+
+        $file = self::copyTestAttachment('city-museum.jpg');
+        $src = Timber::compile_string('{{ file|tojpg|resize(200, 100) }}', [
+            'file' => $file,
+        ]);
+        $path = Timber\ImageHelper::get_server_location($src);
+
+        $this->assertFileExists($path);
+
+        Timber\ImageHelper::delete_generated_files($file);
+
+        $this->assertFileDoesNotExist($path);
+    }
+
+    public function testAdvancedFileNamesToJpegResizedInversed()
+    {
+        $this->add_filter_temporarily('timber/image/advanced_file_names', '__return_true');
+
+        $file = self::copyTestAttachment('city-museum.jpg');
+        $src = Timber::compile_string('{{ file|resize(200, 100)|tojpg }}', [
+            'file' => $file,
+        ]);
+        $path = Timber\ImageHelper::get_server_location($src);
+
+        $this->assertFileExists($path);
+
+        Timber\ImageHelper::delete_generated_files($file);
+
+        $this->assertFileDoesNotExist($path);
+    }
+
+    public function testAdvancedFileNamesToWebP()
+    {
+        $this->add_filter_temporarily('timber/image/advanced_file_names', '__return_true');
+
+        $file = self::copyTestAttachment('city-museum.jpg');
+        $src = Timber::compile_string('{{ file|towebp }}', [
+            'file' => $file,
+        ]);
+        $path = Timber\ImageHelper::get_server_location($src);
+
+        $this->assertFileExists($path);
+        $this->assertStringEndsWith('-towebp.webp', $path);
+
+        Timber\ImageHelper::delete_generated_files($file);
+
+        $this->assertFileDoesNotExist($path);
+    }
+
+    public function testAdvancedFilesNamesWithScaledImage()
+    {
+        $this->add_filter_temporarily('timber/image/advanced_file_names', '__return_true');
+
+        // Use a low image threshold.
+        $this->add_filter_temporarily('big_image_size_threshold', function () {
+            return 500;
+        });
+
+        $attachment_id = self::get_attachment(0, 'pizza.jpg');
+        $attachment = Timber\Timber::get_attachment($attachment_id);
+
+        $src = Timber::compile_string('{{ attachment.src|towebp }}', [
+            'attachment' => $attachment,
+        ]);
+
+        $path = Timber\ImageHelper::get_server_location($src);
+
+        $this->assertFileExists($path);
+    }
+}

--- a/tests/test-timber-image.php
+++ b/tests/test-timber-image.php
@@ -647,6 +647,45 @@ class TestTimberImage extends TimberAttachment_UnitTestCase
         $this->assertFileExists($arch_2night);
     }
 
+    /**
+     * Loops through all the registered WordPress image sizes and checks if all
+     * the generated sizes exist and Timber doesn’t delete them accidentally
+     * when an image is uploaded.
+     *
+     * Timber hooks into wp_generate_attachment_metadata in
+     * Timber\ImageHelper::init(), which then calls Timber image sizes to be
+     * deleted to make sure image sizes are regenerated.
+     *
+     * @see \Timber\ImageHelper::init()
+     */
+    public function testTimberDoesntDeleteWpImageSizes()
+    {
+        $attachment_id = self::get_attachment(0, 'pizza.jpg');
+        $metadata = wp_get_attachment_metadata($attachment_id);
+        $dir = dirname($metadata['file']);
+
+        foreach ($metadata['sizes'] as $size => $data) {
+            $this->assertFileExists(wp_upload_dir()['basedir'] . '/' . $dir . '/' . $data['file']);
+        }
+    }
+
+    /**
+     * The idea behind this is test is the same as for
+     * testTimberDoesntDeleteWpImageSizes, but it checks for scaled images.
+     *
+     * @see \TestTimberImage::testTimberDoesntDeleteWpImageSizes()
+     */
+    public function testTimberDoesntDeleteScaledImages()
+    {
+        $this->add_filter_temporarily('big_image_size_threshold', function () {
+            return 500;
+        });
+
+        $attachment_id = self::get_attachment(0, 'pizza.jpg');
+        $metadata = wp_get_attachment_metadata($attachment_id);
+        $this->assertFileExists(wp_upload_dir()['basedir'] . '/' . $metadata['file']);
+    }
+
     public function testImageDeletion()
     {
         $data = [];


### PR DESCRIPTION
Related:

- #2882
- #2866
- #2556


## Issue
Some generated image sizes (especially those produced via the Timber filters `tojpg` and `towebp`, as well as files generated from scaled originals) are not being properly deleted when the original image is removed. This leaves behind stray files (e.g. `example-768x958-c-center-towebp.webp`) in the uploads folder.


## Solution
This PR refactors the deletion logic in `ImageHelper::delete_generated_files()` by integrating an advanced, broad glob-based deletion mode into the existing `process_delete_generated_files()` method. A new optional parameter `$advanced` has been added to that method. When the developer opts in via the filter:
```php
add_filter('timber/image/advanced_file_names', '__return_true');
```
The method will ignore the original fixed regex patterns and instead delete any file that starts with the original filename followed by a hyphen (e.g. matching the glob pattern example-*.jpg or example-*.webp). This also covers generated files from the unsclaed variant (when the original filename contains -scaled). The original deletion logic is preserved if the filter is not enabled.


## Impact
- **Backwards Compatibility:**
By default, if the filter is not enabled, the existing deletion logic remains unchanged.

- **Performance:**
The advanced mode uses glob patterns which are efficient for typical uploads directories. However, on directories with a very large number of files, there could be a slight performance impact.

## Usage Changes
To enable the advanced deletion logic (which covers all generated sizes including both JPG and WEBP variants and handles -scaled filenames), add the following filter in your theme’s or plugin’s initialization:
```php
add_filter('timber/image/advanced_file_names', '__return_true');
```
The conversion operations still append the -tojpg or -towebp suffix to generated filenames to avoid collisions with original files.

## Considerations
- The -towebp and -tojpg suffixes are still maintained. Even though the advanced deletion mode uses a glob pattern that deletes any file starting with the original base name and a hyphen, these prefixes help differentiate generated images from the originals and prevent accidental overwriting.

- Future improvements might consider a complete redesign of both naming and deletion logic to handle more edge cases. For now, this opt-in advanced mode provides a balance between backward compatibility and improved cleanup.

## Testing
Manual Testing Scenario (Pseudo-code):

1. Upload an image named example.jpg.
2. Generate various image sizes using Timber filters (e.g., resize, tojpg, towebp) so that files like:
        - example-150x150-c-default-towebp.webp
        - example-150x150-c-default.jpg
        - example-scaled.jpg
        - … and others are created.
3. Delete the original image.
4. Without the filter enabled, verify that some generated files may remain.
5. With the filter enabled via `add_filter('timber/image/advanced_file_names', '__return_true');` verify that all generated variants (files matching example-*.jpg and example-*.webp) are properly deleted.

No new unit tests are provided in this PR; manual testing has confirmed the intended behavior.
