### PR TITLE
docs: Fix documentation references to `post.modified_date()` and `post.modified_time()`

### DIFF
--- a/docs/v2/guides/date-time.md
+++ b/docs/v2/guides/date-time.md
@@ -181,11 +181,11 @@ The date a post was published is accessible through `{{ post.date }}`.
 {{ post.date }}
 ```
 
-Similarly, to get the date a post was modified, you can use `{{ post.modified }}`.
+Similarly, to get the date a post was modified, you can use `{{ post.modified_date }}`.
 
 ```twig
 {# With default date format from Settings → General #}
-{{ post.modified }}
+{{ post.modified_date }}
 ```
 
 If you want to change the display format, use an argument for the function. Check the documentation for [date()](https://www.php.net/manual/en/function.date.php) to see which formatting options you can use.
@@ -194,7 +194,7 @@ If you want to change the display format, use an argument for the function. Chec
 
 ```twig
 {{ post.date('F j, Y @ g:i a') }}
-{{ post.modified('F j, Y @ g:i a') }}
+{{ post.modified_date('F j, Y @ g:i a') }}
 ```
 
 ## Twig filters and functions
@@ -206,7 +206,7 @@ Twig includes a [`date`](https://twig.symfony.com/doc/3.x/filters/date.html) fil
 ```twig
 {{ my_date|date('j. F Y') }}
 {{ post.date|date('j. F Y') }}
-{{ post.modified|date('j. F Y') }}
+{{ post.modified_date|date('j. F Y') }}
 {{ '2020-02-20 20:20'|date('j. F Y') }}
 {{ 'now'|date('j. F Y') }}
 ```

--- a/src/Post.php
+++ b/src/Post.php
@@ -1478,7 +1478,7 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
      * {# Uses time format set in Settings → General #}
      * Published at {{ post.time }}
      * OR
-     * Published at {{ post.time|time('G:i') }}
+     * Published at {{ post.time('G:i') }}
      * ```
      *
      * ```html
@@ -1524,9 +1524,9 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
      * @example
      * ```twig
      * {# Uses time format set in Settings → General #}
-     * Published at {{ post.time }}
+     * Published at {{ post.modified_time }}
      * OR
-     * Published at {{ post.time|time('G:i') }}
+     * Published at {{ post.modified_time('G:i') }}
      * ```
      *
      * ```html


### PR DESCRIPTION
Related:

- #3099 

## Issue

This PR continues the work done in #3099 and fixes some more issues with the `post.modified_time()` examples.