### PR TITLE
feat: Add PostQuery::terms() to get terms scoped to the current query

### DIFF
--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -162,6 +162,115 @@ Or you can use a for loop:
 {%- endfor %}
 ```
 
-We make use of the `loop` variable in Twig to either display an *and* or a comma.
+We make use of the `loop` variable in Twig to either display an _and_ or a comma.
 
-See how we end the opening tag of the for-loop with `-%}` and start the closing tag with `{%-`? These are [Whitespace Controls](https://twig.symfony.com/doc/2.x/templates.html#whitespace-control) and can come in quite handy. Here, we use them to remove all the superfluous markup whitespace we don’t need.
+See how we end the opening tag of the for-loop with `-%}` and start the closing tag with `{%-`? These are [Whitespace Controls](https://twig.symfony.com/doc/2.x/templates.html#whitespace-control) and can come in quite handy. Here, we use them to remove all the superfluous markup whitespace we don’t need.## Get terms from a post collection
+
+## Get terms from a post collection
+
+When working with a collection of posts (via `Timber::get_posts()`), you can get all the terms that are associated with those posts using the `terms()` method. This is useful for creating taxonomy filters, tag clouds, or displaying all terms used across a set of posts.
+
+```php
+$posts = Timber::get_posts([
+    'post_type' => 'article',
+    'posts_per_page' => 20,
+]);
+
+// Get all terms from all taxonomies used by these posts
+$all_terms = $posts->terms();
+
+// Get only categories
+$categories = $posts->terms('category');
+
+// Get multiple taxonomies, grouped by taxonomy name
+$terms_by_taxonomy = $posts->terms(['category', 'post_tag'], ['merge' => false]);
+```
+
+In Twig, you can use the same approach:
+
+```twig
+{# Get posts #}
+{% set posts = get_posts({
+    post_type: 'project',
+    posts_per_page: 10
+}) %}
+
+{# Display all categories used in these posts as filter links #}
+<div class="filters">
+    {% for category in posts.terms('category') %}
+        <a href="{{ category.link }}" class="filter-link">
+            {{ category.name }}
+        </a>
+    {% endfor %}
+</div>
+
+{# Or group terms by taxonomy #}
+{% set terms_by_tax = posts.terms('all', {merge: false}) %}
+{% for taxonomy, terms in terms_by_tax %}
+    <h3>{{ taxonomy|title }}</h3>
+    <ul>
+        {% for term in terms %}
+            <li><a href="{{ term.link }}">{{ term.name }}</a></li>
+        {% endfor %}
+    </ul>
+{% endfor %}
+```
+
+### Parameters
+
+The `terms()` method accepts two parameters:
+
+**`$query_args`** (string|array) – Optional. Default: `[]`
+
+- A taxonomy slug as a string: `'category'`
+- An array of taxonomy slugs: `['category', 'post_tag']`
+- A full `WP_Term_Query` arguments array with additional parameters
+
+**`$options`** (array) – Optional. Default: `[]`
+
+- **`merge`** (bool) – Whether to merge terms from all taxonomies into a single array (`true`, default) or return them grouped by taxonomy name (`false`)
+
+### Examples
+
+**Get terms from a specific query**
+
+```php
+$featured_posts = Timber::get_posts([
+    'post_type' => 'post',
+    'meta_key' => 'featured',
+    'meta_value' => '1',
+]);
+
+// Get all tags used in featured posts
+$featured_tags = $featured_posts->terms('post_tag');
+```
+
+**Create a dynamic filter navigation**
+
+```twig
+{% set posts = get_posts({category_name: 'news'}) %}
+
+<nav class="tag-filters">
+    <h4>Filter by tag:</h4>
+    {% for tag in posts.terms('post_tag') %}
+        <a href="{{ tag.link }}">{{ tag.name }}</a>
+    {% endfor %}
+</nav>
+```
+
+**Get terms grouped by taxonomy**
+
+```php
+$posts = Timber::get_posts(['post_type' => 'article']);
+
+// Get terms organized by taxonomy
+$grouped_terms = $posts->terms('all', ['merge' => false]);
+
+// $grouped_terms will be an array like:
+// [
+//     'category' => [Term, Term, ...],
+//     'post_tag' => [Term, Term, ...],
+// ]
+```
+
+This feature works on both `PostQuery` objects (when querying with `WP_Query` arguments) and `PostArrayObject` (when passing an array of post IDs or existing posts to `Timber::get_posts()`).

--- a/src/CollectsTerms.php
+++ b/src/CollectsTerms.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Timber;
+
+/**
+ * Trait CollectsTerms
+ *
+ * Provides the ability to get terms from a collection of posts.
+ *
+ * @internal
+ */
+trait CollectsTerms
+{
+   /**
+    * Get terms from all posts in the collection.
+    *
+    * Get terms associated with the posts in this collection, optionally filtered by taxonomy.
+    * This is useful for creating taxonomy filters or displaying all terms used across a set of posts.
+    *
+    * @api
+    * @since 2.4.0
+    * @example
+    * ```php
+    * $posts = Timber::get_posts([
+    *     'post_type' => 'projects',
+    *     'category_name' => 'featured',
+    * ]);
+    *
+    * // Get all terms from all taxonomies
+    * $all_terms = $posts->terms();
+    *
+    * // Get terms from a specific taxonomy
+    * $categories = $posts->terms('category');
+    *
+    * // Get terms from multiple taxonomies, grouped by taxonomy
+    * $terms_by_tax = $posts->terms(['category', 'post_tag'], ['merge' => false]);
+    * ```
+    * ```twig
+    * {# Display filter links for all categories used in the collection #}
+    * {% for category in posts.terms('category') %}
+    *     <a href="{{ category.link }}">{{ category.name }}</a>
+    * {% endfor %}
+    *
+    * {# Get terms grouped by taxonomy #}
+    * {% set terms_by_taxonomy = posts.terms('all', {merge: false}) %}
+    * {% for taxonomy, terms in terms_by_taxonomy %}
+    *     <h3>{{ taxonomy }}</h3>
+    *     <ul>
+    *         {% for term in terms %}
+    *             <li>{{ term.name }}</li>
+    *         {% endfor %}
+    *     </ul>
+    * {% endfor %}
+    * ```
+    *
+    * @param string|array $query_args Optional. A taxonomy slug (string), an array of
+    *                                    taxonomy slugs, or an array of `WP_Term_Query`
+    *                                    arguments. Default `[]` (all taxonomies).
+    * @param array        $options      Optional. Configuration options. Default `[]`.
+    *                                    - **merge**: (bool) Whether to merge terms from
+    *                                      all taxonomies into a single array (`true`) or
+    *                                      return them grouped by taxonomy (`false`).
+    *                                      Default `true`.
+    * @return iterable|array An iterable of `Timber\Term` objects, or an array of
+    *                        iterables grouped by taxonomy name when `merge` is `false`.
+    */
+   public function terms($query_args = [], $options = [])
+   {
+      // Make it possible to use a taxonomy or an array of taxonomies as a shorthand.
+      if (!\is_array($query_args) || isset($query_args[0])) {
+         $query_args = [
+            'taxonomy' => $query_args,
+         ];
+      }
+
+      // Defaults.
+      $query_args = \wp_parse_args($query_args, [
+         'taxonomy' => 'all',
+      ]);
+
+      $options = \wp_parse_args($options, [
+         'merge' => true,
+      ]);
+
+      $taxonomies = $query_args['taxonomy'];
+
+      // Get all post IDs from this collection.
+      $post_ids = [];
+      foreach ($this as $post) {
+         $post_ids[] = $post->ID;
+      }
+
+      // If no posts, return empty result.
+      if (empty($post_ids)) {
+         return [];
+      }
+
+      // Determine which taxonomies to query.
+      if (\in_array($taxonomies, ['all', 'any', ''])) {
+         $post_types = $this->getPostTypesForTermQuery();
+
+         $taxonomies = [];
+         foreach ($post_types as $post_type) {
+            $taxonomies = \array_merge(
+               $taxonomies,
+               \get_object_taxonomies($post_type)
+            );
+         }
+         $taxonomies = \array_unique($taxonomies);
+      }
+
+      if (!\is_array($taxonomies)) {
+         $taxonomies = [$taxonomies];
+      }
+
+      // Build the query with all post IDs.
+      $query = \array_merge($query_args, [
+         'object_ids' => $post_ids,
+         'taxonomy' => $taxonomies,
+      ]);
+
+      return Timber::get_terms($query, $options);
+   }
+
+   /**
+    * Get the post types to use when determining which taxonomies to query.
+    *
+    * This method should be implemented by classes using this trait.
+    *
+    * @internal
+    * @return array Array of post type slugs.
+    */
+   abstract protected function getPostTypesForTermQuery();
+}

--- a/src/CollectsTerms.php
+++ b/src/CollectsTerms.php
@@ -97,7 +97,7 @@ trait CollectsTerms
 
       // Determine which taxonomies to query.
       if (\in_array($taxonomies, ['all', 'any', ''])) {
-         $post_types = $this->getPostTypesForTermQuery();
+         $post_types = $this->get_post_types_for_term_query();
 
          $taxonomies = [];
          foreach ($post_types as $post_type) {
@@ -130,5 +130,5 @@ trait CollectsTerms
     * @internal
     * @return array Array of post type slugs.
     */
-   abstract protected function getPostTypesForTermQuery();
+   abstract protected function get_post_types_for_term_query();
 }

--- a/src/PostArrayObject.php
+++ b/src/PostArrayObject.php
@@ -44,7 +44,7 @@ class PostArrayObject extends ArrayObject implements PostCollectionInterface, Js
      * @internal
      * @return array Array of post type slugs.
      */
-    protected function getPostTypesForTermQuery()
+    protected function get_post_types_for_term_query()
     {
         // Get all post types from the actual posts in this collection.
         $post_types = [];

--- a/src/PostArrayObject.php
+++ b/src/PostArrayObject.php
@@ -16,6 +16,7 @@ use WP_Post;
 class PostArrayObject extends ArrayObject implements PostCollectionInterface, JsonSerializable
 {
     use AccessesPostsLazily;
+    use CollectsTerms;
 
     /**
      * Takes an arbitrary array of WP_Posts to wrap and (lazily) translate to
@@ -35,6 +36,22 @@ class PostArrayObject extends ArrayObject implements PostCollectionInterface, Js
     public function pagination(array $options = [])
     {
         return null;
+    }
+
+    /**
+     * Get the post types to use when determining which taxonomies to query.
+     *
+     * @internal
+     * @return array Array of post type slugs.
+     */
+    protected function getPostTypesForTermQuery()
+    {
+        // Get all post types from the actual posts in this collection.
+        $post_types = [];
+        foreach ($this as $post) {
+            $post_types[] = $post->post_type;
+        }
+        return \array_unique($post_types);
     }
 
     /**

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -135,7 +135,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
      * @internal
      * @return array Array of post type slugs.
      */
-    protected function getPostTypesForTermQuery()
+    protected function get_post_types_for_term_query()
     {
         $post_types = $this->wp_query->query_vars['post_type'] ?? 'post';
         if (\is_string($post_types)) {

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -135,7 +135,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
      * This is useful for creating taxonomy filters or displaying all terms used across a set of posts.
      *
      * @api
-     * @since 2.1.0
+     * @since 2.4.0
      * @example
      * ```php
      * $posts = Timber::get_posts([

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -22,6 +22,7 @@ use WP_Query;
 class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSerializable
 {
     use AccessesPostsLazily;
+    use CollectsTerms;
 
     /**
      * Found posts.
@@ -129,118 +130,18 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     }
 
     /**
-     * Get terms from all posts in the query.
+     * Get the post types to use when determining which taxonomies to query.
      *
-     * Get terms associated with the posts in this collection, optionally filtered by taxonomy.
-     * This is useful for creating taxonomy filters or displaying all terms used across a set of posts.
-     *
-     * @api
-     * @since 2.4.0
-     * @example
-     * ```php
-     * $posts = Timber::get_posts([
-     *     'post_type' => 'projects',
-     *     'category_name' => 'featured',
-     * ]);
-     *
-     * // Get all terms from all taxonomies
-     * $all_terms = $posts->terms();
-     *
-     * // Get terms from a specific taxonomy
-     * $categories = $posts->terms('category');
-     *
-     * // Get terms from multiple taxonomies, grouped by taxonomy
-     * $terms_by_tax = $posts->terms(['category', 'post_tag'], ['merge' => false]);
-     * ```
-     * ```twig
-     * {# Display filter links for all categories used in the query #}
-     * {% for category in posts.terms('category') %}
-     *     <a href="{{ category.link }}">{{ category.name }}</a>
-     * {% endfor %}
-     *
-     * {# Get terms grouped by taxonomy #}
-     * {% set terms_by_taxonomy = posts.terms('all', {merge: false}) %}
-     * {% for taxonomy, terms in terms_by_taxonomy %}
-     *     <h3>{{ taxonomy }}</h3>
-     *     <ul>
-     *         {% for term in terms %}
-     *             <li>{{ term.name }}</li>
-     *         {% endfor %}
-     *     </ul>
-     * {% endfor %}
-     * ```
-     *
-     * @param string|array $query_args Optional. A taxonomy slug (string), an array of
-     *                                    taxonomy slugs, or an array of `WP_Term_Query`
-     *                                    arguments. Default `[]` (all taxonomies).
-     * @param array        $options      Optional. Configuration options. Default `[]`.
-     *                                    - **merge**: (bool) Whether to merge terms from
-     *                                      all taxonomies into a single array (`true`) or
-     *                                      return them grouped by taxonomy (`false`).
-     *                                      Default `true`.
-     * @return iterable|array An iterable of `Timber\Term` objects, or an array of
-     *                        iterables grouped by taxonomy name when `merge` is `false`.
+     * @internal
+     * @return array Array of post type slugs.
      */
-    public function terms($query_args = [], $options = [])
+    protected function getPostTypesForTermQuery()
     {
-        // Make it possible to use a taxonomy or an array of taxonomies as a shorthand.
-        if (!\is_array($query_args) || isset($query_args[0])) {
-            $query_args = [
-                'taxonomy' => $query_args,
-            ];
+        $post_types = $this->wp_query->query_vars['post_type'] ?? 'post';
+        if (\is_string($post_types)) {
+            $post_types = [$post_types];
         }
-
-        // Defaults.
-        $query_args = \wp_parse_args($query_args, [
-            'taxonomy' => 'all',
-        ]);
-
-        $options = \wp_parse_args($options, [
-            'merge' => true,
-        ]);
-
-        $taxonomies = $query_args['taxonomy'];
-
-        // Get all post IDs from this collection.
-        $post_ids = [];
-        foreach ($this as $post) {
-            $post_ids[] = $post->ID;
-        }
-
-        // If no posts, return empty result.
-        if (empty($post_ids)) {
-            return [];
-        }
-
-        // Determine which taxonomies to query.
-        if (\in_array($taxonomies, ['all', 'any', ''])) {
-            // Get all taxonomies for the post types in this query.
-            $post_types = $this->wp_query->query_vars['post_type'] ?? 'post';
-            if (\is_string($post_types)) {
-                $post_types = [$post_types];
-            }
-
-            $taxonomies = [];
-            foreach ($post_types as $post_type) {
-                $taxonomies = \array_merge(
-                    $taxonomies,
-                    \get_object_taxonomies($post_type)
-                );
-            }
-            $taxonomies = \array_unique($taxonomies);
-        }
-
-        if (!\is_array($taxonomies)) {
-            $taxonomies = [$taxonomies];
-        }
-
-        // Build the query with all post IDs.
-        $query = \array_merge($query_args, [
-            'object_ids' => $post_ids,
-            'taxonomy' => $taxonomies,
-        ]);
-
-        return Timber::get_terms($query, $options);
+        return $post_types;
     }
 
     /**

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -129,6 +129,131 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     }
 
     /**
+     * Get terms from all posts in the query.
+     *
+     * Get terms associated with the posts in this collection, optionally filtered by taxonomy.
+     * This is useful for creating taxonomy filters or displaying all terms used across a set of posts.
+     *
+     * @api
+     * @since 2.1.0
+     * @example
+     * ```php
+     * $posts = Timber::get_posts([
+     *     'post_type' => 'projects',
+     *     'category_name' => 'featured',
+     * ]);
+     *
+     * // Get all terms from all taxonomies
+     * $all_terms = $posts->terms();
+     *
+     * // Get terms from a specific taxonomy
+     * $categories = $posts->terms('category');
+     *
+     * // Get terms from multiple taxonomies, grouped by taxonomy
+     * $terms_by_tax = $posts->terms(['category', 'post_tag'], ['merge' => false]);
+     * ```
+     * ```twig
+     * {# Display filter links for all categories used in the query #}
+     * {% for category in posts.terms('category') %}
+     *     <a href="{{ category.link }}">{{ category.name }}</a>
+     * {% endfor %}
+     *
+     * {# Get terms grouped by taxonomy #}
+     * {% set terms_by_taxonomy = posts.terms('all', {merge: false}) %}
+     * {% for taxonomy, terms in terms_by_taxonomy %}
+     *     <h3>{{ taxonomy }}</h3>
+     *     <ul>
+     *         {% for term in terms %}
+     *             <li>{{ term.name }}</li>
+     *         {% endfor %}
+     *     </ul>
+     * {% endfor %}
+     * ```
+     *
+     * @param string|array $query_args Optional. A taxonomy slug (string), an array of
+     *                                    taxonomy slugs, or an array of `WP_Term_Query`
+     *                                    arguments. Default `[]` (all taxonomies).
+     * @param array        $options      Optional. Configuration options. Default `[]`.
+     *                                    - **merge**: (bool) Whether to merge terms from
+     *                                      all taxonomies into a single array (`true`) or
+     *                                      return them grouped by taxonomy (`false`).
+     *                                      Default `true`.
+     * @return iterable|array An iterable of `Timber\Term` objects, or an array of
+     *                        iterables grouped by taxonomy name when `merge` is `false`.
+     */
+    public function terms($query_args = [], $options = [])
+    {
+        // Make it possible to use a taxonomy or an array of taxonomies as a shorthand.
+        if (!\is_array($query_args) || isset($query_args[0])) {
+            $query_args = [
+                'taxonomy' => $query_args,
+            ];
+        }
+
+        // Defaults.
+        $query_args = \wp_parse_args($query_args, [
+            'taxonomy' => 'all',
+        ]);
+
+        $options = \wp_parse_args($options, [
+            'merge' => true,
+        ]);
+
+        $taxonomies = $query_args['taxonomy'];
+        $merge = $options['merge'];
+
+        // Get all post IDs from this collection.
+        $post_ids = [];
+        foreach ($this as $post) {
+            $post_ids[] = $post->ID;
+        }
+
+        // If no posts, return empty result.
+        if (empty($post_ids)) {
+            return $merge ? [] : [];
+        }
+
+        // Determine which taxonomies to query.
+        if (\in_array($taxonomies, ['all', 'any', ''])) {
+            // Get all taxonomies for the post types in this query.
+            $post_types = $this->wp_query->query_vars['post_type'] ?? 'post';
+            if (\is_string($post_types)) {
+                $post_types = [$post_types];
+            }
+
+            $taxonomies = [];
+            foreach ($post_types as $post_type) {
+                $taxonomies = \array_merge(
+                    $taxonomies,
+                    \get_object_taxonomies($post_type)
+                );
+            }
+            $taxonomies = \array_unique($taxonomies);
+        }
+
+        if (!\is_array($taxonomies)) {
+            $taxonomies = [$taxonomies];
+        }
+
+        // Build the query with all post IDs.
+        $query = \array_merge($query_args, [
+            'object_ids' => $post_ids,
+            'taxonomy' => $taxonomies,
+        ]);
+
+        if (!$merge) {
+            // Get results segmented out per taxonomy.
+            $queries = $this->partition_tax_queries($query, $taxonomies);
+            $termGroups = Timber::get_terms($queries);
+
+            // Zip 'em up with the right keys.
+            return \array_combine($taxonomies, $termGroups);
+        }
+
+        return Timber::get_terms($query, $options);
+    }
+
+    /**
      * Gets the original query used to get a collection of Timber posts.
      *
      * @since 2.0
@@ -195,5 +320,21 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     public function jsonSerialize()
     {
         return $this->getArrayCopy();
+    }
+
+    /**
+     * Given a base query and a list of taxonomies, return a list of queries
+     * each of which queries for one of the taxonomies.
+     *
+     * @internal
+     * @param array $query      Base query arguments.
+     * @param array $taxonomies List of taxonomy slugs.
+     * @return array Array of query arguments, one per taxonomy.
+     */
+    private function partition_tax_queries(array $query, array $taxonomies): array
+    {
+        return \array_map(fn(string $tax): array => \array_merge($query, [
+            'taxonomy' => [$tax],
+        ]), $taxonomies);
     }
 }

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -200,7 +200,6 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
         ]);
 
         $taxonomies = $query_args['taxonomy'];
-        $merge = $options['merge'];
 
         // Get all post IDs from this collection.
         $post_ids = [];
@@ -210,7 +209,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
 
         // If no posts, return empty result.
         if (empty($post_ids)) {
-            return $merge ? [] : [];
+            return [];
         }
 
         // Determine which taxonomies to query.
@@ -240,15 +239,6 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
             'object_ids' => $post_ids,
             'taxonomy' => $taxonomies,
         ]);
-
-        if (!$merge) {
-            // Get results segmented out per taxonomy.
-            $queries = $this->partition_tax_queries($query, $taxonomies);
-            $termGroups = Timber::get_terms($queries);
-
-            // Zip 'em up with the right keys.
-            return \array_combine($taxonomies, $termGroups);
-        }
 
         return Timber::get_terms($query, $options);
     }
@@ -320,21 +310,5 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     public function jsonSerialize()
     {
         return $this->getArrayCopy();
-    }
-
-    /**
-     * Given a base query and a list of taxonomies, return a list of queries
-     * each of which queries for one of the taxonomies.
-     *
-     * @internal
-     * @param array $query      Base query arguments.
-     * @param array $taxonomies List of taxonomy slugs.
-     * @return array Array of query arguments, one per taxonomy.
-     */
-    private function partition_tax_queries(array $query, array $taxonomies): array
-    {
-        return \array_map(fn(string $tax): array => \array_merge($query, [
-            'taxonomy' => [$tax],
-        ]), $taxonomies);
     }
 }

--- a/tests/PostArrayObjectTest.php
+++ b/tests/PostArrayObjectTest.php
@@ -57,7 +57,7 @@ class PostArrayObjectTest extends TimberIntegrationTestCase
             $postTypeCounts[$post->post_type]++;
             return Post::class;
         };
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'post' => $callback,
             'page' => $callback,
         ]);
