### PR TITLE
fix: Fix bug with transient cache expiration

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -109,7 +109,7 @@ class Loader
             $encoded = \json_encode($data);
 
             /**
-             * The encoding might fail, e.g. when an object has a recursion. In that case, we'd rather not cache the
+             * The encoding might fail, e.g. when an object has a recursion. In that case, we’d rather not cache the
              * data instead of possibly returning the wrong data.
              */
             if (false !== $encoded) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -103,17 +103,21 @@ class Loader
 
         $key = null;
         $output = false;
+        $cache_hit = false;
         if (false !== $expires) {
             \ksort($data);
             $encoded = \json_encode($data);
 
             /**
-             * The encoding might fail, e.g. when an object has a recursion. In that case, we’d rather not cache the
+             * The encoding might fail, e.g. when an object has a recursion. In that case, we'd rather not cache the
              * data instead of possibly returning the wrong data.
              */
             if (false !== $encoded) {
                 $key = \md5($file . $encoded);
                 $output = $this->get_cache($key, self::CACHEGROUP, $cache_mode);
+                if (false !== $output && null !== $output) {
+                    $cache_hit = true;
+                }
             }
         }
 
@@ -190,7 +194,7 @@ class Loader
             $output = \apply_filters('timber/output/pre-cache', $output, $data, $file);
         }
 
-        if (false !== $output && false !== $expires && null !== $key) {
+        if (!$cache_hit && false !== $output && false !== $expires && null !== $key) {
             $this->delete_cache();
             $this->set_cache($key, $output, self::CACHEGROUP, $expires, $cache_mode);
         }

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -73,7 +73,7 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $is_locked = Helper::transient($transient, fn() => Helper::_is_transient_locked($transient), 30);
+        $is_locked = Helper::transient($transient, fn () => Helper::_is_transient_locked($transient), 30);
 
         $this->assertTrue($is_locked);
     }
@@ -92,7 +92,7 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $result = Helper::transient($transient, fn() => 'pooptime', 200);
+        $result = Helper::transient($transient, fn () => 'pooptime', 200);
         $this->assertEquals($result, 'pooptime');
     }
 
@@ -100,9 +100,9 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $first_value = Helper::transient($transient, fn() => 'first_value', 30);
+        $first_value = Helper::transient($transient, fn () => 'first_value', 30);
 
-        $second_value = Helper::transient($transient, fn() => 'second_value', 30);
+        $second_value = Helper::transient($transient, fn () => 'second_value', 30);
 
         $this->assertEquals('first_value', $second_value);
     }
@@ -111,9 +111,9 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $first_value = Helper::transient($transient, fn() => 'first_value', 30);
+        $first_value = Helper::transient($transient, fn () => 'first_value', 30);
 
-        $second_value = Helper::transient($transient, fn() => 'second_value', false);
+        $second_value = Helper::transient($transient, fn () => 'second_value', false);
 
         $this->assertEquals('second_value', $second_value);
     }
@@ -207,11 +207,11 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $first_value = Helper::transient($transient, fn() => 'first_value', 1);
+        $first_value = Helper::transient($transient, fn () => 'first_value', 1);
 
         \sleep(2);
 
-        $second_value = Helper::transient($transient, fn() => 'second_value', 1);
+        $second_value = Helper::transient($transient, fn () => 'second_value', 1);
 
         $this->assertEquals('second_value', $second_value);
     }
@@ -544,7 +544,7 @@ class CacheTest extends TimberIntegrationTestCase
 
     public function testCacheTransientKeyFilter()
     {
-        $this->add_filter_temporarily('timber/cache/transient_key', fn($key) => 'my_custom_key');
+        $this->add_filter_temporarily('timber/cache/transient_key', fn ($key) => 'my_custom_key');
 
         $loader = new Loader();
         $loader->set_cache('test', 'foobar', Loader::CACHE_TRANSIENT);
@@ -559,7 +559,9 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $pid = static::factory()->post->create();
         $post = Timber::get_post($pid);
-        $data = ['post' => $post];
+        $data = [
+            'post' => $post,
+        ];
 
         // First render: cache miss — stores transient with 600 s expiry.
         Timber::compile('assets/single-post.twig', $data, 600);

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -73,7 +73,7 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $is_locked = Helper::transient($transient, fn () => Helper::_is_transient_locked($transient), 30);
+        $is_locked = Helper::transient($transient, fn() => Helper::_is_transient_locked($transient), 30);
 
         $this->assertTrue($is_locked);
     }
@@ -92,7 +92,7 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $result = Helper::transient($transient, fn () => 'pooptime', 200);
+        $result = Helper::transient($transient, fn() => 'pooptime', 200);
         $this->assertEquals($result, 'pooptime');
     }
 
@@ -100,9 +100,9 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $first_value = Helper::transient($transient, fn () => 'first_value', 30);
+        $first_value = Helper::transient($transient, fn() => 'first_value', 30);
 
-        $second_value = Helper::transient($transient, fn () => 'second_value', 30);
+        $second_value = Helper::transient($transient, fn() => 'second_value', 30);
 
         $this->assertEquals('first_value', $second_value);
     }
