### PR TITLE
docs: Add security notice to the compile string function in Timber class

### DIFF
--- a/src/Timber.php
+++ b/src/Timber.php
@@ -1528,6 +1528,10 @@ class Timber
     /**
      * Compile a string.
      *
+     * This function compiles a string with Twig variables and returns the output.
+     * Please be aware that this function might cause a security risk if you pass untrusted data into this function.
+     * If you want to minimize the risk, you could remove fn from the Timber function array. See https://timber.github.io/docs/v2/hooks/filters/#timber/twig/functions
+     *
      * @api
      * @example
      * ```php


### PR DESCRIPTION
Related:

- #3092

## Issue
compile_string is somewhat vulnereble to security issues.

## Solution
Described a solution in the docblock of the method.


## Impact
Better understanding of the risks involved of using this method.

## Usage Changes
none