### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,28 +5,24 @@ inputs:
     description: PHP version
     default: "8.2"
     required: false
-    type: string
   PHP_TOOLS:
-    description: PHP version
+    description: Additional PHP tools to install via setup-php.
     default: ""
     required: false
-    type: string
   COMPOSER_ARGS:
     description: Set of arguments passed to Composer.
     default: '--prefer-dist --no-scripts'
     required: false
-    type: string
   INSTALL_DEPS:
     description: Whether to install dependencies or not.
-    default: true
+    default: "true"
     required: false
-    type: boolean
 
 runs:
   using: composite
   steps:
     - name: Set up PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # 2.37.1
       with:
         php-version: ${{ inputs.PHP_VERSION }}
         tools: ${{ format('composer,{0}', inputs.PHP_TOOLS) }}
@@ -39,6 +35,6 @@ runs:
       run: composer config audit.block-insecure false
     - name: Install Composer dependencies
       if: ${{ inputs.INSTALL_DEPS == 'true' }}
-      uses: ramsey/composer-install@v4
+      uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
       with:
         composer-options: ${{ inputs.COMPOSER_ARGS }}

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -22,12 +22,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   composer-lint:
     name: Composer lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/links-check.yml
+++ b/.github/workflows/links-check.yml
@@ -2,25 +2,32 @@ name: Docs links checker
 
 on: [workflow_dispatch]
 
+permissions: {}
+
 jobs:
   links-check:
     name: Link Checker
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-            ref: 2.x
+          ref: 2.x
+          persist-credentials: false
 
-      - uses: lycheeverse/lychee-action@v2.8.0
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         id: lychee
         with:
-            args: --verbose './docs/**/*.md' --max-concurrency 1 --max-retries 0 --accept 200,429 --cache
+          args: --verbose './docs/**/*.md' --max-concurrency 1 --max-retries 0 --accept 200,429 --cache
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -24,12 +24,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   php-cs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/setup
@@ -38,11 +45,14 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
         with:
           files: |
             **/*.php
+          safe_output: true
 
       - name: Run coding standards
         if: steps.changed-files.outputs.all_changed_files != ''
-        run: ./vendor/bin/ecs check --output-format=checkstyle ${{ join(steps.changed-files.outputs.all_changed_files, ' ') }} | cs2pr
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: ./vendor/bin/ecs check --output-format=checkstyle $CHANGED_FILES | cs2pr

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -24,12 +24,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   php-lint:
     name: PHP lint
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/setup
@@ -39,10 +46,13 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
         with:
-           files: '**.php'
+          files: '**.php'
+          safe_output: true
 
       - name: Run PHP lint
         if: steps.changed-files.outputs.all_changed_files != ''
-        run: parallel-lint --exclude .git --exclude vendor --checkstyle ${{ join(steps.changed-files.outputs.all_changed_files, ' ') }} | cs2pr
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: parallel-lint --exclude .git --exclude vendor --checkstyle $CHANGED_FILES | cs2pr

--- a/.github/workflows/php-rector.yml
+++ b/.github/workflows/php-rector.yml
@@ -24,20 +24,31 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
-  php-cs:
+  php-rector:
     name: PHP Rector
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/setup
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+        with:
+          safe_output: true
 
       - name: Run Rector checks
         if: steps.changed-files.outputs.all_changed_files != ''
-        run: ./vendor/bin/rector process --dry-run ${{ steps.changed-files.outputs.files }}
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: ./vendor/bin/rector process --dry-run $CHANGED_FILES

--- a/.github/workflows/php-static-analysis.yml
+++ b/.github/workflows/php-static-analysis.yml
@@ -24,12 +24,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   php-static-analysis:
     name: PHP static analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/setup
@@ -38,12 +45,15 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
         with:
           files: |
             src/**/*.php
             phpstan/**/*.php
+          safe_output: true
 
       - name: Run static analysis
         if: steps.changed-files.outputs.all_changed_files != ''
-        run: ./vendor/bin/phpstan analyse --memory-limit=-1 --error-format=checkstyle ${{ steps.changed-files.outputs.all_changed_files }} | cs2pr
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: ./vendor/bin/phpstan analyse --memory-limit=-1 --error-format=checkstyle $CHANGED_FILES | cs2pr

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -28,18 +28,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   # =============================================================================
   # Detect PHP versions from composer.json
   # =============================================================================
   php-versions:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       versions: ${{ steps.versions.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - id: versions
-        uses: WyriHaximus/github-action-composer-php-versions-in-range@v2
+        uses: WyriHaximus/github-action-composer-php-versions-in-range@c066c91df855ca2563dc4ec46ac6674e0752ae65 # v2.0.0
         with:
           upcomingReleases: true
 
@@ -49,6 +56,9 @@ jobs:
   php-unit-tests:
     needs: php-versions
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -81,10 +91,12 @@ jobs:
     name: PHP ${{ matrix.php }} | WP ${{ matrix.wp }} | ${{ matrix.dependency-version }}${{ matrix.coverage && ' | coverage' || '' }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           coverage: ${{ matrix.coverage && 'pcov' || 'none' }}
@@ -100,7 +112,7 @@ jobs:
       - name: Disable insecure-package block (TMP)
         run: composer config audit.block-insecure false
 
-      - uses: ramsey/composer-install@v4
+      - uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
         with:
           dependency-versions: ${{ matrix.dependency-version }}
 
@@ -148,14 +160,14 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: build/logs/clover.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage to Coveralls
         if: matrix.coverage
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           file: build/logs/clover.xml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,22 @@
+name: Release
+
 on:
   push:
     branches:
       - 2.x
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-
-name: Release
+permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json


### PR DESCRIPTION
- Pin all third-party actions to commit SHAs via pinact
- Add `permissions: {}` workflow-scope and least-privilege per-job permissions on every workflow
- Scope release.yml's contents/pull-requests/issues:write to the release job instead of the whole workflow
- Set `persist-credentials: false` on all `actions/checkout` calls
- Add `timeout-minutes` on every job (5-30 min vs. 360 default)
- Pass tj-actions/changed-files output through a `CHANGED_FILES` env var and enable `safe_output: true` to close template-injection vectors
- Rename php-rector job from `php-cs` to `php-rector` (no branch protection or ruleset depends on the old name)
- Drop invalid `type:` keys from the setup composite action's inputs (only valid on workflow_call, silently ignored on composite)

zizmor: 65 findings -> 0