@@ -109,7 +109,7 @@ class PostArrayObjectTest extends TimberIntegrationTestCase
             $postTypeCounts[$post->post_type]++;
             return Post::class;
         };
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'post' => $callback,
             'page' => $callback,
         ]);
@@ -187,7 +187,7 @@ class PostArrayObjectTest extends TimberIntegrationTestCase
             'post_type' => 'post',
         ]);
 
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'post' => CollectionTestPost::class,
             'page' => CollectionTestPage::class,
             'custom' => CollectionTestCustom::class,
@@ -220,7 +220,7 @@ class PostArrayObjectTest extends TimberIntegrationTestCase
             ],
         ]);
 
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'funke' => SerializablePost::class,
         ]);
 
@@ -235,5 +235,204 @@ class PostArrayObjectTest extends TimberIntegrationTestCase
                 'how_many_of_us' => 'DOZENS',
             ],
         ], \json_decode(\json_encode($coll), true));
+    }
+
+    public function testPostArrayObjectTermsBasic()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'News',
+            'taxonomy' => 'category',
+        ]);
+        $cat2 = static::factory()->term->create([
+            'name' => 'Reviews',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Featured',
+            'taxonomy' => 'post_tag',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        $post2 = static::factory()->post->create();
+        $post3 = static::factory()->post->create();
+
+        \wp_set_object_terms($post1, [$cat1, $tag1], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+        \wp_set_object_terms($post2, [$cat2], 'category');
+        \wp_set_object_terms($post3, [$cat1], 'category');
+
+        $wp_posts = \get_posts([
+            'post__in' => [$post1, $post2, $post3],
+        ]);
+
+        $collection = new PostArrayObject($wp_posts);
+
+        // Get all terms (merged).
+        $all_terms = $collection->terms();
+        $this->assertCount(3, $all_terms); // 2 categories + 1 tag
+
+        // Verify we got the right terms.
+        $term_names = \array_map(fn($term) => $term->name, \iterator_to_array($all_terms));
+        $this->assertContains('News', $term_names);
+        $this->assertContains('Reviews', $term_names);
+        $this->assertContains('Featured', $term_names);
+    }
+
+    public function testPostArrayObjectTermsSpecificTaxonomy()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'Category A',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Tag A',
+            'taxonomy' => 'post_tag',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        \wp_set_object_terms($post1, [$cat1], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+
+        $wp_posts = \get_posts([
+            'post__in' => [$post1],
+        ]);
+
+        $collection = new PostArrayObject($wp_posts);
+
+        // Get only categories.
+        $categories = $collection->terms('category');
+        $this->assertCount(1, $categories);
+        $cat_array = \iterator_to_array($categories);
+        $this->assertEquals('Category A', $cat_array[0]->name);
+
+        // Get only tags.
+        $tags = $collection->terms('post_tag');
+        $this->assertCount(1, $tags);
+        $tag_array = \iterator_to_array($tags);
+        $this->assertEquals('Tag A', $tag_array[0]->name);
+    }
+
+    public function testPostArrayObjectTermsMultipleTaxonomies()
+    {
+        \register_taxonomy('project_type', 'post');
+
+        $cat1 = static::factory()->term->create([
+            'name' => 'Cat 1',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Tag 1',
+            'taxonomy' => 'post_tag',
+        ]);
+        $type1 = \wp_insert_term('Type 1', 'project_type');
+
+        $post1 = static::factory()->post->create();
+        \wp_set_object_terms($post1, [$cat1], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+        \wp_set_object_terms($post1, [$type1['term_id']], 'project_type');
+
+        $wp_posts = \get_posts([
+            'post__in' => [$post1],
+        ]);
+
+        $collection = new PostArrayObject($wp_posts);
+
+        // Get terms from multiple taxonomies (merged).
+        $terms = $collection->terms(['category', 'post_tag']);
+        $this->assertCount(2, $terms);
+    }
+
+    public function testPostArrayObjectTermsGroupedByTaxonomy()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'News',
+            'taxonomy' => 'category',
+        ]);
+        $cat2 = static::factory()->term->create([
+            'name' => 'Reviews',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Featured',
+            'taxonomy' => 'post_tag',
+        ]);
+        $tag2 = static::factory()->term->create([
+            'name' => 'Popular',
+            'taxonomy' => 'post_tag',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        $post2 = static::factory()->post->create();
+
+        \wp_set_object_terms($post1, [$cat1, $cat2], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+        \wp_set_object_terms($post2, [$cat1], 'category');
+        \wp_set_object_terms($post2, [$tag2], 'post_tag');
+
+        $wp_posts = \get_posts([
+            'post__in' => [$post1, $post2],
+        ]);
+
+        $collection = new PostArrayObject($wp_posts);
+
+        // Get terms grouped by taxonomy.
+        $terms_by_tax = $collection->terms(['category', 'post_tag'], ['merge' => false]);
+
+        $this->assertIsArray($terms_by_tax);
+        $this->assertArrayHasKey('category', $terms_by_tax);
+        $this->assertArrayHasKey('post_tag', $terms_by_tax);
+        $this->assertCount(2, $terms_by_tax['category']); // News, Reviews
+        $this->assertCount(2, $terms_by_tax['post_tag']); // Featured, Popular
+    }
+
+    public function testPostArrayObjectTermsWithEmptyCollection()
+    {
+        $collection = new PostArrayObject([]);
+
+        $terms = $collection->terms();
+        $this->assertEmpty($terms);
+
+        // Test with merge = false.
+        $terms_grouped = $collection->terms('all', ['merge' => false]);
+        $this->assertIsArray($terms_grouped);
+        $this->assertEmpty($terms_grouped);
+    }
+
+    public function testPostArrayObjectTermsWithMixedPostTypes()
+    {
+        \register_taxonomy('team', 'post');
+        \register_post_type('project', [
+            'public' => true,
+            'taxonomies' => ['category'],
+        ]);
+
+        $cat1 = static::factory()->term->create([
+            'name' => 'News',
+            'taxonomy' => 'category',
+        ]);
+        $team1 = \wp_insert_term('Patriots', 'team');
+
+        $post1 = static::factory()->post->create(['post_type' => 'post']);
+        $project1 = static::factory()->post->create(['post_type' => 'project']);
+
+        \wp_set_object_terms($post1, [$team1['term_id']], 'team');
+        // Explicitly remove default category from post1
+        \wp_set_object_terms($post1, [], 'category');
+        \wp_set_object_terms($project1, [$cat1], 'category');
+
+        $wp_posts = \array_merge(
+            \get_posts(['post__in' => [$post1], 'post_type' => 'post']),
+            \get_posts(['post__in' => [$project1], 'post_type' => 'project'])
+        );
+
+        $collection = new PostArrayObject($wp_posts);
+
+        // Get all terms from all post types in the collection.
+        $all_terms = $collection->terms();
+        $this->assertCount(2, $all_terms); // 1 team + 1 category
+
+        $term_names = \array_map(fn($term) => $term->name, \iterator_to_array($all_terms));
+        $this->assertContains('Patriots', $term_names);
+        $this->assertContains('News', $term_names);
     }
 }

--- a/tests/PostQueryTest.php
+++ b/tests/PostQueryTest.php
@@ -336,7 +336,7 @@ class PostQueryTest extends TimberIntegrationTestCase
             $postTypeCounts[$post->post_type]++;
             return Post::class;
         };
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'post' => $callback,
             'page' => $callback,
         ]);
