### PR TITLE
chore: remove deprecated escaper functions and streamline escaper setup

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -412,7 +412,7 @@ class Twig
             ],
 
             'relative' => [
-                'callable' => fn($link) => URLHelper::get_rel_url($link, true),
+                'callable' => fn ($link) => URLHelper::get_rel_url($link, true),
             ],
 
             /**
@@ -428,7 +428,7 @@ class Twig
                 'callable' => [DateTimeHelper::class, 'time_ago'],
             ],
             'truncate' => [
-                'callable' => fn($text, $len) => TextHelper::trim_words($text, $len),
+                'callable' => fn ($text, $len) => TextHelper::trim_words($text, $len),
             ],
 
             // Numbers filters

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -12,7 +12,6 @@ use Twig\DeprecatedCallableInfo;
 use Twig\Environment;
 use Twig\Error\RuntimeError;
 use Twig\Extension\CoreExtension;
-use Twig\Extension\EscaperExtension;
 use Twig\Runtime\EscaperRuntime;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
@@ -413,7 +412,7 @@ class Twig
             ],
 
             'relative' => [
-                'callable' => fn ($link) => URLHelper::get_rel_url($link, true),
+                'callable' => fn($link) => URLHelper::get_rel_url($link, true),
             ],
 
             /**
@@ -429,7 +428,7 @@ class Twig
                 'callable' => [DateTimeHelper::class, 'time_ago'],
             ],
             'truncate' => [
-                'callable' => fn ($text, $len) => TextHelper::trim_words($text, $len),
+                'callable' => fn($text, $len) => TextHelper::trim_words($text, $len),
             ],
 
             // Numbers filters
@@ -597,27 +596,11 @@ class Twig
      */
     public function add_timber_escapers($twig)
     {
-        $esc_url = fn (Environment $env, $string) => \esc_url($string);
-
-        $wp_kses_post = fn (Environment $env, $string) => \wp_kses_post($string);
-
-        $esc_html = fn (Environment $env, $string) => \esc_html($string);
-
-        $esc_js = fn (Environment $env, $string) => \esc_js($string);
-
-        if (\class_exists(EscaperRuntime::class)) {
-            $escaper_extension = $twig->getRuntime(EscaperRuntime::class);
-            $escaper_extension->setEscaper('esc_url', '\esc_url');
-            $escaper_extension->setEscaper('wp_kses_post', '\wp_kses_post');
-            $escaper_extension->setEscaper('esc_html', '\esc_html');
-            $escaper_extension->setEscaper('esc_js', '\esc_js');
-        } elseif ($twig->hasExtension(EscaperExtension::class)) {
-            $escaper_extension = $twig->getExtension(EscaperExtension::class);
-            $escaper_extension->setEscaper('esc_url', $esc_url);
-            $escaper_extension->setEscaper('wp_kses_post', $wp_kses_post);
-            $escaper_extension->setEscaper('esc_html', $esc_html);
-            $escaper_extension->setEscaper('esc_js', $esc_js);
-        }
+        $escaper_extension = $twig->getRuntime(EscaperRuntime::class);
+        $escaper_extension->setEscaper('esc_url', '\esc_url');
+        $escaper_extension->setEscaper('wp_kses_post', '\wp_kses_post');
+        $escaper_extension->setEscaper('esc_html', '\esc_html');
+        $escaper_extension->setEscaper('esc_js', '\esc_js');
 
         return $twig;
     }


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/pull/2997

Since we now have a minimum version of Twig 3.19 its safe to cleanup twig workaround dating back almost two years ago.

## Impact
Cleaner code


## Usage Changes
none

## Considerations
We should probably do more of these cleanups.

## Testing
no, tests stay the same
