### PR TITLE
chore: bump minimum WordPress version to 6.4

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
         include:
           # Oldest supported WP with lowest deps
           - php: '8.2'
-            wp: '6.3'
+            wp: '6.4'
             dependency-version: 'lowest'
             experimental: false
             coverage: false

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -71,7 +71,7 @@ jobs:
         include:
           # Oldest supported WP with lowest deps
           - php: '8.2'
-            wp: '6.4'
+            wp: '6.8'
             dependency-version: 'lowest'
             experimental: false
             coverage: false

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -7,33 +7,24 @@ namespace Timber;
  */
 class Admin
 {
-    public static function init()
+    public static function init(?string $wp_version = null): void
     {
-        global $wp_version;
+        // wp_get_wp_version() exists since WP 6.7; fall back to the global for older versions
+        // (which is exactly the range this notice targets).
+        $wp_version ??= \function_exists('wp_get_wp_version') ? \wp_get_wp_version() : (string) ($GLOBALS['wp_version'] ?? '');
 
-        $minimum_version = '6.0.0';
-
-        // Show notice if user is running something older than the required
-        // WordPress version.
-        if (\version_compare($minimum_version, $wp_version) === 1) {
-            $upgrade_url = \admin_url('update-core.php');
-
-            self::show_notice("<a href='https://github.com/timber/timber'>Timber 2.0</a> requires <strong>WordPress $minimum_version</strong> or greater, but you are running <strong>WordPress $wp_version</strong>. Please <a href='$upgrade_url'>update WordPress</a> in order to use Timber 2.0.");
+        // Bail if the running WordPress version meets Timber's tested minimum.
+        if (\version_compare(Timber::MINIMUM_WP_VERSION, $wp_version) !== 1) {
+            return;
         }
-    }
 
-    /**
-     * Display a message in the admin.
-     *
-     * @date    01/07/2020
-     *
-     * @param string  $text to display
-     * @param string  $class of the notice 'error' (red) or 'warning' (yellow)
-     */
-    protected static function show_notice($text, $class = 'error')
-    {
-        \add_action('admin_notices', function () use ($text, $class) {
-            echo '<div class="' . $class . '"><p>' . $text . '</p></div>';
+        \add_action('admin_notices', static function () use ($wp_version): void {
+            \printf(
+                '<div class="error"><p>Your installed version of <a href="https://github.com/timber/timber" target="_blank" rel="noopener noreferrer">Timber</a> is only tested against <strong>WordPress %1$s</strong> or greater, but you are running <strong>WordPress %2$s</strong>. Please <a href="%3$s">update WordPress</a> to make sure Timber runs fine.</p></div>',
+                Timber::MINIMUM_WP_VERSION,
+                $wp_version,
+                \admin_url('update-core.php'),
+            );
         }, 1);
     }
 }

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -45,6 +45,11 @@ class Timber
     public const VERSION = '2.4.1'; // x-release-please-version
 
     /**
+     * Minimum WordPress version Timber is tested against.
+     */
+    public const MINIMUM_WP_VERSION = '6.4.0';
+
+    /**
      * @deprecated 2.4.2 Use {@see Timber::VERSION} instead.
      * @var string
      */
@@ -1298,7 +1303,7 @@ class Timber
              * first time. That’s why you should add this filter before you call
              * `Timber::context()`.
              *
-             * @see \Timber\Timber::context()
+             * @see Timber::context()
              * @since 0.21.7
              * @example
              * ```php
@@ -1651,7 +1656,7 @@ class Timber
         /**
          * Filters the compiled result before it is returned.
          *
-         * @see \Timber\Timber::fetch()
+         * @see Timber::fetch()
          * @since 0.16.7
          * @deprecated 2.0.0 use timber/compile/result
          *

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -47,7 +47,7 @@ class Timber
     /**
      * Minimum WordPress version Timber is tested against.
      */
-    public const MINIMUM_WP_VERSION = '6.4.0';
+    public const MINIMUM_WP_VERSION = '6.8.0';
 
     /**
      * @deprecated 2.4.2 Use {@see Timber::VERSION} instead.

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Timber\Tests;
+
+use Timber\Admin;
+use Timber\Timber;
+
+class AdminTest extends TimberIntegrationTestCase
+{
+    public function tear_down()
+    {
+        \remove_all_actions('admin_notices');
+        parent::tear_down();
+    }
+
+    public function testNoticeShownWhenWpVersionBelowMinimum(): void
+    {
+        Admin::init('6.0.0');
+
+        \ob_start();
+        \do_action('admin_notices');
+        $output = \ob_get_clean();
+
+        $this->assertStringContainsString(Timber::MINIMUM_WP_VERSION, $output);
+        $this->assertStringContainsString('6.0.0', $output);
+        $this->assertStringContainsString('update WordPress', $output);
+    }
+
+    public function testNoNoticeWhenWpVersionMeetsMinimum(): void
+    {
+        Admin::init(Timber::MINIMUM_WP_VERSION);
+
+        \ob_start();
+        \do_action('admin_notices');
+        $output = \ob_get_clean();
+
+        $this->assertStringNotContainsString('timber/timber', $output);
+    }
+
+    public function testNoNoticeWhenWpVersionAboveMinimum(): void
+    {
+        Admin::init('99.0.0');
+
+        \ob_start();
+        \do_action('admin_notices');
+        $output = \ob_get_clean();
+
+        $this->assertStringNotContainsString('timber/timber', $output);
+    }
+}

--- a/tests/TimberContextTest.php
+++ b/tests/TimberContextTest.php
@@ -228,11 +228,6 @@ class TimberContextTest extends TimberIntegrationTestCase
 
         global $wp_query;
 
-        // Reset loop state to test that Timber::context() sets it up.
-        // WP 6.3 sets in_the_loop=true during request setup due to a workaround
-        // that was fixed in WP 6.4. See: https://core.trac.wordpress.org/ticket/58154
-        $wp_query->in_the_loop = false;
-
         $this->assertFalse($wp_query->in_the_loop);
 
         Timber::context();

--- a/tests/TimberWPFunctionsTest.php
+++ b/tests/TimberWPFunctionsTest.php
@@ -18,9 +18,7 @@ namespace Timber\Tests {
         #[IgnoreDeprecations]
         public function testFooterOnFooterFW()
         {
-            if ($this->isWordPressVersion('6.4', '>=')) {
-                $this->setExpectedDeprecated('the_block_template_skip_link');
-            }
+            $this->setExpectedDeprecated('the_block_template_skip_link');
 
             global $wp_scripts;
             $wp_scripts = null;
@@ -38,9 +36,7 @@ namespace Timber\Tests {
         #[IgnoreDeprecations]
         public function testFooterAlone()
         {
-            if ($this->isWordPressVersion('6.4', '>=')) {
-                $this->setExpectedDeprecated('the_block_template_skip_link');
-            }
+            $this->setExpectedDeprecated('the_block_template_skip_link');
             global $wp_scripts;
             $wp_scripts = null;
             \wp_enqueue_script('jquery', false, [], false, true);
@@ -62,9 +58,7 @@ namespace Timber\Tests {
         #[IgnoreDeprecations]
         public function testDoubleActionWPFooter()
         {
-            if ($this->isWordPressVersion('6.4', '>=')) {
-                $this->setExpectedDeprecated('the_block_template_skip_link');
-            }
+            $this->setExpectedDeprecated('the_block_template_skip_link');
             global $wp_scripts;
             $wp_scripts = null;
             $this->add_action_temporarily('wp_footer', 'echo_junk');
@@ -78,9 +72,7 @@ namespace Timber\Tests {
         #[IgnoreDeprecations]
         public function testInTwig()
         {
-            if ($this->isWordPressVersion('6.4', '>=')) {
-                $this->setExpectedDeprecated('the_block_template_skip_link');
-            }
+            $this->setExpectedDeprecated('the_block_template_skip_link');
             global $wp_scripts;
             $wp_scripts = null;
             \wp_enqueue_script('jquery', false, [], false, true);
@@ -92,9 +84,7 @@ namespace Timber\Tests {
         #[IgnoreDeprecations]
         public function testInTwigString()
         {
-            if ($this->isWordPressVersion('6.4', '>=')) {
-                $this->setExpectedDeprecated('the_block_template_skip_link');
-            }
+            $this->setExpectedDeprecated('the_block_template_skip_link');
             global $wp_scripts;
             $wp_scripts = null;
             \wp_enqueue_script('jquery', false, [], false, true);
@@ -106,9 +96,7 @@ namespace Timber\Tests {
         #[IgnoreDeprecations]
         public function testAgainstFooterFunctionOutput()
         {
-            if ($this->isWordPressVersion('6.4', '>=')) {
-                $this->setExpectedDeprecated('the_block_template_skip_link');
-            }
+            $this->setExpectedDeprecated('the_block_template_skip_link');
             global $wp_scripts;
             $wp_scripts = null;
             \wp_enqueue_script('colorpicker', false, [], false, true);


### PR DESCRIPTION
Update the CI matrix lowest-deps job from WP 6.3 to 6.4, and drop the now-dead version conditionals in TimberWPFunctionsTest (the the_block_template_skip_link deprecation is always emitted on 6.4+) and the WP 6.3 in_the_loop workaround in TimberContextTest.

## Issue

Bump WP minimum tested version as per our policy. We should probably display it somewhere BTW. 

## Considerations

Just wonder if we should change version here?
https://github.com/timber/timber/blob/35b869a7f1029d0b54e10066eb0da04c9c54e46f/src/Admin.php#L14-L22

But the minimum WP version is only the minimum version we test ≠ version Timber actually supports. 