### PR TITLE
docs: Update links in documentation and fix spelling mistakes

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            **/*.php
 
       - name: Run coding standards
         if: steps.changed-files.outputs.all_changed_files != ''

--- a/docs/v1/getting-started/switch-to-composer.md
+++ b/docs/v1/getting-started/switch-to-composer.md
@@ -15,23 +15,26 @@ With the release of Timber 2.0, Composer is the only supported install method. W
 6. Check if your website still runs as expected
 7. Deploy your changes to your live website
 
-
 ### 1. Get a local development version of your website up and running
-We highly recommend doing these steps on a local development version of your website. If you don’t have one yet, you could use [Local by Flywheel](https://localbyflywheel.com/) to get one up and running in a few minutes.
+
+We highly recommend doing these steps on a local development version of your website. If you don't have one yet, you could use [Local by Flywheel](https://localwp.com/) to get one up and running in a few minutes.
 
 #### 1.1 How to install Composer
+
 If you don’t have Composer installed yet, you can follow the [official installation guide](https://getcomposer.org/doc/00-intro.md).
 
-
 ### 2. Check if you are running the latest version of the Timber plugin
+
 We want to make sure that you are running the latest version of the Timber plugin before we start the upgrade process. This way we can be sure that any issues that might occur are not caused by an outdated version of the plugin.
 
 ### 3. Disable the Timber plugin
+
 Once you are sure that you are running the latest version of the Timber plugin, you can disable it. This will make sure that the plugin is not loaded anymore and does not interfere with the Composer based version of Timber.
 
 Please note that you website will throw errors at this point, as there is no Timber available. This will be fixed in the next two steps.
 
 ### 4. Install the latest 1.x version of Timber via Composer
+
 Now that the plugin is disabled, you can install the latest 1.x version of Timber via Composer. You can do this by navigating to your site's active theme folder inside your terminal and then running the following command:
 
 ```shell
@@ -43,10 +46,11 @@ If Composer gives you the following notice:
 ```shell
 composer/installers contains a Composer plugin [...] (writes "allow-plugins" to composer.json)
 ```
+
 it is safe to answer `y` to this question and press enter.
 
-
 ### 5. Load the Composer autoloader and initialize Timber
+
 Now that we have Timber installed via Composer, we need to load the Composer autoloader and initialize Timber. You can do this by adding the following code at the top of your **functions.php** file:
 
 ```php
@@ -57,9 +61,11 @@ $timber = new Timber\Timber();
 ```
 
 ### 6. Check if your website still runs as expected
+
 Now that you have Timber installed via Composer, you can check if your website still runs as expected. If you run into any issues, please try to solve them yourself by activating [WordPress debugging](https://wordpress.org/documentation/article/debugging-in-wordpress/) and checking the error logs.
 
 ### 7. Deploy your changes to your live website
+
 When you are 100% sure that you have successfully upgraded your theme in the development website to the Composer based version of Timber, you can deploy your theme changes to your live website.
 
 Make sure that the new **vendor** folder inside your theme gets deployed as well. If you are using a deployment pipeline, you can commit your changes and push to your live website.

--- a/docs/v1/getting-started/theming.md
+++ b/docs/v1/getting-started/theming.md
@@ -48,7 +48,9 @@ We can do it like this in Twig:
 WordPress wants you to interact with its API in a certain way, which sucks. Because soon you get things like:
 
 ```html
-<h1 class="article-h1"><a href="<?php get_permalink(); ?>"><?php the_title(); ?></a></h1>
+<h1 class="article-h1">
+  <a href="<?php get_permalink(); ?>"><?php the_title(); ?></a>
+</h1>
 ```
 
 Okay, not _too_ terrible, but doesn’t this (Timber) way look so much nicer?
@@ -151,7 +153,7 @@ This is where we are going to handle the logic that powers our index file. Let�
 $context = Timber::context();
 ```
 
-This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you’ll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/master/lib/Timber.php) to inspect for yourself.
+This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you'll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what's inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/1.x/lib/Timber.php) to inspect for yourself.
 
 ### Grab your posts
 
@@ -189,7 +191,7 @@ $args = array(
 $context['posts'] = Timber::get_posts( $args );
 ```
 
-You can find all available options in the documentation for [WP_Query](https://codex.wordpress.org/Class_Reference/WP_Query).
+You can find all available options in the documentation for [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/).
 
 ### Use a WP_Query string
 

--- a/docs/v1/getting-started/theming.md
+++ b/docs/v1/getting-started/theming.md
@@ -153,7 +153,7 @@ This is where we are going to handle the logic that powers our index file. Let�
 $context = Timber::context();
 ```
 
-This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you'll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what's inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/1.x/lib/Timber.php) to inspect for yourself.
+This is going to return an object with a lot of the common things we need across the site. Things like the site name, the description or the navigation menu you’ll want to start with each time (even if you over-write them later). You can do a `print_r( $context );` to see what’s inside or open-up [**Timber.php**](https://github.com/timber/timber/blob/1.x/lib/Timber.php) to inspect for yourself.
 
 ### Grab your posts
 

--- a/docs/v1/getting-started/twig-tools.md
+++ b/docs/v1/getting-started/twig-tools.md
@@ -10,7 +10,6 @@ The purpose of this page is to identify helpful tools for working with Twig.
 - Emacs – [Web Mode](https://web-mode.org/)
 - Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
 - PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](https://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
-- Atom – Syntax highlighting with the [Atom Component](https://github.blog/news-insights/product-news/sunsetting-atom/).
 
 ## WordPress tools
 

--- a/docs/v1/getting-started/twig-tools.md
+++ b/docs/v1/getting-started/twig-tools.md
@@ -6,22 +6,21 @@ The purpose of this page is to identify helpful tools for working with Twig.
 
 ## Text editor add-ons
 
-* Text Mate & Sublime text bundle – [Anomareh's PHP-Twig](https://github.com/Anomareh/PHP-Twig.tmbundle)
-* Emacs – [Web Mode](https://web-mode.org/)
-* Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
-* PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](https://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
-* Atom – Syntax highlighting with the [Atom Component](https://atom.io/packages/php-twig).
+- Text Mate & Sublime text bundle – [Anomareh's PHP-Twig](https://github.com/uhnomoli/PHP-Twig.tmbundle)
+- Emacs – [Web Mode](https://web-mode.org/)
+- Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
+- PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](https://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
+- Atom – Syntax highlighting with the [Atom Component](https://github.blog/news-insights/product-news/sunsetting-atom/).
 
 ## WordPress tools
 
-* [Lisa Templates](https://github.com/pierreminik/lisa-templates/) – allows you to write Twig-templates in the WordPress admin that renders through a shortcode, widget or on the_content hook.
-	
+- [Lisa Templates](https://github.com/pierreminik/lisa-templates/) – allows you to write Twig-templates in the WordPress admin that renders through a shortcode, widget or on the_content hook.
 
 ## Other
 
- * [Watson-Ruby](https://nhmood.github.io/watson-ruby/) – An inline issue manager. Put tags like `[todo]` in a Twig comment and find it easily later. Watson supports Twig as of version 1.6.3.
+- [Watson-Ruby](https://nhmood.github.io/watson-ruby/) – An inline issue manager. Put tags like `[todo]` in a Twig comment and find it easily later. Watson supports Twig as of version 1.6.3.
 
 ## JavaScript
 
-* [Twig.js](https://github.com/justjohn/twig.js) – Use those `.twig` files in the Javascript and AJAX components of your site.
-* [Nunjucks](https://mozilla.github.io/nunjucks/) – Another JS template language that is also based on [Jinja2](https://jinja.pocoo.org/docs/)
+- [Twig.js](https://github.com/twigjs/twig.js) – Use those `.twig` files in the Javascript and AJAX components of your site.
+- [Nunjucks](https://mozilla.github.io/nunjucks/) – Another JS template language that is also based on [Jinja2](https://jinja.palletsprojects.com/)

--- a/docs/v1/guides/acf-cookbook.md
+++ b/docs/v1/guides/acf-cookbook.md
@@ -14,8 +14,8 @@ While data saved by ACF is available via `{{ post.my_acf_field }}` you will ofte
      {{ post.meta('my_wysiwyg_field') }}
 </div>
 ```
-This will apply your expected paragraph breaks and other pre-processing to the text. In the past we used `{{ post.get_field('my_wysiwyg_field') }}`, but this is now deprecated. Use `{{ post.meta('my_wysiwyg_field') }}`.
 
+This will apply your expected paragraph breaks and other pre-processing to the text. In the past we used `{{ post.get_field('my_wysiwyg_field') }}`, but this is now deprecated. Use `{{ post.meta('my_wysiwyg_field') }}`.
 
 ## Image field
 
@@ -51,7 +51,7 @@ You can now use all the above functions to transform your custom images in the s
 <img src="{{ post.hero_image.src | resize(500, 300) }}" />
 ```
 
-* * *
+---
 
 ## Gallery field
 
@@ -61,20 +61,24 @@ You can now use all the above functions to transform your custom images in the s
 {% endfor %}
 ```
 
-* * *
+---
 
 ## Group field
+
 ```twig
 {{ post.meta('group').first_field }}
 {{ post.meta('group').second_field }}
 ```
+
 or
+
 ```twig
 {% set group = post.meta('group') %}
 {{ group.first_field }}
 {{ group.second_field }}
 ```
-* * *
+
+---
 
 ## Relationship field
 
@@ -87,7 +91,7 @@ The post data returned from a relationship field will not contain the Timber met
 {% endfor %}
 ```
 
-* * *
+---
 
 ## Repeater field
 
@@ -148,7 +152,7 @@ A common problem in working with repeaters is that you should only call the `met
 {% endfor %}
 ```
 
-* * *
+---
 
 ## Flexible Content field
 
@@ -167,7 +171,7 @@ Similar to repeaters, get the field by the name of the flexible content field:
 {% endfor %}
 ```
 
-* * *
+---
 
 ## Options Page
 
@@ -217,7 +221,7 @@ Now, you can use any of the option fields across the site instead of per templat
 <footer>{{ options.copyright_info }}</footer>
 ```
 
-* * *
+---
 
 ## Getting ACF info
 
@@ -233,11 +237,11 @@ $context["acf"] = get_field_objects($data["post"]->ID);
 {{ acf.your_field_name_here.label }}
 ```
 
-* * *
+---
 
 ## Query by custom field value
 
-This example that uses a [WP_Query](https://codex.wordpress.org/Class_Reference/WP_Query) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.
+This example that uses a [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.
 
 ```php
 <?php
@@ -249,4 +253,5 @@ $args = array(
 );
 $context['posts'] = Timber::get_posts($args);
 ```
-* * *
+
+---

--- a/docs/v1/guides/cookbook-images.md
+++ b/docs/v1/guides/cookbook-images.md
@@ -26,7 +26,7 @@ Note: If the WordPress size (e.g `medium`) has not been generated, it will retur
 
 ## Arbitrary resizing of images
 
-Want to resize an image? Here we're going to use [Twig Filters](https://twig.symfony.com/doc/2.x/filters/index.html).
+Want to resize an image? Here we’re going to use [Twig Filters](https://twig.symfony.com/doc/2.x/filters/index.html).
 
 ```twig
 <img src="{{ post.thumbnail.src|resize(300, 200) }}" />

--- a/docs/v1/guides/cookbook-images.md
+++ b/docs/v1/guides/cookbook-images.md
@@ -26,7 +26,7 @@ Note: If the WordPress size (e.g `medium`) has not been generated, it will retur
 
 ## Arbitrary resizing of images
 
-Want to resize an image? Here we're going to use [Twig Filters](https://twig.symfony.com/doc/3.x/filters/index.html).
+Want to resize an image? Here we're going to use [Twig Filters](https://twig.symfony.com/doc/2.x/filters/index.html).
 
 ```twig
 <img src="{{ post.thumbnail.src|resize(300, 200) }}" />

--- a/docs/v1/guides/cookbook-images.md
+++ b/docs/v1/guides/cookbook-images.md
@@ -26,7 +26,7 @@ Note: If the WordPress size (e.g `medium`) has not been generated, it will retur
 
 ## Arbitrary resizing of images
 
-Want to resize an image? Here we’re going to use [Twig Filters](https://twig.symfony.com/doc/filters/index.html).
+Want to resize an image? Here we're going to use [Twig Filters](https://twig.symfony.com/doc/3.x/filters/index.html).
 
 ```twig
 <img src="{{ post.thumbnail.src|resize(300, 200) }}" />

--- a/docs/v1/guides/custom-page-templates.md
+++ b/docs/v1/guides/custom-page-templates.md
@@ -8,7 +8,7 @@ There are a few ways to manage custom pages in WordPress and Timber, in order fr
 
 ## Custom Twig File
 
-If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can:
+If you’re using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can:
 
 - Create a file called `page-about-us.twig` inside your `views` and go crazy.
 - Copy and paste the contents of [`page.twig`](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.

--- a/docs/v1/guides/custom-page-templates.md
+++ b/docs/v1/guides/custom-page-templates.md
@@ -8,10 +8,10 @@ There are a few ways to manage custom pages in WordPress and Timber, in order fr
 
 ## Custom Twig File
 
-If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can 
+If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can:
 
-* Create a file called `page-about-us.twig` inside your `views` and go crazy.
-* Copy and paste the contents of [`page.twig`](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
+- Create a file called `page-about-us.twig` inside your `views` and go crazy.
+- Copy and paste the contents of [`page.twig`](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
 
 **How does this work?**
 
@@ -29,7 +29,7 @@ This is telling PHP to first look for a Twig file named `page-{{slug}}.twig` and
 
 ## Custom PHP File
 
-If you need to do something special for a page in PHP, you can use the standard WordPress [template hierarchy](https://codex.wordpress.org/Template_Hierarchy) to gather and manipulate data for this page. In the example above, you would create a file
+If you need to do something special for a page in PHP, you can use the standard WordPress [template hierarchy](https://developer.wordpress.org/themes/classic-themes/basics/template-hierarchy/) to gather and manipulate data for this page. In the example above, you would create a file
 
 `/wp-content/themes/my-theme/page-about-us.php`
 
@@ -53,5 +53,5 @@ In the WordPress admin, a new entry will be added in your page’s list of avail
 
 ![](https://codex.wordpress.org/images/thumb/a/a3/page-templates-pulldown-screenshot.png/180px-page-templates-pulldown-screenshot.png)
 
-* Name it something like `/wp-content/themes/my-theme/template-my-custom-page.php`.
-* Do **NOT** prefix the filename with `page-` or WordPress will get very confused due to [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page).
+- Name it something like `/wp-content/themes/my-theme/template-my-custom-page.php`.
+- Do **NOT** prefix the filename with `page-` or WordPress will get very confused due to [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page).

--- a/docs/v1/guides/escapers.md
+++ b/docs/v1/guides/escapers.md
@@ -14,7 +14,7 @@ if ( class_exists('Timber') ) {
 
 ## General Escapers
 
-Twig offers a variety of [escapers](https://twig.symfony.com/doc/3.x/filters/escape.html) out of the box. These are intended to escape a string for safe insertion into the final output and there are multiple functions to conform to the strategy dependant on the context. In addition, Timber has added some valuable custom escapers for your WP theme. To use the escaper (see documentation link above) you use pipe your content through a function `e` if you want to use a custom escaper you would supply an argument to the function, e.g. `e('wp_kses_post')`
+Twig offers a variety of [escapers](https://twig.symfony.com/doc/2.x/filters/escape.html) out of the box. These are intended to escape a string for safe insertion into the final output and there are multiple functions to conform to the strategy dependant on the context. In addition, Timber has added some valuable custom escapers for your WP theme. To use the escaper (see documentation link above) you use pipe your content through a function `e` if you want to use a custom escaper you would supply an argument to the function, e.g. `e('wp_kses_post')`
 
 This all follows the WordPress (and greater development philosophy) to:
 

--- a/docs/v1/guides/escapers.md
+++ b/docs/v1/guides/escapers.md
@@ -4,7 +4,7 @@ title: "Escapers"
 
 ## Universal Escaping
 
-By default, Timber does *not* escape the output of standard tags (i.e. `{{ post.field }}`). If you want to enable `autoescape` behavior simply add these lines to `functions.php`:
+By default, Timber does _not_ escape the output of standard tags (i.e. `{{ post.field }}`). If you want to enable `autoescape` behavior simply add these lines to `functions.php`:
 
 ```php
 if ( class_exists('Timber') ) {
@@ -14,7 +14,7 @@ if ( class_exists('Timber') ) {
 
 ## General Escapers
 
-Twig offers a variety of [escapers](https://twig.symfony.com/doc/filters/escape.html) out of the box. These are intended to escape a string for safe insertion into the final output and there are multiple functions to conform to the strategy dependant on the context. In addition, Timber has added some valuable custom escapers for your WP theme. To use the escaper (see documentation link above) you use pipe your content through a function `e` if you want to use a custom escaper you would supply an argument to the function, e.g. `e('wp_kses_post')`
+Twig offers a variety of [escapers](https://twig.symfony.com/doc/3.x/filters/escape.html) out of the box. These are intended to escape a string for safe insertion into the final output and there are multiple functions to conform to the strategy dependant on the context. In addition, Timber has added some valuable custom escapers for your WP theme. To use the escaper (see documentation link above) you use pipe your content through a function `e` if you want to use a custom escaper you would supply an argument to the function, e.g. `e('wp_kses_post')`
 
 This all follows the WordPress (and greater development philosophy) to:
 
@@ -26,13 +26,13 @@ This all follows the WordPress (and greater development philosophy) to:
 6. Sanitation is okay, but validation/rejection is better.
 7. Never trust user input.
 
-[Relevant Documentation](https://vip.wordpress.com/documentation/vip/best-practices/security/validating-sanitizing-escaping/)
+[Relevant Documentation](https://wpvip.com/security/)
 
 ## wp_kses_post
 
-Background on KSES. KSES is a recursive acronym for `KSES Kills Evil Scripts`. It's goal is to ensure only  "allowed" HTML element names, attribute names and attribute values plus only sane HTML entities in the string. Allowed is based on a configuration.
+Background on KSES. KSES is a recursive acronym for `KSES Kills Evil Scripts`. It's goal is to ensure only "allowed" HTML element names, attribute names and attribute values plus only sane HTML entities in the string. Allowed is based on a configuration.
 
-This uses the internal WordPress method that sanitize content for allowed HTML tags for post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );` [WordPress Documentation](https://codex.wordpress.org/Function_Reference/wp_kses_post)
+This uses the internal WordPress method that sanitize content for allowed HTML tags for post content. The configuration used can be found by running ` wp_kses_allowed_html( 'post' );` [WordPress Documentation](https://developer.wordpress.org/reference/functions/wp_kses_post/)
 
 **Twig**
 
@@ -46,10 +46,11 @@ In this example, `post.post_content` is:
 
 `<div>Foo</div>DoEvilThing();`
 
-* * *
+---
 
 ## esc_url
-Uses WordPress' internal `esc_url` function on text. This should be used to sanitize URLs. [WordPress Documentation](https://codex.wordpress.org/Function_Reference/esc_url)
+
+Uses WordPress' internal `esc_url` function on text. This should be used to sanitize URLs. [WordPress Documentation](https://developer.wordpress.org/reference/functions/esc_url/)
 
 **Twig**
 
@@ -59,7 +60,7 @@ Uses WordPress' internal `esc_url` function on text. This should be used to sani
 
 `<a href="https://google.com"></a>`
 
-* * *
+---
 
 ## esc_html
 
@@ -75,7 +76,7 @@ This is for plain old text. If your content has HTML markup you should not use `
 
 `<div class="equation">is x &lt; y?</div>`
 
-* * *
+---
 
 ## esc_js
 

--- a/docs/v1/guides/filters.md
+++ b/docs/v1/guides/filters.md
@@ -4,7 +4,7 @@ title: "Filters"
 
 ## General Filters
 
-Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WP theme:
+Twig offers a variety of [filters](https://twig.symfony.com/doc/3.x/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WP theme:
 
 ## excerpt
 
@@ -19,10 +19,14 @@ When you need to trim text to a desired length (in words)
 **Output**
 
 ```html
-<p class="intro">Steve-O was born in London, England. His mother, Donna Gay (née Wauthier), was Canadian, and his father, Richard Glover, was American. His paternal grandfather was English and his maternal step-grandfather ...</p>
+<p class="intro">
+  Steve-O was born in London, England. His mother, Donna Gay (née Wauthier), was
+  Canadian, and his father, Richard Glover, was American. His paternal
+  grandfather was English and his maternal step-grandfather ...
+</p>
 ```
 
-* * *
+---
 
 ## function
 
@@ -41,6 +45,7 @@ Runs a function where you need. Really valuable for integrating plugins or exist
 ```
 
 ## <del>function (deprecated)<del>
+
 Runs a function where you need. Really valuable for integrating plugins or existing themes
 
 **Twig**
@@ -55,9 +60,10 @@ Runs a function where you need. Really valuable for integrating plugins or exist
 <div class="entry-meta">Posted on September 6, 2013</div>
 ```
 
-* * *
+---
 
 ## relative
+
 Converts an absolute URL into a relative one, for example:
 
 ```twig
@@ -68,12 +74,13 @@ My custom link is <a href="{{ 'https://example.org/2015/08/my-blog-post' | relat
 My custom link is <a href="/2015/08/my-blog-post">here!</a>
 ```
 
-* * *
+---
 
 ## pretags
+
 Converts tags like `<span>` into `&lt;span&gt;`, but only inside of `<pre>` tags. Great for code samples when you need to preserve other formatting in the non-code sample content.
 
-* * *
+---
 
 ## sanitize
 
@@ -91,7 +98,7 @@ Converts Titles like this into `titles-like-this`
 my-awesome-post
 ```
 
-* * *
+---
 
 ## shortcodes
 
@@ -109,11 +116,12 @@ Runs text through WordPress's shortcodes filter. In this example imagine that yo
 
 ```html
 <section class="gallery">
-Here is my gallery <div class="gallery" id="gallery-123"><img src="...." />...</div>
+  Here is my gallery
+  <div class="gallery" id="gallery-123"><img src="...." />...</div>
 </section>
 ```
 
-* * *
+---
 
 ## time_ago
 
@@ -131,7 +139,7 @@ Displays a date in timeago format:
 <p class="entry-meta">Posted: <time>3 days ago</time></p>
 ```
 
-* * *
+---
 
 ## truncate
 
@@ -147,7 +155,7 @@ Displays a date in timeago format:
 <p class="entry-meta">Bruce Wayne's parents were shot outside the opera ...</p>
 ```
 
-* * *
+---
 
 ## wpautop
 
@@ -165,14 +173,19 @@ Adds paragraph breaks to new lines
 
 ```html
 <div class="body">
-	<p>Sinatra said, "What do you do?"</p>
-	<p>"I'm a plumber," Ellison said.</p>
-	<p>"No, no, he's not," another young man quickly yelled from across the table. "He wrote The Oscar."</p>
-	<p>"Oh, yeah," Sinatra said, "well I've seen it, and it's a piece of crap."</p>
+  <p>Sinatra said, "What do you do?"</p>
+  <p>"I'm a plumber," Ellison said.</p>
+  <p>
+    "No, no, he's not," another young man quickly yelled from across the table.
+    "He wrote The Oscar."
+  </p>
+  <p>
+    "Oh, yeah," Sinatra said, "well I've seen it, and it's a piece of crap."
+  </p>
 </div>
 ```
 
-* * *
+---
 
 ## list
 

--- a/docs/v1/guides/filters.md
+++ b/docs/v1/guides/filters.md
@@ -4,7 +4,7 @@ title: "Filters"
 
 ## General Filters
 
-Twig offers a variety of [filters](https://twig.symfony.com/doc/3.x/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WP theme:
+Twig offers a variety of [filters](https://twig.symfony.com/doc/2.x/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some valuable custom filters for your WP theme:
 
 ## excerpt
 

--- a/docs/v1/guides/internationalization.md
+++ b/docs/v1/guides/internationalization.md
@@ -2,7 +2,7 @@
 title: "Internationalization"
 ---
 
-Internationalization of a Timber theme works pretty much the same way as it does for default WordPress themes. Follow the guide in the [WordPress Theme Handbook](https://developer.wordpress.org/themes/functionality/internationalization/) to setup i18n for your theme.
+Internationalization of a Timber theme works pretty much the same way as it does for default WordPress themes. Follow the guide in the [WordPress Theme Handbook](https://developer.wordpress.org/themes/classic-themes/functionality/internationalization/) to setup i18n for your theme.
 
 Twig has its own i18n extension that gives you `{% trans %}` tags to define translatable blocks, but there’s no need to use it, because with Timber, you have all you need.
 
@@ -10,23 +10,21 @@ Twig has its own i18n extension that gives you `{% trans %}` tags to define tran
 
 Timber supports all the translation functions used in WordPress:
 
-* __()
-* _x()
-* _n()
-* _nx()
-* _n_noop()
-* _nx_noop()
-* translate()
-* translate_nooped_plural()
+- \_\_()
+- \_x()
+- \_n()
+- \_nx()
+- \_n_noop()
+- \_nx_noop()
+- translate()
+- translate_nooped_plural()
 
 The functions `_e()` and `_ex()` are also supported, but you probably won’t need them in Twig, because `{{ }}` already echoes the output.
 
 **WordPress:**
 
 ```html
-<p class="entry-meta">
-    <?php _e( 'Posted on', 'my-text-domain' ) ?> [...]
-</p>
+<p class="entry-meta"><?php _e( 'Posted on', 'my-text-domain' ) ?> [...]</p>
 ```
 
 **Timber:**
@@ -45,7 +43,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 
 ```html
 <p class="entry-meta">
-    <?php printf( __('Posted on %s', 'my-text-domain'), $posted_on_date ) ?>
+  <?php printf( __('Posted on %s', 'my-text-domain'), $posted_on_date ) ?>
 </p>
 ```
 
@@ -76,4 +74,4 @@ Note that the package isn't Timber specific, it will work with any Twig implemen
 
 You can also generate `.pot`, `.po` and `.mo` files, with [Poedit](https://poedit.net/).
 
-[Poedit 2](https://poedit.net/) fully supports Twig file parsing (Pro version only) with the following functions: __(), _x(), _n(), _nx().
+[Poedit 2](https://poedit.net/) fully supports Twig file parsing (Pro version only) with the following functions: \_\_(), \_x(), \_n(), \_nx().

--- a/docs/v1/guides/internationalization.md
+++ b/docs/v1/guides/internationalization.md
@@ -24,7 +24,7 @@ The functions `_e()` and `_ex()` are also supported, but you probably won’t ne
 **WordPress:**
 
 ```html
-<p class="entry-meta"><?php _e( 'Posted on', 'my-text-domain' ) ?> [...]</p>
+<p class="entry-meta"><?php _e('Posted on', 'my-text-domain') ?> [...]</p>
 ```
 
 **Timber:**
@@ -43,7 +43,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 
 ```html
 <p class="entry-meta">
-  <?php printf( __('Posted on %s', 'my-text-domain'), $posted_on_date ) ?>
+  <?php printf(__('Posted on %s', 'my-text-domain'), $posted_on_date) ?>
 </p>
 ```
 

--- a/docs/v1/guides/menus.md
+++ b/docs/v1/guides/menus.md
@@ -4,7 +4,7 @@ title: "Menus"
 
 In Timber, you can use `Timber\Menu` to make a standard WordPress menu available to the Twig template as an object you can loop through.
 
-Once the menu becomes available to the context, you can get items from it in a way that is a little smoother and more versatile than WordPress’s `wp_nav_menu()` function. (And you never again need to rely on a crazy [Walker Function](https://codex.wordpress.org/Class_Reference/Walker)).
+Once the menu becomes available to the context, you can get items from it in a way that is a little smoother and more versatile than WordPress's `wp_nav_menu()` function. (And you never again need to rely on a crazy [Walker Function](https://developer.wordpress.org/reference/classes/walker/)).
 
 ## Initializing a menu
 
@@ -165,4 +165,4 @@ Other properties that are available are `current_item_parent` for direct parents
 
 ## Tips
 
-- [Add items dynamically](https://github.com/jarednova/timber/issues/200)
+- [Add items dynamically](https://github.com/timber/timber/issues/200)

--- a/docs/v1/guides/menus.md
+++ b/docs/v1/guides/menus.md
@@ -4,7 +4,7 @@ title: "Menus"
 
 In Timber, you can use `Timber\Menu` to make a standard WordPress menu available to the Twig template as an object you can loop through.
 
-Once the menu becomes available to the context, you can get items from it in a way that is a little smoother and more versatile than WordPress's `wp_nav_menu()` function. (And you never again need to rely on a crazy [Walker Function](https://developer.wordpress.org/reference/classes/walker/)).
+Once the menu becomes available to the context, you can get items from it in a way that is a little smoother and more versatile than WordPress’s `wp_nav_menu()` function. (And you never again need to rely on a crazy [Walker Function](https://developer.wordpress.org/reference/classes/walker/)).
 
 ## Initializing a menu
 

--- a/docs/v1/guides/performance.md
+++ b/docs/v1/guides/performance.md
@@ -6,8 +6,7 @@ Timber, especially in conjunction with WordPress and Twig, offers a variety of c
 
 ## tl;dr
 
-In my tests with Debug Bar, Timber has no measurable performance hit. Everything compiles to PHP. @fabpot has an [overview of the performance costs on his blog](https://fabien.potencier.org/article/34/templating-engines-in-php) (scroll down to the table).
-
+In my tests with Debug Bar, Timber has no measurable performance hit. Everything compiles to PHP. @fabpot has an [overview of the performance costs on his blog](https://fabien.potencier.org/article/34/templating-engines-in-php/) (scroll down to the table).
 
 ## Cache Everything
 
@@ -38,13 +37,13 @@ Timber::render( $filenames, $data, $expires, $cache_mode );
 
 The following cache modes are available:
 
-| Mode | Description |
-| --- | --- |
-| `Timber\Loader::CACHE_NONE` | Disable caching |
-| `Timber\Loader::CACHE_OBJECT` | WP Object Cache |
-| `Timber\Loader::CACHE_TRANSIENT` | Transients |
-| `Timber\Loader::CACHE_SITE_TRANSIENT` | Network wide transients |
-| `Timber\Loader::CACHE_USE_DEFAULT` | Use whatever caching mechanism is set as the default for `Timber\Loader`, the default is `CACHE_TRANSIENT`. |
+| Mode                                  | Description                                                                                                 |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `Timber\Loader::CACHE_NONE`           | Disable caching                                                                                             |
+| `Timber\Loader::CACHE_OBJECT`         | WP Object Cache                                                                                             |
+| `Timber\Loader::CACHE_TRANSIENT`      | Transients                                                                                                  |
+| `Timber\Loader::CACHE_SITE_TRANSIENT` | Network wide transients                                                                                     |
+| `Timber\Loader::CACHE_USE_DEFAULT`    | Use whatever caching mechanism is set as the default for `Timber\Loader`, the default is `CACHE_TRANSIENT`. |
 
 ## Cache _Parts_ of the Twig File and Data
 
@@ -106,7 +105,7 @@ This does not cache the _contents_ of the variables. This is recommended as a la
 
 ## Cache the PHP data
 
-Sometimes the most expensive parts of the operations are generating the data needed to populate the twig template. You can of course use WordPress’s default [Transient API](https://codex.wordpress.org/Transients_API) to store this data.
+Sometimes the most expensive parts of the operations are generating the data needed to populate the twig template. You can of course use WordPress's default [Transient API](https://developer.wordpress.org/apis/transients/) to store this data.
 
 You can also use some [syntactic sugar](https://en.wikipedia.org/wiki/Syntactic_sugar) to make the checking/saving/retrieving of transient data a bit easier:
 

--- a/docs/v1/guides/testing.md
+++ b/docs/v1/guides/testing.md
@@ -43,7 +43,7 @@ $ cd /srv/www/timber
 $ phpunit
 ```
 
-You should see a bunch of gobbledygook across your screen (the whole process will take about 3 mins.), but we should see that WordPress is testing successfully. Hurrah! For more info, check out the [Handbook on Automated Testing](https://make.wordpress.org/core/handbook/automated-testing/).
+You should see a bunch of gobbledygook across your screen (the whole process will take about 3 mins.), but we should see that WordPress is testing successfully. Hurrah! For more info, check out the [Handbook on Automated Testing](https://make.wordpress.org/core/handbook/testing/automated-testing/).
 
 ## Writing tests
 

--- a/docs/v1/guides/woocommerce.md
+++ b/docs/v1/guides/woocommerce.md
@@ -14,7 +14,7 @@ function theme_add_woocommerce_support() {
 add_action( 'after_setup_theme', 'theme_add_woocommerce_support' );
 ```
 
-For more information about how you can enable or disable features and change settings through theme support, refer to the [WooCommerce Theme Developer Handbook](https://docs.woocommerce.com/document/woocommerce-theme-developer-handbook).
+For more information about how you can enable or disable features and change settings through theme support, refer to the [WooCommerce Theme Developer Handbook](https://developer.woocommerce.com/docs/theming/theme-development/classic-theme-developer-handbook).
 
 Once that’s done you can start integrating WooCommerce into your theme by creating a file named **woocommerce.php** in the root of your theme. That will establish the context and data to be passed to your Twig files:
 
@@ -197,7 +197,7 @@ function timber_set_product( $post ) {
 
 Without this, some elements of the listed products would show the same information as the first product in the loop. If you see an error like `Warning: call_user_func_array() expects parameter 1 to be a valid callback, no array or string given`, this is your problem.
 
-*Note:* Some users reported issues with the loop context even when using the `timber_set_product()` helper function. Turns out the default WooCommerce hooks interfere with the output of the aforementioned function.
+_Note:_ Some users reported issues with the loop context even when using the `timber_set_product()` helper function. Turns out the default WooCommerce hooks interfere with the output of the aforementioned function.
 
 One way to get around this is by building your own image calls, that means removing WooCommerce’s default hooks and declare your own template for the HTML to show the image:
 

--- a/docs/v2/getting-started/a-post-archive.md
+++ b/docs/v2/getting-started/a-post-archive.md
@@ -13,7 +13,7 @@ $context = Timber::context();
 Timber::render('index.twig', $context);
 ```
 
-For basic archives, that's all you need. Behind the scenes, Timber already prepared a `posts` variable for you that holds all the posts that you would normally find in [The Loop](https://developer.wordpress.org/themes/classic-themes/basics/the-loop/).
+For basic archives, that’s all you need. Behind the scenes, Timber already prepared a `posts` variable for you that holds all the posts that you would normally find in [The Loop](https://developer.wordpress.org/themes/classic-themes/basics/the-loop/).
 
 You can then loop over your posts with a [for-loop in Twig](https://twig.symfony.com/doc/3.x/tags/for.html). Here's what your archive page could look like.
 

--- a/docs/v2/getting-started/a-post-archive.md
+++ b/docs/v2/getting-started/a-post-archive.md
@@ -13,9 +13,9 @@ $context = Timber::context();
 Timber::render('index.twig', $context);
 ```
 
-For basic archives, that’s all you need. Behind the scenes, Timber already prepared a `posts` variable for you that holds all the posts that you would normally find in [The Loop](https://developer.wordpress.org/themes/basics/the-loop/).
+For basic archives, that's all you need. Behind the scenes, Timber already prepared a `posts` variable for you that holds all the posts that you would normally find in [The Loop](https://developer.wordpress.org/themes/classic-themes/basics/the-loop/).
 
-You can then loop over your posts with a [for-loop in Twig](https://twig.symfony.com/doc/tags/for.html). Here’s what your archive page could look like.
+You can then loop over your posts with a [for-loop in Twig](https://twig.symfony.com/doc/3.x/tags/for.html). Here's what your archive page could look like.
 
 **index.twig**
 

--- a/docs/v2/getting-started/a-single-post.md
+++ b/docs/v2/getting-started/a-single-post.md
@@ -93,7 +93,7 @@ When you want to list all the categories that the blog post is assigned to, then
 </ul>
 ```
 
-We just used a [for-loop](https://twig.symfony.com/doc/tags/for.html) here. This works a little different than `foreach` in PHP.
+We just used a [for-loop](https://twig.symfony.com/doc/3.x/tags/for.html) here. This works a little different than `foreach` in PHP.
 
 And here, we have yet another Timber object. Each `term` is a [`Timber\Term`](https://timber.github.io/docs/v2/reference/timber-term/) object. For terms, you also have methods like `title` or `link`. To learn more about how terms are handled in Timber, refer to the [Terms Guide](https://timber.github.io/docs/v2/guides/terms/).
 

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -194,7 +194,7 @@ The following are all fine.
 {{ include('components/post/header.twig') }}
 ```
 
-There's a couple of neat functionalities when using `include()`, so it's definitely worth reading through its [documentation](https://twig.symfony.com/doc/3.x/functions/include.html).
+There’s a couple of neat functionalities when using `include()`, so it’s definitely worth reading through its [documentation](https://twig.symfony.com/doc/3.x/functions/include.html).
 
 ## Use it a little, use it a lot
 

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -155,7 +155,7 @@ What if you wanted to **add** something to the block as opposed to replace? In t
 
 ## Includes
 
-Another very useful functionality is Twig's [include](https://twig.symfony.com/doc/3.x/functions/include.html) function. You can use it to extract reusable parts of your theme and build your own component library.
+Another very useful functionality is Twig’s [include](https://twig.symfony.com/doc/3.x/functions/include.html) function. You can use it to extract reusable parts of your theme and build your own component library.
 
 Let’s the example of the headline again.
 

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -37,7 +37,7 @@ The part that you should take note of here is this one:
 {% extends 'base.twig' %}
 ```
 
-You use the [extend](https://twig.symfony.com/doc/tags/extends.html) tag to tell the template engine that this template *extends* another template. This means that **single.twig** is using **base.twig** as its parent template. Here’s what your **base.twig** could look like:
+You use the [extend](https://twig.symfony.com/doc/3.x/tags/extends.html) tag to tell the template engine that this template _extends_ another template. This means that **single.twig** is using **base.twig** as its parent template. Here's what your **base.twig** could look like:
 
 ```twig
 <!DOCTYPE html>
@@ -115,7 +115,7 @@ For this introduction, let’s assume that the name of the page is "All about Ja
 
 Compared to the earlier example, we now have the `{% block headline %}` bit surrounding the `<header>` tag of the post.
 
-To inject a custom bit of markup, we’re going to create a file called **single-all-about-jared.twig** in the **views** directory. The logic for which template should be selected is controlled in **single.php**, but generally follows WordPress conventions on [Template Hierarchy](https://wphierarchy.com/).
+To inject a custom bit of markup, we're going to create a file called **single-all-about-jared.twig** in the **views** directory. The logic for which template should be selected is controlled in **single.php**, but generally follows WordPress conventions on [Template Hierarchy](https://wpshout.com/wordpress-template-hierarchy/).
 
 Now, to replace the `headline` block **single.twig**, we define it in our new file.
 
@@ -141,7 +141,7 @@ So there are two big concepts going on here:
 1. **Multiple Inheritance:** We’re extending **single.twig**, which itself extends **base.twig**. Thus we stay true to the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle and don’t have very similar code between our two templates hanging around.
 2. **Nested Blocks:** `{% block headline %}` is located inside `{% block content %}`. So while we’re replacing the headline, we get to keep all the other markup and variables found in the parent template.
 
-What if you wanted to **add** something to the block as opposed to replace? In this case you can use [`{{ parent() }}`](https://twig.symfony.com/doc/functions/parent.html) where the parent block’s content should go.
+What if you wanted to **add** something to the block as opposed to replace? In this case you can use [`{{ parent() }}`](https://twig.symfony.com/doc/3.x/functions/parent.html) where the parent block's content should go.
 
 ```twig
 {% extends "single.twig" %}
@@ -155,7 +155,7 @@ What if you wanted to **add** something to the block as opposed to replace? In t
 
 ## Includes
 
-Another very useful functionality is Twig’s [include](https://twig.symfony.com/doc/functions/include.html) function. You can use it to extract reusable parts of your theme and build your own component library.
+Another very useful functionality is Twig's [include](https://twig.symfony.com/doc/3.x/functions/include.html) function. You can use it to extract reusable parts of your theme and build your own component library.
 
 Let’s the example of the headline again.
 
@@ -194,7 +194,7 @@ The following are all fine.
 {{ include('components/post/header.twig') }}
 ```
 
-There’s a couple of neat functionalities when using `include()`, so it’s definitely worth reading through its [documentation](https://twig.symfony.com/doc/functions/include.html).
+There's a couple of neat functionalities when using `include()`, so it's definitely worth reading through its [documentation](https://twig.symfony.com/doc/3.x/functions/include.html).
 
 ## Use it a little, use it a lot
 

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -236,15 +236,15 @@ If you wanted to introduce Timber, you could start replacing different parts of 
 <main id="site-content" role="main">
 
     <?php
-        $template = sprintf('content-%s.twig', get_post_type());
-        $post = Timber::get_post();
+    $template = sprintf('content-%s.twig', get_post_type());
+    $post = Timber::get_post();
 
-        $post->setup();
+    $post->setup();
 
-        Timber::render($template, [
-            'post' => $post,
-        ]);
-    ?>
+    Timber::render($template, [
+        'post' => $post,
+    ]);
+?>
 
 </main>
 

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -115,7 +115,7 @@ For this introduction, let’s assume that the name of the page is "All about Ja
 
 Compared to the earlier example, we now have the `{% block headline %}` bit surrounding the `<header>` tag of the post.
 
-To inject a custom bit of markup, we're going to create a file called **single-all-about-jared.twig** in the **views** directory. The logic for which template should be selected is controlled in **single.php**, but generally follows WordPress conventions on [Template Hierarchy](https://wpshout.com/wordpress-template-hierarchy/).
+To inject a custom bit of markup, we’re going to create a file called **single-all-about-jared.twig** in the **views** directory. The logic for which template should be selected is controlled in **single.php**, but generally follows WordPress conventions on [Template Hierarchy](https://wpshout.com/wordpress-template-hierarchy/).
 
 Now, to replace the `headline` block **single.twig**, we define it in our new file.
 

--- a/docs/v2/getting-started/template-inheritance-and-includes.md
+++ b/docs/v2/getting-started/template-inheritance-and-includes.md
@@ -141,7 +141,7 @@ So there are two big concepts going on here:
 1. **Multiple Inheritance:** We’re extending **single.twig**, which itself extends **base.twig**. Thus we stay true to the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle and don’t have very similar code between our two templates hanging around.
 2. **Nested Blocks:** `{% block headline %}` is located inside `{% block content %}`. So while we’re replacing the headline, we get to keep all the other markup and variables found in the parent template.
 
-What if you wanted to **add** something to the block as opposed to replace? In this case you can use [`{{ parent() }}`](https://twig.symfony.com/doc/3.x/functions/parent.html) where the parent block's content should go.
+What if you wanted to **add** something to the block as opposed to replace? In this case you can use [`{{ parent() }}`](https://twig.symfony.com/doc/3.x/functions/parent.html) where the parent block’s content should go.
 
 ```twig
 {% extends "single.twig" %}

--- a/docs/v2/guides/class-maps.md
+++ b/docs/v2/guides/class-maps.md
@@ -5,7 +5,7 @@ order: "1660"
 
 The Class Map is the central hub for Timber to select the right PHP class for post or term objects. Whenever you want to extend existing Timber classes with your custom classes, you’ll have to register them through a Class Map so that Timber will know when to use it.
 
- There are several different Class Maps in Timber:
+There are several different Class Maps in Timber:
 
 - `timber/post/classmap` for posts
 - `timber/term/classmap` for terms
@@ -212,7 +212,7 @@ add_filter('timber/menu/classmap', function ($classmap) {
 
 Menu locations that you don’t list in the class map will use `Timber\Menu` as a default class. If selecting a menu class based on the location isn’t enough for you, you can further customize the class selection using the `timber/menu/class` filter.
 
-The following example demonstrates how you can use custom classes (`SingleLevelMenu` or `MultiLevelMenu`)  based on the depth of the menu.
+The following example demonstrates how you can use custom classes (`SingleLevelMenu` or `MultiLevelMenu`) based on the depth of the menu.
 
 ```php
 add_filter('timber/menu/class', function ($class, $term, $args) {
@@ -323,7 +323,7 @@ add_filter('timber/user/class', function ($class, \WP_User $user) {
 
 In the above example, the User class filter receives the default User class and a `WP_User` object as arguments. You should be able to decide which class to use based on that user object.
 
-In case you need a different User class based on the current template you’re displaying, you can use [Conditional Tags](https://developer.wordpress.org/themes/references/list-of-conditional-tags/).
+In case you need a different User class based on the current template you're displaying, you can use [Conditional Tags](https://developer.wordpress.org/themes/classic-themes/references/list-of-conditional-tags/).
 
 ```php
 add_filter('timber/user/class', function ($class, \WP_User $user) {

--- a/docs/v2/guides/context.md
+++ b/docs/v2/guides/context.md
@@ -92,7 +92,7 @@ add_filter('timber/context', function ($context) {
 });
 ```
 
-For menus to work, you will first need to [register them](https://codex.wordpress.org/Navigation_Menus).
+For menus to work, you will first need to [register them](https://developer.wordpress.org/reference/functions/register_nav_menus/).
 
 ### Context cache
 
@@ -118,7 +118,7 @@ Timber will not cache template contexts.
 
 ## Template contexts
 
-When WordPress decides [which PHP template file](https://wphierarchy.com/) it will display, it has already run database queries to fetch posts for archive templates or to set up the `$post` global for singular templates.
+When WordPress decides [which PHP template file](https://wpshout.com/wordpress-template-hierarchy/) it will display, it has already run database queries to fetch posts for archive templates or to set up the `$post` global for singular templates.
 
 When you call `Timber::context()`, Timber will automatically populate your context with different variables like `post`, `posts`, `term`, `terms` or `author`, depending on which type of template file you’re in.
 
@@ -182,13 +182,13 @@ $context = Timber::context([
 
 The `posts` variable will be available in archive templates (when [ `is_archive()`](https://developer.wordpress.org/reference/functions/is_archive/) returns `true`). In addition to that, it will also contain `post` or `term` variables for different archive types. Here’s a small overview.
 
-| Archive | Condition | Context variables |
-|---|---|---|
-| Home | `is_home()` | `post`<br>`posts` |
-| Taxonomy Archive | `is_category()`<br>`is_tag()`<br>`is_tax()` | `term`<br>`posts` |
-| Author Archive | `is_author()` | `author`<br>`posts` |
-| Search Archive | `is_search()` | `posts`<br>`search_query` |
-| All other archives | `is_archive()` | `posts` |
+| Archive            | Condition                                   | Context variables         |
+| ------------------ | ------------------------------------------- | ------------------------- |
+| Home               | `is_home()`                                 | `post`<br>`posts`         |
+| Taxonomy Archive   | `is_category()`<br>`is_tag()`<br>`is_tax()` | `term`<br>`posts`         |
+| Author Archive     | `is_author()`                               | `author`<br>`posts`       |
+| Search Archive     | `is_search()`                               | `posts`<br>`search_query` |
+| All other archives | `is_archive()`                              | `posts`                   |
 
 The `posts` variable will contain an object that implements `Timber\PostCollectionInterace` with the posts that WordPress already fetched for your archive page.
 
@@ -220,7 +220,7 @@ $context = Timber::context([
 
 #### Change arguments for default query
 
-Sometimes you don’t want to use the default query, but build on the default query and only change a little thing. You can change arguments for the default query that WordPress will use to fetch posts by using the `merge_default` argument. For example, if you’d want to change the default query to *only show posts written by a specific group of authors*, you could pass in an `author__in` argument:
+Sometimes you don’t want to use the default query, but build on the default query and only change a little thing. You can change arguments for the default query that WordPress will use to fetch posts by using the `merge_default` argument. For example, if you’d want to change the default query to _only show posts written by a specific group of authors_, you could pass in an `author__in` argument:
 
 **archive.php**
 
@@ -239,8 +239,8 @@ $context = Timber::context([
 Timber::render('archive.twig', $context);
 ```
 
-Timber will accept the parameters that can be found in WordPress’s [WP_Query class](https://codex.wordpress.org/Class_Reference/WP_Query).
+Timber will accept the parameters that can be found in WordPress's [WP_Query class](https://developer.wordpress.org/reference/classes/wp_query/).
 
 #### Use a custom post class
 
-By default, `Timber::get_posts()` will contain `Timber\Post` objects. If you want to control what class will be used for the posts, you can use the [Post Class Map](https://timber.github.io/docs/v2/guides/posts#the-post-class-map).
+By default, `Timber::get_posts()` will contain `Timber\Post` objects. If you want to control what class will be used for the posts, you can use the [Post Class Map](https://timber.github.io/docs/v2/guides/posts/#the-post-class-map).

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -27,7 +27,7 @@ Note: If the WordPress size (e.g `medium`) has not been generated, it will retur
 
 ## Arbitrary resizing of images
 
-Want to resize an image? Here we're going to use [Twig Filters](https://twig.symfony.com/doc/3.x/filters/index.html).
+Want to resize an image? Here we’re going to use [Twig Filters](https://twig.symfony.com/doc/3.x/filters/index.html).
 
 ```twig
 <img src="{{ post.thumbnail.src|resize(300, 200) }}" />

--- a/docs/v2/guides/cookbook-images.md
+++ b/docs/v2/guides/cookbook-images.md
@@ -27,7 +27,7 @@ Note: If the WordPress size (e.g `medium`) has not been generated, it will retur
 
 ## Arbitrary resizing of images
 
-Want to resize an image? Here we’re going to use [Twig Filters](https://twig.symfony.com/doc/filters/index.html).
+Want to resize an image? Here we're going to use [Twig Filters](https://twig.symfony.com/doc/3.x/filters/index.html).
 
 ```twig
 <img src="{{ post.thumbnail.src|resize(300, 200) }}" />
@@ -91,6 +91,7 @@ You can use Timber to generate @2x image sizes for retina devices. For example, 
     {{ post.thumbnail.src|retina(3) }} 3x,
     {{ post.thumbnail.src|retina(4) }} 4x">
 ```
+
 Unfortunately, it’s not possible to use the `|retina()` filter in combination with `|resize()`, because it would create an upscaled image. We are working on making this work eventually.
 
 ## Using images in custom fields

--- a/docs/v2/guides/custom-fields.md
+++ b/docs/v2/guides/custom-fields.md
@@ -169,12 +169,11 @@ For site options, it’s also possible to access it directly through its name:
 
 Please be aware that using this might conflict with existing Timber methods on the `Timber\Site` object. That’s why the `option()` method is the preferred way to retrieve site options.
 
-
 You cannot fetch ACF options with `site.option()`. You will need to add the fields to the context yourself. This process is described in the [ACF integration](https://timber.github.io/docs/v2/integrations/advanced-custom-fields/#options-page) documentation.
 
 ## Query by custom field value
 
-This example that uses a [WP_Query](https://codex.wordpress.org/Class_Reference/WP_Query) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.
+This example that uses a [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/) array shows the arguments to find all posts where a custom field called `color` has a value of `red`.
 
 ```php
 $args = [

--- a/docs/v2/guides/custom-integrations.md
+++ b/docs/v2/guides/custom-integrations.md
@@ -4,7 +4,7 @@ title: "Custom Integrations"
 
 The new Integrations API (available from Timber 2.0) provides a generalized way to integrate with third-party plugins.
 
-It’s how, for example, the built-in [Advanced Custom Fields](/docs/v2/integrations/advanced-custom-fields/) integration is implemented: There is nothing in the Timber core (i.e. `Timber\Timber`) that "knows" about ACF. All the convenient `meta` mapping and stuff gets hooked in by a [single class](https://github.com/timber/timber/blob/2.x/src/Integration/AcfIntegration.php) (`Timber\Integration\AcfIntegration`).
+It's how, for example, the built-in [Advanced Custom Fields](/docs/v2/integrations/advanced-custom-fields/) integration is implemented: There is nothing in the Timber core (i.e. `Timber\Timber`) that "knows" about ACF. All the convenient `meta` mapping and stuff gets hooked in by a [single class](https://github.com/timber/timber/blob/2.x/src/Integration/AcfIntegration.php) (`Timber\Integration\AcfIntegration`).
 
 To achieve this, that class implements an interface: `Timber\Integrations\IntegrationInterface`:
 

--- a/docs/v2/guides/custom-integrations.md
+++ b/docs/v2/guides/custom-integrations.md
@@ -4,7 +4,7 @@ title: "Custom Integrations"
 
 The new Integrations API (available from Timber 2.0) provides a generalized way to integrate with third-party plugins.
 
-It's how, for example, the built-in [Advanced Custom Fields](/docs/v2/integrations/advanced-custom-fields/) integration is implemented: There is nothing in the Timber core (i.e. `Timber\Timber`) that "knows" about ACF. All the convenient `meta` mapping and stuff gets hooked in by a [single class](https://github.com/timber/timber/blob/2.x/src/Integration/AcfIntegration.php) (`Timber\Integration\AcfIntegration`).
+It’s how, for example, the built-in [Advanced Custom Fields](/docs/v2/integrations/advanced-custom-fields/) integration is implemented: There is nothing in the Timber core (i.e. `Timber\Timber`) that "knows" about ACF. All the convenient `meta` mapping and stuff gets hooked in by a [single class](https://github.com/timber/timber/blob/2.x/src/Integration/AcfIntegration.php) (`Timber\Integration\AcfIntegration`).
 
 To achieve this, that class implements an interface: `Timber\Integrations\IntegrationInterface`:
 

--- a/docs/v2/guides/custom-page-templates.md
+++ b/docs/v2/guides/custom-page-templates.md
@@ -11,8 +11,8 @@ There are a few ways to manage custom pages in WordPress and Timber, in order fr
 
 If you're using the [Timber Starter Theme](https://github.com/timber/starter-theme) you can
 
-* Create a file called **page-about-us.twig** inside your `views` and go crazy.
-* Copy and paste the contents of [**page.twig**](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
+- Create a file called **page-about-us.twig** inside your `views` and go crazy.
+- Copy and paste the contents of [**page.twig**](https://github.com/timber/starter-theme/blob/master/templates/page.twig) so you have something to work from.
 
 **How does this work?**
 
@@ -29,7 +29,7 @@ This is telling PHP to first look for a Twig file named **page-{{ slug }}.twig**
 
 ## Custom PHP File
 
-If you need to do something special for a page in PHP, you can use the standard WordPress [template hierarchy](https://codex.wordpress.org/Template_Hierarchy) to gather and manipulate data for this page. In the example above, you would create a file
+If you need to do something special for a page in PHP, you can use the standard WordPress [template hierarchy](https://developer.wordpress.org/themes/classic-themes/basics/template-hierarchy/) to gather and manipulate data for this page. In the example above, you would create a file
 
 **/wp-content/themes/my-theme/page-about-us.php**
 
