### PR TITLE
fix: fix empty $params returning timber object

### DIFF
--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -21,6 +21,7 @@ class PostFactory
 {
     public function from($params)
     {
+
         if (\is_int($params) || \is_string($params) && \is_numeric($params)) {
             return $this->from_id((int) $params);
         }
@@ -41,7 +42,7 @@ class PostFactory
             return $this->from_id($params['ID']);
         }
 
-        if (\is_array($params)) {
+        if (\is_array($params) && !empty($params)) {
             return $this->from_wp_query(new WP_Query($params));
         }
 
@@ -209,7 +210,7 @@ class PostFactory
 
     protected function is_numeric_array($arr)
     {
-        if (!\is_array($arr)) {
+        if (!\is_array($arr) || empty($arr)) {
             return false;
         }
         foreach (\array_keys($arr) as $k) {

--- a/src/Factory/PostFactory.php
+++ b/src/Factory/PostFactory.php
@@ -42,7 +42,7 @@ class PostFactory
             return $this->from_id($params['ID']);
         }
 
-        if (\is_array($params) && !empty($params)) {
+        if (\is_array($params) && [] !== $params) {
             return $this->from_wp_query(new WP_Query($params));
         }
 
@@ -210,7 +210,7 @@ class PostFactory
 
     protected function is_numeric_array($arr)
     {
-        if (!\is_array($arr) || empty($arr)) {
+        if (!\is_array($arr) || [] === $arr) {
             return false;
         }
         foreach (\array_keys($arr) as $k) {

--- a/src/Post.php
+++ b/src/Post.php
@@ -906,10 +906,9 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
             return $this->_ancestors;
         }
 
-        $ancestors = \array_reverse(\get_post_ancestors($this->ID));
-        $this->_ancestors = $this->factory()->from($ancestors);
+        $ancestors = $this->factory()->from(\array_reverse(\get_post_ancestors($this->ID)));
 
-        return $this->_ancestors;
+        return $this->_ancestors = \is_iterable($ancestors) ? $ancestors : new PostArrayObject([]);
     }
 
     /**

--- a/tests/Factory/PostFactoryTest.php
+++ b/tests/Factory/PostFactoryTest.php
@@ -369,4 +369,26 @@ class PostFactoryTest extends TimberIntegrationTestCase
 
         $this->assertTrue(Post::class === $res[0]::class);
     }
+
+    public function testFromEmptyArray()
+    {
+        // Create a post to ensure there's a "current" post in the context
+        $post_id = static::factory()->post->create([
+            'post_type' => 'post',
+            'post_title' => 'Current Post',
+        ]);
+
+        // Set up the global post to simulate being on a page/post
+        global $post;
+        $post = \get_post($post_id);
+        \setup_postdata($post);
+
+        $postFactory = new PostFactory();
+        $result = $postFactory->from([]);
+
+        // Passing an empty array should return null, not the current post
+        $this->assertNull($result);
+
+        \wp_reset_postdata();
+    }
 }

--- a/tests/Factory/PostFactoryTest.php
+++ b/tests/Factory/PostFactoryTest.php
@@ -379,16 +379,12 @@ class PostFactoryTest extends TimberIntegrationTestCase
         ]);
 
         // Set up the global post to simulate being on a page/post
-        global $post;
-        $post = \get_post($post_id);
-        \setup_postdata($post);
+        $this->get(\get_permalink($post_id));
 
         $postFactory = new PostFactory();
         $result = $postFactory->from([]);
 
         // Passing an empty array should return null, not the current post
         $this->assertNull($result);
-
-        \wp_reset_postdata();
     }
 }

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -780,19 +780,18 @@ class PostTest extends TimberIntegrationTestCase
         $this->assertEquals($pid, $post->ID);
     }
 
+    #[PermalinkStructure('')]
     public function testPostPathUglyPermalinks()
     {
-        \update_option('permalink_structure', '');
         $pid = static::factory()->post->create();
         $post = Timber::get_post($pid);
         $this->assertEquals('http://example.org/?p=' . $pid, $post->link());
         $this->assertEquals('/?p=' . $pid, $post->path());
     }
 
+    #[PermalinkStructure('/blog/%year%/%monthnum%/%postname%/')]
     public function testPostPathPrettyPermalinks()
     {
-        $struc = '/blog/%year%/%monthnum%/%postname%/';
-        \update_option('permalink_structure', $struc);
         $pid = static::factory()->post->create([
             'post_date' => '2014-05-28 00:00:00',
             'post_name' => 'post-title',

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -772,6 +772,26 @@ class PostTest extends TimberIntegrationTestCase
         $this->assertInstanceOf(Post::class, $ancestors[0]);
     }
 
+    public function testPostAncestorsAreCached()
+    {
+        global $wpdb;
+
+        $parent_id = static::factory()->post->create();
+        $child_id = static::factory()->post->create([
+            'post_parent' => $parent_id,
+        ]);
+        $child = Timber::get_post($child_id);
+
+        $first_call = $child->ancestors();
+        $queries_after_first_call = $wpdb->num_queries;
+
+        $second_call = $child->ancestors();
+        $queries_after_second_call = $wpdb->num_queries;
+
+        $this->assertSame($first_call, $second_call);
+        $this->assertSame($queries_after_first_call, $queries_after_second_call, 'Second call to ancestors() should not trigger additional queries');
+    }
+
     public function testPostNoConstructorArgument()
     {
         $pid = static::factory()->post->create();


### PR DESCRIPTION
Related:

- #3169

## Issue
See ticket

## Solution
Add two additional checks for array types.


## Impact
Better API usage


## Usage Changes
no

## Considerations
Are there better ways to check for empty arrays?

## Testing
Yes
