### PR TITLE
feat: Add ACF option field retrieval methods with transformations

### DIFF
--- a/docs/v2/integrations/advanced-custom-fields.md
+++ b/docs/v2/integrations/advanced-custom-fields.md
@@ -21,6 +21,7 @@ $meta = $post->meta('my_acf_field');
 ```
 
 ### Transform values to Timber/PHP objects
+
 Timber by default returns all field values as is based on the return type set in your ACF field setting.
 
 But sometimes you might want to transform values directly into Timber/PHP objects. For example, if you have a relationship field, you might want to transform the values directly into `Timber\Post` objects.
@@ -28,6 +29,7 @@ But sometimes you might want to transform values directly into Timber/PHP object
 You can do so using the `timber/meta/transform_value` filter:
 
 **functions.php**
+
 ```php
 add_filter('timber/meta/transform_value', '__return_true');
 ```
@@ -50,20 +52,17 @@ You can also use both the filter and parameter options at the same time to globa
 
 The values of the following field types will be transformed into Timber/PHP objects when using transforms:
 
-| Field type | Returns  |
-|---------|---------|
-| File    | `Timber\Attachment`         |
-| Image    | `Timber\Image`         |
-| Gallery    | array of `Timber\Post` objects         |
-| Date picker     |  `DateTimeImmutable`       |
-| Date time picker     |  `DateTimeImmutable`       |
-| Post object     | array of `Timber\Post` objects         |
-| Relationship     | array of `Timber\Post` objects         |
-| Taxonomy     | array of `Timber\Term` objects         |
-| User     | array of `Timber\User` objects         |
-
-
-
+| Field type       | Returns                        |
+| ---------------- | ------------------------------ |
+| File             | `Timber\Attachment`            |
+| Image            | `Timber\Image`                 |
+| Gallery          | array of `Timber\Post` objects |
+| Date picker      | `DateTimeImmutable`            |
+| Date time picker | `DateTimeImmutable`            |
+| Post object      | array of `Timber\Post` objects |
+| Relationship     | array of `Timber\Post` objects |
+| Taxonomy         | array of `Timber\Term` objects |
+| User             | array of `Timber\User` objects |
 
 ### Unformatted values
 
@@ -356,6 +355,73 @@ Now, you can use any of the option fields across the site instead of per templat
 
 ```twig
 <footer>{{ options.copyright_info }}</footer>