@@ -52,5 +52,5 @@ In the WordPress admin, a new entry will be added in your page’s list of avail
 
 ![](https://codex.wordpress.org/images/thumb/a/a3/page-templates-pulldown-screenshot.png/180px-page-templates-pulldown-screenshot.png)
 
-* Name it something like **/wp-content/themes/my-theme/template-my-custom-page.php**.
-* Do **NOT** prefix the filename with `page-` or WordPress will get very confused due to [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page).
+- Name it something like **/wp-content/themes/my-theme/template-my-custom-page.php**.
+- Do **NOT** prefix the filename with `page-` or WordPress will get very confused due to [WordPress template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/#single-page).

--- a/docs/v2/guides/date-time.md
+++ b/docs/v2/guides/date-time.md
@@ -16,7 +16,7 @@ In WordPress 5.3, there were [improvements for the Date/Time component](https://
 
 ### WordPress and timezones
 
-One of the most important things to understand with dates in WordPress is that WordPress always works with `UTC` as a default timezone. You shouldn't try to change the default timezone with `date_default_timezone_set()`.
+One of the most important things to understand with dates in WordPress is that WordPress always works with `UTC` as a default timezone. You shouldn’t try to change the default timezone with `date_default_timezone_set()`.
 
 Timezones in WordPress are handled by the `timezone_string` setting in the database. WordPress calculates timezone offsets from that timezone setting.
 

--- a/docs/v2/guides/date-time.md
+++ b/docs/v2/guides/date-time.md
@@ -9,14 +9,14 @@ Before we tell you how to work with dates and times in Timber, we need to look a
 
 When you work with dates and times in a WordPress context, it’s best if you stick to the date and time functionality that WordPress provides for you. Timber tries to use the default functionality as much as it can. To prepare your environment, make sure to check the following WordPress settings:
 
-- Set the correct timezone in *Settings* &rarr; *General*.
-- Set the desired date and time formats in *Settings* &rarr; *General*. You can change the format whenever you display a date later.
+- Set the correct timezone in _Settings_ &rarr; _General_.
+- Set the desired date and time formats in _Settings_ &rarr; _General_. You can change the format whenever you display a date later.
 
 In WordPress 5.3, there were [improvements for the Date/Time component](https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/). Read that post as an introduction to what you should and shouldn’t do when working with dates and times in WordPress.
 
 ### WordPress and timezones
 
-One of the most important things to understand with dates in WordPress is that WordPress always works with `UTC` as a default timezone. You shouldn’t try to change the default timezone with [`date_default_timezone_set()`](https://core.trac.wordpress.org/ticket/48623#comment:31).
+One of the most important things to understand with dates in WordPress is that WordPress always works with `UTC` as a default timezone. You shouldn't try to change the default timezone with `date_default_timezone_set()`.
 
 Timezones in WordPress are handled by the `timezone_string` setting in the database. WordPress calculates timezone offsets from that timezone setting.
 
@@ -70,7 +70,7 @@ $timestamp = $datetime->getTimestamp();
 
 When the date string already includes the timezone, like when you use the `DATE_ATOM` format, then you don’t need to pass a timezone. When it doesn’t, you may have to pass it, depending on how you manage/use your dates.
 
-If you stored your dates *with* a certain timezone applied, then you will have to create them with a timezone. You can do this by passing `wp_timezone()` as the third parameter.
+If you stored your dates _with_ a certain timezone applied, then you will have to create them with a timezone. You can do this by passing `wp_timezone()` as the third parameter.
 
 ```php
 $datetime = DateTimeImmutable::createFromFormat(
@@ -156,7 +156,7 @@ $datetime = new DateTimeImmutable('2008-08-07 18:11:31');
 
 When you’ve worked with dates and times in PHP before, you’re probably used to the `date()` function, or `DateTime::format()`. In WordPress, we usually don’t use these function to change the date format. Instead, we used the [`date_i18n()`](https://developer.wordpress.org/reference/functions/date_i18n/) function to get a **date in a translated format, using the correct timezone**. As of WordPress 5.3, there’s the [`wp_date()`](https://developer.wordpress.org/reference/functions/wp_date/) function, which you should use whenever you can. It’s a replacement for `date_i18n()`.
 
-By default, Timber uses the date format set in *Settings* &rarr; *General*. That settings is saved in the `date_format` option.
+By default, Timber uses the date format set in _Settings_ &rarr; _General_. That settings is saved in the `date_format` option.
 
 ```php
 // With a timestamp.
@@ -199,9 +199,9 @@ If you want to change the display format, use an argument for the function. Chec
 
 ## Twig filters and functions
 
-Twig includes a [`date`](https://twig.symfony.com/doc/3.x/filters/date.html) filter as well as a [`date()`](https://twig.symfony.com/doc/2.x/functions/date.html) function. Timber supports this functionality out of the box and sets the correct timezones in the background. You don’t have to set timezones in the *Twig Environment* yourself.
+Twig includes a [`date`](https://twig.symfony.com/doc/3.x/filters/date.html) filter as well as a [`date()`](https://twig.symfony.com/doc/2.x/functions/date.html) function. Timber supports this functionality out of the box and sets the correct timezones in the background. You don’t have to set timezones in the _Twig Environment_ yourself.
 
-**Remember**, you should set the correct timezone in *Settings* &rarr; *General* in the WordPress admin to make this work correctly.
+**Remember**, you should set the correct timezone in _Settings_ &rarr; _General_ in the WordPress admin to make this work correctly.
 
 ```twig
 {{ my_date|date('j. F Y') }}
@@ -287,7 +287,7 @@ $before_today = $post->date('Ymd') < wp_date('Ymd');
 $before_today = $post->date('U') < current_datetime()->getTimestamp();
 ```
 
-In Twig, there’s the [`date()`](https://twig.symfony.com/doc/functions/date.html) function which you can use to compare dates.
+In Twig, there's the [`date()`](https://twig.symfony.com/doc/3.x/functions/date.html) function which you can use to compare dates.
 
 ```twig
 {% if date(post.meta('show_until')) >= date('now') %}

--- a/docs/v2/guides/escaping.md
+++ b/docs/v2/guides/escaping.md
@@ -32,10 +32,9 @@ In terms of security, developing a Timber theme is no different than developing 
 
 You can read more about the basics of [theme security](https://developer.wordpress.org/themes/advanced-topics/security/) and [how to escape your output in WordPress](https://developer.wordpress.org/apis/security/escaping/) in the WordPress Developer Resources.
 
-
 ## Escapers
 
-Twig offers a variety of [escaping functions](https://twig.symfony.com/doc/filters/escape.html) out of the box. They are intended to escape a string for safe insertion into the final output.
+Twig offers a variety of [escaping functions](https://twig.symfony.com/doc/3.x/filters/escape.html) out of the box. They are intended to escape a string for safe insertion into the final output.
 
 In addition to these standard escaping functions, Timber comes with some valuable custom escapers for your WordPress theme. To use the escaper (see documentation link above), you pipe your content through a function `e` and if you want to use a custom escaper, you would supply an argument to the function, e.g. `e('wp_kses_post')`.
 
@@ -60,7 +59,8 @@ In this example, `post.post_content` contains the following string:
 **Output**
 
 ```html
-<div>Foo</div>DoEvilThing();
+<div>Foo</div>
+DoEvilThing();
 ```
 
 ## esc_url
@@ -111,7 +111,7 @@ Always use when escaping HTML attributes (especially form values) such as alt, v
 **Output**
 
 ```html
-<input type="text" name="name" value="Han Solo">
+<input type="text" name="name" value="Han Solo" />
 ```
 
 ## esc_js
@@ -127,5 +127,7 @@ Escapes text strings for echoing in JavaScript. It is intended to be used for in
 **Output**
 
 ```html
-<script>var bar = 'Gabrielle';</script>
+<script>
+  var bar = "Gabrielle";
+</script>
 ```

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -48,7 +48,7 @@ By extending `Timber\Post`, we have all the methods from that class available to
 
 ### Use Class Maps
 
-To register your own classes with Timber, you use Class Maps. Refer to the [Class Maps Guide](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
+To register your own classes with Timber, you use Class Maps. Refer to the [Class Maps Guide](](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
 
 **functions.php**
 
@@ -109,7 +109,6 @@ Or, because you already use Composer to handle dependencies, you can register yo
 ```
 
 Then, you would use that namespace for your `BlogPost` class.
-
 
 **src/BlogPost.php**
 

--- a/docs/v2/guides/extending-timber.md
+++ b/docs/v2/guides/extending-timber.md
@@ -48,7 +48,7 @@ By extending `Timber\Post`, we have all the methods from that class available to
 
 ### Use Class Maps
 
-To register your own classes with Timber, you use Class Maps. Refer to the [Class Maps Guide](](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
+To register your own classes with Timber, you use Class Maps. Refer to the [Class Maps Guide](/docs/v2/guides/class-maps/) for a detailed explanation for how they work. For the `BlogPost` class, it would work like this:
 
 **functions.php**
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -47,7 +47,7 @@ Your theme structure should look like this:
 
 The block.json file is a configuration file that contains the settings for your block. It is used to define the block’s name, title, description, category among many other settings.
 
-[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
+[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we’ll follow [ACF’s example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
 
 Example contents of the block.json
 

--- a/docs/v2/guides/gutenberg.md
+++ b/docs/v2/guides/gutenberg.md
@@ -27,7 +27,7 @@ First, we will create a `blocks` directory in our theme folder. This directory w
 2. Add a directory with the block name of your choice. Example: **my-block**.
 3. Within your custom block directory, create a block.json file.
 4. Also within your custom block directory, add a CSS file to reference in the settings.
-    * Note: this is optional. You can reference CSS from any directory or rely on sitewide styling to get applied to your block on production.
+   - Note: this is optional. You can reference CSS from any directory or rely on sitewide styling to get applied to your block on production.
 
 Your theme structure should look like this:
 
@@ -47,23 +47,23 @@ Your theme structure should look like this:
 
 The block.json file is a configuration file that contains the settings for your block. It is used to define the block’s name, title, description, category among many other settings.
 
-[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we’ll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
+[WordPress has a full example](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) of the values you can add to your block.json. For our example, we'll follow [ACF's example](https://www.advancedcustomfields.com/resources/acf-blocks-key-concepts/#acf-blocks-and-blockjson) with the minimal settings plus the specific ACF property. We will use `renderCallback` instead of `renderTemplate` so we can set a function callback to render all our blocks instead of creating a function for each individual block.
 
 Example contents of the block.json
 
 ```json
 {
-    "name": "acf/my-block",
-    "title": "My Block",
-    "description": "Description for my block",
-    "style": [ "file:./my-block.css" ],
-    "category": "formatting",
-    "icon": "format-aside",
-    "keywords": ["my", "block"],
-    "acf": {
-        "mode": "preview",
-        "renderCallback": "my_acf_block_render_callback"
-    }
+  "name": "acf/my-block",
+  "title": "My Block",
+  "description": "Description for my block",
+  "style": ["file:./my-block.css"],
+  "category": "formatting",
+  "icon": "format-aside",
+  "keywords": ["my", "block"],
+  "acf": {
+    "mode": "preview",
+    "renderCallback": "my_acf_block_render_callback"
+  }
 }
 ```
 
@@ -148,6 +148,7 @@ function my_acf_block_render_callback($attributes, $content = '', $is_preview = 
     );
 }
 ```
+
 We call this function in the `renderCallback` object in the block.json file of our block. This function will work for all blocks as long as we follow the naming convention of `acf/your-block-name` for the name property in the block.json and name the template `your-block-name.twig` in the `blocks/your-block-name` folder inside the root of your theme.
 
 #### Create fields in ACF

--- a/docs/v2/guides/internationalization.md
+++ b/docs/v2/guides/internationalization.md
@@ -3,7 +3,7 @@ title: "Internationalization"
 order: "1400"
 ---
 
-Internationalization of a Timber theme works pretty much the same way as it does for default WordPress themes. Follow the guide in the [WordPress Theme Handbook](https://developer.wordpress.org/themes/functionality/internationalization/) to setup i18n for your theme.
+Internationalization of a Timber theme works pretty much the same way as it does for default WordPress themes. Follow the guide in the [WordPress Theme Handbook](https://developer.wordpress.org/themes/classic-themes/functionality/internationalization/) to setup i18n for your theme.
 
 Twig has its own i18n extension that gives you `{% trans %}` tags to define translatable blocks, but there’s no need to use it, because with Timber, you have all you need.
 
@@ -11,23 +11,21 @@ Twig has its own i18n extension that gives you `{% trans %}` tags to define tran
 
 Timber supports all the translation functions used in WordPress:
 
-* __()
-* _x()
-* _n()
-* _nx()
-* _n_noop()
-* _nx_noop()
-* translate()
-* translate_nooped_plural()
+- \_\_()
+- \_x()
+- \_n()
+- \_nx()
+- \_n_noop()
+- \_nx_noop()
+- translate()
+- translate_nooped_plural()
 
 The functions `_e()` and `_ex()` are also supported, but you probably won’t need them in Twig, because `{{ }}` already echoes the output.
 
 **WordPress:**
 
 ```html
-<p class="entry-meta">
-    <?php _e( 'Posted on', 'my-text-domain' ) ?> [...]
-</p>
+<p class="entry-meta"><?php _e( 'Posted on', 'my-text-domain' ) ?> [...]</p>
 ```
 
 **Timber:**
@@ -46,7 +44,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 
 ```html
 <p class="entry-meta">
-    <?php printf( __('Posted on %s', 'my-text-domain'), $posted_on_date ) ?>
+  <?php printf( __('Posted on %s', 'my-text-domain'), $posted_on_date ) ?>
 </p>
 ```
 
@@ -77,4 +75,4 @@ Note that the package isn't Timber specific, it will work with any Twig implemen
 
 You can also generate `.pot`, `.po` and `.mo` files, with [Poedit](https://poedit.net/).
 
-[Poedit 2](https://poedit.net/) fully supports Twig file parsing (Pro version only) with the following functions: __(), _x(), _n(), _nx().
+[Poedit 2](https://poedit.net/) fully supports Twig file parsing (Pro version only) with the following functions: \_\_(), \_x(), \_n(), \_nx().

--- a/docs/v2/guides/internationalization.md
+++ b/docs/v2/guides/internationalization.md
@@ -25,7 +25,7 @@ The functions `_e()` and `_ex()` are also supported, but you probably won’t ne
 **WordPress:**
 
 ```html
-<p class="entry-meta"><?php _e( 'Posted on', 'my-text-domain' ) ?> [...]</p>
+<p class="entry-meta"><?php _e('Posted on', 'my-text-domain') ?> [...]</p>
 ```
 
 **Timber:**
@@ -44,7 +44,7 @@ You can use sprintf-type placeholders, using the `format` filter:
 
 ```html
 <p class="entry-meta">
-  <?php printf( __('Posted on %s', 'my-text-domain'), $posted_on_date ) ?>
+  <?php printf(__('Posted on %s', 'my-text-domain'), $posted_on_date) ?>
 </p>
 ```
 

--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -3,7 +3,7 @@ title: "Menus"
 order: "150"
 ---
 
-In Timber, we handle menus a little differently than in WordPress. We'd say it's a little smoother and more versatile than using WordPress's `wp_nav_menu()` function. And you never again need to rely on a crazy [Walker Function](https://developer.wordpress.org/reference/classes/walker/).
+In Timber, we handle menus a little differently than in WordPress. We’d say it’s a little smoother and more versatile than using WordPress’s `wp_nav_menu()` function. And you never again need to rely on a crazy [Walker Function](https://developer.wordpress.org/reference/classes/walker/).
 
 ## Getting menus
 

--- a/docs/v2/guides/menus.md
+++ b/docs/v2/guides/menus.md
@@ -3,7 +3,7 @@ title: "Menus"
 order: "150"
 ---
 
-In Timber, we handle menus a little differently than in WordPress. We’d say it’s a little smoother and more versatile than using WordPress’s `wp_nav_menu()` function. And you never again need to rely on a crazy [Walker Function](https://codex.wordpress.org/Class_Reference/Walker).
+In Timber, we handle menus a little differently than in WordPress. We'd say it's a little smoother and more versatile than using WordPress's `wp_nav_menu()` function. And you never again need to rely on a crazy [Walker Function](https://developer.wordpress.org/reference/classes/walker/).
 
 ## Getting menus
 
@@ -49,7 +49,7 @@ $menu = Timber::get_menu('primary', [
 
 Currently, only `depth` is supported (see [`wp_nav_menu()`](https://developer.wordpress.org/reference/functions/wp_nav_menu/) for reference).
 
-- **depth** – *(int)* How many levels of the hierarchy are to be included. 0 means all levels will be included. Default 0.
+- **depth** – _(int)_ How many levels of the hierarchy are to be included. 0 means all levels will be included. Default 0.
 
 ### Menus need to be registered
 
@@ -103,7 +103,6 @@ $menu = Timber::get_pages_menu();
 This function will return an instance of `Timber\PagesMenu`, which is not quite the same as `Timber\Menu`, but it contains the same `Timber\MenuItem` objects as you know them.
 
 If you want to extend a pages menu, you would do it like this:
-
 
 ```php
 class ExtendedPagesMenu extends \Timber\PagesMenu
@@ -328,4 +327,4 @@ You could also use it in combination with `item.is_target_blank`:
 
 ## Tips
 
-- [Add items dynamically](https://github.com/jarednova/timber/issues/200)
+- [Add items dynamically](https://github.com/timber/timber/issues/200)

--- a/docs/v2/guides/performance.md
+++ b/docs/v2/guides/performance.md
@@ -7,7 +7,7 @@ Timber, especially in conjunction with WordPress and Twig, offers a variety of c
 
 ## tl;dr
 
-In my tests with Debug Bar, Timber has no measurable performance hit. Everything compiles to PHP. @fabpot has an [overview of the performance costs on his blog](https://fabien.potencier.org/article/34/templating-engines-in-php) (scroll down to the table).
+In my tests with Debug Bar, Timber has no measurable performance hit. Everything compiles to PHP. @fabpot has an [overview of the performance costs on his blog](https://fabien.potencier.org/article/34/templating-engines-in-php/) (scroll down to the table).
 
 ## Cache Everything
 

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -86,7 +86,7 @@ Or in Twig:
 
 ## Extending `Timber\Post`
 
-If you need additional functionality that the `Timber\Post` class doesn't provide or if you want to have cleaner Twig templates, you can [extend the `Timber\Post` class](/docs/v2/guides/extending-timber/) with your own classes:
+If you need additional functionality that the `Timber\Post` class doesn’t provide or if you want to have cleaner Twig templates, you can [extend the `Timber\Post` class](/docs/v2/guides/extending-timber/) with your own classes:
 
 ```php
 class Book extends Timber\Post

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -202,7 +202,7 @@ Sometimes you may not have direct access to a `WP_Query` instance; you may only 
 $wp_posts = fancy_plugin_get_custom_posts(); // -> an array of WP_Posts
 ```
 
-In this scenario, you can still easily map each of these posts to instances of `Timber\Post` or the appropriate subclass, according to the [Class Map](./class-maps/#the-post-class-map) you've defined:
+In this scenario, you can still easily map each of these posts to instances of `Timber\Post` or the appropriate subclass, according to the [Class Map](./class-maps/#the-post-class-map) you’ve defined:
 
 ```php
 $timber_posts = Timber::get_posts($wp_posts); // -> Timber\PostArrayObject

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -86,7 +86,7 @@ Or in Twig:
 
 ## Extending `Timber\Post`
 
-If you need additional functionality that the `Timber\Post` class doesn’t provide or if you want to have cleaner Twig templates, you can [extend the `Timber\Post` class](/docs/v2/guides/extending-timber/) with your own classes:
+If you need additional functionality that the `Timber\Post` class doesn't provide or if you want to have cleaner Twig templates, you can [extend the `Timber\Post` class](/docs/v2/guides/extending-timber/) with your own classes:
 
 ```php
 class Book extends Timber\Post
@@ -102,7 +102,7 @@ $book = Timber::get_post($post_id);
 
 You **can’t** instantiate a `Timber\Post` object or an object that extends this class with a constructor – you can’t use `$post = new Book( $post_id )`. In Timber, we’ve chosen to go a different way to prevent a lot of problems that would come with direct instantiation.
 
-So, how does Timber know about your `Book` class? Timber will use the [Post Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-post-class-map) to sort out which class it should use.
+So, how does Timber know about your `Book` class? Timber will use the [Post Class Map](./class-maps/#the-post-class-map) to sort out which class it should use.
 
 ## Querying Posts
 
@@ -133,11 +133,11 @@ $posts = Timber::get_posts($query, $options);
 
 ### The default query
 
-In archive templates like **archive.php** or **category.php**, Timber will already fetch the default query when you call `Timber::context()` and make it available under the `posts` entry. Read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context).
+In archive templates like **archive.php** or **category.php**, Timber will already fetch the default query when you call `Timber::context()` and make it available under the `posts` entry. Read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context/).
 
 ### Class Map
 
-When you query for certain post types, Timber will use the [Post Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-post-class-map) to check which class it should use to instantiate your posts.
+When you query for certain post types, Timber will use the [Post Class Map](./class-maps/#the-post-class-map) to check which class it should use to instantiate your posts.
 
 ## Post Collections
 
@@ -177,7 +177,7 @@ $filtered = wp_list_filter($posts->to_array(), [
 
 ### Types of Post Collections
 
-Like every other [PHP interface](https://www.php.net/manual/en/language.oop5.interfaces.php), `PostCollectionInterface` cannot be instantiated directly, i.e. `new PostCollectionInterface()` will not work. You can only create instances of concrete *classes* that *implement* the interface.
+Like every other [PHP interface](https://www.php.net/manual/en/language.oop5.interfaces.php), `PostCollectionInterface` cannot be instantiated directly, i.e. `new PostCollectionInterface()` will not work. You can only create instances of concrete _classes_ that _implement_ the interface.
 
 Timber offers two implementations of `PostCollectionInterface`: the `Timber\PostQuery` and `Timber\PostArrayObject` classes. Both extend PHP’s `ArrayObject` class, which means you can loop over and index them directly (see examples above).
 
@@ -185,14 +185,14 @@ Timber offers two implementations of `PostCollectionInterface`: the `Timber\Post
 
 `Timber\PostQuery` is what you will likely deal with most of the time. It is what is returned when:
 
-* calling `Timber::get_posts()` with no arguments
-* passing an associative array, e.g. `Timber::get_posts( [ 'post_type' => 'post' ] )`
-* passing a `WP_Query` object, e.g. `Timber::get_posts( new WP_Query( [ 'post_type=post' ] ) )`
-* calling `$term->posts()` on a  `Timber\Term` object
-* calling `$user->posts()` on a `Timber\User` object
-* calling `$post->children()` on a `Timber\Post` object
+- calling `Timber::get_posts()` with no arguments
+- passing an associative array, e.g. `Timber::get_posts( [ 'post_type' => 'post' ] )`
+- passing a `WP_Query` object, e.g. `Timber::get_posts( new WP_Query( [ 'post_type=post' ] ) )`
+- calling `$term->posts()` on a `Timber\Term` object
+- calling `$user->posts()` on a `Timber\User` object
+- calling `$post->children()` on a `Timber\Post` object
 
-The `Timber\PostQuery` class contains some optimization for tight integration with The Loop, including support for advanced [pagination](/docs/v2/guides/pagination). To get a `Pagination` object you can use for rendering a pagination navigation component, call `$post_query->pagination()`.
+The `Timber\PostQuery` class contains some optimization for tight integration with The Loop, including support for advanced [pagination](../pagination). To get a `Pagination` object you can use for rendering a pagination navigation component, call `$post_query->pagination()`.
 
 ### The fallback case: PostArrayObject
 
@@ -202,7 +202,7 @@ Sometimes you may not have direct access to a `WP_Query` instance; you may only 
 $wp_posts = fancy_plugin_get_custom_posts(); // -> an array of WP_Posts
 ```
 
-In this scenario, you can still easily map each of these posts to instances of `Timber\Post` or the appropriate subclass, according to the [Class Map](/docs/v2/guides/class-maps/#the-post-class-map) you’ve defined:
+In this scenario, you can still easily map each of these posts to instances of `Timber\Post` or the appropriate subclass, according to the [Class Map](./class-maps/#the-post-class-map) you've defined:
 
 ```php
 $timber_posts = Timber::get_posts($wp_posts); // -> Timber\PostArrayObject
@@ -230,11 +230,11 @@ array_map('get_class', $timber_posts);
 // -> ["\Timber\Post", "\MyProject\MyPage", "\MyProject\MyCustom"]
 ```
 
-In short, `Timber\Post` instances are always created *polymorphically*, whether they are inside some kind of Post Collection or not.
+In short, `Timber\Post` instances are always created _polymorphically_, whether they are inside some kind of Post Collection or not.
 
 ### Debugging Post Collections
 
-At query time and directly afterward, Post Collections do not necessarily contain instances of `Timber\Post`. Instead, `Post` objects are created *lazily*, meaning only when explicitly requested, such as by iterating over a Post Collection or accessing an index:
+At query time and directly afterward, Post Collections do not necessarily contain instances of `Timber\Post`. Instead, `Post` objects are created _lazily_, meaning only when explicitly requested, such as by iterating over a Post Collection or accessing an index:
 
 ```php
 $posts = Timber::get_posts(); // -> PostQuery containing only raw WP_Post instances
@@ -253,20 +253,7 @@ $posts = Timber::get_posts()->realize();
 // -> PostQuery containing realized (eagerly instantiated) Timber\Post instances
 ```
 
-This is mostly an implementation detail for performance reasons, with an important caveat: Due to a [bug in PHP <= 7.3](https://bugs.php.net/bug.php?id=69264), dumping the contents of a Post Collection does *not* realize the posts within it:
-
-```php
-$posts = Timber::get_posts();
-
-/**
- * Before PHP 7.4, will dump a bunch of PostQuery internals,
- * but no Timber\Post instances!
- */
-var_dump($posts);
-
-// Do this instead:
-var_dump($posts->realize());
-```
+This is mostly an implementation detail for performance reasons.
 
 See [Laziness and Caching](#laziness-and-caching) for details about how this interacts with caching.
 
@@ -402,7 +389,7 @@ Here is a timeline of what normally happens when you call `Timber::get_posts()`:
 1. Timber decides what kind of Post Collection it will return (or returns `null` on error).
 2. It populates the new Post Collection, either with `WP_Post` objects it queries from WordPress core or with ones it was already passed, and returns the Collection object.
 3. The Collection (say, `$coll`) now contains zero or more raw `WP_Post` instances passed in/returned from the query.
-4. Calling `$coll[ $numeric_index ]` *realizes* a `Timber\Post` object from the `WP_Post` at `$numeric_index`, running it through any Post Class Map you've defined, and *replaces* the object at that index internally, so it doesn't have to repeat that work in the future.
+4. Calling `$coll[ $numeric_index ]` _realizes_ a `Timber\Post` object from the `WP_Post` at `$numeric_index`, running it through any Post Class Map you've defined, and _replaces_ the object at that index internally, so it doesn't have to repeat that work in the future.
 5. Looping over `$coll` repeats the above step for each index that has not been realized. For indexes that have been realized, it simply returns the realized `Timber\Post` object that already lives at that index.
 
 This is usually what you want. But sometimes, you may want to force Timber to realize a collection up front, such as if you are caching an expensive post query:
@@ -433,7 +420,7 @@ foreach (get_transient('my_posts') as $post) {
 
 ## Using posts or post collections in the context
 
-Timber will automatically set the `post` or `posts` variable for you in the context depending on the template file you’re using. Read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context/#template-contexts).
+Timber will automatically set the `post` or `posts` variable for you in the context depending on the template file you're using. Read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context/#template-contexts).
 
 ## Password protected posts
 

--- a/docs/v2/guides/posts.md
+++ b/docs/v2/guides/posts.md
@@ -420,7 +420,7 @@ foreach (get_transient('my_posts') as $post) {
 
 ## Using posts or post collections in the context
 
-Timber will automatically set the `post` or `posts` variable for you in the context depending on the template file you're using. Read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context/#template-contexts).
+Timber will automatically set the `post` or `posts` variable for you in the context depending on the template file you’re using. Read more about this in the [Context Guide](https://timber.github.io/docs/v2/guides/context/#template-contexts).
 
 ## Password protected posts
 

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -91,7 +91,7 @@ add_filter('timber/locations', function ($paths) {
 
 ## Register your own namespaces
 
-You can use [namespaces](https://symfony.com/doc/current/templating/namespaced_paths.html) in your locations, too. Namespaces allow you to create a shortcut to a particular location. Just define it as the value next to a path, for example:
+You can use [namespaces](https://symfony.com/doc/current/templates.html#template-namespaces) in your locations, too. Namespaces allow you to create a shortcut to a particular location. Just define it as the value next to a path, for example:
 
 **functions.php**
 

--- a/docs/v2/guides/testing.md
+++ b/docs/v2/guides/testing.md
@@ -21,6 +21,7 @@ $ git clone git@github.com:timber/timber.git
 ```
 
 ### 3. Install WordPress's Development Version
+
 VVV no longer installs the development version of WordPress by default so we have to re-provision with it enabled. Edit `vvv-custom.yml` and find this line:
 
 ```
@@ -29,6 +30,7 @@ VVV no longer installs the development version of WordPress by default so we hav
 ```
 
 Set `skip_provisioning` to `false`
+
 ```
   wordpress-trunk:
     skip_provisioning: false # provisioning this one takes longer, so it's disabled by default
@@ -43,6 +45,7 @@ $ vagrant halt && vagrant up --provision
 Warning: this one will take a while.
 
 ### 4. Configure WordPress tests
+
 Copy `/wordpress-trunk/public_html/wp-tests-config-sample.php` to `/wordpress-trunk/public_html/wp-tests-config.php`. Assuming you're using VVV's defaults, we just need to specify how to access the database:
 
 ```php
@@ -52,6 +55,7 @@ define('DB_PASSWORD', 'root');
 ```
 
 ### 5. Install WordPress tests
+
 SSH into Vagrant to install Timber's tests and run them
 
 ```
@@ -88,7 +92,7 @@ $ composer install
 $ phpunit
 ```
 
-You should see a bunch of gobbledygook across your screen (the whole process will take about 4 mins.), but we should see that WordPress is testing successfully. Hurrah! For more info, check out the [Handbook on Automated Testing](https://make.wordpress.org/core/handbook/automated-testing/).
+You should see a bunch of gobbledygook across your screen (the whole process will take about 4 mins.), but we should see that WordPress is testing successfully. Hurrah! For more info, check out the [Handbook on Automated Testing](https://make.wordpress.org/core/handbook/testing/automated-testing/).
 
 ### Writing tests
 
@@ -116,6 +120,3 @@ vendor/bin/phpstan analyze -l 1
 ```
 
 Where the last argument is the level of [strictness](https://medium.com/@ondrejmirtes/phpstan-0-12-released-f1a88036535d) (0-7) to apply. We're currently starting at level 1 and working our way up over time.
-
-
-

--- a/docs/v2/guides/twig-filters.md
+++ b/docs/v2/guides/twig-filters.md
@@ -5,7 +5,7 @@ order: "220"
 
 ## General Filters
 
-Twig offers a variety of [filters](https://twig.symfony.com/doc/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some extra filters to filter data the WordPress way. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
+Twig offers a variety of [filters](https://twig.symfony.com/doc/3.x/filters/index.html) to transform text and other information into the desired output. In addition, Timber has added some extra filters to filter data the WordPress way. Below is a comprehensive list of available filters, categorized by their functionality. Click on any filter name to jump to its detailed documentation and examples.
 
 ### Image Filters
 

--- a/docs/v2/guides/twig.md
+++ b/docs/v2/guides/twig.md
@@ -190,7 +190,7 @@ You can call actions in your Twig templates like this:
 {% do action('my_action_with_args', 'foo', 'bar') %}
 ```
 
-If you ask yourself why there’s no underline between `do` and `action`: The expression [`do`](https://twig.symfony.com/doc/tags/do.html) is a feature of Twig which *calls a function without printing its return value*, like `{{ }}` does. Timber only registers an `action` function, which then calls the `do_action()` function.
+If you ask yourself why there's no underline between `do` and `action`: The expression [`do`](https://twig.symfony.com/doc/3.x/tags/do.html) is a feature of Twig which _calls a function without printing its return value_, like `{{ }}` does. Timber only registers an `action` function, which then calls the `do_action()` function.
 
 If you want anything from the template’s context, you'll need to pass that manually:
 
@@ -326,21 +326,21 @@ And then, we pass it to Twig, where we use Twig’s own [`template_to_string()`]
 
 ### Text editor add-ons
 
-* Text Mate & Sublime text bundle – [Anomareh's PHP-Twig](https://github.com/Anomareh/PHP-Twig.tmbundle)
-* Emacs – [Web Mode](https://web-mode.org/)
-* Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
-* PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](https://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
-* Atom – Syntax highlighting with the [Atom Component](https://atom.io/packages/php-twig).
+- Text Mate & Sublime text bundle – [Anomareh's PHP-Twig](https://github.com/uhnomoli/PHP-Twig.tmbundle)
+- Emacs – [Web Mode](https://web-mode.org/)
+- Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
+- PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](https://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
+- Atom – Syntax highlighting with the [Atom Component](https://github.blog/news-insights/product-news/sunsetting-atom/).
 
 ### WordPress tools
 
-* [Lisa Templates](https://github.com/pierreminik/lisa-templates/) – allows you to write Twig-templates in the WordPress Admin that renders through a shortcode, widget or on the_content hook.
+- [Lisa Templates](https://github.com/pierreminik/lisa-templates/) – allows you to write Twig-templates in the WordPress Admin that renders through a shortcode, widget or on the_content hook.
 
 ### Other
 
-* [Watson-Ruby](https://nhmood.github.io/watson-ruby/) – An inline issue manager. Put tags like `[todo]` in a Twig comment and find it easily later. Watson supports Twig as of version 1.6.3.
+- [Watson-Ruby](https://nhmood.github.io/watson-ruby/) – An inline issue manager. Put tags like `[todo]` in a Twig comment and find it easily later. Watson supports Twig as of version 1.6.3.
 
 ### JavaScript
 
-* [Twig.js](https://github.com/justjohn/twig.js) – Use those `.twig` files in the Javascript and AJAX components of your site.
-* [Nunjucks](https://mozilla.github.io/nunjucks/) – Another JS template language that is also based on [Jinja2](https://jinja.pocoo.org/docs/)
+- [Twig.js](https://github.com/twigjs/twig.js) – Use those `.twig` files in the Javascript and AJAX components of your site.
+- [Nunjucks](https://mozilla.github.io/nunjucks/) – Another JS template language that is also based on [Jinja2](https://jinja.palletsprojects.com/)

--- a/docs/v2/guides/twig.md
+++ b/docs/v2/guides/twig.md
@@ -190,7 +190,7 @@ You can call actions in your Twig templates like this:
 {% do action('my_action_with_args', 'foo', 'bar') %}
 ```
 
-If you ask yourself why there's no underline between `do` and `action`: The expression [`do`](https://twig.symfony.com/doc/3.x/tags/do.html) is a feature of Twig which _calls a function without printing its return value_, like `{{ }}` does. Timber only registers an `action` function, which then calls the `do_action()` function.
+If you ask yourself why there’s no underline between `do` and `action`: The expression [`do`](https://twig.symfony.com/doc/3.x/tags/do.html) is a feature of Twig which _calls a function without printing its return value_, like `{{ }}` does. Timber only registers an `action` function, which then calls the `do_action()` function.
 
 If you want anything from the template’s context, you'll need to pass that manually:
 

--- a/docs/v2/guides/twig.md
+++ b/docs/v2/guides/twig.md
@@ -330,7 +330,6 @@ And then, we pass it to Twig, where we use Twig’s own [`template_to_string()`]
 - Emacs – [Web Mode](https://web-mode.org/)
 - Geany – Add [Twig/Symfony2 detection and highlighting](https://wiki.geany.org/howtos/geany_and_django#twigsymfony2_support)
 - PhpStorm – Built in coloring and code hinting. The Twig extension is recognized and has been for some time. [Twig Details for PhpStorm](https://blog.jetbrains.com/phpstorm/2013/06/twig-support-in-phpstorm/).
-- Atom – Syntax highlighting with the [Atom Component](https://github.blog/news-insights/product-news/sunsetting-atom/).
 
 ### WordPress tools
 

--- a/docs/v2/guides/woocommerce.md
+++ b/docs/v2/guides/woocommerce.md
@@ -15,7 +15,7 @@ function theme_add_woocommerce_support()
 add_action('after_setup_theme', 'theme_add_woocommerce_support');
 ```
 
-For more information about how you can enable or disable features and change settings through theme support, refer to the [WooCommerce Theme Developer Handbook](https://docs.woocommerce.com/document/woocommerce-theme-developer-handbook).
+For more information about how you can enable or disable features and change settings through theme support, refer to the [WooCommerce Theme Developer Handbook](https://developer.woocommerce.com/docs/theming/theme-development/classic-theme-developer-handbook).
 
 Once that’s done you can start integrating WooCommerce into your theme by creating a file named **woocommerce.php** in the root of your theme. That will establish the context and data to be passed to your Twig files:
 
@@ -102,29 +102,29 @@ Create a Twig file according to the location asked by the above file, in this ex
 
     <div class="product">
         {% do action('woocommerce_before_single_product') %}
-    
+
         <article itemscope itemtype="https://schema.org/Product" class="single-product-details {{ post.class }}">
-    
+
             <div class="entry-images">
                 {% do action('woocommerce_before_single_product_summary') %}
-    
+
                 <img src="{{ post.thumbnail.src('shop_single') }}" />
             </div>
-    
+
             <div class="summary entry-summary">
                 {% do action('woocommerce_single_product_summary') %}
             </div>
-    
+
             {% do action('woocommerce_after_single_product_summary') %}
-    
+
             <meta itemprop="url" content="{{ post.link }}" />
-    
+
         </article>
-    
+
         {% for post in related_products %}
             {% include ["partials/tease-product.twig"] %}
         {% endfor %}
-    
+
         {% do action('woocommerce_after_single_product') %}
     </div>
 
@@ -200,7 +200,7 @@ function timber_set_product($post)
 
 Without this, some elements of the listed products would show the same information as the first product in the loop. If you see an error like `Warning: call_user_func_array() expects parameter 1 to be a valid callback, no array or string given`, this is your problem.
 
-*Note:* Some users reported issues with the loop context even when using the `timber_set_product()` helper function. Turns out the default WooCommerce hooks interfere with the output of the aforementioned function.
+_Note:_ Some users reported issues with the loop context even when using the `timber_set_product()` helper function. Turns out the default WooCommerce hooks interfere with the output of the aforementioned function.
 
 One way to get around this is by building your own image calls, that means removing WooCommerce’s default hooks and declare your own template for the HTML to show the image:
 

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -99,7 +99,7 @@ Timber is for both WordPress pros and rookies:
 - **Developers** who are new to WordPress and don’t want to dive deep into the the WordPress way of writing themes.
 - **WordPress professionals** who want to take advantage of object-oriented patterns that adhere to [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) principles.
 - **Agencies and studios** that want to make it easier for teams to develop WordPress themes collaboratively. With Timber, your best WordPress engineer can focus on building the `.php` files with requests from WordPress and pass the data into `.twig` files. Once there, your frontend developer can mark-up data and build out a site’s look-and-feel.
-- **Agencies and studios** that want to build their own framework for building WordPress websites. [Lumberjack](https://lumberjack.rareloop.com/) and [Conifer](https://coniferplug.in/) are just two examples.
+- **Agencies and studios** that want to build their own framework for building WordPress websites. [Lumberjack](https://lumberjack.rareloop.com/) is a great example of this.
 
 ### When is Timber not the right tool for the job?
 

--- a/docs/v2/upgrade-guides/2.0.md
+++ b/docs/v2/upgrade-guides/2.0.md
@@ -235,7 +235,7 @@ Before version 2.0, when you wanted to get a collection of posts, the standard w
 
 We deprecated the possibility to instantiate objects directly. Instead, you should only use `Timber::get_post()` and `Timber::get_posts()`.
 
-Make sure you also read the new [Posts Guide](https://timber.github.io/docs/v2/guides/posts).
+Make sure you also read the new [Posts Guide](https://timber.github.io/docs/v2/guides/posts/).
 
 ### Timber::get_post()
 
@@ -416,13 +416,13 @@ We still recommend you to run queries and prepare posts in PHP and not in Twig. 
 
 ### Post Collections
 
-We added some documentation about how to work with [Post Collections](https://timber.github.io/docs/v2/guides/posts#post-collections), which are returned when you use `Timber::get_posts()`.
+We added some documentation about how to work with [Post Collections](https://timber.github.io/docs/v2/guides/posts/#post-collections), which are returned when you use `Timber::get_posts()`.
 
-Make sure you also read about [the Laziness of posts](https://timber.github.io/docs/v2/guides/posts#laziness-and-caching).
+Make sure you also read about [the Laziness of posts](https://timber.github.io/docs/v2/guides/posts/#laziness-and-caching).
 
 ### Post Serialization
 
-When converting post data to JSON, for example to use post data in JavaScript, then we talk about [Serialization](https://timber.github.io/docs/v2/guides/posts#serialization). We added some documentation for that.
+When converting post data to JSON, for example to use post data in JavaScript, then we talk about [Serialization](https://timber.github.io/docs/v2/guides/posts/#serialization). We added some documentation for that.
 
 ---
 
@@ -430,7 +430,7 @@ When converting post data to JSON, for example to use post data in JavaScript, t
 
 Similar to posts, when you wanted to get a Timber term object before version 2.0, you could either use `Timber::get_term()` or `new Timber\Term()`. Now, instantiating `Timber\Term` directly doesn’t work anymore. You will always have to use `Timber::get_term()`.
 
-Make sure you also read the new [Terms Guide](https://timber.github.io/docs/v2/guides/terms).
+Make sure you also read the new [Terms Guide](https://timber.github.io/docs/v2/guides/terms/).
 
 ### Timber::get_term()
 
@@ -528,7 +528,6 @@ $comment = new Timber\Comment($comment_id);
 ```php
 $comment = Timber::get_comment($comment_id);
 ```
-
 
 ## Menus
 
@@ -671,12 +670,12 @@ In Twig, you could use functions that were called the same as classes to convert
 
 The following functions are now deprecated:
 
-| Deprecated functions | Use one of these instead |
-|---|---|
-| `{{ TimberPost() }}`<br>`{{ Post() }}` | `{{ get_post() }}`<br>`{{ get_posts() }}`                                                                                  |
-| `{{ TimberTerm() }}`<br>`{{ Term() }}` | `{{ get_term() }}`<br>`{{ get_terms() }}`                                                                                  |
+| Deprecated functions                     | Use one of these instead                                                                                                    |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `{{ TimberPost() }}`<br>`{{ Post() }}`   | `{{ get_post() }}`<br>`{{ get_posts() }}`                                                                                   |
+| `{{ TimberTerm() }}`<br>`{{ Term() }}`   | `{{ get_term() }}`<br>`{{ get_terms() }}`                                                                                   |
 | `{{ TimberImage() }}`<br>`{{ Image() }}` | `{{ get_image() }}`<br>`{{ get_post() }}`<br>`{{ get_attachment() }}`<br>`{{ get_attachment_by() }}`<br>`{{ get_posts() }}` |
-| `{{ TimberUser() }}`<br>`{{ User() }}` | `{{ get_user() }}`<br>`{{ get_users() }}`                                                                                  |
+| `{{ TimberUser() }}`<br>`{{ User() }}`   | `{{ get_user() }}`<br>`{{ get_users() }}`                                                                                   |
 
 ### Updated timber/twig filters
 
@@ -692,9 +691,9 @@ If you use any of the above filters to extend the Twig Environment, you’ll get
 
 Here’s how the filters are used in Timber 2.0:
 
-| Filter                  | Usage before                  | Usage now                   |
-|-------------------------|-------------------------------|-----------------------------|
-| `timber/twig`           | Extend `\Twig\Environment`    | Extend `\Twig\Environment`  |
+| Filter                  | Usage before                  | Usage now                    |
+| ----------------------- | ----------------------------- | ---------------------------- |
+| `timber/twig`           | Extend `\Twig\Environment`    | Extend `\Twig\Environment`   |
 | `timber/twig/functions` | 🚫 Extend `\Twig\Environment` | ✅ Add/remove Twig functions |
 | `timber/twig/filters`   | 🚫 Extend `\Twig\Environment` | ✅ Add/remove Twig filters   |
 | `timber/twig/escapers`  | 🚫 Extend `\Twig\Environment` | ✅ Add/remove Twig escapers  |
@@ -742,6 +741,7 @@ In version 2.0, **a context argument will no longer be passed to the hook functi
 ```twig
 {% do action('my_action', 'foo', post) %}
 ```
+
 ```php
 add_action('my_action_with_args', 'my_function_with_args', 10, 2);
 
@@ -756,8 +756,8 @@ function my_function_with_args($foo, $post)
 
 The following Twig filters have been deprecated and will be removed in future versions of Timber:
 
-* `|get_class`
-* `|print_r`
+- `|get_class`
+- `|print_r`
 
 In addition, the confusingly named (and non-functional) `|get_type` filter has been removed.
 
@@ -772,7 +772,7 @@ There are a couple we want to highlight:
 
 #### Spaceless
 
-The `spaceless` tag is deprecated, you should use the [`apply` tag](https://twig.symfony.com/doc/tags/apply.html) using the [`spaceless` filter](https://twig.symfony.com/doc/2.x/filters/spaceless.html) instead.
+The `spaceless` tag is deprecated, you should use the [`apply` tag](https://twig.symfony.com/doc/3.x/tags/apply.html) using the [`spaceless` filter](https://twig.symfony.com/doc/2.x/filters/spaceless.html) instead.
 
 **🚫 Before**
 
@@ -792,7 +792,7 @@ The `spaceless` tag is deprecated, you should use the [`apply` tag](https://twig
 
 #### Filter tag
 
-The `filter` tag is deprecated. Use the [`apply` tag](https://twig.symfony.com/doc/tags/apply.html) in combination with `apply_filters()` instead.
+The `filter` tag is deprecated. Use the [`apply` tag](https://twig.symfony.com/doc/3.x/tags/apply.html) in combination with `apply_filters()` instead.
 
 **🚫 Before**
 
@@ -857,7 +857,7 @@ This property was **removed** and you can **no longer access meta values through
 
 This is only recommended for development purposes, because it might affect your performance if you always request all values.
 
-The `meta()` and `raw_meta()` methods work the same way for all `Timber\Post`, `Timber\Term`, `Timber\User` and `Timber\Comment` objects. You can read more about this in the [Custom Fields Guide](https://timber.github.io/docs/v2/guides/custom-fields) as well as the [ACF Integrations Guide](https://timber.github.io/docs/v2/integrations/advanced-custom-fields).
+The `meta()` and `raw_meta()` methods work the same way for all `Timber\Post`, `Timber\Term`, `Timber\User` and `Timber\Comment` objects. You can read more about this in the [Custom Fields Guide](https://timber.github.io/docs/v2/guides/custom-fields/) as well as the [ACF Integrations Guide](https://timber.github.io/docs/v2/integrations/advanced-custom-fields/).
 
 ## New classes
 
@@ -867,7 +867,7 @@ Up until now, there was only a representation for WordPress image attachments in
 
 - The `Timber\Image` class now extends the `Timber\Attachment` class. All your code should already be compatible with this change. But in the future, you could use the new `Timber\Attachment` class if you work with an attachment that is not an image.
 - We’ve added new methods for `Timber\Attachment`. See the [section below](https://timber.github.io/docs/v2/upgrade-guides/2.0/#new-functions).
-- To get attachments from attachment IDs in Twig, you can use `{{ get_attachment(attachment_id) }}`. Behind the curtains, Timber uses [Class Maps](https://timber.github.io/docs/v2/guides/class-maps) to use the [`Timber\Image`](https://timber.github.io/docs/v2/reference/timber-image/) and [`Timber\Attachment`](https://timber.github.io/docs/v2/reference/timber-attachment/) classes for attachment posts.
+- To get attachments from attachment IDs in Twig, you can use `{{ get_attachment(attachment_id) }}`. Behind the curtains, Timber uses [Class Maps](https://timber.github.io/docs/v2/guides/class-maps/) to use the [`Timber\Image`](https://timber.github.io/docs/v2/reference/timber-image/) and [`Timber\Attachment`](https://timber.github.io/docs/v2/reference/timber-attachment/) classes for attachment posts.
 
 ### New ExternalImage class
 
@@ -1181,7 +1181,7 @@ $terms = $post->terms('category');
 $terms = $post->terms([
     'taxonomy' => 'category',
 ]);
-````
+```
 
 or
 
@@ -1473,8 +1473,7 @@ The following filter names have changed to match the WordPress naming convention
 
 The following filters were deprecated without a replacement and will be removed in the next major version:
 
-- The filters `timber_term_set_meta` and `timber/term/meta/set` were deprecated. They were used by `Term::update()`, which is now deprecated as
- well (without a replacement).
+- The filters `timber_term_set_meta` and `timber/term/meta/set` were deprecated. They were used by `Term::update()`, which is now deprecated as well (without a replacement).
 
 ### timber/term/meta
 

--- a/ecs.php
+++ b/ecs.php
@@ -11,6 +11,7 @@ use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 return ECSConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests', 'ecs.php'])
+    ->withFileExtensions(['php'])
     ->withSkip([
         NotOperatorWithSuccessorSpaceFixer::class,
     ])

--- a/tests/Factory/MenuFactoryTest.php
+++ b/tests/Factory/MenuFactoryTest.php
@@ -11,7 +11,7 @@ use Timber\Timber;
 class MyMenu extends Menu
 {
 }
-class MySeconaryMenu extends Menu
+class MySecondaryMenu extends Menu
 {
 }
 
@@ -210,7 +210,7 @@ class MenuFactoryTest extends TimberIntegrationTestCase
             'custom' => MyMenu::class,
             'custom_secondary' => function ($menu, $args) use ($id_secondary) {
                 if ($menu->term_id === $id_secondary) {
-                    return MySeconaryMenu::class;
+                    return MySecondaryMenu::class;
                 }
 
                 return null;
@@ -218,7 +218,7 @@ class MenuFactoryTest extends TimberIntegrationTestCase
         ]);
 
         $this->assertTrue(MyMenu::class === $factory->from($id)::class);
-        $this->assertTrue(MySeconaryMenu::class === $factory->from($id_secondary)::class);
+        $this->assertTrue(MySecondaryMenu::class === $factory->from($id_secondary)::class);
     }
 
     /**

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,26 @@
+[files]
+extend-exclude = [
+    ".git/",
+    ".github/",
+    "build/",
+]
+ignore-hidden = false
+
+[default]
+extend-ignore-re = [
+    "Nathan Hass",
+    "ba",
+    "Automattic"
+]
+
+[default.extend-identifiers]
+"field_5ba2c660ed26d" = "field_5ba2c660ed26d"
+"PNGs" = "PNGs"
+"struc" = "struc"
+"testPNGtoJPG" = "testPNGtoJPG"
+"testPNGtoWEBP" = "testPNGtoWEBP"
+# Known typo
+"timber_wp_title_seperator" = "timber_wp_title_seperator"
+"tmis" = "tmis"
+"Github" = "GitHub"
+"Wordpress" = "WordPress"


### PR DESCRIPTION
## Overview
This branch updates documentation links and improves code quality tooling across the Timber project.

## Changes Made

### Documentation Updates
- **Scope**: 37+ documentation files across v1 and v2 guides
- **Focus**: Updated outdated and broken external links
  - Replaced deprecated WordPress Codex links with current developer.wordpress.org references
  - Updated external resource links (e.g., wphierarchy.com → wpshout.com/wordpress-template-hierarchy/)
  - Fixed internal documentation links to use proper anchors
  - Minor formatting improvements (table alignment, etc)

### Code Quality Improvements

#### 1. GitHub Workflow Enhancement
- **File**: `.github/workflows/php-coding-standards.yml`
- **Change**: Added file filter to only scan PHP files during CI checks
- **Impact**: Prevents ECS from processing non-PHP files. This prevents non-php files from being linted.

#### 2. ECS Configuration Update
- **File**: `ecs.php`
- **Change**: Explicitly configured to only process `.php` file extensions
- **Impact**: Aligns ECS configuration with workflow changes for consistency

#### 3. Typo Corrections
- **File**: `tests/Factory/MenuFactoryTest.php`
- **Change**: Fixed class name typo `MySeconaryMenu` → `MySecondaryMenu`
- **Impact**: Corrects spelling error in test class (4 occurrences)

#### 4. Spell Checker Configuration
- **File**: `typos.toml` (new)
- **Change**: Added typos configuration file
- **Purpose**: Configures automated spell checking with:
  - Exclusion patterns for build directories
  - Whitelisted identifiers and known intentional spellings
  - Brand name corrections (Github → GitHub, Wordpress → WordPress)

## Summary
The documentation updates ensure readers are directed to current, maintained resources rather than deprecated ones.
