### PR TITLE
fix: Fix bug with WP version notice in admin

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -9,9 +9,14 @@ class Admin
 {
     public static function init(?string $wp_version = null): void
     {
+        // Resolve the version ourselves when none was passed. WordPress fires `admin_init`
+        // with no args, which reaches this callback as an empty string (not null), so we
+        // can't rely on the parameter default alone.
         // wp_get_wp_version() exists since WP 6.7; fall back to the global for older versions
         // (which is exactly the range this notice targets).
-        $wp_version ??= \function_exists('wp_get_wp_version') ? \wp_get_wp_version() : (string) ($GLOBALS['wp_version'] ?? '');
+        if ($wp_version === null || $wp_version === '') {
+            $wp_version = \function_exists('wp_get_wp_version') ? \wp_get_wp_version() : (string) ($GLOBALS['wp_version'] ?? '');
+        }
 
         // Bail if the running WordPress version meets Timber's tested minimum.
         if (\version_compare(Timber::MINIMUM_WP_VERSION, $wp_version) !== 1) {

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -46,8 +46,12 @@ class Timber
 
     /**
      * Minimum WordPress version Timber is tested against.
+     *
+     * Use the same shape WordPress reports for its own version: a major release is
+     * `6.8` (not `6.8.0`). version_compare() treats a missing segment as lower than an
+     * explicit `.0`, so `6.8.0` would wrongly flag a site running the `6.8` release.
      */
-    public const MINIMUM_WP_VERSION = '6.8.0';
+    public const MINIMUM_WP_VERSION = '6.8';
 
     /**
      * @deprecated 2.5.0 Use {@see Timber::VERSION} instead.

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -49,6 +49,22 @@ class AdminTest extends TimberIntegrationTestCase
     }
 
     /**
+     * WordPress reports a major release as `6.8`, not `6.8.0`. The two-segment string
+     * must be treated as meeting the minimum, otherwise the notice shows on the exact
+     * release Timber targets.
+     */
+    public function testNoNoticeWhenRunningMajorReleaseOfMinimum(): void
+    {
+        Admin::init('6.8');
+
+        \ob_start();
+        \do_action('admin_notices');
+        $output = \ob_get_clean();
+
+        $this->assertStringNotContainsString('timber/timber', $output);
+    }
+
+    /**
      * WordPress fires `admin_init` with no args, which reaches the callback as an
      * empty string rather than null. The version must still be resolved instead of
      * being compared as an empty string (which would make the notice show always).

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -47,4 +47,20 @@ class AdminTest extends TimberIntegrationTestCase
 
         $this->assertStringNotContainsString('timber/timber', $output);
     }
+
+    /**
+     * WordPress fires `admin_init` with no args, which reaches the callback as an
+     * empty string rather than null. The version must still be resolved instead of
+     * being compared as an empty string (which would make the notice show always).
+     */
+    public function testNoNoticeWhenVersionResolvedFromEmptyString(): void
+    {
+        Admin::init('');
+
+        \ob_start();
+        \do_action('admin_notices');
+        $output = \ob_get_clean();
+
+        $this->assertStringNotContainsString('timber/timber', $output);
+    }
 }


### PR DESCRIPTION
The "tested against WordPress X" admin notice was showing on every install, regardless of the running WordPress version.

Root cause: `Admin::init` is registered as an `admin_init` callback. The `admin_init` action passes no arguments, but `do_action()` injects an empty string when the arg list is empty, so the callback receives `''` (not null). The parameter default `?string $wp_version = null` and the `??=` fallback only handle null, so the version was never resolved. `version_compare(MINIMUM_WP_VERSION, '')` then returns 1, the early return is skipped, and the notice prints unconditionally.

Fix: treat an empty string like null so the running version is resolved from `wp_get_wp_version()` (or the global fallback).

Added a regression test that calls `init('')`, which is the exact path the hook hits. It fails before the fix and passes after. The existing tests pass explicit version strings, so they never exercised the empty-string case.