@@ -388,7 +388,7 @@ class PostQueryTest extends TimberIntegrationTestCase
             $postTypeCounts[$post->post_type]++;
             return Post::class;
         };
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'post' => $callback,
             'page' => $callback,
         ]);
@@ -441,7 +441,7 @@ class PostQueryTest extends TimberIntegrationTestCase
             'post_type' => 'post',
         ]);
 
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'post' => CollectionTestPost::class,
             'page' => CollectionTestPage::class,
             'custom' => CollectionTestCustom::class,
@@ -468,7 +468,7 @@ class PostQueryTest extends TimberIntegrationTestCase
             ],
         ]);
 
-        $this->add_filter_temporarily('timber/post/classmap', fn () => [
+        $this->add_filter_temporarily('timber/post/classmap', fn() => [
             'funke' => SerializablePost::class,
         ]);
 
@@ -481,5 +481,254 @@ class PostQueryTest extends TimberIntegrationTestCase
                 'how_many_of_us' => 'DOZENS',
             ],
         ], \json_decode(\json_encode($query), true));
+    }
+
+    public function testPostQueryTermsBasic()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'News',
+            'taxonomy' => 'category',
+        ]);
+        $cat2 = static::factory()->term->create([
+            'name' => 'Reviews',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Featured',
+            'taxonomy' => 'post_tag',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        $post2 = static::factory()->post->create();
+        $post3 = static::factory()->post->create();
+
+        \wp_set_object_terms($post1, [$cat1, $tag1], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+        \wp_set_object_terms($post2, [$cat2], 'category');
+        \wp_set_object_terms($post3, [$cat1], 'category');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1, $post2, $post3],
+        ]));
+
+        // Get all terms (merged).
+        $all_terms = $query->terms();
+        $this->assertCount(3, $all_terms); // 2 categories + 1 tag
+
+        // Verify we got the right terms.
+        $term_names = \array_map(fn($term) => $term->name, \iterator_to_array($all_terms));
+        $this->assertContains('News', $term_names);
+        $this->assertContains('Reviews', $term_names);
+        $this->assertContains('Featured', $term_names);
+    }
+
+    public function testPostQueryTermsSpecificTaxonomy()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'Category A',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Tag A',
+            'taxonomy' => 'post_tag',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        \wp_set_object_terms($post1, [$cat1], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1],
+        ]));
+
+        // Get only categories.
+        $categories = $query->terms('category');
+        $this->assertCount(1, $categories);
+        $cat_array = \iterator_to_array($categories);
+        $this->assertEquals('Category A', $cat_array[0]->name);
+
+        // Get only tags.
+        $tags = $query->terms('post_tag');
+        $this->assertCount(1, $tags);
+        $tag_array = \iterator_to_array($tags);
+        $this->assertEquals('Tag A', $tag_array[0]->name);
+    }
+
+    public function testPostQueryTermsMultipleTaxonomies()
+    {
+        \register_taxonomy('project_type', 'post');
+
+        $cat1 = static::factory()->term->create([
+            'name' => 'Cat 1',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Tag 1',
+            'taxonomy' => 'post_tag',
+        ]);
+        $type1 = \wp_insert_term('Type 1', 'project_type');
+
+        $post1 = static::factory()->post->create();
+        \wp_set_object_terms($post1, [$cat1], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+        \wp_set_object_terms($post1, [$type1['term_id']], 'project_type');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1],
+        ]));
+
+        // Get terms from multiple taxonomies (merged).
+        $terms = $query->terms(['category', 'post_tag']);
+        $this->assertCount(2, $terms);
+    }
+
+    public function testPostQueryTermsGroupedByTaxonomy()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'News',
+            'taxonomy' => 'category',
+        ]);
+        $cat2 = static::factory()->term->create([
+            'name' => 'Reviews',
+            'taxonomy' => 'category',
+        ]);
+        $tag1 = static::factory()->term->create([
+            'name' => 'Featured',
+            'taxonomy' => 'post_tag',
+        ]);
+        $tag2 = static::factory()->term->create([
+            'name' => 'Popular',
+            'taxonomy' => 'post_tag',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        $post2 = static::factory()->post->create();
+
+        \wp_set_object_terms($post1, [$cat1, $cat2], 'category');
+        \wp_set_object_terms($post1, [$tag1], 'post_tag');
+        \wp_set_object_terms($post2, [$cat1], 'category');
+        \wp_set_object_terms($post2, [$tag2], 'post_tag');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1, $post2],
+        ]));
+
+        // Get terms grouped by taxonomy.
+        $terms_by_tax = $query->terms(['category', 'post_tag'], ['merge' => false]);
+
+        $this->assertIsArray($terms_by_tax);
+        $this->assertArrayHasKey('category', $terms_by_tax);
+        $this->assertArrayHasKey('post_tag', $terms_by_tax);
+        $this->assertCount(2, $terms_by_tax['category']); // News, Reviews
+        $this->assertCount(2, $terms_by_tax['post_tag']); // Featured, Popular
+    }
+
+    public function testPostQueryTermsWithEmptyQuery()
+    {
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [999999], // Non-existent post
+        ]));
+
+        $terms = $query->terms();
+        $this->assertEmpty($terms);
+
+        // Test with merge = false.
+        $terms_grouped = $query->terms('all', ['merge' => false]);
+        $this->assertIsArray($terms_grouped);
+        $this->assertEmpty($terms_grouped);
+    }
+
+    public function testPostQueryTermsWithCustomTaxonomy()
+    {
+        \register_taxonomy('team', 'post');
+
+        $team1 = \wp_insert_term('Patriots', 'team');
+        $team2 = \wp_insert_term('Bills', 'team');
+
+        $post1 = static::factory()->post->create();
+        $post2 = static::factory()->post->create();
+
+        \wp_set_object_terms($post1, [$team1['term_id']], 'team');
+        \wp_set_object_terms($post2, [$team2['term_id']], 'team');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1, $post2],
+        ]));
+
+        $teams = $query->terms('team');
+        $this->assertCount(2, $teams);
+
+        $team_names = \array_map(fn($term) => $term->name, \iterator_to_array($teams));
+        $this->assertContains('Patriots', $team_names);
+        $this->assertContains('Bills', $team_names);
+    }
+
+    public function testPostQueryTermsUniqueness()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'Shared Category',
+            'taxonomy' => 'category',
+        ]);
+
+        // Create multiple posts with the same category.
+        $post1 = static::factory()->post->create();
+        $post2 = static::factory()->post->create();
+        $post3 = static::factory()->post->create();
+
+        \wp_set_object_terms($post1, [$cat1], 'category');
+        \wp_set_object_terms($post2, [$cat1], 'category');
+        \wp_set_object_terms($post3, [$cat1], 'category');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1, $post2, $post3],
+        ]));
+
+        $terms = $query->terms('category');
+        // Should only return 1 term even though 3 posts share it.
+        $this->assertCount(1, $terms);
+
+        $term_array = \iterator_to_array($terms);
+        $this->assertEquals('Shared Category', $term_array[0]->name);
+    }
+
+    public function testPostQueryTermsWithQueryArgs()
+    {
+        $cat1 = static::factory()->term->create([
+            'name' => 'Zebra',
+            'taxonomy' => 'category',
+        ]);
+        $cat2 = static::factory()->term->create([
+            'name' => 'Apple',
+            'taxonomy' => 'category',
+        ]);
+        $cat3 = static::factory()->term->create([
+            'name' => 'Banana',
+            'taxonomy' => 'category',
+        ]);
+
+        $post1 = static::factory()->post->create();
+        \wp_set_object_terms($post1, [$cat1, $cat2, $cat3], 'category');
+
+        $query = new PostQuery(new WP_Query([
+            'post_type' => 'post',
+            'post__in' => [$post1],
+        ]));
+
+        // Test ordering.
+        $terms = $query->terms([
+            'taxonomy' => 'category',
+            'orderby' => 'name',
+            'order' => 'ASC',
+        ]);
+
+        $term_names = \array_map(fn($term) => $term->name, \iterator_to_array($terms));
+        $this->assertEquals(['Apple', 'Banana', 'Zebra'], $term_names);
     }
 }


