### PR TITLE
fix(security): Bump minimum required Twig version to fix security issue in Twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
   },
   "require": {
     "php": "^8.1",
-    "twig/twig": "^3.17"
+    "twig/twig": "^3.19"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.28",


### PR DESCRIPTION
## Issue

Twig v3.19.0 fixes a security issues related to escaping, see https://github.com/twigphp/Twig/pull/4561.

## Solution

This pull request bumps the **minimum required Twig version** to `^3.19.0` to fix the security issue.