### PR TITLE
Fix typehints

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -225,7 +225,7 @@ class Image extends Attachment implements ImageInterface
      * <img src="https://example.org/wp-content/uploads/2015/08/pic.jpg" width="1600" />
      * ```
      *
-     * @return int The width of the image in pixels.
+     * @return int|null The width of the image in pixels.
      */
     public function width()
     {
@@ -244,7 +244,7 @@ class Image extends Attachment implements ImageInterface
      * <img src="https://example.org/wp-content/uploads/2015/08/pic.jpg" height="900" />
      * ```
      *
-     * @return int The height of the image in pixels.
+     * @return int|null The height of the image in pixels.
      */
     public function height()
     {


### PR DESCRIPTION
## Issue

Type hints are wrong. I would prefer to just remove them altogether, but it seems to be a theme of this package so I corrected them.

## Solution

Returns `int|null` instead of just `int` (see corresponding methods in ImageDimensions).

## Impact

If developers rely on these type hints they get unexpected behavior.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->

## Considerations

Don't specify `@return` unless you have to.

## Testing

N/A