### PR TITLE
test: Install svn to revert replacing svn with other methods when it’s missing in GitHub Actions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -87,6 +87,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Subversion
+        run: |
+          sudo apt-get install -y subversion
+          sudo apt-get update
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -65,8 +65,8 @@ install_wp() {
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 		mkdir -p $TMPDIR/wordpress-trunk
 		rm -rf $TMPDIR/wordpress-trunk/*
-		git clone --depth 1 git://develop.git.wordpress.org/ $TMPDIR/wordpress-trunk/wordpress
-		mv $TMPDIR/wordpress-trunk/wordpress/src/* $WP_CORE_DIR
+		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
 	else
 		if [ $WP_VERSION == 'latest' ]; then
 			local ARCHIVE_NAME='latest'
@@ -109,17 +109,8 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		rm -rf $WP_TESTS_DIR/{includes,data}
-
-		if [ $WP_VERSION == 'latest' ]; then
-			 echo "Using latest version ${LATEST_VERSION} of WordPress for testing."
-			 BRANCH=$LATEST_VERSION
-		else
-			 BRANCH=$WP_VERSION
-		fi
-		
-		git clone --depth 1 --branch $BRANCH git://develop.git.wordpress.org/ $TMPDIR/wordpress-develop/wordpress
-		cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/includes $WP_TESTS_DIR/includes
-		cp -r $TMPDIR/wordpress-develop/wordpress/tests/phpunit/data $WP_TESTS_DIR/data
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then


### PR DESCRIPTION
We replaced installing WordPress through SVN because SVN was removed from GitHub Actions. The easier way is to just install svn again.

This will make it easier to update install-wp-tests.sh in the future.