### PR TITLE
ci: surface public API changes on pull requests

### DIFF
--- a/.github/workflows/api-surface-check.yml
+++ b/.github/workflows/api-surface-check.yml
@@ -1,0 +1,31 @@
+name: API Surface Check
+
+# Minimal pull_request workflow whose only job is to fire workflow_run for the
+# api-surface-comment workflow (which has pull-requests:write even on fork PRs
+# and runs the actual analysis from trusted action code).
+
+on:
+  pull_request:
+    branches:
+      - master
+      - 2.x
+    paths:
+      - 'src/**.php'
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: api-surface-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  signal:
+    name: Trigger check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: 'true'

--- a/.github/workflows/api-surface-comment.yml
+++ b/.github/workflows/api-surface-comment.yml
@@ -1,0 +1,35 @@
+name: API Surface Comment
+
+# Runs in workflow_run context (base-repo permissions, trusted action code) so
+# the API surface comment can be posted even on fork PRs. The PR head is only
+# parsed via static reflection, never executed: the action code is loaded from
+# a pinned SHA (never from the PR), the PR number is re-resolved via the GitHub
+# API rather than trusted from artifacts, and permissions are limited to
+# posting the PR comment.
+
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ['API Surface Check']
+    types:
+      - completed
+
+# Cancel an in-progress comment run when a force-push or workflow_run re-run
+# fires for the same PR. head_sha alone wouldn't catch force-pushes (each push
+# has a different SHA); the (head repo + head branch) pair survives that and
+# disambiguates forks using identical branch names.
+concurrency:
+  group: api-surface-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-api-surface:
+    name: API surface comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write # required to create the comment on the pull request
+    steps:
+      - uses: composer/api-surface-check@bba9f1cb940df6e02271b1b6158679ac0b3f39d3 # 1.0.1


### PR DESCRIPTION
Add composer/api-surface-check, which statically diffs the public API surface of changed PHP files and posts a summary comment on PRs. Split into a permissionless pull_request trigger and a workflow_run comment workflow so fork PRs are analyzed without granting them write access.
