### PR TITLE
fix: Prevent ValueError for faulty or empty sideloaded image URLs in …

### DIFF
--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -461,9 +461,11 @@ class ImageHelper
 
         $file_array = [];
         $file_array['tmp_name'] = $tmp;
-        // If error storing temporarily, do not use
+        // If error storing temporarily, return empty string
         if (\is_wp_error($tmp)) {
-            $file_array['tmp_name'] = '';
+            \remove_filter('upload_dir', [self::class, 'set_sideload_image_upload_dir']);
+
+            return '';
         }
         // do the validation and storage stuff
         $locinfo = PathHelper::pathinfo($loc);

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -61,7 +61,7 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
     {
         $image =  Timber\ImageHelper::sideload_image('invalid-url');
 
-        $this->assertEmpty($image, 'Sideloading an invalid URL should return null');
+        $this->assertSame($image, 'Sideloading an invalid URL should return an empty string');
     }
 
     public function delete_existing_sideloaded_image($file)

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -61,7 +61,8 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
     {
         $image =  Timber\ImageHelper::sideload_image('invalid-url');
 
-        $this->assertSame($image, 'Sideloading an invalid URL should return an empty string');
+        // Sideloading an invalid URL should return an empty string
+        $this->assertSame($image, '');
     }
 
     public function delete_existing_sideloaded_image($file)

--- a/tests/test-external-image.php
+++ b/tests/test-external-image.php
@@ -57,6 +57,13 @@ class TestExternalImage extends TimberAttachment_UnitTestCase
         return $dest;
     }
 
+    public function testFailingToSideloadImage()
+    {
+        $image =  Timber\ImageHelper::sideload_image('invalid-url');
+
+        $this->assertEmpty($image, 'Sideloading an invalid URL should return null');
+    }
+
     public function delete_existing_sideloaded_image($file)
     {
         // @see \Timber\ImageHelper::sideload_image()


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:
- #3124 

## Issue
When sideloading a non-existent image url e.g. a 404 url, ImageHelper throws a ValueError from `file_get_contents()` because the function gets called with an empty value. Since PHP 8.0, `file_get_contents()` cannot be called on an empty string.


## Solution
Return an empty string if there's a problem with the iamge URL before instead of passing it to `file_get_contents()`


## Impact
None


## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
Force `string` as return type in function signature as other typed functions in code base rely on a string as return type of this function. 

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
