### PR TITLE
chore: Fix Rector ruleset to use Composer based set

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -18,8 +18,7 @@ return RectorConfig::configure()
         php82: true,
     )
     ->withSets([
-        PHPUnitSetList::PHPUNIT_100,
-        PHPUnitSetList::PHPUNIT_110,
+        PHPUnitSetList::COMPOSER_BASED,
     ])
     ->withSkip([
         ArrayToFirstClassCallableRector::class,

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -3,6 +3,7 @@
 namespace Timber\Tests;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Ticket;
 use Sport;
@@ -390,6 +391,7 @@ class HelperTest extends TimberIntegrationTestCase
         $this->assertEquals('ESPN', $sport_post->channel());
     }
 
+    #[DoesNotPerformAssertions]
     public function testDoingItWrong()
     {
         $this->setExpectedIncorrectUsage('Accessing the thumbnail ID through {{ post._thumbnail_id }}');

--- a/tests/Image/ImageTest.php
+++ b/tests/Image/ImageTest.php
@@ -2,6 +2,7 @@
 
 namespace Timber\Tests\Image;
 
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
 use Timber\Attachment;
 use Timber\Image;
@@ -1093,6 +1094,7 @@ class ImageTest extends TimberAttachmentTestCase
         return $data;
     }
 
+    #[DoesNotPerformAssertions]
     public function testAnimagedGifResizeWithoutImagick(): never
     {
         // This test verifies behavior when Imagick is unavailable.

--- a/tests/Integration/ACFTest.php
+++ b/tests/Integration/ACFTest.php
@@ -2,6 +2,7 @@
 
 namespace Timber\Tests\Integration;
 
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\Ticket;
@@ -401,6 +402,7 @@ class ACFTest extends TimberIntegrationTestCase
     }
 
     #[IgnoreDeprecations]
+    #[DoesNotPerformAssertions]
     public function testPostGetFieldDeprecated()
     {
         $this->setExpectedDeprecated("{{ post.get_field('field_name') }}");
@@ -411,6 +413,7 @@ class ACFTest extends TimberIntegrationTestCase
     }
 
     #[IgnoreDeprecations]
+    #[DoesNotPerformAssertions]
     public function testTermGetFieldDeprecated()
     {
         $this->setExpectedDeprecated("{{ term.get_field('field_name') }}");
@@ -421,6 +424,7 @@ class ACFTest extends TimberIntegrationTestCase
     }
 
     #[IgnoreDeprecations]
+    #[DoesNotPerformAssertions]
     public function testUserGetFieldDeprecated()
     {
         $this->setExpectedDeprecated("{{ user.get_field('field_name') }}");
@@ -431,6 +435,7 @@ class ACFTest extends TimberIntegrationTestCase
     }
 
     #[IgnoreDeprecations]
+    #[DoesNotPerformAssertions]
     public function testCommentGetFieldDeprecated()
     {
         $this->setExpectedDeprecated("{{ comment.get_field('field_name') }}");


### PR DESCRIPTION
The latest version of Rector caused a fatal error with the referenced set list. In 2.6.2, Rector introduced composer-based sets, so it can read the required sets from composer.json, see https://github.com/rectorphp/rector/releases/tag/2.6.2.

Along with the change in **rector.php**, I also ran Rector to fix outstanding issues.