### PR TITLE
fix: Fix bug in image letterboxing when transparent background was converted to black

### DIFF
--- a/src/Image/Operation/Letterbox.php
+++ b/src/Image/Operation/Letterbox.php
@@ -71,6 +71,7 @@ class Letterbox extends ImageOperation
 
         $bg = \imagecreatetruecolor($w, $h);
         if (!$this->color) {
+            \imagealphablending($bg, false);
             \imagesavealpha($bg, true);
             $bgColor = \imagecolorallocatealpha($bg, 0, 0, 0, 127);
         } else {


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #3200 

## Issue
<!-- Description of the problem that this code change is solving -->
Transparent background is converted to black

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Add `\imagealphablending($bg, false);` to allow fix transparent background being converted to black

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
Fix

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->


## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
