### PR TITLE
fix: Fix incorrect ACF user filter

### DIFF
--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -295,7 +295,7 @@ class AcfIntegration implements IntegrationInterface
         \add_filter('acf/format_value/type=post_object', [$post_object_field_type, 'format_value'], 10, 3);
         \add_filter('acf/format_value/type=relationship', [$relationship_field_type, 'format_value'], 10, 3);
         \add_filter('acf/format_value/type=taxonomy', [$taxonomy_field_type, 'format_value'], 10, 3);
-        \add_filter('acf/format_value/type=user', [$taxonomy_field_type, 'format_value'], 10, 3);
+        \add_filter('acf/format_value/type=user', [$user_field_type, 'format_value'], 10, 3);
 
         \remove_filter('acf/format_value/type=file', [self::class, 'transform_file']);
         \remove_filter('acf/format_value/type=image', [self::class, 'transform_image']);


### PR DESCRIPTION


## Issue
<!-- Description of the problem that this code change is solving -->
After removing the user field format filter earlier in the method, it was incorrectly recreated with the `taxonomy_field_type`. 

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
This fix recreates the correct filter for the `format_value` method for user fields.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
Fixes breaking issue with ACF user fields being interpreted as a taxonomy field.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->
None

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->
None

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
