### PR TITLE
fix: Update Helper::deprecated to use E_USER_DEPRECATED instead of the e default E_USER_NOTICE

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -458,7 +458,7 @@ class Helper
 
         // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
         // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-        \trigger_error('[ Timber ] ' . $error_message);
+        \trigger_error('[ Timber ] ' . $error_message, \E_USER_DEPRECATED);
     }
 
     /**


### PR DESCRIPTION
Related:

- #2961

## Issue
Deprecated notices were not being caught.

## Solution
Set error level to `E_USER_DEPRECATED`


## Impact
Now deprecation messages are being reported in a proper way.


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
