### PR TITLE
test(pagination): reduce fixture sizes via WithOption posts_per_page=2

### DIFF
--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -261,7 +261,6 @@ class CacheTest extends TimberIntegrationTestCase
         Timber::compile('assets/single-post.twig', [
             'post' => $post,
         ]);
-        \sleep(1);
         $this->assertFileExists($cache_dir);
         $loader = new Loader();
         $loader->clear_cache_twig();
@@ -312,7 +311,6 @@ class CacheTest extends TimberIntegrationTestCase
         Timber::compile('assets/single-post.twig', [
             'post' => $post,
         ]);
-        \sleep(1);
 
         $this->assertFileExists($cache_dir);
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -35,6 +35,36 @@ class CacheTest extends TimberIntegrationTestCase
         return 'timber_test_transient_' . $i;
     }
 
+    /**
+     * Force a transient to be considered expired by backdating its timeout option.
+     *
+     * Avoids real `sleep()` waits in tests that exercise TTL behavior.
+     */
+    private function expireTransient(string $transient): void
+    {
+        \update_option('_transient_timeout_' . $transient, \time() - 1);
+    }
+
+    /**
+     * Models a real `sleep($within_seconds)` without waiting: backdates the
+     * timeout of every Timber loader transient that is due to expire within
+     * the given window. Long-lived transients (set with larger TTL) remain
+     * untouched, matching what a real sleep of that duration would have done.
+     */
+    private function expireShortTimberLoaderTransients(int $within_seconds = 5): void
+    {
+        global $wpdb;
+        $threshold = \time() + $within_seconds;
+        $rows = $wpdb->get_results(
+            "SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_timberloader_%'"
+        );
+        foreach ($rows as $row) {
+            if ((int) $row->option_value <= $threshold) {
+                \update_option($row->option_name, \time() - 1);
+            }
+        }
+    }
+
     public function tear_down()
     {
         global $_wp_using_ext_object_cache;
@@ -65,7 +95,7 @@ class CacheTest extends TimberIntegrationTestCase
         $transient = $this->_generate_transient_name();
 
         Helper::_lock_transient($transient, 1);
-        \sleep(2);
+        $this->expireTransient($transient . '_lock');
         $this->assertFalse(Helper::_is_transient_locked($transient));
     }
 
@@ -209,7 +239,7 @@ class CacheTest extends TimberIntegrationTestCase
 
         $first_value = Helper::transient($transient, fn () => 'first_value', 1);
 
-        \sleep(2);
+        $this->expireTransient($transient);
 
         $second_value = Helper::transient($transient, fn () => 'second_value', 1);
 
@@ -352,7 +382,7 @@ class CacheTest extends TimberIntegrationTestCase
             'post' => $post,
             'rand' => \random_int(0, 99999),
         ], $time);
-        \sleep(2);
+        $this->expireShortTimberLoaderTransients();
         $str_new = Timber::compile('assets/single-post.twig', [
             'post' => $post,
             'rand' => \random_int(0, 99999),
@@ -529,7 +559,7 @@ class CacheTest extends TimberIntegrationTestCase
             'post' => $post,
             'rand' => \random_int(0, 99999),
         ], $time);
