### PR TITLE
fix: Fix context stacking issue with `Timber\Site::switch_to_blog()` in multisite environment

### DIFF
--- a/src/Site.php
+++ b/src/Site.php
@@ -338,7 +338,7 @@ class Site extends Core implements CoreInterface
         }
 
         // Always call switch_to_blog to add the blog switch to the stack. WordPress doesn't perform complex logic if the blog ID stays the same.
-        \switch_to_blog((int)$blog_identifier);
+        \switch_to_blog((int) $blog_identifier);
 
         return (int) $blog_identifier;
     }

--- a/src/Site.php
+++ b/src/Site.php
@@ -337,17 +337,8 @@ class Site extends Core implements CoreInterface
             $blog_identifier = $current_id;
         }
 
-        $info = \get_blog_details($blog_identifier, false);
-
-        if (false === $info) {
-            return $current_id;
-        }
-
-        $blog_identifier = $info->blog_id;
-
-        if ((int) $current_id !== (int) $blog_identifier) {
-            \switch_to_blog($blog_identifier);
-        }
+        // Always call switch_to_blog to add the blog switch to the stack. WordPress doesn't perform complex logic if the blog ID stays the same.
+        \switch_to_blog((int)$blog_identifier);
 
         return (int) $blog_identifier;
     }

--- a/tests/TimberMultisiteTest.php
+++ b/tests/TimberMultisiteTest.php
@@ -245,10 +245,9 @@ class TimberMultisiteTest extends TimberIntegrationTestCase
 
         $sites = Timber::get_sites();
         foreach ($sites as $site) {
-            \switch_to_blog($site->blog_id);
+            \switch_to_blog((int) $site->blog_id);
             $ts = new Site();
-            $this->assertSame($site->blog_id, $ts->ID);
-            $this->assertSame($site->blog_id, \get_current_blog_id());
+            $this->assertSame((int) $site->blog_id, \get_current_blog_id());
             \restore_current_blog();
         }
     }

--- a/tests/TimberMultisiteTest.php
+++ b/tests/TimberMultisiteTest.php
@@ -232,6 +232,27 @@ class TimberMultisiteTest extends TimberIntegrationTestCase
         $this->assertStringStartsWith($site_2_upload_dir['baseurl'], $img_resized_src);
     }
 
+    /**
+     * Tests whether the blog ID is still the same after creating an instance of the Site object.
+     */
+    #[Ticket('https://github.com/timber/timber/issues/3222')]
+    public function test_switch_to_blog_in_site_object()
+    {
+        if (!\is_multisite()) {
+            $this->markTestSkipped("You can't get sites except on Multisite");
+            return;
+        }
+
+        $sites = Timber::get_sites();
+        foreach ($sites as $site) {
+            \switch_to_blog($site->blog_id);
+            $ts = new Site();
+            $this->assertSame($site->blog_id, $ts->ID);
+            $this->assertSame($site->blog_id, \get_current_blog_id());
+            \restore_current_blog();
+        }
+    }
+
     public function testTimberSiteWPObject()
     {
         $this->skipWithoutMultisite();

--- a/tests/TimberMultisiteTest.php
+++ b/tests/TimberMultisiteTest.php
@@ -243,13 +243,26 @@ class TimberMultisiteTest extends TimberIntegrationTestCase
             return;
         }
 
+        $ids = [];
+        $mapped_ids = [];
+
+        $ids[] = (int) \get_current_blog_id();
+        $ids[] = self::createSubDomainSite('foo-3222.example.org', 'Site 3222 Foo');
+        \restore_current_blog();
+        $ids[] = self::createSubDomainSite('bar-3222.example.org', 'Site 3222 Bar');
+        \restore_current_blog();
+
         $sites = Timber::get_sites();
+
         foreach ($sites as $site) {
             \switch_to_blog((int) $site->blog_id);
+            $mapped_ids[] = (int) $site->blog_id;
             $ts = new Site();
             $this->assertSame((int) $site->blog_id, \get_current_blog_id());
             \restore_current_blog();
         }
+
+        $this->assertSame($ids, $mapped_ids);
     }
 
     public function testTimberSiteWPObject()


### PR DESCRIPTION
<!--
First off, hello!

Thanks for submitting a PR. We love/welcome PRs (especially if it's your first).
Have any questions? Read this section in CONTRIBUTING.md: https://github.com/timber/timber/blob/master/CONTRIBUTING.md#pull-requests.
-->

<!-- Remove this if no related tickets exist. -->
<!-- You can add the related ticket numbers here using #. Example: #2471 -->
Related:

- #3222

## Issue
<!-- Description of the problem that this code change is solving -->
When rendering a template timber runs the constructor of the Site class.
This then only does a switch_to_blog if the blog ID is not the same, but always calls restore_current_blog.
This causes issues when twig templates get rendered when someone has already switched to another blog.
Code after the template render will then run on the main blog ID, instead of the blog ID the template was rendered on.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
To always run WordPress's `switch_to_blog()` function, even if the blog ID stays the same. This will make sure that the blog switch is added to the stack. WordPress doesn't perform complex logic if the blog ID stays the same, so this shouldn't impact performance.

## Impact
<!-- What impact will this have on the current codebase, performance, backwards compatibility? -->
- It should have no impact on performance
- It should not have impact on the current codebase or backward compatibility, except for people who're already actively bypassing this issue in their own projects, instead of writing a bug report.

## Usage Changes
<!-- Are there are any usage changes that we need to know about? If so, list them here so that we can integrate it in the release notes and developers know what usage changes are associated to your PR.
-->
None.

## Considerations
<!-- As we do not live in an ideal world it's worth to share your thought on how we could make the solution even better. -->

I've also considered to not always run WordPress's `restore_current_blog()`, but determined that removing complex logic in `Site::switch_to_blog()` and instead relying on how WordPress handles it already is way less complex and less prone to bugs than writing a custom `Site::restore_current_blog()` function.

## Testing
<!-- Are unit tests included? If they need to be written, please provide pseudo code for a scenario that fails without your code, but succeeds with it -->
Yes, unit test is included.

⚠️ The Unit test created cannot test the bugfix at the moment, as `Timber::get_sites()` returns two blogs with the same blog ID (1). Therefore testing this scenario is only possible if that will return two blogs with different ID's. I don't know how to solve that, so i'm hoping someone can assist with that.