### PR TITLE
test: Update image test to prevent race conditions

### DIFF
--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -20,7 +20,7 @@ class ImageTest extends TimberAttachmentTestCase
 {
     public function tear_down()
     {
-        $img_dir = \get_stylesheet_directory_uri() . '/images';
+        $img_dir = \get_stylesheet_directory() . '/images';
         if (\file_exists($img_dir)) {
             \exec(\sprintf("rm -rf %s", \escapeshellarg($img_dir)));
         }
@@ -552,7 +552,8 @@ class ImageTest extends TimberAttachmentTestCase
             return $alpha === 127;
         }
         if (isset($upper_colors) && $upper_colors) {
-            if (self::checkChannel('red', $test_colors, $colors_of_file, $upper_colors) &&
+            if (
+                self::checkChannel('red', $test_colors, $colors_of_file, $upper_colors) &&
                 self::checkChannel('green', $test_colors, $colors_of_file, $upper_colors) &&
                 self::checkChannel('blue', $test_colors, $colors_of_file, $upper_colors)
             ) {
@@ -560,9 +561,11 @@ class ImageTest extends TimberAttachmentTestCase
             }
             return false;
         }
-        if ($test_colors['red'] === $colors_of_file['red'] &&
-             $test_colors['blue'] === $colors_of_file['blue'] &&
-             $test_colors['green'] === $colors_of_file['green']) {
+        if (
+            $test_colors['red'] === $colors_of_file['red'] &&
+            $test_colors['blue'] === $colors_of_file['blue'] &&
+            $test_colors['green'] === $colors_of_file['green']
+        ) {
             return true;
         }
         return false;
@@ -1050,7 +1053,12 @@ class ImageTest extends TimberAttachmentTestCase
         $result = Timber::compile_string($str, [
             'post' => $post,
         ]);
-        $this->assertEquals('http://example.org/wp-content/uploads/' . \date('Y/m') . '/arch.jpeg', $result);
+        // Verify the filter was applied (jpg -> jpeg) and the base filename is present
+        // Don't check for exact filename as WordPress may add numeric suffixes (-2, -8, etc.)
+        // to avoid filename conflicts if the file already exists
+        $this->assertStringStartsWith('http://example.org/wp-content/uploads/' . \date('Y/m') . '/arch', $result);
+        $this->assertStringEndsWith('.jpeg', $result);
+        $this->assertStringNotContainsString('.jpg', $result);
     }
 
     public function testTimberImageForExtraSlashes()


### PR DESCRIPTION
## Fix intermittent test failure in ImageTest::testFilteredImageURL on PHP 8.5

### Problem

The `ImageTest::testFilteredImageURL` test was failing intermittently on PHP 8.5 with random numeric suffixes in the filename:

```
FAILED  Timber\Tests\Image\ImageTest              
  Failed asserting that two strings are equal.
  -'...tent/uploads/2026/04/arch.jpeg'
  +'...tent/uploads/2026/04/arch-2.jpeg'
```

This was caused by WordPress automatically adding numeric suffixes (`-2`, `-8`, etc.) to avoid filename conflicts when a file with the same name already exists from incomplete test cleanup.

### Changes

1. **Updated `testFilteredImageURL` assertions**: Changed from exact filename matching to pattern-based assertions that verify:
   - The URL starts with the expected path and base filename
   - The URL ends with `.jpeg` (confirming the filter worked)
   - The URL doesn't contain `.jpg` (confirming the filter was applied)
   
   This makes the test resilient to WordPress's automatic filename deduplication while still validating the filter's behavior.

2. **Fixed `tear_down()` cleanup bug**: Changed `get_stylesheet_directory_uri()` to `get_stylesheet_directory()` on line 22. The function was returning a URL instead of a filesystem path, causing `file_exists()` to always return false and preventing proper cleanup of test files. This bug was likely contributing to the filename conflicts that triggered the test failures.

### Testing

The test now passes consistently regardless of whether WordPress renames the uploaded file, and the improved cleanup should reduce the frequency of filename conflicts in future test runs.