@@ -111,9 +111,9 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $first_value = Helper::transient($transient, fn () => 'first_value', 30);
+        $first_value = Helper::transient($transient, fn() => 'first_value', 30);
 
-        $second_value = Helper::transient($transient, fn () => 'second_value', false);
+        $second_value = Helper::transient($transient, fn() => 'second_value', false);
 
         $this->assertEquals('second_value', $second_value);
     }
@@ -207,11 +207,11 @@ class CacheTest extends TimberIntegrationTestCase
     {
         $transient = $this->_generate_transient_name();
 
-        $first_value = Helper::transient($transient, fn () => 'first_value', 1);
+        $first_value = Helper::transient($transient, fn() => 'first_value', 1);
 
         \sleep(2);
 
-        $second_value = Helper::transient($transient, fn () => 'second_value', 1);
+        $second_value = Helper::transient($transient, fn() => 'second_value', 1);
 
         $this->assertEquals('second_value', $second_value);
     }
@@ -334,8 +334,10 @@ class CacheTest extends TimberIntegrationTestCase
         $this->assertTrue($clear);
         $works = true;
 
-        if (isset($wp_object_cache->cache[Loader::CACHEGROUP])
-            && !empty($wp_object_cache->cache[Loader::CACHEGROUP])) {
+        if (
+            isset($wp_object_cache->cache[Loader::CACHEGROUP])
+            && !empty($wp_object_cache->cache[Loader::CACHEGROUP])
+        ) {
             $works = false;
         }
         $this->assertTrue($works);
@@ -542,11 +544,41 @@ class CacheTest extends TimberIntegrationTestCase
 
     public function testCacheTransientKeyFilter()
     {
-        $this->add_filter_temporarily('timber/cache/transient_key', fn ($key) => 'my_custom_key');
+        $this->add_filter_temporarily('timber/cache/transient_key', fn($key) => 'my_custom_key');
 
         $loader = new Loader();
         $loader->set_cache('test', 'foobar', Loader::CACHE_TRANSIENT);
 
         $this->assertEquals('foobar', \get_transient('my_custom_key'));
+    }
+
+    /**
+     * @see https://github.com/timber/timber/issues/3219
+     */
+    public function testTransientExpirationNotResetOnCacheHit()
+    {
+        $pid = static::factory()->post->create();
+        $post = Timber::get_post($pid);
+        $data = ['post' => $post];
+
+        // First render: cache miss — stores transient with 600 s expiry.
+        Timber::compile('assets/single-post.twig', $data, 600);
+
+        global $wpdb;
+        $timeout_query = "SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_timberloader_%' LIMIT 1";
+        $initial_timeout = (int) $wpdb->get_var($timeout_query);
+
+        \sleep(2);
+
+        // Second render: cache hit — must NOT reset the transient expiration.
+        Timber::compile('assets/single-post.twig', $data, 600);
+
+        $after_timeout = (int) $wpdb->get_var($timeout_query);
+
+        $this->assertSame(
+            $initial_timeout,
+            $after_timeout,
+            'Transient expiration must not be reset when the cache is already populated (issue #3219).'
+        );
     }
 }


### PR DESCRIPTION
Related:

- #3219

## Issue

When `Timber::render()` (or `Timber::compile()`) is called with a cache duration, the rendered output is stored as a WordPress transient. On every subsequent request — even when the result is served from the cache — the transient was being overwritten with `set_transient()`, which silently **reset the expiration timer** back to the full TTL. This means a frequently visited page could remain cached indefinitely, never expiring.

## Solution

Track whether the output came from a cache hit in `Loader::render()`. A new `$cache_hit` boolean flag is set to `true` when `get_cache()` returns a valid (non-false, non-null) value. The `set_cache()` call at the end of `render()` is now guarded by `!$cache_hit`, so the transient is only written on a cache miss and is never touched (or refreshed) on a cache hit.

```php
// Before — set_cache() is always called, resetting the TTL on every request:
if (false !== $output && false !== $expires && null !== $key) {
    $this->set_cache(...);
}

// After — set_cache() is only called when there was no cached value:
if (!$cache_hit && false !== $output && false !== $expires && null !== $key) {
    $this->set_cache(...);
}
```

## Impact

- **Correctness**: Transient expiration now behaves as documented, the TTL (stored in epoch) counts from the moment the cache entry was *created*, not from the last page view.
- **Performance**: A small positive improvement on cache hits, as one redundant `set_transient()` DB write per request is eliminated.

## Usage Changes

None.

## Testing

A regression test has been added to `tests/Cache/CacheTest.php` (`testTransientExpirationNotResetOnCacheHit`):

1. Render a template with a 600 s TTL — records the transient timeout value from the DB.
2. Sleep 2 seconds.
3. Render the same template again (cache hit).
4. Assert the epoch time stored in the transient remains the same (+600s from initial hit) and not +600 seconds from second hit.

Without the fix the timeout advances by ~2 seconds on every request. With the fix the assertion passes.
