### PR TITLE
V1.23.4

### DIFF
--- a/bin/deploy-to-wp-org.sh
+++ b/bin/deploy-to-wp-org.sh
@@ -14,7 +14,7 @@ function deploy () {
 	composer install --no-dev --optimize-autoloader
 
 	# Install the lowest compatible version of Twig.
-	composer update twig/twig:1.44.7 --no-dev
+	composer update twig/twig:1.44.8 --no-dev
 
 	rm -rf ~/Sites/timber/vendor/upstatement/routes/.git
 	cd ~/Sites/timber-wp

--- a/bin/timber.php
+++ b/bin/timber.php
@@ -4,7 +4,7 @@ Plugin Name: Timber
 Description: The WordPress Timber Library allows you to write themes using the power of Twig templates.
 Plugin URI: https://upstatement.com/timber
 Author: Timber Team & Contributors
-Version: 1.23.1
+Version: 1.23.3
 Author URI: http://upstatement.com/
 Requires PHP: 7.2.5
 Requires at least: 5.3.0

--- a/bin/timber.php
+++ b/bin/timber.php
@@ -4,7 +4,7 @@ Plugin Name: Timber
 Description: The WordPress Timber Library allows you to write themes using the power of Twig templates.
 Plugin URI: https://upstatement.com/timber
 Author: Timber Team & Contributors
-Version: 1.23.3
+Version: 1.23.4
 Author URI: http://upstatement.com/
 Requires PHP: 7.2.5
 Requires at least: 5.3.0

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "php": ">=7.2.5 || ^8.0",
-    "twig/twig": "^1.44.7 || ^2.10",
+    "twig/twig": "^1.44.8 || ^2.10",
     "upstatement/routes": "^0.9",
     "composer/installers": "^1.0 || ^2.0",
     "twig/cache-extension": "^1.5"

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -35,7 +35,7 @@ use Timber\Loader;
  */
 class Timber {
 
-	public static $version = '1.23.3';
+	public static $version = '1.23.4';
 	public static $locations;
 	public static $dirname = 'views';
 	public static $twig_cache = false;

--- a/lib/Timber.php
+++ b/lib/Timber.php
@@ -35,7 +35,7 @@ use Timber\Loader;
  */
 class Timber {
 
-	public static $version = '1.23.1';
+	public static $version = '1.23.3';
 	public static $locations;
 	public static $dirname = 'views';
 	public static $twig_cache = false;

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jarednova
 Tags: template engine, templates, twig
 Tested up to: 6.8.1
-Stable tag: 1.23.2
+Stable tag: 1.23.3
 Requires PHP: 7.2.5
 Requires at least: 5.3.0
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jarednova
 Tags: template engine, templates, twig
 Tested up to: 6.8.1
-Stable tag: 1.23.3
+Stable tag: 1.23.4
 Requires PHP: 7.2.5
 Requires at least: 5.3.0
 License: GPLv2 or later
@@ -40,6 +40,9 @@ _Twig is the template language powering Timber; if you need a little background 
 * [GitHub issues](https://github.com/timber/timber/issues) are for reporting bugs and errors
 
 == Changelog ==
+
+= 1.23.4 =
+* Correct issues with faulty build script in order to implement security fix for 1.23.3
 
 = 1.23.3 =
 * Fix security vulnerabilities in Twig. See GHSA-6j75-5wfj-gh66. This updates the minimum required Twig version for the plugin version of Timber to ^1.44.8 to fix the issue.

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Timber ===
 Contributors: jarednova
 Tags: template engine, templates, twig
-Tested up to: 6.5.2
-Stable tag: 1.23.1
+Tested up to: 6.8.1
+Stable tag: 1.23.2
 Requires PHP: 7.2.5
 Requires at least: 5.3.0
 License: GPLv2 or later
@@ -40,6 +40,9 @@ _Twig is the template language powering Timber; if you need a little background 
 * [GitHub issues](https://github.com/timber/timber/issues) are for reporting bugs and errors
 
 == Changelog ==
+
+= 1.23.3 =
+* Fix security vulnerabilities in Twig. See GHSA-6j75-5wfj-gh66. This updates the minimum required Twig version for the plugin version of Timber to ^1.44.8 to fix the issue.
 
 = 1.23.1 =
 


### PR DESCRIPTION
This fixes issues with the most recent wp.org deployments by correcting a faulty override in the build script that was overriding the update to twig 1.44.8