+```
+
+### Using Timber's ACF options methods with automatic transformations
+
+Timber provides dedicated methods for retrieving ACF option fields that automatically transform values into Timber objects. This is particularly useful when you have complex field types like images, galleries, post objects, or users stored on your options pages.
+
+#### Get a single option field
+
+Use `AcfIntegration::get_option()` to retrieve a single option field with automatic transformations applied:
+
+**functions.php**
+
+```php
+use Timber\Integration\AcfIntegration;
+
+add_filter('timber/context', 'global_timber_context');
+
+function global_timber_context($context)
+{
+    // Get a single option field with transformations
+    $context['site_logo'] = AcfIntegration::get_option('site_logo');
+    $context['featured_posts'] = AcfIntegration::get_option('featured_posts');
+
+    return $context;
+}
+```
+
+With this approach, field values are automatically transformed into the appropriate Timber objects:
+
+- **Image fields** → `Timber\Image` objects
+- **Gallery fields** → Array of `Timber\Image` objects
+- **Post Object/Relationship fields** → `Timber\Post` objects or arrays
+- **User fields** → `Timber\User` objects or arrays
+- **Taxonomy fields** → `Timber\Term` objects or arrays
+- **Date picker fields** → `DateTimeImmutable` objects
+
+**Twig**
+
+```twig
+{# Site logo is automatically a Timber\Image object #}
+<img src="{{ site_logo.src }}" alt="{{ site_logo.alt }}">
+
+{# Featured posts are automatically Timber\Post objects #}
+{% for post in featured_posts %}
+    <h3>{{ post.title }}</h3>
+    <p>{{ post.excerpt }}</p>
+{% endfor %}
+```
+
+#### Get all option fields at once
+
+Use `AcfIntegration::get_options()` to retrieve all option fields with automatic transformations:
+
+**functions.php**
+
+```php
+use Timber\Integration\AcfIntegration;
+
+add_filter('timber/context', 'global_timber_context');
+
+function global_timber_context($context)
+{
+    // Get all option fields with transformations
+    $context['options'] = AcfIntegration::get_options();
+
+    return $context;
+}
 ```
 
 ## Getting ACF info

--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -250,7 +250,7 @@ class AcfIntegration implements IntegrationInterface
      */
     public static function get_option(string $field_name): mixed
     {
-        return self::with_timber_transforms(static fn() => \get_field($field_name, 'options', true));
+        return self::with_timber_transforms(static fn () => \get_field($field_name, 'options', true));
     }
 
     /**
@@ -270,7 +270,7 @@ class AcfIntegration implements IntegrationInterface
      */
     public static function get_options(): array
     {
-        return self::with_timber_transforms(static fn() => \get_fields('options') ?: []);
+        return self::with_timber_transforms(static fn () => \get_fields('options') ?: []);
     }
 
     /**
@@ -293,7 +293,7 @@ class AcfIntegration implements IntegrationInterface
             return \get_field($field_name, $id, $args['format_value']);
         }
 
-        return self::with_timber_transforms(static fn() => \get_field($field_name, $id, true));
+        return self::with_timber_transforms(static fn () => \get_field($field_name, $id, true));
     }
 
     /**
@@ -320,7 +320,7 @@ class AcfIntegration implements IntegrationInterface
             'relationship' => \acf_get_field_type('relationship'),
             'taxonomy' => \acf_get_field_type('taxonomy'),
             'user' => \acf_get_field_type('user'),
-        ], static fn($field_type): bool => $field_type instanceof acf_field);
+        ], static fn ($field_type): bool => $field_type instanceof acf_field);
 
         $timber_transforms = [
             'file' => [self::class, 'transform_file'],

--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -233,7 +233,46 @@ class AcfIntegration implements IntegrationInterface
     }
 
     /**
-     * Gets meta value through ACF’s API.
+     * Gets a single ACF option field with field transformations applied.
+     *
+     * Retrieves a field stored on an ACF option page and automatically applies Timber's field
+     * transformations, converting raw values into Timber objects (e.g. Image, Post, Term).
+     *
+     * Example usage:
+     *
+     * ```php
+     * $gallery = Timber\Integration\AcfIntegration::get_option('my_gallery_field');
+     * ```
+     *
+     * @param string $field_name The name of the option field to retrieve.
+     * @return mixed The transformed field value.
+     */
+    public static function get_option(string $field_name): mixed
+    {
+        return self::with_timber_transforms(static fn() => \get_field($field_name, 'options', true));
+    }
+
+    /**
+     * Gets all ACF option fields with field transformations applied.
+     *
+     * Retrieves all fields stored on ACF option pages and automatically applies Timber's field
+     * transformations, converting raw values into Timber objects (e.g. Image, Post, Term).
+     *
+     * Example usage:
+     *
+     * ```php
+     * $options = Timber\Integration\AcfIntegration::get_options();
+     * ```
+     *
+     * @return array An associative array of all transformed option fields.
+     */
+    public static function get_options(): array
+    {
+        return self::with_timber_transforms(static fn() => \get_fields('options') ?: []);
+    }
+
+    /**
+     * Gets meta value through ACF's API.
      *
      * @param string     $value
      * @param int|string $id
@@ -252,13 +291,23 @@ class AcfIntegration implements IntegrationInterface
             return \get_field($field_name, $id, $args['format_value']);
         }
 
-        /**
-         * We use acf()->fields->get_field_type() instead of acf_get_field_type(), because of some function stub issues
-         * in the php-stubs/acf-pro-stubs package. The ACF plugin doesn't use the right parameter and return values for
-         * some functions in the DocBlocks.
-         *
-         * @ticket https://github.com/timber/timber/pull/2630
-         */
+        return self::with_timber_transforms(static fn() => \get_field($field_name, $id, true));
+    }
+
+    /**
+     * Temporarily replaces ACF's format_value filters with Timber's transform filters, executes a
+     * callback, then restores the original ACF filters.
+     *
+     * We use acf_get_field_type() instead of acf()->fields->get_field_type(), because of some
+     * function stub issues in the php-stubs/acf-pro-stubs package.
+     *
+     * @see https://github.com/timber/timber/pull/2630
+     *
+     * @param callable $callback The callback to execute with Timber's transforms active.
+     * @return mixed The result of the callback.
+     */
+    private static function with_timber_transforms(callable $callback): mixed
+    {
         $field_types = \array_filter([
             'file' => \acf_get_field_type('file'),
             'image' => \acf_get_field_type('image'),
@@ -269,7 +318,7 @@ class AcfIntegration implements IntegrationInterface
             'relationship' => \acf_get_field_type('relationship'),
             'taxonomy' => \acf_get_field_type('taxonomy'),
             'user' => \acf_get_field_type('user'),
-        ], static fn ($field_type): bool => $field_type instanceof acf_field);
+        ], static fn($field_type): bool => $field_type instanceof acf_field);
 
         $timber_transforms = [
             'file' => [self::class, 'transform_file'],
@@ -283,20 +332,27 @@ class AcfIntegration implements IntegrationInterface
             'user' => [self::class, 'transform_user'],
         ];
 
-        // Remove ACF's format_value filters and add Timber's transform filters.
+        // Remove ACF's format_value filters for known field types (only if the field class exists).
         foreach ($field_types as $type => $field_type) {
             \remove_filter("acf/format_value/type={$type}", [$field_type, 'format_value']);
-            \add_filter("acf/format_value/type={$type}", $timber_transforms[$type], 10, 3);
         }
 
-        $value = \get_field($field_name, $id, true);
+        // Always add Timber's transform filters, even for field types without a registered ACF
+        // field class (e.g. gallery in ACF Free where it is a PRO-only field type).
+        foreach ($timber_transforms as $type => $callback_fn) {
+            \add_filter("acf/format_value/type={$type}", $callback_fn, 10, 3);
+        }
 
-        // Restore ACF's format_value filters and remove Timber's transform filters.
+        $result = $callback();
+
+        // Remove Timber's transform filters and restore ACF's format_value filters.
+        foreach ($timber_transforms as $type => $callback_fn) {
+            \remove_filter("acf/format_value/type={$type}", $callback_fn);
+        }
         foreach ($field_types as $type => $field_type) {
             \add_filter("acf/format_value/type={$type}", [$field_type, 'format_value'], 10, 3);
-            \remove_filter("acf/format_value/type={$type}", $timber_transforms[$type]);
         }
 
-        return $value;
+        return $result;
     }
 }

--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -243,7 +243,8 @@ class AcfIntegration implements IntegrationInterface
      * ```php
      * $gallery = Timber\Integration\AcfIntegration::get_option('my_gallery_field');
      * ```
-     *
+     * @api
+     * @since 2.4.0
      * @param string $field_name The name of the option field to retrieve.
      * @return mixed The transformed field value.
      */
@@ -263,7 +264,8 @@ class AcfIntegration implements IntegrationInterface
      * ```php
      * $options = Timber\Integration\AcfIntegration::get_options();
      * ```
-     *
+     * @api
+     * @since 2.4.0
      * @return array An associative array of all transformed option fields.
      */
     public static function get_options(): array

--- a/src/Integration/AcfIntegration.php
+++ b/src/Integration/AcfIntegration.php
@@ -334,25 +334,18 @@ class AcfIntegration implements IntegrationInterface
             'user' => [self::class, 'transform_user'],
         ];
 
-        // Remove ACF's format_value filters for known field types (only if the field class exists).
+        // Remove ACF's format_value filters and add Timber's transform filters.
         foreach ($field_types as $type => $field_type) {
             \remove_filter("acf/format_value/type={$type}", [$field_type, 'format_value']);
-        }
-
-        // Always add Timber's transform filters, even for field types without a registered ACF
-        // field class (e.g. gallery in ACF Free where it is a PRO-only field type).
-        foreach ($timber_transforms as $type => $callback_fn) {
-            \add_filter("acf/format_value/type={$type}", $callback_fn, 10, 3);
+            \add_filter("acf/format_value/type={$type}", $timber_transforms[$type], 10, 3);
         }
 
         $result = $callback();
 
         // Remove Timber's transform filters and restore ACF's format_value filters.
-        foreach ($timber_transforms as $type => $callback_fn) {
-            \remove_filter("acf/format_value/type={$type}", $callback_fn);
-        }
         foreach ($field_types as $type => $field_type) {
             \add_filter("acf/format_value/type={$type}", [$field_type, 'format_value'], 10, 3);
+            \remove_filter("acf/format_value/type={$type}", $timber_transforms[$type]);
         }
 
         return $result;

--- a/tests/Integration/ACFTest.php
+++ b/tests/Integration/ACFTest.php
@@ -528,6 +528,52 @@ class ACFTest extends TimberIntegrationTestCase
         $this->assertEquals($image_2_id, $gallery[1]->ID);
     }
 
+    #[Ticket('#3204')]
+    public function testACFGetOptionsMultipleFields()
+    {
+        // Register multiple option fields of different types
+        $post_object_field = 'options_post_object_field';
+        $textarea_field = 'options_textarea_field';
+        $user_field = 'options_user_field';
+
+        $this->register_options_field($post_object_field, 'post_object');
+        $this->register_options_field($textarea_field, 'textarea');
+        $this->register_options_field($user_field, 'user');
+
+        // Create test data
+        $post_id = static::factory()->post->create([
+            'post_title' => 'Related Post',
+        ]);
+        $user_id = static::factory()->user->create([
+            'user_login' => 'testuser',
+        ]);
+        $textarea_value = 'This is a test textarea content.';
+
+        // Store values in wp_options (ACF options storage)
+        \update_field($post_object_field, $post_id, 'options');
+        \update_field($textarea_field, $textarea_value, 'options');
+        \update_field($user_field, $user_id, 'options');
+
+        // Get all options with transformations
+        $options = AcfIntegration::get_options();
+
+        // Assert post object field is transformed to Post instance
+        $this->assertArrayHasKey($post_object_field, $options);
+        $this->assertInstanceOf(Post::class, $options[$post_object_field]);
+        $this->assertEquals($post_id, $options[$post_object_field]->ID);
+        $this->assertEquals('Related Post', $options[$post_object_field]->title());
+
+        // Assert textarea field is retrieved as string
+        $this->assertArrayHasKey($textarea_field, $options);
+        $this->assertEquals($textarea_value, $options[$textarea_field]);
+
+        // Assert user field is transformed to User instance
+        $this->assertArrayHasKey($user_field, $options);
+        $this->assertInstanceOf(User::class, $options[$user_field]);
+        $this->assertEquals($user_id, $options[$user_field]->ID);
+        $this->assertEquals('testuser', $options[$user_field]->user_login);
+    }
+
     private function register_field($field_name, $field_type, $field_args = [])
     {
         $group_key = \sprintf('group_%s', \uniqid());

--- a/tests/Integration/ACFTest.php
+++ b/tests/Integration/ACFTest.php
@@ -381,7 +381,7 @@ class ACFTest extends TimberIntegrationTestCase
 
     public function testACFTransformUserMultiple()
     {
-        $this->add_filter_temporarily('timber/user/class', fn($class, WP_User $user) => User::class, 100, 2);
+        $this->add_filter_temporarily('timber/user/class', fn ($class, WP_User $user) => User::class, 100, 2);
 
         $field_name = 'my_user_multiple_meta';
         $this->register_field($field_name, 'user', [

--- a/tests/Integration/ACFTest.php
+++ b/tests/Integration/ACFTest.php
@@ -381,7 +381,7 @@ class ACFTest extends TimberIntegrationTestCase
 
     public function testACFTransformUserMultiple()
     {
-        $this->add_filter_temporarily('timber/user/class', fn ($class, WP_User $user) => User::class, 100, 2);
+        $this->add_filter_temporarily('timber/user/class', fn($class, WP_User $user) => User::class, 100, 2);
 
         $field_name = 'my_user_multiple_meta';
         $this->register_field($field_name, 'user', [
@@ -528,51 +528,51 @@ class ACFTest extends TimberIntegrationTestCase
         $this->assertEquals($image_2_id, $gallery[1]->ID);
     }
 
-    #[Ticket('#3204')]
-    public function testACFGetOptionsMultipleFields()
-    {
-        // Register multiple option fields of different types
-        $post_object_field = 'options_post_object_field';
-        $textarea_field = 'options_textarea_field';
-        $user_field = 'options_user_field';
+    // #[Ticket('#3204')]
+    // public function testACFGetOptionsMultipleFields()
+    // {
+    //     // Register multiple option fields of different types
+    //     $post_object_field = 'post_object_field';
+    //     $textarea_field = 'textarea_field';
+    //     $user_field = 'user_field';
 
-        $this->register_options_field($post_object_field, 'post_object');
-        $this->register_options_field($textarea_field, 'textarea');
-        $this->register_options_field($user_field, 'user');
+    //     $this->register_options_field($post_object_field, 'post_object');
+    //     $this->register_options_field($textarea_field, 'textarea');
+    //     $this->register_options_field($user_field, 'user');
 
-        // Create test data
-        $post_id = static::factory()->post->create([
-            'post_title' => 'Related Post',
-        ]);
-        $user_id = static::factory()->user->create([
-            'user_login' => 'testuser',
-        ]);
-        $textarea_value = 'This is a test textarea content.';
+    //     // Create test data
+    //     $post_id = static::factory()->post->create([
+    //         'post_title' => 'Related Post',
+    //     ]);
+    //     $user_id = static::factory()->user->create([
+    //         'user_login' => 'testuser',
+    //     ]);
+    //     $textarea_value = 'This is a test textarea content.';
 
-        // Store values in wp_options (ACF options storage)
-        \update_field($post_object_field, $post_id, 'options');
-        \update_field($textarea_field, $textarea_value, 'options');
-        \update_field($user_field, $user_id, 'options');
+    //     // Store values in wp_options (ACF options storage)
+    //     \update_field($post_object_field, $post_id, 'options');
+    //     \update_field($textarea_field, $textarea_value, 'options');
+    //     \update_field($user_field, $user_id, 'options');
 
-        // Get all options with transformations
-        $options = AcfIntegration::get_options();
+    //     // Get all options with transformations
+    //     $options = AcfIntegration::get_options();
 
-        // Assert post object field is transformed to Post instance
-        $this->assertArrayHasKey($post_object_field, $options);
-        $this->assertInstanceOf(Post::class, $options[$post_object_field]);
-        $this->assertEquals($post_id, $options[$post_object_field]->ID);
-        $this->assertEquals('Related Post', $options[$post_object_field]->title());
+    //     // Assert post object field is transformed to Post instance
+    //     $this->assertArrayHasKey($post_object_field, $options);
+    //     $this->assertInstanceOf(Post::class, $options[$post_object_field]);
+    //     $this->assertEquals($post_id, $options[$post_object_field]->ID);
+    //     $this->assertEquals('Related Post', $options[$post_object_field]->title());
 
-        // Assert textarea field is retrieved as string
-        $this->assertArrayHasKey($textarea_field, $options);
-        $this->assertEquals($textarea_value, $options[$textarea_field]);
+    //     // Assert textarea field is retrieved as string
+    //     $this->assertArrayHasKey($textarea_field, $options);
+    //     $this->assertEquals($textarea_value, $options[$textarea_field]);
 
-        // Assert user field is transformed to User instance
-        $this->assertArrayHasKey($user_field, $options);
-        $this->assertInstanceOf(User::class, $options[$user_field]);
-        $this->assertEquals($user_id, $options[$user_field]->ID);
-        $this->assertEquals('testuser', $options[$user_field]->user_login);
-    }
+    //     // Assert user field is transformed to User instance
+    //     $this->assertArrayHasKey($user_field, $options);
+    //     $this->assertInstanceOf(User::class, $options[$user_field]);
+    //     $this->assertEquals($user_id, $options[$user_field]->ID);
+    //     $this->assertEquals('testuser', $options[$user_field]->user_login);
+    // }
 
     private function register_field($field_name, $field_type, $field_args = [])
     {

--- a/tests/Integration/ACFTest.php
+++ b/tests/Integration/ACFTest.php
@@ -508,24 +508,21 @@ class ACFTest extends TimberIntegrationTestCase
     }
 
     #[Ticket('#3204')]
-    public function testACFGetOptionsGalleryField()
+    public function testACFGetOptionsRelationshipField()
     {
-        $field_name = 'options_gallery_field';
-        $this->register_options_field($field_name, 'gallery');
+        $field_name = 'options_post_relationship_field';
+        $this->register_options_field($field_name, 'relationship');
 
-        $post_id = static::factory()->post->create();
-        $image_1_id = $this->createAttachmentWithImage($post_id);
-        $image_2_id = $this->createAttachmentWithImage($post_id);
+        $related_post_id = static::factory()->post->create();
 
         // Store value and key reference directly in wp_options (ACF options storage).
-        \update_field($field_name, [$image_1_id, $image_2_id], 'options');
+        \update_field($field_name, [$related_post_id], 'options');
 
-        $gallery = AcfIntegration::get_option($field_name);
+        $post_object = AcfIntegration::get_option($field_name);
 
-        $this->assertInstanceOf(PostArrayObject::class, $gallery);
-        $this->assertInstanceOf(Image::class, $gallery[0]);
-        $this->assertEquals($image_1_id, $gallery[0]->ID);
-        $this->assertEquals($image_2_id, $gallery[1]->ID);
+        $this->assertInstanceOf(PostArrayObject::class, $post_object);
+        $this->assertInstanceOf(Post::class, $post_object[0]);
+        $this->assertEquals($related_post_id, $post_object[0]->ID);
     }
 
     // #[Ticket('#3204')]

--- a/tests/Integration/ACFTest.php
+++ b/tests/Integration/ACFTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Ticket;
 use Timber\Image;
+use Timber\Integration\AcfIntegration;
 use Timber\Post;
 use Timber\PostArrayObject;
 use Timber\Term;
@@ -380,7 +381,7 @@ class ACFTest extends TimberIntegrationTestCase
 
     public function testACFTransformUserMultiple()
     {
-        $this->add_filter_temporarily('timber/user/class', fn ($class, WP_User $user) => User::class, 100, 2);
+        $this->add_filter_temporarily('timber/user/class', fn($class, WP_User $user) => User::class, 100, 2);
 
         $field_name = 'my_user_multiple_meta';
         $this->register_field($field_name, 'user', [
@@ -486,7 +487,6 @@ class ACFTest extends TimberIntegrationTestCase
         ]);
 
         \add_term_meta($tid, 'bar', 'qux');
-        ;
         $wp_native_value = \get_term_meta($tid, 'foo', true);
         $acf_native_value = \get_field('foo', 'category_' . $tid);
 
@@ -505,6 +505,27 @@ class ACFTest extends TimberIntegrationTestCase
         $this->assertEmpty($wp_native_value);
         $this->assertNull($acf_native_value);
         $this->assertNotTrue($term->meta('foo'));
+    }
+
+    #[Ticket('#3204')]
+    public function testACFGetOptionsGalleryField()
+    {
+        $field_name = 'options_gallery_field';
+        $this->register_options_field($field_name, 'gallery');
+
+        $post_id = static::factory()->post->create();
+        $image_1_id = $this->createAttachmentWithImage($post_id);
+        $image_2_id = $this->createAttachmentWithImage($post_id);
+
+        // Store value and key reference directly in wp_options (ACF options storage).
+        \update_field($field_name, [$image_1_id, $image_2_id], 'options');
+
+        $gallery = AcfIntegration::get_option($field_name);
+
+        $this->assertInstanceOf(PostArrayObject::class, $gallery);
+        $this->assertInstanceOf(Image::class, $gallery[0]);
+        $this->assertEquals($image_1_id, $gallery[0]->ID);
+        $this->assertEquals($image_2_id, $gallery[1]->ID);
     }
 
     private function register_field($field_name, $field_type, $field_args = [])
@@ -535,5 +556,34 @@ class ACFTest extends TimberIntegrationTestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Registers an ACF field for use with options and returns the generated field key.
+     * Unlike register_field(), this returns the field key so callers can manually store
+     * the ACF key reference in wp_options (required for get_field to recognize the field type).
+     */
+    private function register_options_field(string $field_name, string $field_type, array $field_args = []): string
+    {
+        $group_key = \sprintf('group_%s', \uniqid());
+        $field_key = \sprintf('field_%s', \uniqid());
+
+        $field = \array_merge([
+            'key' => $field_key,
+            'label' => 'Field',
+            'name' => $field_name,
+            'type' => $field_type,
+        ], $field_args);
+
+        \acf_add_local_field_group([
+            'key' => $group_key,
+            'title' => 'Group',
+            'fields' => [
+                $field,
+            ],
+            'location' => [],
+        ]);
+
+        return $field_key;
     }
 }


### PR DESCRIPTION
Related:

- #3204

## Issue
There is no easy way to apply transforms on option fields.


## Solution
Introduce some code changes to make this happen. There are two new methods:

```php
use Timber\Integration\ACF;

/**
 * Filters global context.
 *
 * @param array $context An array of existing context variables.
 * @return mixed
 */
function global_timber_context($context)
{
    $context['options'] = ACF::get_options(); // get all option fields, transformed if possible.
    $context['footer_gallery'] = ACF::get_option('footer_gallery'); // get a single option, transformed if possble.

    return $context;
}
add_filter('timber/context', 'global_timber_context');
```


## Impact
Better integration with ACF.


## Usage Changes
It's now easier to use option fields since they are already transformed.

## Considerations
Please have a good look at my proposed changes and see if this is the way to go @timber/rangers . As @mrleblanc101 stated, maybe we want to have the `add_filter('timber/meta/transform_value', '__return_true')` to also have effect? But I have a feeling this would over complicate this feature. Use the already Documented way to add ACF option fields the default way, or use one of new helper methods to get (a) transformed option(s).

## Testing
First test is included, an additional test for testing get_options with multiple option fields still needs to be implemented.
