### PR TITLE
feat: Add `Timber::get_taxonomy()` and `Timber::get_taxonomies()`

### DIFF
--- a/docs/v2/guides/class-maps.md
+++ b/docs/v2/guides/class-maps.md
@@ -135,6 +135,52 @@ add_filter('timber/term/classmap', function ($classmap) {
 
 The callback function receives a `WP_Term` object and should return the name of the class to use.
 
+## The Taxonomy Class Map
+
+When you extend `Timber\Taxonomy`, you can use the `timber/taxonomy/classmap` filter to tell Timber which class it should use for a certain taxonomy.
+
+The Taxonomy Class Map is used:
+
+- When you get a taxonomy through `Timber::get_taxonomy()`.
+- When you get a collection of taxonomies through `Timber::get_taxonomies()`.
+
+**functions.php**
+
+```php
+use GenreTaxonomy;
+
+add_filter('timber/taxonomy/classmap', function ($classmap) {
+    $custom_classmap = [
+        'genre' => GenreTaxonomy::class,
+    ];
+
+    return array_merge($classmap, $custom_classmap);
+});
+```
+
+Taxonomies that you don’t list in the Taxonomy Class Map will take the default `Timber\Taxonomy` class.
+
+As with the other class maps, you can use a callback function that receives a `WP_Taxonomy` object and returns the name of the class to use:
+
+```php
+use HierarchicalTaxonomy;
+use GenreTaxonomy;
+
+add_filter('timber/taxonomy/classmap', function ($classmap) {
+    $custom_classmap = [
+        'genre' => function (\WP_Taxonomy $taxonomy) {
+            if ($taxonomy->hierarchical) {
+                return HierarchicalTaxonomy::class;
+            }
+
+            return GenreTaxonomy::class;
+        },
+    ];
+
+    return array_merge($classmap, $custom_classmap);
+});
+```
+
 ## The Comment Class Map
 
 When you extend `Timber\Comment`, the logic you add is usually for comments related to a certain post type. With the `timber/comment/classmap` filter, you can tell Timber which class it should use for comments that belong to a certain post type.

--- a/docs/v2/guides/taxonomies.md
+++ b/docs/v2/guides/taxonomies.md
@@ -1,0 +1,193 @@
+---
+title: "Taxonomies"
+order: "125"
+---
+
+While [`Timber::get_term()`](https://timber.github.io/docs/v2/guides/terms/) gives you a single term, sometimes you need the taxonomy itself – for example to display the labels you defined in `register_taxonomy()`.
+
+## Get a taxonomy
+
+```php
+$taxonomy = Timber::get_taxonomy('genre');
+```
+
+What you get in return is a `Timber\Taxonomy` object, which is similar to `WP_Taxonomy`. Everything you passed to [`register_taxonomy()`](https://developer.wordpress.org/reference/functions/register_taxonomy/) is available on it.
+
+```twig
+<h1>{{ taxonomy.labels.all_items }}</h1>
+
+{% if taxonomy.hierarchical %}
+    {# … #}
+{% endif %}
+```
+
+Because `name` holds the name the taxonomy was registered with (ex: `post_tag`), use `title` when you want the human-readable label (ex: `Tags`):
+
+```twig
+<h1>{{ taxonomy.title }}</h1>
+```
+
+If you defined a `default_term` when registering the taxonomy, you can get it as a `Timber\Term`:
+
+```twig
+{% if taxonomy.default_term %}
+    <a href="{{ taxonomy.default_term.link }}">{{ taxonomy.default_term.title }}</a>
+{% endif %}
+```
+
+And to link editors to the term overview in the admin:
+
+```twig
+{% if taxonomy.can_edit %}
+    <a href="{{ taxonomy.edit_link }}">Manage {{ taxonomy.title }}</a>
+{% endif %}
+```
+
+If you don’t pass in any argument, Timber will use the taxonomy of the currently queried term. This is handy on `taxonomy.php`, `category.php` or `tag.php`.
+
+```php
+$taxonomy = Timber::get_taxonomy();
+```
+
+If no taxonomy with that name is registered, `Timber::get_taxonomy()` returns `null`.
+
+## Get the terms of a taxonomy
+
+The terms of a taxonomy are only queried when you access them, so getting a taxonomy stays cheap when you never display its terms.
+
+```twig
+{% for term in taxonomy.terms %}
+    <a href="{{ term.link }}">{{ term.title }}</a>
+{% endfor %}
+```
+
+You can pass [`WP_Term_Query`](https://developer.wordpress.org/reference/classes/wp_term_query/) arguments to refine the result. The `taxonomy` argument is always set for you.
+
+```twig
+{% for term in taxonomy.terms({ hide_empty: false, orderby: 'count', order: 'DESC' }) %}
+    {{ term.title }} ({{ term.count }})
+{% endfor %}
+```
+
+The terms you get back are `Timber\Term` objects, which means the [Term Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-term-class-map) applies here as well.
+
+## Querying taxonomies
+
+To get more than one taxonomy, use `Timber::get_taxonomies()`. Without any arguments, you get all public taxonomies.
+
+```php
+$taxonomies = Timber::get_taxonomies();
+```
+
+You can pass a taxonomy name, a list of taxonomy names, or the same arguments you would pass to [`get_taxonomies()`](https://developer.wordpress.org/reference/functions/get_taxonomies/).
+
+```php
+// A list of taxonomy names.
+$taxonomies = Timber::get_taxonomies(['category', 'genre']);
+
+// All hierarchical taxonomies.
+$taxonomies = Timber::get_taxonomies([
+    'hierarchical' => true,
+]);
+```
+
+In addition to the arguments supported by `get_taxonomies()`, you can use `post_type` to get all taxonomies that are registered for a post type. It can be combined with any of the other arguments.
+
+```php
+$taxonomies = Timber::get_taxonomies([
+    'post_type' => 'recipe',
+]);
+
+// Only the hierarchical ones.
+$taxonomies = Timber::get_taxonomies([
+    'post_type' => 'recipe',
+    'hierarchical' => true,
+]);
+```
+
+The result is an array of `Timber\Taxonomy` objects, keyed by taxonomy name. This makes it straightforward to build filter navigations:
+
+```twig
+{% for taxonomy in get_taxonomies({ post_type: 'recipe' }) %}
+    <fieldset>
+        <legend>{{ taxonomy.labels.all_items }}</legend>
+
+        {% for term in taxonomy.terms %}
+            <a href="{{ term.link }}">{{ term.title }}</a>
+        {% endfor %}
+    </fieldset>
+{% endfor %}
+```
+
+## Get the post types of a taxonomy
+
+```twig
+{% for post_type in taxonomy.post_types %}
+    {{ post_type.labels.name }}
+{% endfor %}
+```
+
+You get an array of `Timber\PostType` objects – the same objects you get through `{{ post.type }}`.
+
+## Twig
+
+Both functions are available in Twig as well.
+
+```twig
+{% set taxonomy = get_taxonomy('genre') %}
+{% set taxonomies = get_taxonomies({ post_type: 'recipe' }) %}
+```
+
+## Extending `Timber\Taxonomy`
+
+If you need additional functionality that the `Timber\Taxonomy` class doesn’t provide, you can extend it with your own class:
+
+```php
+class Genre extends Timber\Taxonomy
+{
+    public function top_level_terms(): iterable
+    {
+        return $this->terms([
+            'parent' => 0,
+            'hide_empty' => false,
+            'orderby' => 'name',
+        ]);
+    }
+
+    public function term_count(): int
+    {
+        return (int) wp_count_terms([
+            'taxonomy' => $this->name,
+            'hide_empty' => false,
+        ]);
+    }
+}
+```
+
+Tell Timber to use your class for the `genre` taxonomy through the [Taxonomy Class Map](https://timber.github.io/docs/v2/guides/class-maps/#the-taxonomy-class-map):
+
+**functions.php**
+
+```php
+add_filter('timber/taxonomy/classmap', function ($classmap) {
+    return array_merge($classmap, [
+        'genre' => Genre::class,
+    ]);
+});
+```
+
+You still use `Timber::get_taxonomy()` – and `Timber::get_taxonomies()` – to get your object, and your methods are available in Twig:
+
+```twig
+{% set genre = get_taxonomy('genre') %}
+
+<h2>{{ genre.title }} ({{ genre.term_count }})</h2>
+
+<ul>
+    {% for term in genre.top_level_terms %}
+        <li><a href="{{ term.link }}">{{ term.title }}</a></li>
+    {% endfor %}
+</ul>
+```
+
+Taxonomies you don’t list in the Taxonomy Class Map keep using the default `Timber\Taxonomy` class.

--- a/docs/v2/guides/terms.md
+++ b/docs/v2/guides/terms.md
@@ -23,6 +23,8 @@ $term = Timber::get_term(get_queried_object_id());
 
 What you get in return is a [`Timber\Term`](https://timber.github.io/docs/v2/reference/timber-term/) object, which is similar to `WP_Term`.
 
+If you’re looking for the taxonomy itself instead of its terms – for example to get the labels you defined in `register_taxonomy()` – have a look at the [Taxonomies guide](https://timber.github.io/docs/v2/guides/taxonomies/).
+
 ## Get term by field
 
 If you don’t have a term ID, you can also get a term by other fields, like `slug` or `name` through `Timber::get_term_by()`.

--- a/src/Factory/TaxonomyFactory.php
+++ b/src/Factory/TaxonomyFactory.php
@@ -36,7 +36,7 @@ class TaxonomyFactory
         }
 
         // A flat list of taxonomy names.
-        if (!empty($params) && $this->is_numeric_array($params) && $this->is_array_of_strings($params)) {
+        if (!empty($params) && \array_is_list($params) && $this->is_array_of_strings($params)) {
             return $this->from_names($params);
         }
 
@@ -181,19 +181,6 @@ class TaxonomyFactory
         $class = $this->get_taxonomy_class($taxonomy);
 
         return $class::build($taxonomy);
-    }
-
-    protected function is_numeric_array($arr)
-    {
-        if (!\is_array($arr)) {
-            return false;
-        }
-        foreach (\array_keys($arr) as $k) {
-            if (!\is_int($k)) {
-                return false;
-            }
-        }
-        return true;
     }
 
     protected function is_array_of_strings($arr)

--- a/src/Factory/TaxonomyFactory.php
+++ b/src/Factory/TaxonomyFactory.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Timber\Factory;
+
+use InvalidArgumentException;
+use Timber\CoreInterface;
+use Timber\Taxonomy;
+use WP_Taxonomy;
+
+/**
+ * Internal API class for instantiating Taxonomies
+ */
+class TaxonomyFactory
+{
+    /**
+     * @param mixed $params A taxonomy name, an array of taxonomy names, an array of arguments for
+     *                      `get_taxonomies()`, a `WP_Taxonomy` object or a `Timber\Taxonomy`.
+     *
+     * @return Taxonomy|Taxonomy[]|null
+     */
+    public function from($params)
+    {
+        if (\is_object($params)) {
+            return $this->from_taxonomy_object($params);
+        }
+
+        if (\is_string($params)) {
+            return $this->from_name($params);
+        }
+
+        if (!\is_array($params)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Expected a taxonomy name, an array or an instance of Timber\CoreInterface or WP_Taxonomy, got %s',
+                \get_debug_type($params)
+            ));
+        }
+
+        // A flat list of taxonomy names.
+        if (!empty($params) && $this->is_numeric_array($params) && $this->is_array_of_strings($params)) {
+            return $this->from_names($params);
+        }
+
+        return $this->from_query_args($params);
+    }
+
+    protected function from_name(string $name): ?Taxonomy
+    {
+        $wp_taxonomy = \get_taxonomy($name);
+
+        if (!$wp_taxonomy) {
+            return null;
+        }
+
+        return $this->build($wp_taxonomy);
+    }
+
+    /**
+     * @param string[] $names
+     * @return Taxonomy[] Keyed by taxonomy name. Names that aren’t registered are skipped.
+     */
+    protected function from_names(array $names): array
+    {
+        $taxonomies = [];
+
+        foreach ($names as $name) {
+            $taxonomy = $this->from_name($name);
+
+            if ($taxonomy) {
+                $taxonomies[$name] = $taxonomy;
+            }
+        }
+
+        return $taxonomies;
+    }
+
+    /**
+     * @return Taxonomy[] Keyed by taxonomy name.
+     */
+    protected function from_query_args(array $args): array
+    {
+        // WP’s own `object_type` argument requires an exact match of the registered post types,
+        // so the `post_type` alias is resolved separately.
+        $post_types = $args['post_type'] ?? null;
+        unset($args['post_type']);
+
+        $names = \get_taxonomies($args);
+
+        if (null !== $post_types) {
+            $names = \array_intersect($names, $this->taxonomy_names_for_post_types((array) $post_types));
+        }
+
+        return $this->from_names(\array_values($names));
+    }
+
+    /**
+     * @param string[] $post_types
+     * @return string[]
+     */
+    protected function taxonomy_names_for_post_types(array $post_types): array
+    {
+        $names = [];
+
+        foreach ($post_types as $post_type) {
+            $names = \array_merge($names, \get_object_taxonomies($post_type));
+        }
+
+        return \array_unique($names);
+    }
+
+    protected function from_taxonomy_object(object $obj): CoreInterface
+    {
+        if ($obj instanceof CoreInterface) {
+            // We already have a Timber Core object of some kind.
+            return $obj;
+        }
+
+        if ($obj instanceof WP_Taxonomy) {
+            return $this->build($obj);
+        }
+
+        throw new InvalidArgumentException(\sprintf(
+            'Expected an instance of Timber\CoreInterface or WP_Taxonomy, got %s',
+            $obj::class
+        ));
+    }
+
+    protected function get_taxonomy_class(WP_Taxonomy $taxonomy): string
+    {
+        /**
+         * Filters the class(es) used for different taxonomies.
+         *
+         * @since 2.6.0
+         * @example
+         * ```
+         * add_filter( 'timber/taxonomy/classmap', function( $classmap ) {
+         *     $custom_classmap = [
+         *         'genre' => GenreTaxonomy::class,
+         *     ];
+         *
+         *     return array_merge( $classmap, $custom_classmap );
+         * } );
+         * ```
+         *
+         * @param array $classmap The taxonomy class(es) to use. An associative array where the key
+         *                        is the taxonomy name and the value the name of the class to use
+         *                        for this taxonomy or a callback that determines the class to use.
+         */
+        $map = \apply_filters('timber/taxonomy/classmap', []);
+
+        $class = $map[$taxonomy->name] ?? null;
+
+        if (\is_callable($class)) {
+            $class = $class($taxonomy);
+        }
+
+        $class ??= Taxonomy::class;
+
+        /**
+         * Filters the taxonomy class based on your custom criteria.
+         *
+         * @since 2.6.0
+         * @example
+         * ```
+         * add_filter( 'timber/taxonomy/class', function( $class, $taxonomy ) {
+         *     if ( $taxonomy->hierarchical ) {
+         *         return MyHierarchicalTaxonomy::class;
+         *     }
+         *
+         *     return $class;
+         * }, 10, 2 );
+         * ```
+         *
+         * @param string      $class    The class to use.
+         * @param WP_Taxonomy $taxonomy The taxonomy object.
+         */
+        return \apply_filters('timber/taxonomy/class', $class, $taxonomy);
+    }
+
+    protected function build(WP_Taxonomy $taxonomy): CoreInterface
+    {
+        $class = $this->get_taxonomy_class($taxonomy);
+
+        return $class::build($taxonomy);
+    }
+
+    protected function is_numeric_array($arr)
+    {
+        if (!\is_array($arr)) {
+            return false;
+        }
+        foreach (\array_keys($arr) as $k) {
+            if (!\is_int($k)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    protected function is_array_of_strings($arr)
+    {
+        if (!\is_array($arr)) {
+            return false;
+        }
+        foreach ($arr as $v) {
+            if (!\is_string($v)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -60,13 +60,6 @@ class Taxonomy extends Core implements CoreInterface, Stringable
     public $cap;
 
     /**
-     * Memoized result of an unfiltered `terms()` call.
-     *
-     * @var iterable|null
-     */
-    private ?iterable $terms_cache = null;
-
-    /**
      * @internal
      */
     protected function __construct()
@@ -232,19 +225,9 @@ class Taxonomy extends Core implements CoreInterface, Stringable
      */
     public function terms(array $query_args = [], array $options = []): iterable
     {
-        if (empty($query_args) && empty($options) && $this->terms_cache !== null) {
-            return $this->terms_cache;
-        }
-
-        $terms = Timber::get_terms(\array_merge($query_args, [
+        return Timber::get_terms(\array_merge($query_args, [
             'taxonomy' => $this->name,
         ]), $options);
-
-        if (empty($query_args) && empty($options)) {
-            $this->terms_cache = $terms;
-        }
-
-        return $terms;
     }
 
     /**

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -247,7 +247,7 @@ class Taxonomy extends Core implements CoreInterface, Stringable
     {
         return \array_map(
             static fn ($post_type) => new PostType($post_type),
-            $this->wp_object?->object_type ?? []
+            \array_values(\array_filter($this->wp_object?->object_type ?? [], post_type_exists(...)))
         );
     }
 }

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Timber;
+
+use Stringable;
+use WP_Taxonomy;
+
+/**
+ * Class Taxonomy
+ *
+ * Represents a registered taxonomy, giving you access to everything that was passed to
+ * `register_taxonomy()` – most notably the `labels` – as well as the terms that belong to it.
+ *
+ * @api
+ * @since 2.6.0
+ * @phpstan-consistent-constructor
+ * @example
+ * ```php
+ * $context['genre'] = Timber::get_taxonomy('genre');
+ *
+ * Timber::render('archive.twig', $context);
+ * ```
+ * ```twig
+ * <h1>{{ genre.labels.all_items }}</h1>
+ *
+ * <ul>
+ *     {% for term in genre.terms %}
+ *         <li><a href="{{ term.link }}">{{ term.title }}</a></li>
+ *     {% endfor %}
+ * </ul>
+ * ```
+ */
+class Taxonomy extends Core implements CoreInterface, Stringable
+{
+    /**
+     * The underlying WordPress Core object.
+     *
+     * @var WP_Taxonomy|null
+     */
+    protected ?WP_Taxonomy $wp_object = null;
+
+    public static $representation = 'taxonomy';
+
+    /**
+     * @api
+     * @var string The name the taxonomy was registered with (ex: `post_tag` or `genre`).
+     */
+    public $name;
+
+    /**
+     * @api
+     * @var object The taxonomy’s labels, as returned by `get_taxonomy_labels()`.
+     */
+    public $labels;
+
+    /**
+     * @api
+     * @var object The taxonomy’s capabilities, as returned by `register_taxonomy()`.
+     */
+    public $cap;
+
+    /**
+     * Memoized result of an unfiltered `terms()` call.
+     *
+     * @var iterable|null
+     */
+    private ?iterable $terms_cache = null;
+
+    /**
+     * @internal
+     */
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @internal
+     *
+     * @param WP_Taxonomy $wp_taxonomy The vanilla WordPress taxonomy object to build from.
+     * @return static
+     */
+    public static function build(WP_Taxonomy $wp_taxonomy): static
+    {
+        $taxonomy = new static();
+        $taxonomy->init($wp_taxonomy);
+
+        return $taxonomy;
+    }
+
+    /**
+     * @internal
+     */
+    protected function init(WP_Taxonomy $wp_taxonomy): void
+    {
+        $this->wp_object = $wp_taxonomy;
+        $this->import($wp_taxonomy);
+    }
+
+    /**
+     * The string the taxonomy will render as by default.
+     *
+     * @api
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Gets the underlying WordPress Core object.
+     *
+     * @api
+     * @return WP_Taxonomy|null
+     */
+    public function wp_object(): ?WP_Taxonomy
+    {
+        return $this->wp_object;
+    }
+
+    /**
+     * Gets the human-readable name of the taxonomy.
+     *
+     * Use this instead of `name`, which holds the name the taxonomy was registered with
+     * (ex: `post_tag`), and not the label you defined for it (ex: `Tags`).
+     *
+     * @api
+     * @example
+     * ```twig
+     * <h1>{{ genre.title }}</h1>
+     * ```
+     *
+     * @return string
+     */
+    public function title(): string
+    {
+        return $this->labels->name ?? $this->name;
+    }
+
+    /**
+     * Gets the default term of the taxonomy.
+     *
+     * A default term can be defined through the `default_term` argument of
+     * `register_taxonomy()`. It is assigned to a post whenever no other term of this taxonomy is.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if genre.default_term %}
+     *     <a href="{{ genre.default_term.link }}">{{ genre.default_term.title }}</a>
+     * {% endif %}
+     * ```
+     *
+     * @return Term|null The default term or `null` if the taxonomy doesn’t have one.
+     */
+    public function default_term(): ?Term
+    {
+        $term_id = \get_option('default_term_' . $this->name);
+
+        if (!$term_id) {
+            return null;
+        }
+
+        return Timber::get_term((int) $term_id);
+    }
+
+    /**
+     * Checks whether the current user can manage the terms of this taxonomy.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if genre.can_edit %}
+     *     <a href="{{ genre.edit_link }}">Manage genres</a>
+     * {% endif %}
+     * ```
+     *
+     * @return bool
+     */
+    public function can_edit(): bool
+    {
+        return \current_user_can($this->cap->manage_terms);
+    }
+
+    /**
+     * Gets the link to the term overview of this taxonomy in the WordPress admin.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% if genre.can_edit %}
+     *     <a href="{{ genre.edit_link }}">Manage genres</a>
+     * {% endif %}
+     * ```
+     *
+     * @return string|null The edit URL or `null` if the current user can’t manage the terms of
+     *                     this taxonomy.
+     */
+    public function edit_link(): ?string
+    {
+        if (!$this->can_edit()) {
+            return null;
+        }
+
+        return \admin_url('edit-tags.php?taxonomy=' . $this->name);
+    }
+
+    /**
+     * Gets the terms that belong to this taxonomy.
+     *
+     * Terms are only queried when this method is called, so getting a taxonomy is cheap even when
+     * you never display its terms.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% for term in genre.terms %}
+     *     <a href="{{ term.link }}">{{ term.title }}</a>
+     * {% endfor %}
+     *
+     * {# Pass in WP_Term_Query arguments to refine the result. #}
+     * {% for term in genre.terms({ hide_empty: false, orderby: 'count' }) %}
+     *     {{ term.title }}
+     * {% endfor %}
+     * ```
+     *
+     * @param array $query_args Optional. Arguments for `WP_Term_Query`. The `taxonomy` argument is
+     *                          always set to this taxonomy. Default empty array.
+     * @param array $options    Optional. Options for `Timber::get_terms()`. Default empty array.
+     *
+     * @return iterable An iterable of `Timber\Term` objects.
+     */
+    public function terms(array $query_args = [], array $options = []): iterable
+    {
+        if (empty($query_args) && empty($options) && $this->terms_cache !== null) {
+            return $this->terms_cache;
+        }
+
+        $terms = Timber::get_terms(\array_merge($query_args, [
+            'taxonomy' => $this->name,
+        ]), $options);
+
+        if (empty($query_args) && empty($options)) {
+            $this->terms_cache = $terms;
+        }
+
+        return $terms;
+    }
+
+    /**
+     * Gets the post types this taxonomy is registered for.
+     *
+     * @api
+     * @example
+     * ```twig
+     * {% for post_type in genre.post_types %}
+     *     {{ post_type.labels.name }}
+     * {% endfor %}
+     * ```
+     *
+     * @return PostType[]
+     */
+    public function post_types(): array
+    {
+        return \array_map(
+            static fn ($post_type) => new PostType($post_type),
+            $this->wp_object?->object_type ?? []
+        );
+    }
+}

--- a/src/Timber.php
+++ b/src/Timber.php
@@ -6,6 +6,7 @@ use Timber\Factory\CommentFactory;
 use Timber\Factory\MenuFactory;
 use Timber\Factory\PagesMenuFactory;
 use Timber\Factory\PostFactory;
+use Timber\Factory\TaxonomyFactory;
 use Timber\Factory\TermFactory;
 use Timber\Factory\UserFactory;
 use Timber\Integration\IntegrationInterface;
@@ -13,6 +14,7 @@ use WP_Comment;
 use WP_Comment_Query;
 use WP_Post;
 use WP_Query;
+use WP_Taxonomy;
 use WP_Term;
 use WP_User;
 
@@ -859,6 +861,123 @@ class Timber
         }
 
         return static::get_term($wp_term);
+    }
+
+    /* Taxonomy Retrieval
+    ================================ */
+
+    /**
+     * Gets a taxonomy.
+     *
+     * In contrast to `Timber::get_term()`, this doesn’t return a single term, but the taxonomy
+     * itself, which gives you access to everything that was passed to `register_taxonomy()` – most
+     * notably the `labels`. The terms of the taxonomy are available through `terms`.
+     *
+     * @api
+     * @since 2.6.0
+     * @see https://developer.wordpress.org/reference/functions/get_taxonomy/
+     * @example
+     * ```php
+     * // Get a taxonomy by name.
+     * $taxonomy = Timber::get_taxonomy( 'genre' );
+     *
+     * // Use the taxonomy of the currently queried term archive.
+     * $taxonomy = Timber::get_taxonomy();
+     * ```
+     * ```twig
+     * <h1>{{ taxonomy.labels.all_items }}</h1>
+     *
+     * {% for term in taxonomy.terms %}
+     *     <a href="{{ term.link }}">{{ term.title }}</a>
+     * {% endfor %}
+     * ```
+     *
+     * @param string|WP_Taxonomy|null $taxonomy Optional. A taxonomy name or a `WP_Taxonomy` object.
+     *                                          Default `null`, which will use the taxonomy of the
+     *                                          currently queried term.
+     *
+     * @return Taxonomy|null A `Timber\Taxonomy` object or `null` if the taxonomy isn’t registered.
+     */
+    public static function get_taxonomy($taxonomy = null): ?Taxonomy
+    {
+        if (null === $taxonomy) {
+            global $wp_query;
+            $taxonomy = $wp_query->queried_object->taxonomy ?? null;
+        }
+
+        if (null === $taxonomy) {
+            return null;
+        }
+
+        $factory = new TaxonomyFactory();
+
+        return $factory->from($taxonomy);
+    }
+
+    /**
+     * Gets taxonomies.
+     *
+     * @api
+     * @since 2.6.0
+     * @see https://developer.wordpress.org/reference/functions/get_taxonomies/
+     * @example
+     * ```php
+     * // Get all public taxonomies.
+     * $taxonomies = Timber::get_taxonomies();
+     *
+     * // Get a list of taxonomies by name.
+     * $taxonomies = Timber::get_taxonomies( [ 'category', 'genre' ] );
+     *
+     * // Get all taxonomies registered for a post type.
+     * $taxonomies = Timber::get_taxonomies( [ 'post_type' => 'recipe' ] );
+     *
+     * // Use any argument that get_taxonomies() supports.
+     * $taxonomies = Timber::get_taxonomies( [
+     *     'hierarchical' => true,
+     *     'show_in_rest' => true,
+     *     '_builtin'     => false,
+     * ] );
+     *
+     * // The post_type argument can be combined with any of them.
+     * $taxonomies = Timber::get_taxonomies( [
+     *     'post_type'    => 'recipe',
+     *     'hierarchical' => true,
+     * ] );
+     * ```
+     * ```twig
+     * {% for taxonomy in taxonomies %}
+     *     <h2>{{ taxonomy.labels.all_items }}</h2>
+     *
+     *     {% for term in taxonomy.terms %}
+     *         <a href="{{ term.link }}">{{ term.title }}</a>
+     *     {% endfor %}
+     * {% endfor %}
+     * ```
+     *
+     * @param string|array|null $args Optional. A taxonomy name, an array of taxonomy names or an
+     *                                array of arguments for
+     *                                [`get_taxonomies()`](https://developer.wordpress.org/reference/functions/get_taxonomies/).
+     *                                In addition to the arguments supported by that function, a
+     *                                `post_type` argument can be used as an alias for
+     *                                `object_type`. Default `null`, which will get all public
+     *                                taxonomies.
+     *
+     * @return Taxonomy[] An array of `Timber\Taxonomy` objects, keyed by taxonomy name. Will be
+     *                    empty if no taxonomies were found.
+     */
+    public static function get_taxonomies($args = null): array
+    {
+        $args ??= [
+            'public' => true,
+        ];
+
+        $factory = new TaxonomyFactory();
+
+        if (\is_string($args)) {
+            $args = [$args];
+        }
+
+        return $factory->from($args);
     }
 
     /* User Retrieval

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -83,6 +83,12 @@ class Twig
             'get_terms' => [
                 'callable' => [Timber::class, 'get_terms'],
             ],
+            'get_taxonomy' => [
+                'callable' => [Timber::class, 'get_taxonomy'],
+            ],
+            'get_taxonomies' => [
+                'callable' => [Timber::class, 'get_taxonomies'],
+            ],
             'get_user' => [
                 'callable' => [Timber::class, 'get_user'],
             ],

--- a/tests/Factory/TaxonomyFactoryTest.php
+++ b/tests/Factory/TaxonomyFactoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Timber\Tests\Factory;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+use Timber\Factory\TaxonomyFactory;
+use Timber\Taxonomy;
+use Timber\Tests\TimberIntegrationTestCase;
+use WP_Post;
+
+class GenreTaxonomy extends Taxonomy
+{
+}
+class HierarchicalTaxonomy extends Taxonomy
+{
+}
+
+#[Group('factory')]
+#[Group('terms-api')]
+#[Ticket('#3282')]
+class TaxonomyFactoryTest extends TimberIntegrationTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        \register_taxonomy('genre', 'post', [
+            'public' => true,
+            'hierarchical' => true,
+        ]);
+        \register_taxonomy('mood', 'post', [
+            'public' => true,
+        ]);
+    }
+
+    public function testFromName()
+    {
+        $factory = new TaxonomyFactory();
+
+        $this->assertInstanceOf(Taxonomy::class, $factory->from('genre'));
+    }
+
+    public function testFromUnregisteredName()
+    {
+        $factory = new TaxonomyFactory();
+
+        $this->assertNull($factory->from('not-a-taxonomy'));
+    }
+
+    public function testFromNames()
+    {
+        $factory = new TaxonomyFactory();
+        $taxonomies = $factory->from(['genre', 'mood']);
+
+        $this->assertEquals(['genre', 'mood'], \array_keys($taxonomies));
+        $this->assertContainsOnlyInstancesOf(Taxonomy::class, $taxonomies);
+    }
+
+    public function testFromQueryArgs()
+    {
+        $factory = new TaxonomyFactory();
+        $taxonomies = $factory->from([
+            'hierarchical' => true,
+            'public' => true,
+        ]);
+
+        $this->assertArrayHasKey('genre', $taxonomies);
+        $this->assertArrayNotHasKey('mood', $taxonomies);
+    }
+
+    public function testFromWpTaxonomy()
+    {
+        $factory = new TaxonomyFactory();
+
+        $this->assertInstanceOf(Taxonomy::class, $factory->from(\get_taxonomy('genre')));
+    }
+
+    public function testFromTimberTaxonomyIsIdempotent()
+    {
+        $factory = new TaxonomyFactory();
+        $taxonomy = $factory->from('genre');
+
+        $this->assertSame($taxonomy, $factory->from($taxonomy));
+    }
+
+    public function testFromInvalidObject()
+    {
+        $factory = new TaxonomyFactory();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $factory->from(new WP_Post((object) []));
+    }
+
+    public function testFromInvalidType()
+    {
+        $factory = new TaxonomyFactory();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $factory->from(123);
+    }
+
+    public function testClassMap()
+    {
+        $this->add_filter_temporarily('timber/taxonomy/classmap', fn () => [
+            'genre' => GenreTaxonomy::class,
+        ]);
+
+        $factory = new TaxonomyFactory();
+
+        $this->assertInstanceOf(GenreTaxonomy::class, $factory->from('genre'));
+        $this->assertInstanceOf(Taxonomy::class, $factory->from('mood'));
+        $this->assertNotInstanceOf(GenreTaxonomy::class, $factory->from('mood'));
+    }
+
+    public function testClassMapCallable()
+    {
+        $this->add_filter_temporarily('timber/taxonomy/classmap', fn () => [
+            'genre' => fn ($taxonomy) => $taxonomy->hierarchical
+               ? HierarchicalTaxonomy::class
+               : Taxonomy::class,
+        ]);
+
+        $factory = new TaxonomyFactory();
+
+        $this->assertInstanceOf(HierarchicalTaxonomy::class, $factory->from('genre'));
+    }
+
+    public function testTaxonomyClassFilter()
+    {
+        $this->add_filter_temporarily(
+            'timber/taxonomy/class',
+            fn ($class, $taxonomy) => 'mood' === $taxonomy->name ? GenreTaxonomy::class : $class,
+            10,
+            2
+        );
+
+        $factory = new TaxonomyFactory();
+
+        $this->assertInstanceOf(GenreTaxonomy::class, $factory->from('mood'));
+    }
+}

--- a/tests/TaxonomyTest.php
+++ b/tests/TaxonomyTest.php
@@ -191,13 +191,6 @@ class TaxonomyTest extends TimberIntegrationTestCase
         $this->assertEquals(['Blues', 'Ambient'], \array_map(strval(...), $terms));
     }
 
-    public function testTermsIsMemoized()
-    {
-        $taxonomy = Timber::get_taxonomy('genre');
-
-        $this->assertSame($taxonomy->terms(), $taxonomy->terms());
-    }
-
     public function testTermsAreLazy()
     {
         $queries = 0;
@@ -213,18 +206,6 @@ class TaxonomyTest extends TimberIntegrationTestCase
         $taxonomy->terms();
 
         $this->assertGreaterThan(0, $queries);
-        $queried = $queries;
-
-        $taxonomy->terms();
-
-        $this->assertSame($queried, $queries, 'A second unfiltered terms() call should be memoized');
-
-        // Passing arguments bypasses the memoized result.
-        $taxonomy->terms([
-            'hide_empty' => false,
-        ]);
-
-        $this->assertGreaterThan($queried, $queries);
     }
 
     public function testGetTaxonomies()

--- a/tests/TaxonomyTest.php
+++ b/tests/TaxonomyTest.php
@@ -1,0 +1,366 @@
+<?php
+
+namespace Timber\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+use Timber\PostType;
+use Timber\Taxonomy;
+use Timber\Term;
+use Timber\Timber;
+use WP_Taxonomy;
+
+class Genre extends Taxonomy
+{
+    public function top_level_terms(): iterable
+    {
+        return $this->terms([
+            'parent' => 0,
+            'hide_empty' => false,
+            'orderby' => 'name',
+        ]);
+    }
+
+    public function term_count(): int
+    {
+        return (int) \wp_count_terms([
+            'taxonomy' => $this->name,
+            'hide_empty' => false,
+        ]);
+    }
+}
+
+#[Group('terms-api')]
+#[Ticket('#3282')]
+class TaxonomyTest extends TimberIntegrationTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        \register_post_type('recipe', [
+            'public' => true,
+        ]);
+
+        \register_taxonomy('genre', ['post', 'recipe'], [
+            'public' => true,
+            'hierarchical' => true,
+            'labels' => [
+                'name' => 'Genres',
+                'all_items' => 'All Genres',
+            ],
+        ]);
+
+        \register_taxonomy('mood', 'post', [
+            'public' => false,
+        ]);
+    }
+
+    public function testGetTaxonomy()
+    {
+        $taxonomy = Timber::get_taxonomy('genre');
+
+        $this->assertInstanceOf(Taxonomy::class, $taxonomy);
+        $this->assertEquals('genre', $taxonomy->name);
+        $this->assertEquals('All Genres', $taxonomy->labels->all_items);
+        $this->assertTrue($taxonomy->hierarchical);
+        $this->assertInstanceOf(WP_Taxonomy::class, $taxonomy->wp_object());
+    }
+
+    public function testGetTaxonomyFromWpTaxonomy()
+    {
+        $taxonomy = Timber::get_taxonomy(\get_taxonomy('genre'));
+
+        $this->assertInstanceOf(Taxonomy::class, $taxonomy);
+        $this->assertEquals('genre', $taxonomy->name);
+    }
+
+    public function testGetUnregisteredTaxonomy()
+    {
+        $this->assertNull(Timber::get_taxonomy('not-a-taxonomy'));
+    }
+
+    public function testToString()
+    {
+        $this->assertEquals('genre', (string) Timber::get_taxonomy('genre'));
+    }
+
+    public function testTitle()
+    {
+        $this->assertEquals('Genres', Timber::get_taxonomy('genre')->title());
+    }
+
+    public function testTitleInTwig()
+    {
+        $this->assertEquals('Genres', Timber::compile_string("{{ get_taxonomy('genre').title }}"));
+    }
+
+    public function testDefaultTerm()
+    {
+        \register_taxonomy('flavour', 'post', [
+            'default_term' => [
+                'name' => 'Neutral',
+            ],
+        ]);
+
+        $default_term = Timber::get_taxonomy('flavour')->default_term();
+
+        $this->assertInstanceOf(Term::class, $default_term);
+        $this->assertEquals('Neutral', $default_term->title());
+    }
+
+    public function testDefaultTermIsNullWhenNoneIsRegistered()
+    {
+        $this->assertNull(Timber::get_taxonomy('genre')->default_term());
+    }
+
+    public function testEditLink()
+    {
+        \wp_set_current_user(static::factory()->user->create([
+            'role' => 'administrator',
+        ]));
+
+        $taxonomy = Timber::get_taxonomy('genre');
+
+        $this->assertTrue($taxonomy->can_edit());
+        $this->assertStringContainsString('edit-tags.php?taxonomy=genre', $taxonomy->edit_link());
+    }
+
+    public function testEditLinkIsNullForUsersWithoutRights()
+    {
+        \wp_set_current_user(static::factory()->user->create([
+            'role' => 'subscriber',
+        ]));
+
+        $taxonomy = Timber::get_taxonomy('genre');
+
+        $this->assertFalse($taxonomy->can_edit());
+        $this->assertNull($taxonomy->edit_link());
+    }
+
+    public function testObjectTypeHoldsPostTypes()
+    {
+        $taxonomy = Timber::get_taxonomy('genre');
+
+        $this->assertEquals(['post', 'recipe'], $taxonomy->object_type);
+
+        $post_types = $taxonomy->post_types();
+
+        $this->assertContainsOnlyInstancesOf(PostType::class, $post_types);
+        $this->assertEquals(['post', 'recipe'], \array_map(strval(...), $post_types));
+    }
+
+    public function testTerms()
+    {
+        static::factory()->term->create_many(3, [
+            'taxonomy' => 'genre',
+        ]);
+        static::factory()->term->create([
+            'taxonomy' => 'mood',
+        ]);
+
+        $terms = Timber::get_taxonomy('genre')->terms([
+            'hide_empty' => false,
+        ]);
+
+        $this->assertCount(3, $terms);
+        $this->assertContainsOnlyInstancesOf(Term::class, $terms);
+
+        foreach ($terms as $term) {
+            $this->assertEquals('genre', $term->taxonomy);
+        }
+    }
+
+    public function testTermsWithQueryArgs()
+    {
+        static::factory()->term->create([
+            'taxonomy' => 'genre',
+            'name' => 'Ambient',
+        ]);
+        static::factory()->term->create([
+            'taxonomy' => 'genre',
+            'name' => 'Blues',
+        ]);
+
+        $terms = Timber::get_taxonomy('genre')->terms([
+            'orderby' => 'name',
+            'order' => 'DESC',
+            'hide_empty' => false,
+        ]);
+
+        $this->assertEquals(['Blues', 'Ambient'], \array_map(strval(...), $terms));
+    }
+
+    public function testTermsIsMemoized()
+    {
+        $taxonomy = Timber::get_taxonomy('genre');
+
+        $this->assertSame($taxonomy->terms(), $taxonomy->terms());
+    }
+
+    public function testTermsAreLazy()
+    {
+        $queries = 0;
+
+        $this->add_filter_temporarily('pre_get_terms', function () use (&$queries) {
+            $queries++;
+        });
+
+        $taxonomy = Timber::get_taxonomy('genre');
+
+        $this->assertSame(0, $queries, 'Getting a taxonomy should not query any terms');
+
+        $taxonomy->terms();
+
+        $this->assertGreaterThan(0, $queries);
+        $queried = $queries;
+
+        $taxonomy->terms();
+
+        $this->assertSame($queried, $queries, 'A second unfiltered terms() call should be memoized');
+
+        // Passing arguments bypasses the memoized result.
+        $taxonomy->terms([
+            'hide_empty' => false,
+        ]);
+
+        $this->assertGreaterThan($queried, $queries);
+    }
+
+    public function testGetTaxonomies()
+    {
+        $taxonomies = Timber::get_taxonomies();
+
+        $this->assertArrayHasKey('genre', $taxonomies);
+        $this->assertArrayNotHasKey('mood', $taxonomies);
+        $this->assertContainsOnlyInstancesOf(Taxonomy::class, $taxonomies);
+    }
+
+    public function testGetTaxonomiesByName()
+    {
+        $taxonomies = Timber::get_taxonomies(['genre', 'mood', 'not-a-taxonomy']);
+
+        $this->assertEquals(['genre', 'mood'], \array_keys($taxonomies));
+        $this->assertContainsOnlyInstancesOf(Taxonomy::class, $taxonomies);
+    }
+
+    public function testGetTaxonomiesByString()
+    {
+        $taxonomies = Timber::get_taxonomies('genre');
+
+        $this->assertEquals(['genre'], \array_keys($taxonomies));
+    }
+
+    public function testGetTaxonomiesForPostType()
+    {
+        $taxonomies = Timber::get_taxonomies([
+            'post_type' => 'recipe',
+        ]);
+
+        $this->assertArrayHasKey('genre', $taxonomies);
+        $this->assertArrayNotHasKey('category', $taxonomies);
+    }
+
+    public function testGetTaxonomiesForPostTypeCombinedWithOtherArgs()
+    {
+        $taxonomies = Timber::get_taxonomies([
+            'post_type' => 'recipe',
+            'hierarchical' => true,
+        ]);
+
+        $this->assertEquals(['genre'], \array_keys($taxonomies));
+
+        $taxonomies = Timber::get_taxonomies([
+            'post_type' => 'recipe',
+            'hierarchical' => false,
+        ]);
+
+        $this->assertArrayNotHasKey('genre', $taxonomies);
+    }
+
+    public function testGetTaxonomiesInTwig()
+    {
+        $result = Timber::compile_string("{{ get_taxonomy('genre').labels.all_items }}");
+
+        $this->assertEquals('All Genres', $result);
+    }
+
+    public function testGetTaxonomyTermsInTwig()
+    {
+        $post_id = static::factory()->post->create();
+        static::factory()->term->create([
+            'taxonomy' => 'genre',
+            'name' => 'Ambient',
+        ]);
+        \wp_set_object_terms($post_id, 'Ambient', 'genre');
+
+        $result = Timber::compile_string(
+            "{% for term in get_taxonomy('genre').terms %}{{ term.title }}{% endfor %}"
+        );
+
+        $this->assertEquals('Ambient', $result);
+    }
+
+    public function testClassMapIsHonoured()
+    {
+        $this->register_genre_class();
+
+        $this->assertInstanceOf(Genre::class, Timber::get_taxonomy('genre'));
+        $this->assertInstanceOf(Genre::class, Timber::get_taxonomies()['genre']);
+
+        $mood = Timber::get_taxonomy('mood');
+
+        $this->assertInstanceOf(Taxonomy::class, $mood);
+        $this->assertNotInstanceOf(Genre::class, $mood);
+    }
+
+    public function testClassMapMethods()
+    {
+        $this->register_genre_class();
+        $this->create_genre_terms();
+
+        $genre = Timber::get_taxonomy('genre');
+
+        $this->assertEquals('Genres', $genre->title());
+        $this->assertEquals(3, $genre->term_count());
+        $this->assertEquals(['Ambient', 'Jazz'], \array_map(strval(...), $genre->top_level_terms()));
+    }
+
+    public function testClassMapMethodsInTwig()
+    {
+        $this->register_genre_class();
+        $this->create_genre_terms();
+
+        $result = Timber::compile_string(
+            "{% set genre = get_taxonomy('genre') %}"
+              . '{{ genre.title }} ({{ genre.term_count }}): '
+              . "{{ genre.top_level_terms|join(', ') }}"
+        );
+
+        $this->assertEquals('Genres (3): Ambient, Jazz', $result);
+    }
+
+    private function register_genre_class(): void
+    {
+        $this->add_filter_temporarily('timber/taxonomy/classmap', fn ($classmap) => \array_merge($classmap, [
+            'genre' => Genre::class,
+        ]));
+    }
+
+    private function create_genre_terms(): void
+    {
+        $jazz = static::factory()->term->create([
+            'taxonomy' => 'genre',
+            'name' => 'Jazz',
+        ]);
+        static::factory()->term->create([
+            'taxonomy' => 'genre',
+            'name' => 'Bebop',
+            'parent' => $jazz,
+        ]);
+        static::factory()->term->create([
+            'taxonomy' => 'genre',
+            'name' => 'Ambient',
+        ]);
+    }
+}

--- a/tests/TaxonomyTest.php
+++ b/tests/TaxonomyTest.php
@@ -203,19 +203,19 @@ class TaxonomyTest extends TimberIntegrationTestCase
 
     public function testTermsAreLazy()
     {
-        $queries = 0;
+        $term_query_count = 0;
 
-        $this->add_filter_temporarily('pre_get_terms', function () use (&$queries) {
-            $queries++;
+        $this->add_filter_temporarily('pre_get_terms', function () use (&$term_query_count) {
+            $term_query_count++;
         });
 
         $taxonomy = Timber::get_taxonomy('genre');
 
-        $this->assertSame(0, $queries, 'Getting a taxonomy should not query any terms');
+        $this->assertSame(0, $term_query_count, 'Getting a taxonomy should not construct a WP_Term_Query');
 
         $taxonomy->terms();
 
-        $this->assertGreaterThan(0, $queries);
+        $this->assertGreaterThan(0, $term_query_count, 'Getting terms should construct a WP_Term_Query');
     }
 
     public function testGetTaxonomies()

--- a/tests/TaxonomyTest.php
+++ b/tests/TaxonomyTest.php
@@ -324,8 +324,8 @@ class TaxonomyTest extends TimberIntegrationTestCase
 
         $result = Timber::compile_string(
             "{% set genre = get_taxonomy('genre') %}"
-              . '{{ genre.title }} ({{ genre.term_count }}): '
-              . "{{ genre.top_level_terms|join(', ') }}"
+                . '{{ genre.title }} ({{ genre.term_count }}): '
+                . "{{ genre.top_level_terms|join(', ') }}"
         );
 
         $this->assertEquals('Genres (3): Ambient, Jazz', $result);

--- a/tests/TaxonomyTest.php
+++ b/tests/TaxonomyTest.php
@@ -150,6 +150,16 @@ class TaxonomyTest extends TimberIntegrationTestCase
         $this->assertEquals(['post', 'recipe'], \array_map(strval(...), $post_types));
     }
 
+    public function testPostTypesExcludesUnregisteredPostTypes()
+    {
+        $wp_taxonomy = clone \get_taxonomy('genre');
+        $wp_taxonomy->object_type[] = 'not-a-post-type';
+
+        $post_types = Timber::get_taxonomy($wp_taxonomy)->post_types();
+
+        $this->assertEquals(['post', 'recipe'], \array_map(strval(...), $post_types));
+    }
+
     public function testTerms()
     {
         static::factory()->term->create_many(3, [


### PR DESCRIPTION
## Issue

Timber has `get_term()` and `get_terms()`, but no way to get the taxonomy itself. That means everything you configure in `register_taxonomy()` – most importantly the `labels` – is out of reach from a template. To display something as simple as “All Genres”, you currently have to drop down to `{{ fn('get_taxonomy', 'genre').labels.all_items }}`, which is exactly the kind of thing the object API exists to avoid.

The workaround that gets suggested is to assemble the data by hand in PHP:

```php
$taxonomy = get_taxonomy('gamme');

$context['filters'][] = [
    'name' => $taxonomy->name,
    'labels' => $taxonomy->labels,
    'terms' => Timber::get_terms(['taxonomy' => 'gamme']),
];
```

Related:

- #3282

## Solution

Adds a `Timber\Taxonomy` object and the two API methods to get it.

`Timber\Taxonomy` extends `Timber\Core` and is built the same way `Timber\Term` is – a protected constructor plus `static build(WP_Taxonomy)` – so it can’t be instantiated directly and always goes through the factory. `init()` imports the `WP_Taxonomy` object, which puts everything from `register_taxonomy()` (`labels`, `hierarchical`, `rewrite`, `show_in_rest`, …) directly on the object. On top of that it adds:

- `terms($query_args = [], $options = [])` – delegates to `Timber::get_terms()`, so you get real `Timber\Term` objects and the Term Class Map keeps applying. Terms are only queried when this is called, and the unfiltered result is memoized.
- `title()` – the human-readable label. Worth having because `name` on a taxonomy is the registration name (`post_tag`), while `name` on a `Timber\Term` is the label. `title()` removes that trap and matches `Post::title()` and `Term::title()`.
- `default_term()` – the term registered through the `default_term` argument of `register_taxonomy()`, resolved from the `default_term_{$taxonomy}` option and returned as a `Timber\Term`.
- `can_edit()` and `edit_link()` – the term overview in the admin, guarded by the taxonomy’s own `manage_terms` capability. Same pair as on `Post` and `Term`.
- `post_types()` – the post types the taxonomy is registered for, as `Timber\PostType` objects.
- `wp_object()` and `__toString()` (returns the taxonomy name), matching `Timber\Term`.

`Timber\Factory\TaxonomyFactory` mirrors `TermFactory`. Its `from()` accepts a taxonomy name, a list of names, an arguments array, a `WP_Taxonomy`, or an existing `Timber\Taxonomy` (idempotent). It introduces the `timber/taxonomy/classmap` and `timber/taxonomy/class` filters, with the same array-or-callable shape as the other class maps.

`Timber::get_taxonomy()` falls back to the taxonomy of the currently queried term when called without arguments, the same way `Timber::get_term()` falls back to the queried term. `Timber::get_taxonomies()` defaults to public taxonomies and returns an array keyed by taxonomy name. Both are registered as Twig functions.

Two implementation details worth calling out for review:

- **`object_type`.** `WP_Taxonomy::$object_type` (the post types the taxonomy is attached to) collides with `Timber\Core::$object_type`. `Timber\Taxonomy` extends `Core` rather than `CoreEntity` – taxonomies have no meta – so `Core::$object_type` is only used for meta lookups and deprecation notices, neither of which apply here. WordPress’ meaning wins, which is what a template author would expect. There’s a test pinning this.
- **The `post_type` argument.** WordPress’ own `object_type` argument to `get_taxonomies()` compares with `wp_filter_object_list()` and therefore requires an _exact_ match of the registered post type array, so `['object_type' => ['recipe']]` will not find a taxonomy registered for `['post', 'recipe']`. The `post_type` alias is resolved through `get_object_taxonomies()` and then intersected with the result of the remaining arguments, so it behaves the way you’d expect and composes with the other arguments.- **`default_term`.** Because a `default_term()` method exists and no matching property is declared, `Core::import()` skips the raw `default_term` registration array from `WP_Taxonomy` and `{{ taxonomy.default_term }}` resolves to the method instead. That’s deliberate – the resolved `Timber\Term` is more useful than the registration arguments – and follows the same approach as the protected `Term::$description`.

## Impact

Additive only. No existing class, method, filter or behaviour changes, so there is no backwards compatibility concern.

Performance impact is limited by design: terms are lazy, so `Timber::get_taxonomies()` on a site with many taxonomies does not fire a term query per taxonomy. Building a `Taxonomy` is just `get_taxonomy()` plus a property import, with no database access.

## Usage Changes

```php
// Get a taxonomy by name.
$taxonomy = Timber::get_taxonomy('genre');

// Use the taxonomy of the currently queried term archive.
$taxonomy = Timber::get_taxonomy();

// All public taxonomies, keyed by name.
$taxonomies = Timber::get_taxonomies();

// A list of taxonomy names.
$taxonomies = Timber::get_taxonomies(['category', 'genre']);

// Any get_taxonomies() argument, plus a post_type alias.
$taxonomies = Timber::get_taxonomies([
    'post_type' => 'recipe',
    'hierarchical' => true,
]);
```

```twig
{% set genre = get_taxonomy('genre') %}

<h1>{{ genre.title }}</h1>

{% for term in genre.terms %}
    <a href="{{ term.link }}">{{ term.title }}</a>
{% endfor %}

{% if genre.can_edit %}
    <a href="{{ genre.edit_link }}">Manage genres</a>
{% endif %}
```

New filters: `timber/taxonomy/classmap` and `timber/taxonomy/class`.

New Twig functions: `get_taxonomy()` and `get_taxonomies()`.

Docs: a new **Taxonomies** guide, a **The Taxonomy Class Map** section in the Class Maps guide, and a cross-link from the Terms guide.

## Considerations

- `Timber::get_taxonomy_by()` is deliberately not included. Unlike terms and users, taxonomies are only ever addressed by name, so there is no second field to look up by.
- `Timber\Term::$taxonomy` is still a string rather than a `Timber\Taxonomy` object. Changing it would be a breaking change and would risk queries in unexpected places, so it stayed as is. `Timber::get_taxonomy(term.taxonomy)` covers the gap.
- While writing the laziness test I noticed each Timber term query fires `pre_get_terms` twice: `WP_Term_Query::__construct()` already runs the query, and `TermFactory::from_wp_term_query()` then calls `get_terms()` on the same instance again. WordPress’ object cache absorbs the second fetch so it isn’t a duplicate database hit, and it predates this PR, but it may be worth a separate look.

## Testing

Yes – 34 tests, all included.

`tests/TaxonomyTest.php` covers getting a taxonomy by name and from a `WP_Taxonomy`, `null` for an unregistered name, `__toString()`, the `object_type`/`post_types()` behaviour described above, `terms()` with and without query arguments, and all four `get_taxonomies()` input shapes including `post_type` on its own and combined with another argument.

The added API methods are covered too: `title()` in PHP and Twig, `default_term()` against a taxonomy registered with a `default_term` as well as one without, and `can_edit()`/`edit_link()` for both an administrator and a subscriber.

Laziness is asserted rather than assumed. `testTermsAreLazy` counts `pre_get_terms` and checks that getting a taxonomy runs no term query at all, that the first `terms()` call does, that a second unfiltered call is served from the memoized result, and that passing arguments bypasses it.

Class map behaviour is covered from both directions. `tests/Factory/TaxonomyFactoryTest.php` tests the array form, the callable form and the `timber/taxonomy/class` filter, plus invalid input. `tests/TaxonomyTest.php` then does it end to end with a `Genre extends Taxonomy` fixture that adds `top_level_terms()` and `term_count()`, asserting that the class map applies through both `get_taxonomy()` and `get_taxonomies()`, that unmapped taxonomies still get the base class, that the methods return the right values against a real parent/child term set, and that they render from Twig:

```twig
{% set genre = get_taxonomy('genre') %}
{{ genre.title }} ({{ genre.term_count }}): {{ genre.top_level_terms|join(', ') }}
{# => Genres (3): Ambient, Jazz #}
```

The full suite (1314 tests), PHPStan and ECS all pass.
