### PR TITLE
fix: switch version property to constant and mark old property as deprecated

### DIFF
--- a/src/Timber.php
+++ b/src/Timber.php
@@ -42,7 +42,13 @@ use WP_User;
  */
 class Timber
 {
-    public static $version = '2.4.1'; // x-release-please-version
+    public const VERSION = '2.4.1'; // x-release-please-version
+
+    /**
+     * @deprecated 2.4.2 Use {@see Timber::VERSION} instead.
+     * @var string
+     */
+    public static $version = self::VERSION;
 
     public static $locations;
 


### PR DESCRIPTION
`$version` is a public static property that can be changed at runtime. 

Switch to a const. 

