### PR TITLE
fix: Improve performance for reading attachment image dimensions

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -87,7 +87,7 @@ class Image extends Attachment implements ImageInterface
         $data = parent::get_info($data);
 
         if ($this->file_loc()) {
-            $data['image_dimensions'] = new ImageDimensions($this->file_loc());
+            $data['image_dimensions'] = new ImageDimensions($this->file_loc(), $data['ID']);
         }
 
         return $data;

--- a/src/ImageDimensions.php
+++ b/src/ImageDimensions.php
@@ -3,7 +3,7 @@
 namespace Timber;
 
 /**
- * Class FileSize
+ * Class ImageDimensions
  *
  * Helper class to deal with Image Dimensions
  *
@@ -26,13 +26,22 @@ class ImageDimensions
      */
     public function __construct(
         /**
-         * File location.
+         * File path.
          *
          * @api
          * @var string The absolute path to the image in the filesystem
          *             (Example: `/var/www/htdocs/wp-content/uploads/2015/08/my-pic.jpg`)
          */
-        public $file_loc = ''
+        public string $file_loc = '',
+        /**
+         * Attachment ID.
+         *
+         * Used to retrieve image dimensions from the attachment metadata.
+         *
+         * @api
+         * @var int|null If passed, image dimensions will be retrieved from the attachment metadata.
+         */
+        public ?int $attachment_id = null
     ) {
     }
 
@@ -118,7 +127,22 @@ class ImageDimensions
             return $this->get_dimension_loaded($dimension);
         }
 
-        // Load dimensions.
+        // Load dimensions from attachment metadata. This should be significantly faster than
+        // reading from the file directly.
+        if ($this->attachment_id) {
+            $meta = \wp_get_attachment_metadata($this->attachment_id);
+
+            if ($meta && isset($meta['width']) && isset($meta['height'])) {
+                $this->dimensions = [
+                    (int) $meta['width'],
+                    (int) $meta['height'],
+                ];
+
+                return $this->get_dimension_loaded($dimension);
+            }
+        }
+
+        // Load dimensions by reading file data.
         if (\file_exists($this->file_loc) && \filesize($this->file_loc)) {
             if (ImageHelper::is_svg($this->file_loc)) {
                 $svg_size = $this->get_dimensions_svg($this->file_loc);
@@ -126,9 +150,7 @@ class ImageDimensions
             } else {
                 [$width, $height] = \getimagesize($this->file_loc);
 
-                $this->dimensions = [];
-                $this->dimensions[0] = (int) $width;
-                $this->dimensions[1] = (int) $height;
+                $this->dimensions = [(int) $width, (int) $height];
             }
 
             return $this->get_dimension_loaded($dimension);

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -301,8 +301,7 @@ class ImageHelper
     public static function _delete_generated_if_image($post_id)
     {
         if (\wp_attachment_is_image($post_id)) {
-            $attachment = Timber::get_post($post_id);
-            /** @var Attachment $attachment */
+            $attachment = Timber::get_attachment($post_id);
             if ($file_loc = $attachment->file_loc()) {
                 ImageHelper::delete_generated_files($file_loc);
             }

--- a/tests/Image/ImageDimensionsTest.php
+++ b/tests/Image/ImageDimensionsTest.php
@@ -48,4 +48,57 @@ class ImageDimensionsTest extends TimberIntegrationTestCase
         $this->assertEquals(100, $imageDimensions->width());
         $this->assertEquals(200, $imageDimensions->height());
     }
+
+    public function testDimensionsFromAttachmentMetadata()
+    {
+        $attachment_id = $this->createAttachmentWithImage();
+
+        // Override the metadata with known dimensions to confirm they come from metadata, not file.
+        $meta = \wp_get_attachment_metadata($attachment_id);
+        $meta['width'] = 640;
+        $meta['height'] = 480;
+        \wp_update_attachment_metadata($attachment_id, $meta);
+
+        $imageDimensions = new ImageDimensions('', $attachment_id);
+
+        $this->assertEquals(640, $imageDimensions->width());
+        $this->assertEquals(480, $imageDimensions->height());
+    }
+
+    public function testDimensionsFallbackToFileWhenMetadataMissingDimensions()
+    {
+        $attachment_id = $this->createAttachmentWithImage();
+        $file_loc = \get_attached_file($attachment_id);
+
+        // Remove width/height from metadata to trigger the file fallback.
+        $meta = \wp_get_attachment_metadata($attachment_id);
+        unset($meta['width'], $meta['height']);
+        \wp_update_attachment_metadata($attachment_id, $meta);
+
+        $imageDimensions = new ImageDimensions($file_loc, $attachment_id);
+
+        // Dimensions should still be readable from the file itself.
+        $this->assertIsInt($imageDimensions->width());
+        $this->assertIsInt($imageDimensions->height());
+        $this->assertGreaterThan(0, $imageDimensions->width());
+        $this->assertGreaterThan(0, $imageDimensions->height());
+    }
+
+    public function testDimensionsMetadataTakesPrecedenceOverFile()
+    {
+        $attachment_id = $this->createAttachmentWithImage();
+        $file_loc = \get_attached_file($attachment_id);
+
+        // Set metadata dimensions that differ from the actual file dimensions.
+        $meta = \wp_get_attachment_metadata($attachment_id);
+        $meta['width'] = 9999;
+        $meta['height'] = 8888;
+        \wp_update_attachment_metadata($attachment_id, $meta);
+
+        $imageDimensions = new ImageDimensions($file_loc, $attachment_id);
+
+        // Should return metadata values, not actual file dimensions.
+        $this->assertEquals(9999, $imageDimensions->width());
+        $this->assertEquals(8888, $imageDimensions->height());
+    }
 }


### PR DESCRIPTION
Related:

- #3162

## Issue

Timber reads image width and height for image attachments from the files directly by using `filesize()`. When we have attachment metadata available, we can also read from the metadata that’s available in the database.

While the issue in #3162 is also related to using a CDN, there is still a benefit to doing this for all environments.

## Solution

Provide an attachment ID to the `ImageDimensions` class when the image is an attachment image, and read from metadata if the relevant metadata exists for an image.

## Impact

- Better performance
- Fewer I/O operations and reduced server load
- If object cache is in use, image dimensions can be read even faster

## Usage Changes

None.

## Considerations

Design-wise, is it fine to add a new parameter to the `ImageDimensions` constructor, or should be do this differently? Maybe @nlemoine has thoughts.

## Testing

Yes.