### PR TITLE
test: stop custom-upload-dir tests leaking into random-order runs

### DIFF
--- a/tests/Image/ExternalImageTest.php
+++ b/tests/Image/ExternalImageTest.php
@@ -74,7 +74,10 @@ class ExternalImageTest extends TimberAttachmentTestCase
     public function delete_existing_sideloaded_image($file)
     {
         // @see \Timber\ImageHelper::sideload_image()
-        \add_filter('upload_dir', ImageHelper::set_sideload_image_upload_dir(...));
+        // Array callable (not first-class callable syntax): remove_filter() only
+        // matches the exact hook identity, and each `ClassName::method(...)` call
+        // creates a distinct Closure that would never match on removal.
+        \add_filter('upload_dir', [ImageHelper::class, 'set_sideload_image_upload_dir']);
 
         $file_loc = ImageHelper::get_sideloaded_file_loc($file);
 
@@ -82,7 +85,7 @@ class ExternalImageTest extends TimberAttachmentTestCase
             \unlink($file_loc);
         }
 
-        \remove_filter('upload_dir', ImageHelper::set_sideload_image_upload_dir(...));
+        \remove_filter('upload_dir', [ImageHelper::class, 'set_sideload_image_upload_dir']);
     }
 
     public function testExternalImageWithInvalidUrl()

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -474,13 +474,16 @@ class ImageTest extends TimberAttachmentTestCase
 
     public function testResizeFileNamingWithLangHome()
     {
-        \add_filter('home_url', $this->addLangToHome(...), 1, 4);
+        // Array callable (not first-class callable syntax) so remove_filter()
+        // matches: each `$this->addLangToHome(...)` mints a distinct Closure,
+        // so the filter would otherwise leak into later random-order tests.
+        \add_filter('home_url', [$this, 'addLangToHome'], 1, 4);
         $file_loc = $this->copyImageToUploads('eastern.jpg');
         $upload_dir = \wp_upload_dir();
         $url_src = $upload_dir['url'] . '/eastern.jpg';
         $filename = ImageHelper::get_resize_file_url($url_src, 300, 500, 'default');
         $this->assertEquals($upload_dir['url'] . '/eastern-300x500-c-default.jpg', $filename);
-        \remove_filter('home_url', $this->addLangToHome(...), 1);
+        \remove_filter('home_url', [$this, 'addLangToHome'], 1);
     }
 
     public function testLetterboxFileNaming()
@@ -1063,14 +1066,17 @@ class ImageTest extends TimberAttachmentTestCase
 
     public function testTimberImageForExtraSlashes()
     {
-        \add_filter('upload_dir', $this->_filter_upload(...), 10, 1);
+        // Array callable (not first-class callable syntax) so remove_filter()
+        // matches: each `$this->_filter_upload(...)` mints a distinct Closure,
+        // so the filter would otherwise leak into later random-order tests.
+        \add_filter('upload_dir', [$this, '_filter_upload'], 10, 1);
 
         $post = $this->get_post_with_image();
         $image = $post->thumbnail();
 
         $resized_520_file = ImageHelper::resize($image->src, 520, 500);
 
-        \remove_filter('upload_dir', $this->_filter_upload(...));
+        \remove_filter('upload_dir', [$this, '_filter_upload']);
 
         $this->assertFalse(\strpos($resized_520_file, '//arch-520x500-c-default.jpg') > -1);
     }

--- a/tests/TimberIntegrationTestCase.php
+++ b/tests/TimberIntegrationTestCase.php
@@ -62,18 +62,35 @@ abstract class TimberIntegrationTestCase extends Integration_Test_Case
 
     public function setupCustomWPDirectoryStructure()
     {
-        \add_filter('content_url', $this->setContentUrl(...));
-        \add_filter('option_upload_path', $this->setUploadPath(...));
-        \add_filter('option_upload_url_path', $this->setUploadUrlPath(...));
-        \add_filter('option_siteurl', $this->setSiteUrl(...));
+        // Use array callables (not first-class callable syntax) so that the
+        // exact same hook identity is registered here and removed in
+        // tearDownCustomWPDirectoryStructure(). Each `$this->method(...)` call
+        // mints a distinct Closure with its own spl_object_hash, so
+        // remove_filter() would never match and the filters would leak into
+        // later tests run in random order.
+        \add_filter('content_url', [$this, 'setContentUrl']);
+        \add_filter('option_upload_path', [$this, 'setUploadPath']);
+        \add_filter('option_upload_url_path', [$this, 'setUploadUrlPath']);
+        \add_filter('option_siteurl', [$this, 'setSiteUrl']);
+
+        // wp_upload_dir() memoizes _wp_upload_dir() (which reads the upload_path /
+        // upload_url_path options filtered above) in a process-lived static cache.
+        // Force a refresh so the custom directory values take effect now, instead
+        // of returning a value cached by an earlier test.
+        \wp_upload_dir(null, false, true);
     }
 
     public function tearDownCustomWPDirectoryStructure()
     {
-        \remove_filter('content_url', $this->setContentUrl(...));
-        \remove_filter('option_upload_path', $this->setUploadPath(...));
-        \remove_filter('option_upload_url_path', $this->setUploadUrlPath(...));
-        \remove_filter('option_siteurl', $this->setSiteUrl(...));
+        \remove_filter('content_url', [$this, 'setContentUrl']);
+        \remove_filter('option_upload_path', [$this, 'setUploadPath']);
+        \remove_filter('option_upload_url_path', [$this, 'setUploadUrlPath']);
+        \remove_filter('option_siteurl', [$this, 'setSiteUrl']);
+
+        // Evict the custom-directory value baked into wp_upload_dir()'s static
+        // cache so it does not leak into later tests run in random order. With
+        // the filters now removed, this recomputes the default uploads location.
+        \wp_upload_dir(null, false, true);
     }
 
     public function setContentUrl($url)


### PR DESCRIPTION
Two compounding issues made the image/URL tests fail intermittently under executionOrder="random":

- add_filter/remove_filter pairs used first-class callable syntax ($this->method(...)). Each (...) mints a distinct Closure with its own spl_object_hash, which WordPress uses as the hook identity, so remove_filter() never matched and the filters leaked into the next test. Switched to array callables so add and remove share one identity.

- wp_upload_dir() memoizes _wp_upload_dir() in a process-lived static cache. The custom-directory test could bake "content/uploads" into that cache, which then survived filter removal and leaked into later tests (wrong URL prefix, accumulated files -> arch-1.jpg, 2 != 1). Refresh the cache on setup and teardown of the custom structure.

