### PR TITLE
docs: Expand documentation for available Twig functions and filters

### DIFF
--- a/docs/v2/guides/extending-twig.md
+++ b/docs/v2/guides/extending-twig.md
@@ -21,8 +21,8 @@ By default, you’ll have to use `{{ fn('function_name') }}` to call a function 
 
 ```php
 add_filter('timber/twig/functions', function ($functions) {
-    $functions['edit_post_link'] = [
-        'callable' => 'edit_post_link',
+    $functions['wp_get_shortlink'] = [
+        'callable' => 'wp_get_shortlink',
     ];
 
     return $functions;
@@ -31,20 +31,18 @@ add_filter('timber/twig/functions', function ($functions) {
 
 The `$functions` variable is an array of functions that Timber already adds by default.
 
-In the example above, we add a `edit_post_link` function by defining an array with a `callable` key that contains the name of the PHP function we want to call. In this case: [`edit_post_link()`](https://developer.wordpress.org/reference/functions/edit_post_link/).
+In the example above, we add a `wp_get_shortlink` function by defining an array with a `callable` key that contains the name of the PHP function we want to call. In this case: [`wp_get_shortlink()`](https://developer.wordpress.org/reference/functions/wp_get_shortlink/).
 
 In Twig, we can then use it like this:
 
 **single.twig**
 
 ```twig
