### PR TITLE
fix: Bump twig/twig to ^3.27 for sandbox security fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require": {
         "php": "^8.2",
-        "twig/twig": "^3.26"
+        "twig/twig": "^3.27"
     },
     "require-dev": {
         "composer/installers": "^2",


### PR DESCRIPTION
3.27.0 fixes several sandbox bypass advisories, notably GHSA-529h-vh3j-85hq (filter/tag/function allow-list bypass when sandbox state changes between renders of a cached Template), plus __toString policy bypasses (GHSA-5v5v-ww74-355v, GHSA-8x9c-rmqh-456c) and the column filter property allow-list bypass (GHSA-h8vq-8gpg-mhcg).