### PR DESCRIPTION
Related:

- #3211

## Issue

When building taxonomy filters alongside a `PostQuery`, calling `Timber::get_terms()` with a taxonomy returns *all* terms in that taxonomy — not just the ones actually used by posts in the current query. Developers had to manually loop over every post, collect term IDs per taxonomy, and then fire a second `get_terms()` call per taxonomy to work around this.

## Solution

Add a `terms()` method to `PostQuery` that returns only the terms attached to the posts in the collection.

Internally it collects the IDs of all posts in the `PostQuery` and passes them as `object_ids` to `WP_Term_Query` via `Timber::get_terms()`. This narrows the result to only terms that are actually used.

The signature mirrors `Timber::get_terms()` and supports the same `merge` option (already introduced in #3213 / PR #3226) so results can be returned either as a flat merged list or grouped by taxonomy:

```php
$posts = Timber::get_posts([
    'post_type'     => 'projects',
    'category_name' => 'featured',
]);

// All terms from all taxonomies (merged flat list).
$all_terms = $posts->terms();

// Only categories used by these posts.
$categories = $posts->terms('category');

// Terms grouped by taxonomy.
$filters = $posts->terms(['category', 'post_tag'], ['merge' => false]);
```

```twig
{# Flat list #}
{% for category in posts.terms('category') %}
    <a href="{{ category.link }}">{{ category.name }}</a>
{% endfor %}

{# Grouped by taxonomy #}
{% set filters = posts.terms('all', {merge: false}) %}
{% for taxonomy, terms in filters %}
    <h3>{{ taxonomy }}</h3>
    {% for term in terms %}{{ term.name }}{% endfor %}
{% endfor %}
```

The grouping work is delegated entirely to `TermFactory::maybe_group_by_taxonomy()`, so `PostQuery` contains no duplicate logic.

## Impact

- **New API**: `PostQuery::terms()` is a new public method
- **No breaking changes**: existing code is unaffected.
- **Performance**: one `WP_Term_Query` call scoped to the post IDs already in memory, replacing the multi-query manual workaround.

## Usage Changes

`PostQuery` gains a `terms()` method. No existing method signatures are changed.

```php
// Before (manual workaround from the issue):
$query_taxonomies = [];
foreach ($posts as $post) {
    foreach ($post->terms() as $term) {
        $query_taxonomies[$term->taxonomy][$term->id] = $term->id;
    }
}
foreach ($query_taxonomies as $tax => $ids) {
    $context['filters'][$tax] = Timber::get_terms(['taxonomy' => $tax, 'include' => $ids]);
}

// After:
$context['filters'] = $posts->terms('all', ['merge' => false]);
```

## Considerations


## Testing

Eight integration tests are added to `PostQueryTest`:

| Test | What it verifies |
|---|---|
| `testPostQueryTermsBasic` | Returns only terms used by the queried posts across all taxonomies |
| `testPostQueryTermsSpecificTaxonomy` | Filters to a single taxonomy |
| `testPostQueryTermsMultipleTaxonomies` | Accepts an array of taxonomy names |
| `testPostQueryTermsGroupedByTaxonomy` | `merge => false` returns results keyed by taxonomy |
| `testPostQueryTermsWithEmptyQuery` | Returns `[]` when the query has no posts |
| `testPostQueryTermsWithCustomTaxonomy` | Works with custom registered taxonomies |
| `testPostQueryTermsUniqueness` | A term shared by many posts appears only once |
| `testPostQueryTermsWithQueryArgs` | Full `WP_Term_Query` args (e.g. `orderby`) pass through correctly |

All 27 `PostQueryTest` tests pass.