-{# Calls edit_post_link using default arguments #}
-<div class="admin-tools">{{ edit_post_link() }}</div>
+{# Get shortlink for the current post #}
+<a href="{{ wp_get_shortlink() }}">Short URL</a>
 
-{# Calls edit_post_link with all defaults, except for second argument #}
-<div class="admin-tools">
-    {{ edit_post_link(null, '<span class="edit-my-post-type-link">') }}
-</div>
+{# Get shortlink for a specific post #}
+<a href="{{ wp_get_shortlink(post.id) }}">Short URL</a>
 ```
 
 ### Functions that Timber provides

--- a/docs/v2/guides/extending-twig.md
+++ b/docs/v2/guides/extending-twig.md
@@ -51,7 +51,7 @@ In Twig, we can then use it like this:
 
 Timber already comes with a list of functions it adds by default. You can read more about these functions in the [Functions Guide](https://timber.github.io/docs/v2/guides/functions/).
 
-If you want to check out the functions that Timber provides, you can do a debug dump using `var_dump()`.
+You can also var dump all filters directly by adding the following code to your `functions.php` file:
 
 **functions.php**
 

--- a/docs/v2/guides/extending-twig.md
+++ b/docs/v2/guides/extending-twig.md
@@ -31,7 +31,7 @@ add_filter('timber/twig/functions', function ($functions) {
 
 The `$functions` variable is an array of functions that Timber already adds by default.
 
-In the example above, we add a `edit_post_link` function by defining  an array with a `callable` key that contains the name of the PHP function we want to call. In this case: [`edit_post_link()`](https://developer.wordpress.org/reference/functions/edit_post_link/).
+In the example above, we add a `edit_post_link` function by defining an array with a `callable` key that contains the name of the PHP function we want to call. In this case: [`edit_post_link()`](https://developer.wordpress.org/reference/functions/edit_post_link/).
 
 In Twig, we can then use it like this:
 
@@ -49,7 +49,9 @@ In Twig, we can then use it like this:
 
 ### Functions that Timber provides
 
-Timber already comes with a list of functions it adds by default. If you want to check out the functions that Timber provides, you can do a debug dump using `var_dump()`.
+Timber already comes with a list of functions it adds by default. You can read more about these functions in the [Functions Guide](https://timber.github.io/docs/v2/guides/functions/).
+
+If you want to check out the functions that Timber provides, you can do a debug dump using `var_dump()`.
 
 **functions.php**
 
@@ -79,11 +81,9 @@ add_filter('timber/twig/functions', function ($functions) {
 });
 ```
 
-### function_wrapper
-
-In Timber versions lower than 1.3, you could use `function_wrapper` to make functions available in Twig. This method is now deprecated. Instead, use the method above.
-
 ## Filters
+
+Timber comes with a set of filters that you can use in your Twig templates. You can read more about these filters in the [Twig Filters Guide](https://timber.github.io/docs/v2/guides/twig-filters/).
 
 To extend Twig with your own filters, you can use the `timber/twig/filters` filter in PHP. The benefit of filters is that they make your code somewhat more readable, because you chain filters with pipes (`|`) instead of nesting a value inside function calls.
 

--- a/docs/v2/guides/functions.md
+++ b/docs/v2/guides/functions.md
@@ -34,7 +34,7 @@ These functions allow you to fetch posts, terms, users, and comments:
 
 ### Utility Functions
 
-- `action()` - Execute WordPress actions
+- `action()` - Execute WordPress actions, see [Twig – WordPress Actions](https://timber.github.io/docs/v2/guides/twig/#wordpress-actions)
 - `shortcode()` - Process WordPress shortcodes via `do_shortcode()`
 - `bloginfo()` - Get WordPress site information
 

--- a/docs/v2/guides/functions.md
+++ b/docs/v2/guides/functions.md
@@ -3,12 +3,61 @@ title: "Functions"
 order: "800"
 ---
 
-My theme/plugin has some functions I need! Do I really have to re-write all of them?
-No, you don’t.
+Timber makes it easy to work with PHP functions in your Twig templates. You have three options:
 
-## function()
+1. **Use built-in Timber functions** - Timber provides a set of functions for common tasks like retrieving posts, terms, users, and rendering content.
+2. **Call any PHP function with `function()`** - Need to use a custom or WordPress function that isn't pre-registered? Use the `function()` helper to call it directly from your templates.
+3. **Register your own functions** - For better performance and cleaner templates, you can register your custom functions to be directly available in Twig, just like the built-in ones.
 
-You can call all PHP functions through `function()` in Twig. For example, if you need to call `wp_head()` and `wp_footer()`, you’d do it like this:
+Let's explore each approach.
+
+## Available Built-in Functions
+
+Timber provides a wide range of built-in functions that are directly available in Twig templates without any additional setup.
+
+### Content Retrieval Functions
+
+These functions allow you to fetch posts, terms, users, and comments:
+
+- `get_post()` - Retrieve a single post
+- `get_posts()` - Retrieve multiple posts
+- `get_image()` - Retrieve an image
+- `get_external_image()` - Retrieve an external image
+- `get_attachment()` - Retrieve an attachment
+- `get_attachment_by()` - Retrieve attachment by specific criteria
+- `get_term()` - Retrieve a single term
+- `get_terms()` - Retrieve multiple terms
+- `get_user()` - Retrieve a single user
+- `get_users()` - Retrieve multiple users
+- `get_comment()` - Retrieve a single comment
+- `get_comments()` - Retrieve multiple comments
+
+### Utility Functions
+
+- `action()` - Execute WordPress actions
+- `shortcode()` - Process WordPress shortcodes via `do_shortcode()`
+- `bloginfo()` - Get WordPress site information
+
+### Translation Functions
+
+Timber supports multilingual sites and provides functions to facilitate translation in Twig templates. You can read more about these functions in the [internationalization Guide](https://timber.github.io/docs/v2/guides/internationalization/):
+
+- `__()` - Translate text
+- `translate()` - Translate text
+- `_e()` - Echo translated text
+- `_n()` - Translate with plural support
+- `_x()` - Translate with context
+- `_ex()` - Echo translated text with context
+- `_nx()` - Translate with plural and context support
+- `_n_noop()` - Register plural strings for translation
+- `_nx_noop()` - Register plural strings with context for translation
+- `translate_nooped_plural()` - Translate plural strings registered with `_n_noop()` or `_nx_noop()`
+
+## Calling Any PHP Function with `function()`
+
+If you need to call a PHP function that isn't available as a built-in Timber function, you can use the `function()` helper. This allows you to call any PHP function directly from your Twig templates.
+
+For example, if you need to call `wp_head()` and `wp_footer()`:
 
 ```twig
 {# single.twig #}
@@ -30,9 +79,9 @@ You can call all PHP functions through `function()` in Twig. For example, if you
 
 You can also use `fn('my_function')` as an alias for `function('my_function')`.
 
-### function() with arguments
+### Passing Arguments
 
-What if you need to pass arguments to a function? Easy, add them as additional arguments (the first argument will always be the name of the function to call):
+To pass arguments to a function, add them as additional arguments after the function name:
 
 ```twig
 {# single.twig #}
@@ -41,7 +90,7 @@ What if you need to pass arguments to a function? Easy, add them as additional a
 </div>
 ```
 
-Nice! Any gotchas? Unfortunately yes. While the above example will totally work in a single.twig file it will not in The Loop. Why? Single.twig/single.php retain the context of the current post. A function like `edit_post_link` will try to guess the ID of the post you want to edit from the current post in The Loop. the same function requires some modification in a file like **archive.twig** or **index.twig**. There, you will need to explicitly pass the post ID:
+**Important note about context:** While this works in a `single.twig` file that retains the context of the current post, it may not work the same way in The Loop (like in `archive.twig` or `index.twig`). Functions like `edit_post_link` try to guess the post ID from the current post context. In archive or index templates, you need to explicitly pass the post ID:
 
 ```twig
 {# index.twig #}
@@ -50,16 +99,20 @@ Nice! Any gotchas? Unfortunately yes. While the above example will totally work 
 </div>
 ```
 
-## Make functions available in Twig
+## Register Your Own Functions in Twig
+
+For better performance and cleaner template syntax, you can register your custom functions to be directly available in Twig. This is preferable to using `function()` for functions you use frequently.
 
 Check out the [Extending Twig Guide](https://timber.github.io/docs/v2/guides/extending-twig/) to learn how to make your own functions available in Twig.
 
-## Functions that echo output
+## Handling Functions That Echo Output
 
-The concept of Timber (and templating engines like Twig in general) is to prepare all the data before you pass it to a template. Some functions in WordPress echo their output directly. We don’t want this, because the output of this function would be echoed before we call `Timber:render()` and appear before every else on your website. There are two ways to work around this:
+The concept of Timber (and templating engines like Twig in general) is to prepare all the data before you pass it to a template. Some functions in WordPress echo their output directly, which can cause issues since the output would appear before your template is rendered.
 
-- If you have a function where you want to bypass the output and instead save it as a string, so that you can add it to your context, use [`Helper::ob_function`](https://timber.github.io/docs/v2/reference/timber-helper/#ob_function).
-- If you have a function that needs to be called exactly where you use it in your template (e.g. because it depends on certain global values) you can use `FunctionWrapper`:
+There are two ways to work around this:
+
+1. **Using `Helper::ob_function`** - If you want to capture the output as a string to use in your context, use [`Helper::ob_function`](https://timber.github.io/docs/v2/reference/timber-helper/#ob_function).
+2. **Using `FunctionWrapper`** - If a function needs to be called exactly where you use it in your template (because it depends on certain global values), use `FunctionWrapper`:
 
 ```php
 $context['my_custom_function'] = new FunctionWrapper('my_custom_function', $array_of_arguments);

--- a/docs/v2/guides/functions.md
+++ b/docs/v2/guides/functions.md
@@ -85,17 +85,17 @@ To pass arguments to a function, add them as additional arguments after the func
 
 ```twig
 {# single.twig #}
-<div class="admin-tools">
-    {{ function('edit_post_link', 'Edit', '<span class="edit-link">', '</span>') }}
+<div class="embed-link">
+    {{ function('get_post_embed_url', post.id) }}
 </div>
 ```
 
-**Important note about context:** While this works in a `single.twig` file that retains the context of the current post, it may not work the same way in The Loop (like in `archive.twig` or `index.twig`). Functions like `edit_post_link` try to guess the post ID from the current post context. In archive or index templates, you need to explicitly pass the post ID:
+**Important note about context:** While this works in a `single.twig` file that retains the context of the current post, it may not work the same way in The Loop (like in `archive.twig` or `index.twig`). Functions like `get_post_embed_url` try to guess the post ID from the current post context. In archive or index templates, you need to explicitly pass the post ID:
 
 ```twig
 {# index.twig #}
-<div class="admin-tools">
-    {{ function('edit_post_link', 'Edit', '<span class="edit-link">', '</span>', post.ID) }}
+<div class="embed-link">
+    {{ function('get_post_embed_url', post.ID) }}
 </div>
 ```
 

--- a/docs/v2/guides/twig-filters.md
+++ b/docs/v2/guides/twig-filters.md
@@ -5,7 +5,7 @@ order: "220"
 
 ## General Filters
 
-Timber provides numerous filters to format and manipulate data in templates. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
+Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some extra filters to make it easier to work with WordPress data in Twig templates. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
 
 ### Image Filters
 
@@ -58,8 +58,6 @@ These filters help protect against security vulnerabilities:
 - [`esc_js`](#esc_js) - Escape JavaScript strings
 - [`wp_kses`](#wp_kses) - Strip unwanted HTML tags with allowed list
 - [`wp_kses_post`](#wp_kses_post) - Strip unwanted HTML tags (allows post content tags)
-
-Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WordPress theme:
 
 ## Available Twig Filters
 

--- a/docs/v2/guides/twig-filters.md
+++ b/docs/v2/guides/twig-filters.md
@@ -5,7 +5,63 @@ order: "220"
 
 ## General Filters
 
+Timber provides numerous filters to format and manipulate data in templates. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
+
+### Image Filters
+
+- [`resize`](#resize) - Resize an image
+- [`retina`](#retina) - Create a retina-ready image
+- [`letterbox`](#letterbox) - Letterbox an image
+- [`tojpg`](#tojpg) - Convert image to JPG format
+- [`towebp`](#towebp) - Convert image to WebP format
+
+### Text Filters
+
+- [`excerpt`](#excerpt) - Trim text to a word count
+- [`excerpt_chars`](#excerpt_chars) - Trim text to a character count
+- [`truncate`](#truncate) - Trim text to a word count
+- [`wpautop`](#wpautop) - Add paragraph tags automatically
+- [`stripshortcodes`](#stripshortcodes) - Remove WordPress shortcodes
+- [`shortcodes`](#shortcodes) - Process WordPress shortcodes
+- [`pretags`](#pretags) - Convert entities in `<pre>` tags
+- [`sanitize`](#sanitize) - Sanitize title for URLs
+
+### Array & Collection Filters
+
+- [`array`](#array) - Convert value to array
+- [`list`](#list) - Format array as list with separators
+- [`pluck`](#pluck) - Extract specific field from array of objects
+- [`wp_list_filter`](#wp_list_filter) - Filter array of objects
+
+### Date & Time Filters
+
+- [`date`](#date) - Format dates (WordPress-compatible)
+- [`time_ago`](#time_ago) - Display relative time ("5 minutes ago")
+
+### URL Filters
+
+- [`relative`](#relative) - Convert absolute URL to relative URL
+
+### Utility Filters
+
+- [`function`](#function) - Execute a PHP function
+- [`apply_filters`](#apply_filters) - Apply WordPress filters
+- [`size_format`](#size_format) - Format file size for display
+
+### Security & Escaping Filters
+
+These filters help protect against security vulnerabilities:
+
+- [`esc_url`](#esc_url) - Escape URLs for safe use in HTML attributes
+- [`esc_attr`](#esc_attr) - Escape HTML attributes
+- [`esc_html`](#esc_html) - Escape HTML content
+- [`esc_js`](#esc_js) - Escape JavaScript strings
+- [`wp_kses`](#wp_kses) - Strip unwanted HTML tags with allowed list
+- [`wp_kses_post`](#wp_kses_post) - Strip unwanted HTML tags (allows post content tags)
+
 Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WordPress theme:
+
+## Available Twig Filters
 
 ## `array`
 
@@ -41,10 +97,11 @@ Trims text to a certain number of words.
 **Output**
 
 ```html
-<p class="intro">Steve-O was born in London, England. His mother,
-Donna Gay (née Wauthier), was Canadian, and his father, Richard
-Glover, was American. His paternal grandfather was English
-and his maternal step-grandfather ...</p>
+<p class="intro">
+  Steve-O was born in London, England. His mother, Donna Gay (née Wauthier), was
+  Canadian, and his father, Richard Glover, was American. His paternal
+  grandfather was English and his maternal step-grandfather ...
+</p>
 ```
 
 ## `excerpt_chars`
@@ -60,9 +117,10 @@ Trims text to a certain number of characters.
 **Output**
 
 ```html
-<p class="intro">Steve-O was born in London, England. His mother,
-Donna Gay (née Wauthier), was Canadian, and his father, Richard
-Glover, was ...</p>
+<p class="intro">
+  Steve-O was born in London, England. His mother, Donna Gay (née Wauthier), was
+  Canadian, and his father, Richard Glover, was ...
+</p>
 ```
 
 ## `function`
@@ -135,7 +193,8 @@ Runs text through WordPress's shortcodes filter. In this example imagine that yo
 
 ```html
 <section class="gallery">
-Here is my gallery <div class="gallery" id="gallery-123"><img src="...." />...</div>
+  Here is my gallery
+  <div class="gallery" id="gallery-123"><img src="...." />...</div>
 </section>
 ```
 
@@ -195,10 +254,15 @@ Adds paragraph breaks to new lines.
 
 ```html
 <div class="body">
-	<p>Sinatra said, "What do you do?"</p>
-	<p>"I'm a plumber," Ellison said.</p>
-	<p>"No, no, he's not," another young man quickly yelled from across the table. "He wrote The Oscar."</p>
-	<p>"Oh, yeah," Sinatra said, "well I've seen it, and it's a piece of crap."</p>
+  <p>Sinatra said, "What do you do?"</p>
+  <p>"I'm a plumber," Ellison said.</p>
+  <p>
+    "No, no, he's not," another young man quickly yelled from across the table.
+    "He wrote The Oscar."
+  </p>
+  <p>
+    "Oh, yeah," Sinatra said, "well I've seen it, and it's a piece of crap."
+  </p>
 </div>
 ```
 
@@ -232,4 +296,197 @@ Contributions made by {{ contributors|list(',', '&') }}
 
 ```html
 Contributions made by Blake Allen, Rachel White & Maddy May
+```
+
+## `pluck`
+
+Extracts a specific attribute or key from each item in an array, useful for getting all values of the same property.
+
+**PHP**
+
+```php
+$context['posts'] = [
+    ['title' => 'First Post', 'author' => 'John'],
+    ['title' => 'Second Post', 'author' => 'Jane'],
+];
+```
+
+**Twig**
+
+```twig
+{% set titles = posts|pluck('title') %}
+Titles: {{ titles|list(', ') }}
+```
+
+**Output**
+
+```
+Titles: First Post, Second Post
+```
+
+## `apply_filters`
+
+Applies a [WordPress filter hook](https://developer.wordpress.org/plugins/hooks/filters/) to the given content. You can read more about this filter in the [Functions Guide](https://timber.github.io/docs/v2/guides/twig/#wordpress-filters).
+
+**Twig**
+
+```twig
+{{ content|apply_filters('my_custom_filter') }}
+```
+
+## `size_format`
+
+Formats a number of bytes into a human-readable file size (e.g., "1 MB", "2.5 GB").
+
+**Twig**
+
+```twig
+File size: {{ 1048576|size_format }} {# 1 MB #}
+Large file: {{ 5368709120|size_format }} {# 5 GB #}
+```
+
+## Image Filters
+
+You can read more about the image filters in the [Image Cookbook](https://timber.github.io/docs/v2/guides/cookbook-images/).
+
+### `resize`
+
+Resizes an image to specific dimensions.
+
+**Twig**
+
+```twig
+<img src="{{ image|resize(400, 300) }}" alt="{{ image.alt }}">
+```
+
+### `retina`
+
+Creates a retina-ready version of an image (doubled dimensions and URL handling).
+
+**Twig**
+
+```twig
+<img src="{{ image|retina }}" alt="{{ image.alt }}">
+```
+
+### `letterbox`
+
+Adds letterboxing to an image to fit specific dimensions while maintaining aspect ratio.
+
+**Twig**
+
+```twig
+<img src="{{ image|letterbox(400, 300) }}" alt="{{ image.alt }}">
+```
+
+### `tojpg`
+
+Converts an image to JPG format.
+
+**Twig**
+
+```twig
+<img src="{{ image|tojpg }}" alt="{{ image.alt }}">
+```
+
+### `towebp`
+
+Converts an image to modern WebP format.
+
+**Twig**
+
+```twig
+<picture>
+    <source srcset="{{ image|towebp }}" type="image/webp">
+    <img src="{{ image }}" alt="{{ image.alt }}">
+</picture>
+```
+
+## `date`
+
+Formats a date using WordPress date formats. For more details, see [Twig's date filter documentation](https://twig.symfony.com/doc/3.x/filters/date.html).
+
+**Twig**
+
+```twig
+Posted on {{ post.post_date|date('Y-m-d') }}
+{{ post.post_date|date('F j, Y') }}
+```
+
+**Output**
+
+```
+Posted on 2023-09-15
+September 15, 2023
+```
+
+## Security & Escaping Filters
+
+You can read more about escaping and security filters in the [Escaping Guide](https://timber.github.io/docs/v2/guides/escaping/).
+
+### `esc_url`
+
+Escapes URLs for safe use in HTML attributes. Prevents XSS attacks in URL contexts.
+
+**Twig**
+
+```twig
+<a href="{{ post.link|esc_url }}">{{ post.title }}</a>
+```
+
+### `esc_attr`
+
+Escapes strings for safe use in HTML attributes.
+
+**Twig**
+
+```twig
+<div class="{{ custom_class|esc_attr }}" data-value="{{ custom_data|esc_attr }}">
+    Content
+</div>
+```
+
+### `esc_html`
+
+Escapes HTML content to display as plain text, preventing scripts from executing.
+
+**Twig**
+
+```twig
+<p>{{ user_comment|esc_html }}</p>
+```
+
+### `esc_js`
+
+Escapes strings for safe use in JavaScript contexts.
+
+**Twig**
+
+```twig
+<script>
+var title = "{{ post.title|esc_js }}";
+</script>
+```
+
+### `wp_kses`
+
+Strips unwanted HTML tags while preserving an allowed list of tags. Requires an allowed tags parameter.
+
+**Twig**
+
+```twig
+{# Only allow <b>, <i>, and <em> tags #}
+{{ user_content|wp_kses('<b><i><em>') }}
+```
+
+### `wp_kses_post`
+
+Strips unwanted HTML tags while allowing standard post formatting tags (paragraphs, lists, links, etc.).
+
+**Twig**
+
+```twig
+<div class="entry-content">
+    {{ post.post_content|wp_kses_post }}
+</div>
 ```

--- a/docs/v2/guides/twig-filters.md
+++ b/docs/v2/guides/twig-filters.md
@@ -404,7 +404,7 @@ Converts an image to modern WebP format.
 
 ## `date`
 
-Formats a date using WordPress date formats. For more details, see [Twig's date filter documentation](https://twig.symfony.com/doc/3.x/filters/date.html).
+Formats a date using WordPress date formats, while considering the timezone and date format settings you set in your WordPress settings. For more details, see [Twig's date filter documentation](https://twig.symfony.com/doc/3.x/filters/date.html).
 
 **Twig**
 

--- a/docs/v2/guides/twig-filters.md
+++ b/docs/v2/guides/twig-filters.md
@@ -5,7 +5,7 @@ order: "220"
 
 ## General Filters
 
-Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some extra filters to make it easier to work with WordPress data in Twig templates. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
+Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some extra filters to filter data the WordPress way. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
 
 ### Image Filters
 


### PR DESCRIPTION
Related:

- https://github.com/timber/timber/issues/3188

## Issue
Without looking into the codebase, you wouldn't have a full picture of filters/functions that are available via twig.


## Solution
I restructured the two guides to give a full picture of the functions/filters that are currently available in the codebase and restructured the functions guide to showcase the three ways to work with functions.


## Impact
For beginners a better understanding whats directly available via twig.


## Usage Changes
none.

## Considerations