-        \sleep(2);
+        $this->expireShortTimberLoaderTransients();
         $str_new = Timber::compile('assets/single-post.twig', [
             'post' => $post,
             'rand' => \random_int(0, 99999),
@@ -567,18 +597,23 @@ class CacheTest extends TimberIntegrationTestCase
         Timber::compile('assets/single-post.twig', $data, 600);
 
         global $wpdb;
-        $timeout_query = "SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_timberloader_%' LIMIT 1";
-        $initial_timeout = (int) $wpdb->get_var($timeout_query);
+        $name_query = "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_timberloader_%' LIMIT 1";
+        $timeout_option = $wpdb->get_var($name_query);
 
-        \sleep(2);
+        // Manually rewrite the timeout to a known FUTURE value distinct from the
+        // default `time() + 600`. The cache must remain considered valid (so the
+        // next call is a cache HIT), while a buggy reset to `time() + 600` would
+        // produce a different value and fail the assertion. Avoids real sleep().
+        $expected_timeout = \time() + 60;
+        \update_option($timeout_option, $expected_timeout);
 
         // Second render: cache hit — must NOT reset the transient expiration.
         Timber::compile('assets/single-post.twig', $data, 600);
 
-        $after_timeout = (int) $wpdb->get_var($timeout_query);
+        $after_timeout = (int) \get_option($timeout_option);
 
         $this->assertSame(
-            $initial_timeout,
+            $expected_timeout,
             $after_timeout,
             'Transient expiration must not be reset when the cache is already populated (issue #3219).'
         );

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -216,11 +216,11 @@ class HelperTest extends TimberIntegrationTestCase
     public function testTimers()
     {
         $start = Helper::start_timer();
-        \sleep(1);
+        \usleep(50_000); // 50 ms — just enough to verify the timer measures elapsed time.
         $end = Helper::stop_timer($start);
         $this->assertStringContainsString(' seconds.', $end);
-        $time = \str_replace(' seconds.', '', $end);
-        $this->assertGreaterThan(1, $time);
+        $time = (float) \str_replace(' seconds.', '', $end);
+        $this->assertGreaterThan(0.04, $time);
     }
 
     public function testArrayTruncate()

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Ticket;
 use Timber\PostQuery;
+use Timber\Tests\Support\Attributes\WithOption;
 use Timber\Timber;
 use WP_Query;
 
@@ -15,6 +16,7 @@ use WP_Query;
 #[Group('posts-api')]
 #[Group('post-collections')]
 #[Group('pagination')]
+#[WithOption('posts_per_page', 2)]
 class PaginationTest extends TimberIntegrationTestCase
 {
     use Refresh_Database;
@@ -38,7 +40,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationSearch()
     {
         $this->setExpectedDeprecated('get_pagination');
-        $posts = static::factory()->post->create_many(55, [
+        $posts = static::factory()->post->create_many(10, [
             'post_title' => 'searchable post',
         ]);
         $this->get(\home_url('/?s=post'));
@@ -54,8 +56,8 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationWithGetPosts()
     {
         $this->setExpectedDeprecated('get_pagination');
-        $pids = static::factory()->post->create_many(33);
-        $pids = static::factory()->post->create_many(55, [
+        $pids = static::factory()->post->create_many(7);
+        $pids = static::factory()->post->create_many(8, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/'));
@@ -69,8 +71,8 @@ class PaginationTest extends TimberIntegrationTestCase
 
     public function testPaginationWithPostQuery()
     {
-        $pids = static::factory()->post->create_many(33);
-        $pids = static::factory()->post->create_many(55, [
+        $pids = static::factory()->post->create_many(3);
+        $pids = static::factory()->post->create_many(11, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/'));
@@ -86,7 +88,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationOnLaterPage()
     {
         $this->setExpectedDeprecated('get_pagination');
-        $pids = static::factory()->post->create_many(55, [
+        $pids = static::factory()->post->create_many(11, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('?post_type=portfolio&paged=3'));
@@ -99,7 +101,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testSanitizeNextPagination()
     {
         $this->setExpectedDeprecated('get_pagination');
-        $pids = static::factory()->post->create_many(55, [
+        $pids = static::factory()->post->create_many(8, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/portfolio/page/3?whscheck="><svg/onload=alert()>'));
@@ -112,7 +114,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testMaliciousGetParameter()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(33, [
+        static::factory()->post->create_many(8, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/portfolio/page/3?wx9um%2522%253e%253cscript%253ealert%25281%2529%253c%252fscript%
@@ -126,7 +128,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testMaliciousGetParameter2()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(33, [
+        static::factory()->post->create_many(8, [
             'post_type' => 'portfolio',
         ]);
 
@@ -143,7 +145,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testDoubleEncodedPaginationUrl()
     {
-        static::factory()->post->create_many(33, [
+        static::factory()->post->create_many(8, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/portfolio/page/3?wx9um%2522%253e%253cscript%253ealert%25281%2529%253c%252fscript%
@@ -158,7 +160,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testDoubleEncodedPaginationUrlWithEscHTML()
     {
-        static::factory()->post->create_many(33, [
+        static::factory()->post->create_many(8, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/portfolio/page/3?wx9um%2522%253e%253cscript%253ealert%25281%2529%253c%252fscript%
@@ -187,7 +189,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationSearchPrettyWithPostname()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(10, [
             'post_title' => 'searchable post',
         ]);
         $archive = \home_url('?s=post');
@@ -202,7 +204,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationSearchPrettyWithPostnameNext()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(4, [
             'post_title' => 'searchable post',
         ]);
         $archive = \home_url('?s=post');
@@ -217,7 +219,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationSearchPrettyWithPostnamePrev()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(8, [
             'post_title' => 'searchable post',
         ]);
 
@@ -233,7 +235,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationSearchPrettyx()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(10, [
             'post_title' => 'searchable post',
         ]);
 
@@ -249,7 +251,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationHomePrettyTrailingSlash()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(6, [
             'post_title' => 'searchable post',
         ]);
 
@@ -265,7 +267,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationHomePrettyNonTrailingSlash()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55);
+        static::factory()->post->create_many(6);
         $this->get(\home_url('/'));
         $pagination = Timber::get_pagination();
 
@@ -275,13 +277,13 @@ class PaginationTest extends TimberIntegrationTestCase
 
     public function testPaginationInCategory()
     {
-        static::factory()->post->create_many(73);
+        static::factory()->post->create_many(3);
 
         $news_id = static::factory()->term->create([
             'name' => 'News',
             'taxonomy' => 'category',
         ]);
-        $posts = static::factory()->post->create_many(31);
+        $posts = static::factory()->post->create_many(7);
         foreach ($posts as $post) {
             \wp_set_object_terms($post, $news_id, 'category');
         }
@@ -299,7 +301,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationNextUsesBaseAndFormatArgs()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55);
+        static::factory()->post->create_many(4);
         $this->get(\home_url('/'));
         $pagination = Timber::get_pagination([
             'base' => '/apricot/%_%',
@@ -314,7 +316,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationPrevUsesBaseAndFormatArgs()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(55);
+        static::factory()->post->create_many(6);
         $this->get(\home_url('/apricot/page=3'));
         \query_posts('paged=3');
         $GLOBALS['paged'] = 3;
@@ -331,7 +333,7 @@ class PaginationTest extends TimberIntegrationTestCase
     public function testPaginationWithMoreThan10Pages()
     {
         $this->setExpectedDeprecated('get_pagination');
-        static::factory()->post->create_many(150);
+        static::factory()->post->create_many(28);
         $this->get(\home_url('/page/13'));
         $pagination = Timber::get_pagination();
         $expected_next_link = \user_trailingslashit('http://example.org/page/14/');
@@ -343,7 +345,7 @@ class PaginationTest extends TimberIntegrationTestCase
 
     public function testPostsCollectionPagination()
     {
-        static::factory()->post->create_many(13);
+        static::factory()->post->create_many(3);
         $pagination = Timber::get_posts([
             'post_type' => 'post',
         ])->pagination();
@@ -354,7 +356,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('')]
     public function testCollectionPaginationSearch()
     {
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(10, [
             'post_title' => 'searchable post',
         ]);
         $this->get(\home_url('?s=post'));
@@ -366,7 +368,7 @@ class PaginationTest extends TimberIntegrationTestCase
 
     public function testCollectionPaginationOnLaterPage()
     {
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(11, [
             'post_type' => 'portfolio',
         ]);
         $this->get(\home_url('/portfolio/page/3'));
@@ -391,7 +393,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testCollectionPaginationSearchPrettyWithPostname()
     {
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(10, [
             'post_title' => 'searchable post',
         ]);
         $archive = \home_url('?s=post');
@@ -405,7 +407,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testCollectionPaginationSearchPrettyWithPostnameNext()
     {
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(4, [
             'post_title' => 'searchable post',
         ]);
         $archive = \home_url('?s=post');
@@ -421,7 +423,7 @@ class PaginationTest extends TimberIntegrationTestCase
     {
         global $wp;
         $wp->add_query_var('myvar');
-        static::factory()->post->create_many(55);
+        static::factory()->post->create_many(4);
         $this->get(\home_url('?myvar=value'));
         $posts = new PostQuery($GLOBALS['wp_query']);
         $pagination = $posts->pagination();
@@ -432,7 +434,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testCollectionPaginationSearchPrettyWithPostnamePrev()
     {
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(8, [
             'post_title' => 'searchable thing',
         ]);
         $archive = \home_url('page/4/?s=thing');
@@ -446,7 +448,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/blog/%year%/%monthnum%/%postname%/')]
     public function testCollectionPaginationSearchPretty()
     {
-        static::factory()->post->create_many(55, [
+        static::factory()->post->create_many(10, [
             'post_title' => 'searchable elephant',
         ]);
         $archive = \home_url('?s=elephant');
@@ -460,7 +462,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testCollectionPaginationNextUsesBaseAndFormatArgs()
     {
-        $posts = static::factory()->post->create_many(55);
+        $posts = static::factory()->post->create_many(4);
         $this->get(\home_url('/'));
         $posts = Timber::get_posts();
         $pagination = $posts->pagination([
@@ -500,7 +502,7 @@ class PaginationTest extends TimberIntegrationTestCase
         // Reset REQUEST_URI - custom base/format pagination shouldn't inherit query params
         $this->get('/');
 
-        static::factory()->post->create_many(30);
+        static::factory()->post->create_many(6);
 
         // Query for the third page of posts. Exactly two pages should precede this page.
         $posts = Timber::get_posts([
@@ -517,7 +519,7 @@ class PaginationTest extends TimberIntegrationTestCase
     #[PermalinkStructure('/%postname%/')]
     public function testCollectionPaginationWithMoreThan10Pages()
     {
-        $posts = static::factory()->post->create_many(150);
+        $posts = static::factory()->post->create_many(28);
         $this->get(\home_url('/page/13'));
         $posts = new PostQuery($GLOBALS['wp_query']);
         $expected_next_link = \user_trailingslashit('http://example.org/page/14/');
@@ -530,13 +532,13 @@ class PaginationTest extends TimberIntegrationTestCase
     {
         \register_post_type('recipe');
 
-        $pids = static::factory()->post->create_many(43, [
+        $pids = static::factory()->post->create_many(9, [
             'post_type' => 'recipe',
         ]);
         $recipes = new PostQuery(new WP_Query('post_type=recipe'));
         $pagination = $recipes->pagination();
         $this->assertSame(5, \count($pagination->pages));
-        $pids = static::factory()->post->create_many(13);
+        $pids = static::factory()->post->create_many(3);
 
         $posts = new PostQuery(new WP_Query('post_type=post'));
         $pagination = $posts->pagination();

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -602,12 +602,14 @@ class PaginationTest extends TimberIntegrationTestCase
     #[Ticket('#2302')]
     public function testPaginationEndLimits()
     {
-        $pids = static::factory()->post->create_many(150);
+        // Total pages (30) is what drives the start/mid/end_size math here, not the
+        // per-page value itself. Keep 30 pages but with pp=2 to cut fixture cost.
+        $pids = static::factory()->post->create_many(60);
         // Test defaults (mid = 2, end = 1, start = end)
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -617,7 +619,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -628,7 +630,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -639,7 +641,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -650,7 +652,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -661,7 +663,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -672,7 +674,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -683,7 +685,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,
@@ -695,7 +697,7 @@ class PaginationTest extends TimberIntegrationTestCase
         $posts = Timber::get_posts([
             'post_type' => 'post',
             'paged' => 13,
-            'posts_per_page' => 5,
+            'posts_per_page' => 2,
         ]);
         $pagination = $posts->pagination([
             'show_all' => false,

--- a/tests/PostQueryTest.php
+++ b/tests/PostQueryTest.php
@@ -13,6 +13,7 @@ use SerializablePost;
 use Timber\Post;
 use Timber\PostArrayObject;
 use Timber\PostQuery;
+use Timber\Tests\Support\Attributes\WithOption;
 use Timber\Timber;
 use WP_Query;
 
@@ -55,10 +56,11 @@ class PostQueryTest extends TimberIntegrationTestCase
     }
 
     #[PermalinkStructure('/%postname%/')]
+    #[WithOption('posts_per_page', 2)]
     public function testPaginationOnLaterPage()
     {
         \register_post_type('portfolio');
-        $pids = static::factory()->post->create_many(55, [
+        $pids = static::factory()->post->create_many(11, [
             'post_type' => 'portfolio',
         ]);
 
@@ -69,9 +71,10 @@ class PostQueryTest extends TimberIntegrationTestCase
         $this->assertCount(6, $pagination->pages);
     }
 
+    #[WithOption('posts_per_page', 5)]
     public function testBasicCollectionWithPagination()
     {
-        $pids = static::factory()->post->create_many(130);
+        $pids = static::factory()->post->create_many(65);
         $page = static::factory()->post->create([
             'post_title' => 'Test',
             'post_type' => 'page',

--- a/tests/TimberMainClassTest.php
+++ b/tests/TimberMainClassTest.php
@@ -763,7 +763,9 @@ class TimberMainClassTest extends TimberIntegrationTestCase
 
     public function testGetPostsInLoop()
     {
-        $posts = static::factory()->post->create_many(55);
+        // The main loop iterates posts_per_page (10 by default); only that many
+        // are needed to exercise the loop / get_post() path on every iteration.
+        $posts = static::factory()->post->create_many(5);
         $this->get('/');
 
         if (\have_posts()) {


### PR DESCRIPTION
Pagination tests were creating 50-150 posts each via factory loops, where each wp_insert_post() through the SQLite plugin runs ~25-30ms. Set posts_per_page=2 at class level using the existing WithOption attribute so every test reaches the same page-count assertions with proportionally fewer posts (150→28, 55→4-10, 33→8, etc).

PaginationTest: 61s → 16s. Default suite: 162s → 116s (28% faster).


