### PR TITLE
docs(template-locations): add example for Drupal-style Single-Directory Component (SDC) path loading or other mapping; resolves #3271

### DIFF
--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -128,3 +128,67 @@ add_filter('timber/locations', function ($paths) {
 ```
 
 You only need to do this once in your project (in **functions.php** of your theme). When you call one of the render or compile functions from a PHP file (say **single.php**), Timber will look for Twig files in these locations before it checks the child or parent theme.
+
+
+## Converting an existing namespace, e.g. Drupal Single-Directory Component (SDC) format
+
+You may have an existing template set with a different system for referencing an include, e.g. templates designed for a Drupal system. In this scenario, it is possible to re-implement the filesystem loader interface to map Drupal-style namespaced template paths to Timber's expectations.
+
+For instance, if trying to implement a template set designed for a Drupal CMS using its [Single-Directory Component (SDC)](https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components/using-your-new-single-directory-component) system, the Twig [include tag](https://twig.symfony.com/doc/3.x/tags/include.html) will not be in the format of an exact filename, but will be in the format of:
+
+`{% include "my_namespace:my_component" with {...} %}`
+
+where `my_namespace:my_component` maps to a component (within the list of paths) and a file with extension, e.g.:
+
+`/somepath/my_namespace/my_component.twig`
+
+The following example shows how the LoaderInterface can be provided with a function which dynamically converts the incoming template name to an actual filesystem path. You could provide whatever mapping you wish in that function.
+
+```
+# Re-implement the filesystem loader interface as an overridden class; see: https://github.com/timber/timber/issues/3271
+add_filter ('timber/loader/loader', function (\Twig\Loader\LoaderInterface $loader): \Twig\Loader\LoaderInterface
+{
+	return new class ($loader) implements \Twig\Loader\LoaderInterface
+	{
+		public function __construct (private \Twig\Loader\LoaderInterface $inner) {
+			
+		}
+		
+		public function getSourceContext (string $name): \Twig\Source
+		{
+			return $this->inner->getSourceContext ($this->map ($name));
+		}
+		
+		public function getCacheKey (string $name): string
+		{
+			return $this->inner->getCacheKey ($this->map ($name));
+		}
+		
+		public function exists (string $name): bool
+		{
+			return $this->inner->exists ($this->map ($name));
+		}
+		
+		public function isFresh (string $name, int $time): bool
+		{
+			return $this->inner->isFresh ($this->map ($name), $time);
+		}
+		
+		# Mapping of the incoming template name to an actual filesystem path
+		private function map (string $name): string
+		{
+			if (str_starts_with ($name, '@') || !str_contains ($name, ':')) {
+				return $name;
+			}
+			
+			list ($ns, $component) = explode (':', $name, 2);
+			
+			if (!str_ends_with ($component, '.twig')) {
+				$component .= '.twig';
+			}
+			
+			return '@' . $ns . '/' . ltrim ($component, '/');
+		}
+	};
+});
+```

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -144,10 +144,9 @@ where `my_namespace:my_component` maps to a component (within the list of paths)
 
 The following example shows how the LoaderInterface can be provided with a function which dynamically converts the incoming template name to an actual filesystem path. You could provide whatever mapping you wish in that function.
 
-```
-# Re-implement the filesystem loader interface as an overridden class; see: https://github.com/timber/timber/issues/3271
-add_filter ('timber/loader/loader', function (\Twig\Loader\LoaderInterface $loader): \Twig\Loader\LoaderInterface
-{
+```php
+// Wrap Timber’s Twig loader to map Drupal SDC template names; see https://github.com/timber/timber/issues/3271
+add_filter('timber/loader/loader', function (\Twig\Loader\LoaderInterface $loader): \Twig\Loader\LoaderInterface {
 	return new class ($loader) implements \Twig\Loader\LoaderInterface
 	{
 		public function __construct (private \Twig\Loader\LoaderInterface $inner) {

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -129,14 +129,19 @@ add_filter('timber/locations', function ($paths) {
 
 You only need to do this once in your project (in **functions.php** of your theme). When you call one of the render or compile functions from a PHP file (say **single.php**), Timber will look for Twig files in these locations before it checks the child or parent theme.
 
+## Examples
 
-## Converting an existing namespace, e.g. Drupal Single-Directory Component (SDC) format
+Here you'll find some examples on how to modify the default loader/location functionality.
 
-You may have an existing template set with a different system for referencing an include, e.g. templates designed for a Drupal system. In this scenario, it is possible to re-implement the filesystem loader interface to map Drupal-style namespaced template paths to Timber's expectations.
+### Converting an existing namespace, e.g. Drupal Single-Directory Component (SDC) format
 
-For instance, if trying to implement a template set designed for a Drupal CMS using its [Single-Directory Component (SDC)](https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components/using-your-new-single-directory-component) system, the Twig [include tag](https://twig.symfony.com/doc/3.x/tags/include.html) will not be in the format of an exact filename, but will be in the format of:
+If your templates use a different include format (for example Drupal), you can extend the filesystem loader interface to map those namespaced paths to what Timber expects.
 
-`{% include 'my_namespace:my_component' with { some: 'data' } %}`
+For a Drupal [Single-Directory Component (SDC)](https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components/using-your-new-single-directory-component) setup, the Twig [include tag](https://twig.symfony.com/doc/3.x/tags/include.html) uses this format instead of a direct filename:
+
+```twig
+{% include 'my_namespace:my_component' with { some: 'data' } %}`
+```
 
 where `my_namespace:my_component` maps to a component (within the list of paths) and a file with extension, e.g.:
 
@@ -145,47 +150,57 @@ where `my_namespace:my_component` maps to a component (within the list of paths)
 The following example shows how you can wrap the LoaderInterface with a mapping function that converts the incoming template name (like `my_namespace:my_component`) to a template name Timber's loader can resolve (like `@my_namespace/my_component.twig`). You can provide whatever mapping you wish in that function.
 
 ```php
+add_filter('timber/locations', function ($paths) {
+    $paths['my_namespace'] = [
+     	get_stylesheet_directory() . '/resources/views/my_namespace',
+    ];
+
+    return $paths;
+});
+```
+
+```php
 // Wrap Timber’s Twig loader to map Drupal SDC template names; see https://github.com/timber/timber/issues/3271
 add_filter('timber/loader/loader', function (\Twig\Loader\LoaderInterface $loader): \Twig\Loader\LoaderInterface {
 	return new class ($loader) implements \Twig\Loader\LoaderInterface
 	{
 		public function __construct (private \Twig\Loader\LoaderInterface $inner) {
-			
+
 		}
-		
+
 		public function getSourceContext (string $name): \Twig\Source
 		{
 			return $this->inner->getSourceContext ($this->map ($name));
 		}
-		
+
 		public function getCacheKey (string $name): string
 		{
 			return $this->inner->getCacheKey ($this->map ($name));
 		}
-		
+
 		public function exists (string $name): bool
 		{
 			return $this->inner->exists ($this->map ($name));
 		}
-		
+
 		public function isFresh (string $name, int $time): bool
 		{
 			return $this->inner->isFresh ($this->map ($name), $time);
 		}
-		
+
 		// Mapping of the incoming template name to a loader-resolvable template name
 		private function map (string $name): string
 		{
 			if (str_starts_with ($name, '@') || !str_contains ($name, ':')) {
 				return $name;
 			}
-			
+
 			list ($ns, $component) = explode (':', $name, 2);
-			
+
 			if (!str_ends_with ($component, '.twig')) {
 				$component .= '.twig';
 			}
-			
+
 			return '@' . $ns . '/' . ltrim ($component, '/');
 		}
 	};

--- a/docs/v2/guides/template-locations.md
+++ b/docs/v2/guides/template-locations.md
@@ -136,13 +136,13 @@ You may have an existing template set with a different system for referencing an
 
 For instance, if trying to implement a template set designed for a Drupal CMS using its [Single-Directory Component (SDC)](https://www.drupal.org/docs/develop/theming-drupal/using-single-directory-components/using-your-new-single-directory-component) system, the Twig [include tag](https://twig.symfony.com/doc/3.x/tags/include.html) will not be in the format of an exact filename, but will be in the format of:
 
-`{% include "my_namespace:my_component" with {...} %}`
+`{% include 'my_namespace:my_component' with { some: 'data' } %}`
 
 where `my_namespace:my_component` maps to a component (within the list of paths) and a file with extension, e.g.:
 
 `/somepath/my_namespace/my_component.twig`
 
-The following example shows how the LoaderInterface can be provided with a function which dynamically converts the incoming template name to an actual filesystem path. You could provide whatever mapping you wish in that function.
+The following example shows how you can wrap the LoaderInterface with a mapping function that converts the incoming template name (like `my_namespace:my_component`) to a template name Timber's loader can resolve (like `@my_namespace/my_component.twig`). You can provide whatever mapping you wish in that function.
 
 ```php
 // Wrap Timber’s Twig loader to map Drupal SDC template names; see https://github.com/timber/timber/issues/3271
@@ -173,7 +173,7 @@ add_filter('timber/loader/loader', function (\Twig\Loader\LoaderInterface $loade
 			return $this->inner->isFresh ($this->map ($name), $time);
 		}
 		
-		# Mapping of the incoming template name to an actual filesystem path
+		// Mapping of the incoming template name to a loader-resolvable template name
 		private function map (string $name): string
 		{
 			if (str_starts_with ($name, '@') || !str_contains ($name, ':')) {

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -355,12 +355,64 @@ class Loader implements LoaderInterface
         }
 
         /**
-         * Filters …
+         * Filters the Twig loader instance used by Timber.
          *
-         * @todo Add summary, description, example, parameter description
+         * Use this filter to customize how templates are resolved after Timber has registered all template
+         * locations. This lets you wrap or replace the default filesystem loader with your own loader behavior,
+         * for example to map non-standard template identifiers (like Drupal SDC-style
+         * `namespace:component`) to Twig namespace paths.
          *
-         * @link https://github.com/timber/timber/pull/1254
+         * @api
          * @since 1.1.11
+         * @link https://timber.github.io/docs/v2/guides/template-locations/
+         * @link https://github.com/timber/timber/pull/1254
+         * @example
+         * ```php
+         * add_filter('timber/loader/loader', function (\Twig\Loader\LoaderInterface $loader): \Twig\Loader\LoaderInterface {
+         *     return new class ($loader) implements \Twig\Loader\LoaderInterface {
+         *         public function __construct(private \Twig\Loader\LoaderInterface $inner)
+         *         {
+         *         }
+         *
+         *         public function getSourceContext(string $name): \Twig\Source
+         *         {
+         *             return $this->inner->getSourceContext($this->map($name));
+         *         }
+         *
+         *         public function getCacheKey(string $name): string
+         *         {
+         *             return $this->inner->getCacheKey($this->map($name));
+         *         }
+         *
+         *         public function exists(string $name): bool
+         *         {
+         *             return $this->inner->exists($this->map($name));
+         *         }
+         *
+         *         public function isFresh(string $name, int $time): bool
+         *         {
+         *             return $this->inner->isFresh($this->map($name), $time);
+         *         }
+         *
+         *         private function map(string $name): string
+         *         {
+         *             if (str_starts_with($name, '@') || !str_contains($name, ':')) {
+         *                 return $name;
+         *             }
+         *
+         *             [$namespace, $component] = explode(':', $name, 2);
+         *
+         *             if (!str_ends_with($component, '.twig')) {
+         *                 $component .= '.twig';
+         *             }
+         *
+         *             return '@' . $namespace . '/' . ltrim($component, '/');
+         *         }
+         *     };
+         * });
+         * ```
+         *
+         * @param FilesystemLoader $fs The default Twig filesystem loader built from Timber template locations.
          */
         $fs = \apply_filters('timber/loader/loader', $fs);
 


### PR DESCRIPTION
Documentation improvement, giving an example of adding a LoaderInterface enabling mapping of e.g. Drupal-style SDC paths to Timber-style filesystem paths, as requested by @Levdbas in #3271.

I release this PR as Public Domain / CC0, i.e. no copyright restrictions or attribution required.