### PR TITLE
feat: Add missing class properties to core entities

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -93,6 +93,11 @@ class Comment extends CoreEntity implements Stringable
     /**
      * @var int
      */
+    public $comment_post_ID;
+
+    /**
+     * @var int
+     */
     public $comment_parent;
 
     /**
@@ -112,6 +117,36 @@ class Comment extends CoreEntity implements Stringable
      * @var string
      */
     public $comment_author;
+
+    /**
+     * @var string
+     */
+    public $comment_author_url;
+
+    /**
+     * @var string
+     */
+    public $comment_author_IP;
+
+    /**
+     * @var string
+     */
+    public $comment_date_gmt;
+
+    /**
+     * @var int
+     */
+    public $comment_karma;
+
+    /**
+     * @var string
+     */
+    public $comment_agent;
+
+    /**
+     * @var string
+     */
+    public $comment_type;
 
     public $_depth = 0;
 

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -91,12 +91,20 @@ class Comment extends CoreEntity implements Stringable
     public $comment_ID;
 
     /**
-     * @var int
+     * ID of the post the comment is associated with.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $comment_post_ID;
 
     /**
-     * @var int
+     * Parent comment ID.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $comment_parent;
 
@@ -119,31 +127,45 @@ class Comment extends CoreEntity implements Stringable
     public $comment_author;
 
     /**
+     * Comment author URL.
+     *
      * @var string
      */
     public $comment_author_url;
 
     /**
+     * Comment author IP address (IPv4 format).
+     *
      * @var string
      */
     public $comment_author_IP;
 
     /**
+     * Comment GMT date in YYYY-MM-DD HH::MM:SS format.
+     *
      * @var string
      */
     public $comment_date_gmt;
 
     /**
-     * @var int
+     * Comment karma count.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $comment_karma;
 
     /**
+     * Comment author HTTP user agent.
+     *
      * @var string
      */
     public $comment_agent;
 
     /**
+     * Comment type.
+     *
      * @var string
      */
     public $comment_type;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -76,36 +76,52 @@ class Menu extends CoreEntity implements Stringable
     public $title;
 
     /**
+     * The term's term_group.
+     *
      * @var int
      */
     public $term_group;
 
     /**
+     * Term Taxonomy ID.
+     *
      * @var int
      */
     public $term_taxonomy_id;
 
     /**
+     * The term's taxonomy name.
+     *
      * @var string
      */
     public $taxonomy;
 
     /**
+     * The term's description.
+     *
      * @var string
      */
     public $description;
 
     /**
+     * ID of a term's parent term.
+     *
      * @var int
      */
     public $parent;
 
     /**
+     * Cached object count for this term.
+     *
      * @var int
      */
     public $count;
 
     /**
+     * Stores the term object's sanitization level.
+     *
+     * Does not correspond to a database field.
+     *
      * @var string
      */
     public $filter;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -76,6 +76,41 @@ class Menu extends CoreEntity implements Stringable
     public $title;
 
     /**
+     * @var int
+     */
+    public $term_group;
+
+    /**
+     * @var int
+     */
+    public $term_taxonomy_id;
+
+    /**
+     * @var string
+     */
+    public $taxonomy;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var int
+     */
+    public $parent;
+
+    /**
+     * @var int
+     */
+    public $count;
+
+    /**
+     * @var string
+     */
+    public $filter;
+
+    /**
      * Menu args.
      *
      * @api
@@ -564,13 +599,13 @@ class Menu extends CoreEntity implements Stringable
 
         if ($args->container) {
             /**
-            * Filters the list of HTML tags that are valid for use as menu containers.
-            *
-            * @since 3.0.0
-            *
-            * @param string[] $tags The acceptable HTML tags for use as menu containers.
-            *                       Default is array containing 'div' and 'nav'.
-            */
+             * Filters the list of HTML tags that are valid for use as menu containers.
+             *
+             * @since 3.0.0
+             *
+             * @param string[] $tags The acceptable HTML tags for use as menu containers.
+             *                       Default is array containing 'div' and 'nav'.
+             */
             $allowed_tags = \apply_filters('wp_nav_menu_container_allowedtags', ['div', 'nav']);
 
             if (\is_string($args->container) && \in_array($args->container, $allowed_tags, true)) {

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -94,6 +94,116 @@ class MenuItem extends CoreEntity implements Stringable
      */
     public $object;
 
+    /**
+     * @var int
+     */
+    public $post_author;
+
+    /**
+     * @var string
+     */
+    public $post_date;
+
+    /**
+     * @var string
+     */
+    public $post_date_gmt;
+
+    /**
+     * @var string
+     */
+    public $post_content;
+
+    /**
+     * @var string
+     */
+    public $post_title;
+
+    /**
+     * @var string
+     */
+    public $post_excerpt;
+
+    /**
+     * @var string
+     */
+    public $post_status;
+
+    /**
+     * @var string
+     */
+    public $comment_status;
+
+    /**
+     * @var string
+     */
+    public $ping_status;
+
+    /**
+     * @var string
+     */
+    public $post_password;
+
+    /**
+     * @var string
+     */
+    public $to_ping;
+
+    /**
+     * @var string
+     */
+    public $pinged;
+
+    /**
+     * @var string
+     */
+    public $post_modified;
+
+    /**
+     * @var string
+     */
+    public $post_modified_gmt;
+
+    /**
+     * @var string
+     */
+    public $post_content_filtered;
+
+    /**
+     * @var int
+     */
+    public $post_parent;
+
+    /**
+     * @var string
+     */
+    public $guid;
+
+    /**
+     * @var int
+     */
+    public $menu_order;
+
+    /**
+     * @var string
+     */
+    public $post_type;
+
+    /**
+     * @var string
+     */
+    public $post_mime_type;
+
+    /**
+     * @var int
+     */
+    public $comment_count;
+
+    /**
+     * @var string
+     */
+    public $filter;
+
     protected $_name;
 
     protected $_menu_item_url;

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -95,111 +95,161 @@ class MenuItem extends CoreEntity implements Stringable
     public $object;
 
     /**
-     * @var int
+     * ID of post author.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $post_author;
 
     /**
+     * The post's local publication time.
+     *
      * @var string
      */
     public $post_date;
 
     /**
+     * The post's GMT publication time.
+     *
      * @var string
      */
     public $post_date_gmt;
 
     /**
+     * The post's content.
+     *
      * @var string
      */
     public $post_content;
 
     /**
+     * The post's title.
+     *
      * @var string
      */
     public $post_title;
 
     /**
+     * The post's excerpt.
+     *
      * @var string
      */
     public $post_excerpt;
 
     /**
+     * The post's status.
+     *
      * @var string
      */
     public $post_status;
 
     /**
+     * Whether comments are allowed.
+     *
      * @var string
      */
     public $comment_status;
 
     /**
+     * Whether pings are allowed.
+     *
      * @var string
      */
     public $ping_status;
 
     /**
+     * The post's password in plain text.
+     *
      * @var string
      */
     public $post_password;
 
     /**
+     * URLs queued to be pinged.
+     *
      * @var string
      */
     public $to_ping;
 
     /**
+     * URLs that have been pinged.
+     *
      * @var string
      */
     public $pinged;
 
     /**
+     * The post's local modified time.
+     *
      * @var string
      */
     public $post_modified;
 
     /**
+     * The post's GMT modified time.
+     *
      * @var string
      */
     public $post_modified_gmt;
 
     /**
+     * A utility DB field for post content.
+     *
      * @var string
      */
     public $post_content_filtered;
 
     /**
+     * ID of a post's parent post.
+     *
      * @var int
      */
     public $post_parent;
 
     /**
+     * The unique identifier for a post, not necessarily a URL, used as the feed GUID.
+     *
      * @var string
      */
     public $guid;
 
     /**
+     * A field used for ordering posts.
+     *
      * @var int
      */
     public $menu_order;
 
     /**
+     * The post's type, like post or page.
+     *
      * @var string
      */
     public $post_type;
 
     /**
+     * An attachment's mime type.
+     *
      * @var string
      */
     public $post_mime_type;
 
     /**
-     * @var int
+     * Cached comment count.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $comment_count;
 
     /**
+     * Stores the post object's sanitization level.
+     *
+     * Does not correspond to a DB field.
+     *
      * @var string
      */
     public $filter;

--- a/src/Post.php
+++ b/src/Post.php
@@ -170,6 +170,81 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
     public $slug;
 
     /**
+     * @var string
+     */
+    public $post_name;
+
+    /**
+     * @var string
+     */
+    public $post_date_gmt;
+
+    /**
+     * @var string
+     */
+    public $comment_status;
+
+    /**
+     * @var string
+     */
+    public $ping_status;
+
+    /**
+     * @var string
+     */
+    public $post_password;
+
+    /**
+     * @var string
+     */
+    public $to_ping;
+
+    /**
+     * @var string
+     */
+    public $pinged;
+
+    /**
+     * @var string
+     */
+    public $post_modified;
+
+    /**
+     * @var string
+     */
+    public $post_modified_gmt;
+
+    /**
+     * @var string
+     */
+    public $post_content_filtered;
+
+    /**
+     * @var string
+     */
+    public $guid;
+
+    /**
+     * @var int
+     */
+    public $menu_order;
+
+    /**
+     * @var string
+     */
+    public $post_mime_type;
+
+    /**
+     * @var int
+     */
+    public $comment_count;
+
+    /**
+     * @var string
+     */
+    public $filter;
+
+    /**
      * @var string Stores the PostType object for the post.
      */
     protected $__type;

--- a/src/Post.php
+++ b/src/Post.php
@@ -170,76 +170,111 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
     public $slug;
 
     /**
+     * The post's slug.
+     *
      * @var string
      */
     public $post_name;
 
     /**
+     * The post's GMT publication time.
+     *
      * @var string
      */
     public $post_date_gmt;
 
     /**
+     * Whether comments are allowed.
+     *
      * @var string
      */
     public $comment_status;
 
     /**
+     * Whether pings are allowed.
+     *
      * @var string
      */
     public $ping_status;
 
     /**
+     * The post's password in plain text.
+     *
      * @var string
      */
     public $post_password;
 
     /**
+     * URLs queued to be pinged.
+     *
      * @var string
      */
     public $to_ping;
 
     /**
+     * URLs that have been pinged.
+     *
      * @var string
      */
     public $pinged;
 
     /**
+     * The post's local modified time.
+     *
      * @var string
      */
     public $post_modified;
 
     /**
+     * The post's GMT modified time.
+     *
      * @var string
      */
     public $post_modified_gmt;
 
     /**
+     * A utility DB field for post content.
+     *
      * @var string
      */
     public $post_content_filtered;
 
     /**
+     * The unique identifier for a post, not necessarily a URL, used as the feed GUID.
+     *
      * @var string
      */
     public $guid;
 
     /**
+     * A field used for ordering posts.
+     *
      * @var int
      */
     public $menu_order;
 
     /**
+     * An attachment's mime type.
+     *
+     * @since 3.5.0
      * @var string
      */
     public $post_mime_type;
 
     /**
-     * @var int
+     * Cached comment count.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $comment_count;
 
     /**
+     * Stores the post object's sanitization level.
+     *
+     * Does not correspond to a DB field.
+     *
      * @var string
      */
     public $filter;

--- a/src/Site.php
+++ b/src/Site.php
@@ -148,62 +148,110 @@ class Site extends Core implements CoreInterface
     public $atom;
 
     /**
-     * @var int
+     * Site ID.
+     *
+     * Named "blog" vs. "site" for legacy reasons.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $blog_id;
 
     /**
+     * Domain of the site.
+     *
      * @var string
      */
     public $domain;
 
     /**
+     * Path of the site.
+     *
      * @var string
      */
     public $path;
 
     /**
-     * @var int
+     * The ID of the site's parent network.
+     *
+     * Named "site" vs. "network" for legacy reasons. An individual site's "site" is
+     * its network.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $site_id;
 
     /**
-     * @var string
+     * The date and time on which the site was created or registered.
+     *
+     * @var string Date in MySQL's datetime format.
      */
     public $registered;
 
     /**
-     * @var string
+     * The date and time on which site settings were last updated.
+     *
+     * @var string Date in MySQL's datetime format.
      */
     public $last_updated;
 
     /**
-     * @var int
+     * Whether the site should be treated as public.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $public;
 
     /**
-     * @var int
+     * Whether the site should be treated as archived.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $archived;
 
     /**
-     * @var int
+     * Whether the site should be treated as mature.
+     *
+     * Handling for this does not exist throughout WordPress core, but custom
+     * implementations exist that require the property to be present.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $mature;
 
     /**
-     * @var int
+     * Whether the site should be treated as spam.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $spam;
 
     /**
-     * @var int
+     * Whether the site should be treated as flagged for deletion.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $deleted;
 
     /**
-     * @var int
+     * The language pack associated with this site.
+     *
+     * A numeric string, for compatibility reasons.
+     *
+     * @var string
      */
     public $lang_id;
 

--- a/src/Site.php
+++ b/src/Site.php
@@ -148,6 +148,66 @@ class Site extends Core implements CoreInterface
     public $atom;
 
     /**
+     * @var int
+     */
+    public $blog_id;
+
+    /**
+     * @var string
+     */
+    public $domain;
+
+    /**
+     * @var string
+     */
+    public $path;
+
+    /**
+     * @var int
+     */
+    public $site_id;
+
+    /**
+     * @var string
+     */
+    public $registered;
+
+    /**
+     * @var string
+     */
+    public $last_updated;
+
+    /**
+     * @var int
+     */
+    public $public;
+
+    /**
+     * @var int
+     */
+    public $archived;
+
+    /**
+     * @var int
+     */
+    public $mature;
+
+    /**
+     * @var int
+     */
+    public $spam;
+
+    /**
+     * @var int
+     */
+    public $deleted;
+
+    /**
+     * @var int
+     */
+    public $lang_id;
+
+    /**
      * Constructs a Timber\Site object
      * @api
      * @example

--- a/src/Term.php
+++ b/src/Term.php
@@ -72,6 +72,46 @@ class Term extends CoreEntity implements Stringable
     public $taxonomy;
 
     /**
+     * @var int
+     */
+    public $term_id;
+
+    /**
+     * @var string
+     */
+    public $slug;
+
+    /**
+     * @var int
+     */
+    public $term_group;
+
+    /**
+     * @var int
+     */
+    public $term_taxonomy_id;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var int
+     */
+    public $parent;
+
+    /**
+     * @var int
+     */
+    public $count;
+
+    /**
+     * @var string
+     */
+    public $filter;
+
+    /**
      * @internal
      */
     protected function __construct()

--- a/src/Term.php
+++ b/src/Term.php
@@ -72,41 +72,59 @@ class Term extends CoreEntity implements Stringable
     public $taxonomy;
 
     /**
+     * Term ID.
+     *
      * @var int
      */
     public $term_id;
 
     /**
+     * The term's slug.
+     *
      * @var string
      */
     public $slug;
 
     /**
+     * The term's term_group.
+     *
      * @var int
      */
     public $term_group;
 
     /**
+     * Term Taxonomy ID.
+     *
      * @var int
      */
     public $term_taxonomy_id;
 
     /**
+     * The term's description.
+     *
      * @var string
      */
     public $description;
 
     /**
+     * ID of a term's parent term.
+     *
      * @var int
      */
     public $parent;
 
     /**
+     * Cached object count for this term.
+     *
      * @var int
      */
     public $count;
 
     /**
+     * Stores the term object's sanitization level.
+     *
+     * Does not correspond to a database field.
+     *
      * @var string
      */
     public $filter;

--- a/src/User.php
+++ b/src/User.php
@@ -141,7 +141,7 @@ class User extends CoreEntity implements Stringable
     /**
      * All capabilities the user has, including individual and role based.
      *
-     * @var bool[] Array of key/value pairs where keys represent a capability name
+     * @var array<string, bool> Array of key/value pairs where keys represent a capability name
      *             and boolean values represent whether the user has that capability.
      */
     public $allcaps;

--- a/src/User.php
+++ b/src/User.php
@@ -126,7 +126,7 @@ class User extends CoreEntity implements Stringable
     /**
      * Capabilities that the individual user has been granted outside of those inherited from their role.
      *
-     * @var bool[] Array of key/value pairs where keys represent a capability name
+     * @var array<string, bool> Array of key/value pairs where keys represent a capability name
      *             and boolean values represent whether the user has that capability.
      */
     public $caps;

--- a/src/User.php
+++ b/src/User.php
@@ -73,6 +73,8 @@ class User extends CoreEntity implements Stringable
     public $id;
 
     /**
+     * The user's ID.
+     *
      * @var int
      */
     public $ID;
@@ -122,21 +124,31 @@ class User extends CoreEntity implements Stringable
     public $display_name;
 
     /**
-     * @var array
+     * Capabilities that the individual user has been granted outside of those inherited from their role.
+     *
+     * @var bool[] Array of key/value pairs where keys represent a capability name
+     *             and boolean values represent whether the user has that capability.
      */
     public $caps;
 
     /**
+     * User metadata option name.
+     *
      * @var string
      */
     public $cap_key;
 
     /**
-     * @var array
+     * All capabilities the user has, including individual and role based.
+     *
+     * @var bool[] Array of key/value pairs where keys represent a capability name
+     *             and boolean values represent whether the user has that capability.
      */
     public $allcaps;
 
     /**
+     * The filter context applied to user data fields.
+     *
      * @var string
      */
     public $filter;

--- a/src/User.php
+++ b/src/User.php
@@ -73,6 +73,16 @@ class User extends CoreEntity implements Stringable
     public $id;
 
     /**
+     * @var int
+     */
+    public $ID;
+
+    /**
+     * @var string
+     */
+    public $user_login;
+
+    /**
      * @api
      * @var string
      */
@@ -85,6 +95,51 @@ class User extends CoreEntity implements Stringable
      * @var string
      */
     public $user_email;
+
+    /**
+     * @var string
+     */
+    public $user_url;
+
+    /**
+     * @var string
+     */
+    public $user_registered;
+
+    /**
+     * @var string
+     */
+    public $user_activation_key;
+
+    /**
+     * @var int
+     */
+    public $user_status;
+
+    /**
+     * @var string
+     */
+    public $display_name;
+
+    /**
+     * @var array
+     */
+    public $caps;
+
+    /**
+     * @var string
+     */
+    public $cap_key;
+
+    /**
+     * @var array
+     */
+    public $allcaps;
+
+    /**
+     * @var string
+     */
+    public $filter;
 
     /**
      * The roles the user is part of.


### PR DESCRIPTION
Related:

- #3196

## Issue
We have quite a few public properties that are missing on our Timber object. 


## Solution
I've added the missing public properties for Comments, Post, Site,Term, Menu, Menuitem and User


## Impact
Better static analysis.


## Usage Changes
No

## Considerations
Any other Timber class that we need to do the same for?

## Testing
no