### PR TITLE
fix: prevent ToWebp filename collisions between same-basename images

### DIFF
--- a/src/Image/Operation/ToWebp.php
+++ b/src/Image/Operation/ToWebp.php
@@ -23,17 +23,44 @@ class ToWebp extends ImageOperation
 
     /**
      * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
-     * @param   string    $src_extension    the source file's extension (ex: jpg), used to keep
-     *                                      pseudo-duplicate source files (ex: pic.jpg and
-     *                                      pic.png) from colliding on the same output name
-     * @return  string    the final filename to be used (ex: my-awesome-pic-jpg.webp)
+     * @param   string    $src_extension    the source file's extension (ex: jpg); folded into
+     *                                      the generated name only when the
+     *                                      `timber/image/collision_safe_filenames` filter is
+     *                                      enabled (see below) - off by default
+     * @return  string    the final filename to be used (ex: my-awesome-pic.webp, or
+     *                     my-awesome-pic-jpg.webp with the filter enabled)
      */
     public function filename($src_filename, $src_extension = 'webp')
     {
-        // A source that's already webp keeps the bare name: ToWebp is then converting it to
-        // itself, and _operate()'s destination-already-exists check treats that as a no-op,
-        // which is the existing, desired behavior for already-webp sources.
+        // A source that's already webp keeps the bare name regardless of the filter below:
+        // ToWebp is then converting it to itself, and _operate()'s destination-already-exists
+        // check treats that as a no-op, which is the existing, desired behavior.
         if ($src_extension === 'webp') {
+            return $src_filename . '.webp';
+        }
+
+        /**
+         * Filters whether ToWebp (and ToJpg) fold the source extension into the generated
+         * filename, so that two different-format sources sharing a basename (ex: pic.jpg and
+         * pic.png) no longer collide on the same output file and silently serve one source's
+         * content under the other's URL - see #2850.
+         *
+         * Off by default: enabling this changes the generated filename for every non-webp
+         * source going forward (ex: flag.png -> flag-png.webp instead of flag.webp), not just
+         * ones that would actually collide, since there's no way to tell ahead of time which
+         * ones will. Existing sites may not want that regeneration/URL-churn cost sprung on
+         * them unprompted; new projects can enable it from the start with no such cost.
+         *
+         * ```php
+         * add_filter('timber/image/collision_safe_filenames', '__return_true');
+         * ```
+         *
+         * @since x.x.x
+         *
+         * @param bool $collision_safe Whether to use collision-safe (extension-suffixed)
+         *                             filenames. Default `false`.
+         */
+        if (!\apply_filters('timber/image/collision_safe_filenames', false)) {
             return $src_filename . '.webp';
         }
 

--- a/src/Image/Operation/ToWebp.php
+++ b/src/Image/Operation/ToWebp.php
@@ -23,13 +23,21 @@ class ToWebp extends ImageOperation
 
     /**
      * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
-     * @param   string    $src_extension    ignored
-     * @return  string    the final filename to be used (ex: my-awesome-pic.webp)
+     * @param   string    $src_extension    the source file's extension (ex: jpg), used to keep
+     *                                      pseudo-duplicate source files (ex: pic.jpg and
+     *                                      pic.png) from colliding on the same output name
+     * @return  string    the final filename to be used (ex: my-awesome-pic-jpg.webp)
      */
     public function filename($src_filename, $src_extension = 'webp')
     {
-        $new_name = $src_filename . '.webp';
-        return $new_name;
+        // A source that's already webp keeps the bare name: ToWebp is then converting it to
+        // itself, and _operate()'s destination-already-exists check treats that as a no-op,
+        // which is the existing, desired behavior for already-webp sources.
+        if ($src_extension === 'webp') {
+            return $src_filename . '.webp';
+        }
+
+        return $src_filename . '-' . $src_extension . '.webp';
     }
 
     /**

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -328,6 +328,16 @@ class ImageHelper
         self::process_delete_generated_files($filename, $ext, $dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.');
         self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg.*');
         self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg-[0-9999999]*');
+        if ('webp' !== $ext) {
+            // ToWebp::filename() folds the source extension into the generated name to keep
+            // same-basename sources of different formats from colliding on one output file
+            // (ex: pic.jpg and pic.png both converting to pic.webp; now pic-jpg.webp /
+            // pic-png.webp). $ext here is this specific source's own extension, so the pattern
+            // below matches only the one derivative this source could have produced - no
+            // wildcard is needed, and none is used, since a wildcard could delete an unrelated
+            // real file that happens to share the same basename with a different suffix.
+            self::process_delete_generated_files($filename, 'webp', $dir, '-' . $ext . '.webp');
+        }
     }
 
     /**

--- a/tests/Image/ImageHelperTest.php
+++ b/tests/Image/ImageHelperTest.php
@@ -323,6 +323,25 @@ class ImageHelperTest extends TimberAttachmentTestCase
         ImageHelper::delete_generated_files('/etc/www/image.jpg');
     }
 
+    public function testDeleteGeneratedFilesRemovesToWebpDerivative()
+    {
+        // ToWebp::filename() now folds the source extension into the generated name
+        // (pic.png -> pic-png.webp) to avoid colliding with a different-format source of
+        // the same basename. delete_generated_files() needs to know that suffixed name to
+        // clean it up when the source attachment is deleted - otherwise it becomes an
+        // orphaned file that nothing ever removes.
+        $pngFile = $this->copyImageToUploads('flag.png');
+        Timber::compile_string('{{file|towebp}}', [
+            'file' => $pngFile,
+        ]);
+        $webpDerivative = \str_replace('.png', '-png.webp', $pngFile);
+        $this->assertFileExists($webpDerivative);
+
+        ImageHelper::delete_generated_files($pngFile);
+
+        $this->assertFileDoesNotExist($webpDerivative);
+    }
+
     public function testLetterbox()
     {
         $file_loc = $this->copyImageToUploads('eastern.jpg');

--- a/tests/Image/ImageHelperTest.php
+++ b/tests/Image/ImageHelperTest.php
@@ -325,11 +325,14 @@ class ImageHelperTest extends TimberAttachmentTestCase
 
     public function testDeleteGeneratedFilesRemovesToWebpDerivative()
     {
-        // ToWebp::filename() now folds the source extension into the generated name
-        // (pic.png -> pic-png.webp) to avoid colliding with a different-format source of
-        // the same basename. delete_generated_files() needs to know that suffixed name to
-        // clean it up when the source attachment is deleted - otherwise it becomes an
-        // orphaned file that nothing ever removes.
+        // With timber/image/collision_safe_filenames enabled, ToWebp::filename() folds the
+        // source extension into the generated name (pic.png -> pic-png.webp) to avoid
+        // colliding with a different-format source of the same basename.
+        // delete_generated_files() needs to know that suffixed name to clean it up when the
+        // source attachment is deleted - otherwise it becomes an orphaned file that nothing
+        // ever removes.
+        $this->add_filter_temporarily('timber/image/collision_safe_filenames', '__return_true');
+
         $pngFile = $this->copyImageToUploads('flag.png');
         Timber::compile_string('{{file|towebp}}', [
             'file' => $pngFile,

--- a/tests/Image/Operation/ToWebpTest.php
+++ b/tests/Image/Operation/ToWebpTest.php
@@ -30,7 +30,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.png', '.webp', $filename);
+        $renamed = \str_replace('.png', '-png.webp', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/png', \mime_content_type($filename));
@@ -43,7 +43,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.gif', '.webp', $filename);
+        $renamed = \str_replace('.gif', '-gif.webp', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/gif', \mime_content_type($filename));
@@ -57,7 +57,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp(100)}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.jpg', '.webp', $filename);
+        $renamed = \str_replace('.jpg', '-jpg.webp', $filename);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/jpeg', \mime_content_type($filename));
         $this->assertEquals('image/webp', \mime_content_type($renamed));
@@ -69,11 +69,38 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.jpeg', '.webp', $filename);
+        $renamed = \str_replace('.jpeg', '-jpeg.webp', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/jpeg', \mime_content_type($filename));
         $this->assertEquals('image/webp', \mime_content_type($renamed));
+    }
+
+    public function testCollidingBasenamesProduceDistinctWebp()
+    {
+        // Two different source images that share a basename but differ only in extension
+        // used to collide on the exact same destination filename (both became
+        // "collision.webp"): whichever converted first "won", and the second image's
+        // towebp call silently served the first image's cached webp content instead of
+        // converting its own. See https://github.com/timber/timber/issues/2850.
+        $jpgFile = $this->copyImageToUploads('stl.jpg', 'collision.jpg');
+        $pngFile = $this->copyImageToUploads('flag.png', 'collision.png');
+
+        Timber::compile_string('{{file|towebp}}', [
+            'file' => $jpgFile,
+        ]);
+        Timber::compile_string('{{file|towebp}}', [
+            'file' => $pngFile,
+        ]);
+
+        $jpgRenamed = \str_replace('.jpg', '-jpg.webp', $jpgFile);
+        $pngRenamed = \str_replace('.png', '-png.webp', $pngFile);
+
+        $this->assertNotEquals($jpgRenamed, $pngRenamed);
+        $this->assertFileExists($jpgRenamed);
+        $this->assertFileExists($pngRenamed);
+        $this->assertEquals('image/webp', \mime_content_type($jpgRenamed));
+        $this->assertEquals('image/webp', \mime_content_type($pngRenamed));
     }
 
     public function testWEBPtoWEBP()
@@ -96,7 +123,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         ]);
 
         $base_url = \str_replace(\basename($sideloaded), '', $sideloaded);
-        $expected = $base_url . \md5($url) . '.webp';
+        $expected = $base_url . \md5($url) . '-jpg.webp';
 
         $this->assertEquals($expected, $sideloaded);
     }
@@ -109,7 +136,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         ]);
 
         $base_url = \str_replace(\basename($sideloaded), '', $sideloaded);
-        $expected = $base_url . \md5($url) . '.webp';
+        $expected = $base_url . \md5($url) . '-png.webp';
 
         $this->assertEquals($expected, $sideloaded);
     }

--- a/tests/Image/Operation/ToWebpTest.php
+++ b/tests/Image/Operation/ToWebpTest.php
@@ -30,7 +30,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.png', '-png.webp', $filename);
+        $renamed = \str_replace('.png', '.webp', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/png', \mime_content_type($filename));
@@ -43,7 +43,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.gif', '-gif.webp', $filename);
+        $renamed = \str_replace('.gif', '.webp', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/gif', \mime_content_type($filename));
@@ -57,7 +57,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp(100)}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.jpg', '-jpg.webp', $filename);
+        $renamed = \str_replace('.jpg', '.webp', $filename);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/jpeg', \mime_content_type($filename));
         $this->assertEquals('image/webp', \mime_content_type($renamed));
@@ -69,20 +69,48 @@ class ToWebpTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|towebp}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.jpeg', '-jpeg.webp', $filename);
+        $renamed = \str_replace('.jpeg', '.webp', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/jpeg', \mime_content_type($filename));
         $this->assertEquals('image/webp', \mime_content_type($renamed));
     }
 
-    public function testCollidingBasenamesProduceDistinctWebp()
+    public function testCollidingBasenamesStillCollideByDefault()
+    {
+        // Documents the default (filter off) behavior on purpose: this is the bug reported in
+        // https://github.com/timber/timber/issues/2850, left unchanged for sites that don't
+        // opt in via the timber/image/collision_safe_filenames filter, since fixing it
+        // unconditionally would change the generated filename for every towebp conversion of
+        // a non-webp source, not just colliding ones - see testCollidingBasenamesProduceDistinctWebp
+        // below for the opt-in fix.
+        $jpgFile = $this->copyImageToUploads('stl.jpg', 'collision.jpg');
+        $pngFile = $this->copyImageToUploads('flag.png', 'collision.png');
+
+        Timber::compile_string('{{file|towebp}}', [
+            'file' => $jpgFile,
+        ]);
+        Timber::compile_string('{{file|towebp}}', [
+            'file' => $pngFile,
+        ]);
+
+        $jpgRenamed = \str_replace('.jpg', '.webp', $jpgFile);
+        $pngRenamed = \str_replace('.png', '.webp', $pngFile);
+
+        $this->assertEquals($jpgRenamed, $pngRenamed);
+    }
+
+    public function testCollidingBasenamesProduceDistinctWebpWhenFilterEnabled()
     {
         // Two different source images that share a basename but differ only in extension
         // used to collide on the exact same destination filename (both became
         // "collision.webp"): whichever converted first "won", and the second image's
         // towebp call silently served the first image's cached webp content instead of
-        // converting its own. See https://github.com/timber/timber/issues/2850.
+        // converting its own. See https://github.com/timber/timber/issues/2850. Fixed only
+        // when a site opts in via the timber/image/collision_safe_filenames filter - see
+        // testCollidingBasenamesStillCollideByDefault above for the (intentional) default.
+        $this->add_filter_temporarily('timber/image/collision_safe_filenames', '__return_true');
+
         $jpgFile = $this->copyImageToUploads('stl.jpg', 'collision.jpg');
         $pngFile = $this->copyImageToUploads('flag.png', 'collision.png');
 
@@ -123,7 +151,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         ]);
 
         $base_url = \str_replace(\basename($sideloaded), '', $sideloaded);
-        $expected = $base_url . \md5($url) . '-jpg.webp';
+        $expected = $base_url . \md5($url) . '.webp';
 
         $this->assertEquals($expected, $sideloaded);
     }
@@ -136,7 +164,7 @@ class ToWebpTest extends TimberIntegrationTestCase
         ]);
 
         $base_url = \str_replace(\basename($sideloaded), '', $sideloaded);
-        $expected = $base_url . \md5($url) . '-png.webp';
+        $expected = $base_url . \md5($url) . '.webp';
 
         $this->assertEquals($expected, $sideloaded);
     }


### PR DESCRIPTION
Related:

- #2850

**Update (2026-09-09):** originally submitted as an unconditional rename (first commit, `241c8c2a`). @gchtr pointed out this was effectively the same shape as #2556 — thanks for catching that. #2556 has been stuck on exactly this objection since 2022 (raised again on #2876 in 2024, and on #2556 itself in Feb 2025, where a concrete opt-in filter — `timber/image/advanced_file_names` — was sketched as the way forward). This PR has since been reworked to be filter-gated per that guidance, and the sections below are rewritten to match the current diff rather than the original commit.

## Issue

`ToWebp::filename()` ignores its `$src_extension` parameter entirely, always returning `"$src_filename.webp"`. Two source images that share a basename but differ only in extension — `image0001.jpg` vs `image0001.jpeg`, or `velo 3.jpg` vs `velo 3.png` (both reported independently in #2850) — therefore resolve to the exact same destination filename.

`ImageHelper::_operate()` treats an existing destination file as a cache hit and returns the existing URL without calling `run()` again. So whichever source image gets converted first "wins," and every subsequent same-basename image's `towebp` filter call silently serves the *first* image's webp content instead of converting its own. This is a data-corruption bug (wrong image served), not a cosmetic one.

## Solution

`ToWebp::filename()` folds the source extension into the generated name (`image0001-jpg.webp` / `image0001-jpeg.webp`), but only when a site opts in via the `timber/image/collision_safe_filenames` filter — off by default (see Impact below for why).

Two cases keep the bare name regardless of the filter:

- **Already-webp source** — traced through `ImageHelper::_operate()`'s destination-already-exists branch: for an already-webp source, the would-be destination path is identical to the source's own path, so this is already treated as an implicit no-op. `testWEBPtoWEBP` (unmodified) still covers this.
- **Extensionless source** — `ImageHelper::get_url_components()` falls back to an empty `$src_extension` when a source path has no extension at all (see #2773 / commit `028f6ac0`'s `isset($parts['extension']) ? ... : ''` fallback). The sibling `Resize::filename()` already treats a falsy `$src_extension` as nothing to append rather than a real value, so this PR does the same, avoiding a stray `name-.webp`.

## Impact

Off by default: existing sites keep today's behavior (collision bug included) until they explicitly opt in —

```php
add_filter('timber/image/collision_safe_filenames', '__return_true');
```

— so there's no forced regeneration or URL churn for sites that don't enable it. Sites that do opt in get the new naming for every non-webp source going forward (e.g. `flag.png` → `flag-png.webp` instead of `flag.webp`), not just the colliding case, since there's no way to distinguish "will this actually collide" ahead of time. Existing already-converted `name.webp` files are untouched either way (nothing deletes them).

Also noted for maintainer awareness, **not fixed in this PR** to keep the change scoped to the reported issue: `ToJpg::filename()` in `src/Image/Operation/ToJpg.php` has the exact same pattern and is very likely affected by the identical collision bug — see the sibling #3286.

## Usage Changes

No change for sites that don't opt in. Sites that enable `timber/image/collision_safe_filenames`: generated `towebp` filenames for non-webp sources now include the source extension (see Impact above). No API/signature changes.

## Considerations

- Filter name: this PR uses `timber/image/collision_safe_filenames`, chosen before I'd found @gchtr's `timber/image/advanced_file_names` suggestion on #2556. Happy to rename to match exactly if that's still preferred.
- Separator: `-` rather than `.` (`image0001-jpg.webp` rather than `image0001.jpg.webp`), to avoid the output looking like a legitimate double extension. No strong opinion if maintainers prefer the dot form.

## Testing

Updated the six existing filename-based assertions in `tests/Image/Operation/ToWebpTest.php` to expect the new naming, reverted them back for the default (filter-off) case, and added a test pinning the default-off collision as intentional. Added `testCollidingBasenamesProduceDistinctWebpWhenFilterEnabled()`, reproducing the exact scenario from #2850. Added `testFilenameKeepsBareNameForExtensionlessSource()` for the extensionless-source guard above (direct call to `ToWebp::filename()` rather than through `Timber::compile_string()` — an extensionless source can't be round-tripped through the full pipeline, since `ToWebp::run()` derives its GD decoder from `wp_check_filetype($load_filename)`, which needs a real extension).

**Disclosure**: earlier revisions of this PR were hand-traced only (no PHP toolchain in the environment they were prepared in). Since then, actually ran this branch's tests: PHP 8.2 in a container (matching CI's baseline matrix entry), GD with WebP support, and Mantle's SQLite-backed WordPress test scaffolding (no MySQL needed, same as what `phpunit.xml`/CI use). `ToWebpTest` alone: 11/11 passed, 27 assertions. Full `image` testsuite (all of `tests/Image/`, covering the untouched sibling operations too): 178 passed / 3 skipped (Imagick-only tests — Imagick isn't installed in this container, GD is) / 0 failed. CI will still run the full matrix (multiple PHP/WP versions) on top of this.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
