### PR TITLE
fix: Fix deprecation notice in `trim_words` method when `null` is passed.

### DIFF
--- a/src/TextHelper.php
+++ b/src/TextHelper.php
@@ -43,7 +43,7 @@ class TextHelper
      */
     public static function trim_words($text, $num_words = 55, $more = null, $allowed_tags = 'p a span b i br blockquote')
     {
-        if (null === $text) {
+        if (empty($text)) {
             return '';
         }
 

--- a/src/TextHelper.php
+++ b/src/TextHelper.php
@@ -43,6 +43,10 @@ class TextHelper
      */
     public static function trim_words($text, $num_words = 55, $more = null, $allowed_tags = 'p a span b i br blockquote')
     {
+        if (null === $text) {
+            return '';
+        }
+
         if (null === $more) {
             $more = \__('&hellip;');
         }
@@ -62,7 +66,7 @@ class TextHelper
          *                             Default `p a span b i br blockquote`.
          */
         $allowed_tags_array = \explode(' ', (string) \apply_filters('timber/trim_words/allowed_tags', $allowed_tags));
-        $allowed_tags_array = \array_filter($allowed_tags_array, fn ($value) => $value !== '');
+        $allowed_tags_array = \array_filter($allowed_tags_array, fn($value) => $value !== '');
         $allowed_tag_string = '<' . \implode('><', $allowed_tags_array) . '>';
 
         $text = \strip_tags($text, $allowed_tag_string);

--- a/tests/test-timber-text-helper.php
+++ b/tests/test-timber-text-helper.php
@@ -31,4 +31,12 @@ class TestTimberTextHelper extends Timber_UnitTestCase
         $result = Timber::compile_string($str);
         $this->assertEquals(wp_trim_words($this->gettysburg, 5), $result);
     }
+
+    public function testNullTruncate()
+    {
+        $chars = null;
+        $str = '{{ null|truncate( 5, true ) }}';
+        $result = Timber::compile_string($str);
+        $this->assertEquals('', $result);
+    }
 }


### PR DESCRIPTION
Related:

- #3129

## Issue
As said in #3129 , passing null to `TextHelper::trip_words ` or `truncate`, causes a deprecation message.

## Solution
Short-circuit the method early when text is null.

## Testing
yes
