### PR TITLE
test(image): fix flaky testReplacedImage caused by uploads leakage

### DIFF
--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -147,8 +147,12 @@ class ImageTest extends TimberAttachmentTestCase
             'img' => $attach_id,
         ]);
         $resized_one = ImageHelper::get_server_location($str);
-        \sleep(1);
-        $filename = $this->copyImageToUploads('cardinals.jpg', 'arch.jpg');
+
+        // Replace the attachment's actual file (its uploaded name may have been
+        // uniquified) and backdate the resized file so the source counts as newer
+        // despite filemtime()'s one-second granularity.
+        \copy($this->getFixtureAsset('cardinals.jpg'), \get_attached_file($attach_id));
+        \touch($resized_one, \filemtime($resized_one) - 2);
 
         $str = Timber::compile_string($template, [
             'img' => $attach_id,

--- a/tests/TimberIntegrationTestCase.php
+++ b/tests/TimberIntegrationTestCase.php
@@ -16,6 +16,14 @@ abstract class TimberIntegrationTestCase extends Integration_Test_Case
     private $temporary_hook_removals = [];
 
     /**
+     * Files copied into the uploads directory by copyImageToUploads(). These have no
+     * attachment, so Mantle never deletes them; without explicit cleanup they leak into
+     * later tests, where wp_upload_bits() then uniquifies colliding filenames (arch.jpg
+     * becomes arch-1.jpg) and breaks tests that assert on exact upload paths.
+     */
+    private array $copied_upload_files = [];
+
+    /**
      * Backup for Timber locations.
      */
     protected $backup_timber_locations;
@@ -50,6 +58,13 @@ abstract class TimberIntegrationTestCase extends Integration_Test_Case
     {
         // Restore original Timber locations
         Timber::$locations = $this->backup_timber_locations;
+
+        foreach ($this->copied_upload_files as $file) {
+            if (\file_exists($file)) {
+                \unlink($file);
+            }
+        }
+        $this->copied_upload_files = [];
 
         parent::tear_down();
     }
@@ -249,6 +264,8 @@ abstract class TimberIntegrationTestCase extends Integration_Test_Case
         }
 
         \copy($this->getFixtureAsset($file), $destination);
+
+        $this->copied_upload_files[] = $destination;
 
         return $destination;
     }


### PR DESCRIPTION
## Problem

`testReplacedImage` fails intermittently under random test order (e.g. seed `1781258302`).

## Root cause

Files created by `copyImageToUploads()` have no attachment, so Mantle never deletes them — they leak into later tests in the same process. When a leftover `arch.jpg` exists in uploads, `wp_upload_bits()` uniquifies the new attachment to `arch-1.jpg`. The test then replaced the hardcoded `arch.jpg` path (the wrong file), the resized image was never regenerated from the replacement, and the pixel assertion failed: the arch resize is grey at (5,5) — only the cardinals replacement is white there.

## Fix

- `copyImageToUploads()` now tracks copied files, and `tear_down()` deletes them, removing the leak suite-wide (any test asserting on exact upload filenames was vulnerable to it).
- `testReplacedImage` replaces the attachment's actual file via `get_attached_file()` instead of a hardcoded filename.
- The `sleep(1)` is replaced by backdating the resized file 2s, sidestepping `filemtime()`'s one-second granularity.

## Verification

- Test passes both from a clean state and with a deliberately pre-seeded `arch.jpg` (previously a deterministic failure).
- Full default suite passes with the originally failing random seed; uploads dir ends with zero leftover files.