### PR TITLE
docs: Fix two relative links in DocBlocks

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -52,7 +52,7 @@ class Loader implements LoaderInterface
          * Filters the cache mode.
          *
          * You can read more about Caching in the
-         * [Performance/Caching]({{<relref "performance.md" >}}) guide.
+         * [Performance/Caching](../../guides/performance/) guide.
          *
          * @since 0.20.10
          *

--- a/src/PostQuery.php
+++ b/src/PostQuery.php
@@ -92,7 +92,7 @@ class PostQuery extends ArrayObject implements PostCollectionInterface, JsonSeri
     /**
      * Get pagination for a post collection.
      *
-     * Refer to the [Pagination Guide]({{< relref "../guides/pagination.md" >}}) for a detailed usage example.
+     * Refer to the [Pagination Guide](../../guides/pagination/) for a detailed usage example.
      *
      * Optionally could be used to get pagination with custom preferences.
      *


### PR DESCRIPTION
## Issue

Found 2 links that come from a time when we still used Hugo for the static documentation site.

## Solution

Fix the links to relative Markdown links.