### PR TITLE
fix: Fix regression bug when Timber would access empty properties in Twig

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -3,6 +3,7 @@
 namespace Timber;
 
 use AllowDynamicProperties;
+use Error;
 
 /**
  * Class Core
@@ -143,9 +144,14 @@ abstract class Core
                     $this->$key = $value;
                 } elseif (\method_exists($this, $key) && \property_exists($this, $key)) {
                     // While we don’t import properties where a method exists by default, this makes
-                    // sure that properties are imported where they are defined. This reduces
-                    // unexpected side effects.
+                    // sure that properties are imported when they are defined. This reduces
+                    // unexpected side effects. The try-catch is here to not trigger a fatal error
+                    // when we try to set a private property.
+                    try {
                     $this->$key = $value;
+                    } catch (Error $e) {
+                        \trigger_error($e->getMessage(), \E_USER_WARNING);
+                    }
                 } elseif (!empty($key) && !\method_exists($this, $key)) {
                     if ($only_declared_properties) {
                         if (\property_exists($this, $key)) {

--- a/src/Core.php
+++ b/src/Core.php
@@ -141,6 +141,11 @@ abstract class Core
                 }
                 if (!empty($key) && $force) {
                     $this->$key = $value;
+                } elseif (\method_exists($this, $key) && \property_exists($this, $key)) {
+                    // While we don’t import properties where a method exists by default, this makes
+                    // sure that properties are imported where they are defined. This reduces
+                    // unexpected side effects.
+                    $this->$key = $value;
                 } elseif (!empty($key) && !\method_exists($this, $key)) {
                     if ($only_declared_properties) {
                         if (\property_exists($this, $key)) {

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -290,12 +290,6 @@ class MenuItem extends CoreEntity implements Stringable
          */
         protected $menu = null
     ) {
-        /**
-         * @property string $title The nav menu item title.
-         */
-        // @phpstan-ignore property.notFound
-        $this->title = $this->wp_object->title;
-
         $this->import($this->wp_object);
         $this->import_classes($this->wp_object);
         $this->id = $this->wp_object->ID;

--- a/src/Post.php
+++ b/src/Post.php
@@ -265,11 +265,12 @@ class Post extends CoreEntity implements DatedInterface, Setupable, Stringable
     /**
      * Cached comment count.
      *
-     * A numeric string, for compatibility reasons.
+     * A numeric string, for compatibility reasons. Protected visibility to make
+     * Twig use the comment_count() method first.
      *
      * @var string
      */
-    public $comment_count;
+    protected $comment_count;
 
     /**
      * Stores the post object's sanitization level.

--- a/src/Term.php
+++ b/src/Term.php
@@ -103,9 +103,11 @@ class Term extends CoreEntity implements Stringable
     /**
      * The term's description.
      *
+     * Protected visibility to make Twig use the description() method first.
+     *
      * @var string
      */
-    public $description;
+    protected $description;
 
     /**
      * ID of a term's parent term.
@@ -321,7 +323,9 @@ class Term extends CoreEntity implements Stringable
     }
 
     /**
-     * Return the description of the term
+     * Returns the description of the term.
+     *
+     * Strips any surrounding `<p></p>` tags from the description.
      *
      * @api
      * @return string

--- a/tests/Support/PostCommentCount.php
+++ b/tests/Support/PostCommentCount.php
@@ -1,0 +1,11 @@
+<?php
+
+use Timber\Post;
+
+class PostCommentCount extends Post
+{
+    public function set_comment_count($count)
+    {
+        $this->comment_count = $count;
+    }
+}

--- a/tests/TermTest.php
+++ b/tests/TermTest.php
@@ -145,6 +145,28 @@ class TermTest extends TimberIntegrationTestCase
         $this->assertEquals($desc, $term->description());
     }
 
+    /**
+     * Tests whether the description() method takes precedence over the description property in
+     * Twig.
+     *
+     * @return void
+     */
+    public function testTermDescriptionInTwig()
+    {
+        $desc = '<p>An honest football team</p>';
+
+        $term_id = static::factory()->term->create([
+            'name' => 'New England Patriots',
+            'description' => $desc,
+        ]);
+
+        $result = Timber::compile_string('{{ term.description }}', [
+            'term' => Timber::get_term($term_id),
+        ]);
+
+        $this->assertSame(\wp_strip_all_tags($desc), $result);
+    }
+
     public function testTermInitObject()
     {
         $term_id = static::factory()->term->create();

--- a/tests/TimberPostCommentsTest.php
+++ b/tests/TimberPostCommentsTest.php
@@ -4,6 +4,7 @@ namespace Timber\Tests;
 
 use CustomComment;
 use PHPUnit\Framework\Attributes\Group;
+use PostCommentCount;
 use Timber\Tests\Support\Attributes\WithOption;
 use Timber\Timber;
 
@@ -38,6 +39,33 @@ class TimberPostCommentsTest extends TimberIntegrationTestCase
         $post = Timber::get_post($post_id);
         $this->assertSame(2, \count($post->comments(2)));
         $this->assertSame(5, \count($post->comments()));
+    }
+
+    // Tests where the comment_count() method takes precedence over the comment_count property in
+    // Twig.
+    public function testCommentCountInTwig()
+    {
+        $post_id = static::factory()->post->create([
+            'post_title' => 'Gobbles',
+        ]);
+        static::factory()->comment->create_many(5, [
+            'comment_post_ID' => $post_id,
+        ]);
+
+        $this->add_filter_temporarily('timber/post/classmap', static fn ($classmap) => \array_merge($classmap, [
+            'post' => PostCommentCount::class,
+        ]));
+
+        $post = Timber::get_post($post_id);
+
+        // Set the comment count into something different on the Timber\Post object only.
+        $post->set_comment_count(24);
+
+        $str = Timber::compile_string('{{ post.comment_count }} comments', [
+            'post' => $post,
+        ]);
+
+        $this->assertEquals('5 comments', $str);
     }
 
     public function testCommentCountZero()


### PR DESCRIPTION
Related:

- #3245 

## Issue
 
By introducing some new properties in https://github.com/timber/timber/pull/3198, we introduced a regression bug where `{{ term.description }}` or `{{ post.comment_count }}` would return empty instead, because the object property was accessed instead of the method with the same name.

## Solution

I looked at the issue more closely, and I found that setting the property to protected fixes the issue. However, the property would still be empty, even though a value would be available on the `WP_Term` object. Even if the property were protected, this would be wrong in my opinion.

The issue is the following line:

https://github.com/timber/timber/blob/43c4e4964b11d2ce6020b14bc77759dfda71de79/src/Core.php#L144

It means that if we have a method defined, we won’t import the property. This logic was introduced 12 years ago in https://github.com/timber/timber/issues/334.

While this was a solution that worked for a long time, I think it’s also quite unexpected that a property that you want to import is not actually set and will always stay null.

We can set the properties that have a corresponding public method to protected to fix the regression.

We actually already use the same approach in `MenuItem`:

https://github.com/timber/timber/blob/43c4e4964b11d2ce6020b14bc77759dfda71de79/src/MenuItem.php#L46-L50

In this class, we had to set the `title` property manually, because it’s not imported:

https://github.com/timber/timber/blob/43c4e4964b11d2ce6020b14bc77759dfda71de79/src/MenuItem.php#L293-L297

That’s why I also changed the logic in `\Timber\Core::import()` to always import properties that exist and also have a method defined.

This will allow us to also remove the custom import fix from `MenuItem`.

I only found the issue to be present for `Term::$description`, `Post::$comment_count` and `MenuItem::$title`, but not for any other property.

## Impact

Fixes regression bug.

## Usage Changes

None.

## Considerations

We might think about removing the `method_exists()` logic entirely from the `import()` method. With dynamic properties going away more and more in modern PHP, this would be a direction that would also help static analysis.

## Testing

Yes, I added two tests that specifically check for the methods to be accessed in Twig instead of the properties.