### PR TITLE
fix: prevent ToJpg filename collisions between same-basename images

### DIFF
--- a/src/Image/Operation/ToJpg.php
+++ b/src/Image/Operation/ToJpg.php
@@ -22,13 +22,21 @@ class ToJpg extends ImageOperation
 
     /**
      * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
-     * @param   string    $src_extension    ignored
-     * @return  string    the final filename to be used (ex: my-awesome-pic.jpg)
+     * @param   string    $src_extension    the source file's extension (ex: png), used to keep
+     *                                      pseudo-duplicate source files (ex: pic.png and
+     *                                      pic.gif) from colliding on the same output name
+     * @return  string    the final filename to be used (ex: my-awesome-pic-png.jpg)
      */
     public function filename($src_filename, $src_extension = 'jpg')
     {
-        $new_name = $src_filename . '.jpg';
-        return $new_name;
+        // A source that's already jpg keeps the bare name: ToJpg is then converting it to
+        // itself, and _operate()'s destination-already-exists check treats that as a no-op,
+        // which is the existing, desired behavior for already-jpg sources.
+        if ($src_extension === 'jpg') {
+            return $src_filename . '.jpg';
+        }
+
+        return $src_filename . '-' . $src_extension . '.jpg';
     }
 
     /**

--- a/src/Image/Operation/ToJpg.php
+++ b/src/Image/Operation/ToJpg.php
@@ -22,17 +22,44 @@ class ToJpg extends ImageOperation
 
     /**
      * @param   string    $src_filename     the basename of the file (ex: my-awesome-pic)
-     * @param   string    $src_extension    the source file's extension (ex: png), used to keep
-     *                                      pseudo-duplicate source files (ex: pic.png and
-     *                                      pic.gif) from colliding on the same output name
-     * @return  string    the final filename to be used (ex: my-awesome-pic-png.jpg)
+     * @param   string    $src_extension    the source file's extension (ex: png); folded into
+     *                                      the generated name only when the
+     *                                      `timber/image/collision_safe_filenames` filter is
+     *                                      enabled (see below) - off by default
+     * @return  string    the final filename to be used (ex: my-awesome-pic.jpg, or
+     *                     my-awesome-pic-png.jpg with the filter enabled)
      */
     public function filename($src_filename, $src_extension = 'jpg')
     {
-        // A source that's already jpg keeps the bare name: ToJpg is then converting it to
-        // itself, and _operate()'s destination-already-exists check treats that as a no-op,
-        // which is the existing, desired behavior for already-jpg sources.
+        // A source that's already jpg keeps the bare name regardless of the filter below:
+        // ToJpg is then converting it to itself, and _operate()'s destination-already-exists
+        // check treats that as a no-op, which is the existing, desired behavior.
         if ($src_extension === 'jpg') {
+            return $src_filename . '.jpg';
+        }
+
+        /**
+         * Filters whether ToJpg (and ToWebp) fold the source extension into the generated
+         * filename, so that two different-format sources sharing a basename (ex: pic.png and
+         * pic.gif) no longer collide on the same output file and silently serve one source's
+         * content under the other's URL - see #2850.
+         *
+         * Off by default: enabling this changes the generated filename for every non-jpg
+         * source going forward (ex: flag.png -> flag-png.jpg instead of flag.jpg), not just
+         * ones that would actually collide, since there's no way to tell ahead of time which
+         * ones will. Existing sites may not want that regeneration/URL-churn cost sprung on
+         * them unprompted; new projects can enable it from the start with no such cost.
+         *
+         * ```php
+         * add_filter('timber/image/collision_safe_filenames', '__return_true');
+         * ```
+         *
+         * @since x.x.x
+         *
+         * @param bool $collision_safe Whether to use collision-safe (extension-suffixed)
+         *                             filenames. Default `false`.
+         */
+        if (!\apply_filters('timber/image/collision_safe_filenames', false)) {
             return $src_filename . '.jpg';
         }
 

--- a/src/ImageHelper.php
+++ b/src/ImageHelper.php
@@ -328,6 +328,16 @@ class ImageHelper
         self::process_delete_generated_files($filename, $ext, $dir, '-lbox-[0-9999999]*', '-lbox-[0-9]*x[0-9]*-[a-zA-Z0-9]*.');
         self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg.*');
         self::process_delete_generated_files($filename, 'jpg', $dir, '-tojpg-[0-9999999]*');
+        if ('jpg' !== $ext) {
+            // ToJpg::filename() folds the source extension into the generated name to keep
+            // same-basename sources of different formats from colliding on one output file
+            // (ex: pic.png and pic.gif both converting to pic.jpg; now pic-png.jpg /
+            // pic-gif.jpg). $ext here is this specific source's own extension, so the pattern
+            // below matches only the one derivative this source could have produced - no
+            // wildcard is needed, and none is used, since a wildcard could delete an unrelated
+            // real file that happens to share the same basename with a different suffix.
+            self::process_delete_generated_files($filename, 'jpg', $dir, '-' . $ext . '.jpg');
+        }
     }
 
     /**

--- a/tests/Image/ImageHelperTest.php
+++ b/tests/Image/ImageHelperTest.php
@@ -323,6 +323,25 @@ class ImageHelperTest extends TimberAttachmentTestCase
         ImageHelper::delete_generated_files('/etc/www/image.jpg');
     }
 
+    public function testDeleteGeneratedFilesRemovesToJpgDerivative()
+    {
+        // ToJpg::filename() now folds the source extension into the generated name
+        // (pic.png -> pic-png.jpg) to avoid colliding with a different-format source of
+        // the same basename. delete_generated_files() needs to know that suffixed name to
+        // clean it up when the source attachment is deleted - otherwise it becomes an
+        // orphaned file that nothing ever removes.
+        $pngFile = $this->copyImageToUploads('flag.png');
+        Timber::compile_string('{{file|tojpg}}', [
+            'file' => $pngFile,
+        ]);
+        $jpgDerivative = \str_replace('.png', '-png.jpg', $pngFile);
+        $this->assertFileExists($jpgDerivative);
+
+        ImageHelper::delete_generated_files($pngFile);
+
+        $this->assertFileDoesNotExist($jpgDerivative);
+    }
+
     public function testLetterbox()
     {
         $file_loc = $this->copyImageToUploads('eastern.jpg');

--- a/tests/Image/ImageHelperTest.php
+++ b/tests/Image/ImageHelperTest.php
@@ -325,11 +325,14 @@ class ImageHelperTest extends TimberAttachmentTestCase
 
     public function testDeleteGeneratedFilesRemovesToJpgDerivative()
     {
-        // ToJpg::filename() now folds the source extension into the generated name
-        // (pic.png -> pic-png.jpg) to avoid colliding with a different-format source of
-        // the same basename. delete_generated_files() needs to know that suffixed name to
-        // clean it up when the source attachment is deleted - otherwise it becomes an
-        // orphaned file that nothing ever removes.
+        // With timber/image/collision_safe_filenames enabled, ToJpg::filename() folds the
+        // source extension into the generated name (pic.png -> pic-png.jpg) to avoid
+        // colliding with a different-format source of the same basename.
+        // delete_generated_files() needs to know that suffixed name to clean it up when the
+        // source attachment is deleted - otherwise it becomes an orphaned file that nothing
+        // ever removes.
+        $this->add_filter_temporarily('timber/image/collision_safe_filenames', '__return_true');
+
         $pngFile = $this->copyImageToUploads('flag.png');
         Timber::compile_string('{{file|tojpg}}', [
             'file' => $pngFile,

--- a/tests/Image/Operation/ToJpgTest.php
+++ b/tests/Image/Operation/ToJpgTest.php
@@ -35,7 +35,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|tojpg}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.png', '-png.jpg', $filename);
+        $renamed = \str_replace('.png', '.jpg', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/png', \mime_content_type($filename));
@@ -50,7 +50,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|tojpg}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.gif', '-gif.jpg', $filename);
+        $renamed = \str_replace('.gif', '.jpg', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/gif', \mime_content_type($filename));
@@ -59,14 +59,45 @@ class ToJpgTest extends TimberIntegrationTestCase
         \unlink($renamed);
     }
 
-    public function testCollidingBasenamesProduceDistinctJpg()
+    public function testCollidingBasenamesStillCollideByDefault()
+    {
+        // Documents the default (filter off) behavior on purpose: this is the bug reported in
+        // https://github.com/timber/timber/issues/2850 (sibling ToWebp operation), left
+        // unchanged for sites that don't opt in via the timber/image/collision_safe_filenames
+        // filter, since fixing it unconditionally would change the generated filename for
+        // every tojpg conversion of a non-jpg source, not just colliding ones - see
+        // testCollidingBasenamesProduceDistinctJpgWhenFilterEnabled below for the opt-in fix.
+        $pngFile = $this->copyImageToUploads('flag.png', 'collision.png');
+        $gifFile = $this->copyImageToUploads('boyer.gif', 'collision.gif');
+
+        Timber::compile_string('{{file|tojpg}}', [
+            'file' => $pngFile,
+        ]);
+        Timber::compile_string('{{file|tojpg}}', [
+            'file' => $gifFile,
+        ]);
+
+        $pngRenamed = \str_replace('.png', '.jpg', $pngFile);
+        $gifRenamed = \str_replace('.gif', '.jpg', $gifFile);
+
+        $this->assertEquals($pngRenamed, $gifRenamed);
+        \unlink($pngFile);
+        \unlink($gifFile);
+        \unlink($pngRenamed);
+    }
+
+    public function testCollidingBasenamesProduceDistinctJpgWhenFilterEnabled()
     {
         // Two different source images that share a basename but differ only in extension
         // used to collide on the exact same destination filename (both became
         // "collision.jpg"): whichever converted first "won", and the second image's
         // tojpg call silently served the first image's cached jpg content instead of
         // converting its own. Same bug class as https://github.com/timber/timber/issues/2850,
-        // in the sibling ToJpg operation.
+        // in the sibling ToJpg operation. Fixed only when a site opts in via the
+        // timber/image/collision_safe_filenames filter - see
+        // testCollidingBasenamesStillCollideByDefault above for the (intentional) default.
+        $this->add_filter_temporarily('timber/image/collision_safe_filenames', '__return_true');
+
         $pngFile = $this->copyImageToUploads('flag.png', 'collision.png');
         $gifFile = $this->copyImageToUploads('boyer.gif', 'collision.gif');
 
@@ -110,7 +141,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|tojpg}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.jpeg', '-jpeg.jpg', $filename);
+        $renamed = \str_replace('.jpeg', '.jpg', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/jpeg', \mime_content_type($filename));
@@ -127,7 +158,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         ]);
 
         $base_url = \str_replace(\basename($sideloaded), '', $sideloaded);
-        $expected = $base_url . \md5($url) . '-png.jpg';
+        $expected = $base_url . \md5($url) . '.jpg';
 
         $this->assertEquals($expected, $sideloaded);
     }

--- a/tests/Image/Operation/ToJpgTest.php
+++ b/tests/Image/Operation/ToJpgTest.php
@@ -35,7 +35,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|tojpg}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.png', '.jpg', $filename);
+        $renamed = \str_replace('.png', '-png.jpg', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/png', \mime_content_type($filename));
@@ -50,13 +50,45 @@ class ToJpgTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|tojpg}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.gif', '.jpg', $filename);
+        $renamed = \str_replace('.gif', '-gif.jpg', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/gif', \mime_content_type($filename));
         $this->assertEquals('image/jpeg', \mime_content_type($renamed));
         \unlink($filename);
         \unlink($renamed);
+    }
+
+    public function testCollidingBasenamesProduceDistinctJpg()
+    {
+        // Two different source images that share a basename but differ only in extension
+        // used to collide on the exact same destination filename (both became
+        // "collision.jpg"): whichever converted first "won", and the second image's
+        // tojpg call silently served the first image's cached jpg content instead of
+        // converting its own. Same bug class as https://github.com/timber/timber/issues/2850,
+        // in the sibling ToJpg operation.
+        $pngFile = $this->copyImageToUploads('flag.png', 'collision.png');
+        $gifFile = $this->copyImageToUploads('boyer.gif', 'collision.gif');
+
+        Timber::compile_string('{{file|tojpg}}', [
+            'file' => $pngFile,
+        ]);
+        Timber::compile_string('{{file|tojpg}}', [
+            'file' => $gifFile,
+        ]);
+
+        $pngRenamed = \str_replace('.png', '-png.jpg', $pngFile);
+        $gifRenamed = \str_replace('.gif', '-gif.jpg', $gifFile);
+
+        $this->assertNotEquals($pngRenamed, $gifRenamed);
+        $this->assertFileExists($pngRenamed);
+        $this->assertFileExists($gifRenamed);
+        $this->assertEquals('image/jpeg', \mime_content_type($pngRenamed));
+        $this->assertEquals('image/jpeg', \mime_content_type($gifRenamed));
+        \unlink($pngFile);
+        \unlink($gifFile);
+        \unlink($pngRenamed);
+        \unlink($gifRenamed);
     }
 
     public function testJPGtoJPG()
@@ -78,7 +110,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         $str = Timber::compile_string('{{file|tojpg}}', [
             'file' => $filename,
         ]);
-        $renamed = \str_replace('.jpeg', '.jpg', $filename);
+        $renamed = \str_replace('.jpeg', '-jpeg.jpg', $filename);
         $this->assertFileExists($renamed);
         $this->assertGreaterThan(1000, \filesize($renamed));
         $this->assertEquals('image/jpeg', \mime_content_type($filename));
@@ -95,7 +127,7 @@ class ToJpgTest extends TimberIntegrationTestCase
         ]);
 
         $base_url = \str_replace(\basename($sideloaded), '', $sideloaded);
-        $expected = $base_url . \md5($url) . '.jpg';
+        $expected = $base_url . \md5($url) . '-png.jpg';
 
         $this->assertEquals($expected, $sideloaded);
     }


### PR DESCRIPTION
Related:

- #2850 (same root cause, sibling `ToJpg` class — see below)

**Update (2026-09-09):** see #3285's update note — same history applies here (originally an unconditional rename, reworked to be filter-gated after @gchtr flagged both PRs as effectively the same shape as #2556). Sections below rewritten to match the current diff.

## Issue

While fixing #2850 for `ToWebp` (see #3285), I found the exact same bug pattern in the sibling `ToJpg` operation: `ToJpg::filename()` also ignores its `$src_extension` parameter, always returning `"$src_filename.jpg"`. Two source images sharing a basename but differing only in extension (e.g. `flag.png` vs `flag.gif`) resolve to the same destination path. `ImageHelper::_operate()`'s destination-already-exists cache-hit branch then returns the first-converted image's jpg content for every subsequent same-basename source instead of converting its own.

No separate GitHub issue exists for this one — it was found via code review while fixing #2850, not from an independent user report. Happy to have this linked/tracked however maintainers prefer.

## Solution

Applied the identical fix as #3285: fold the source extension into the generated filename (`flag-png.jpg`, `flag-gif.jpg`, ...), gated behind the same `timber/image/collision_safe_filenames` filter — off by default.

Two cases keep the bare name regardless of the filter, same as #3285:

- **Already-jpg source** — preserves the existing self-collision-as-no-op behavior, covered by the unmodified `testJPGtoJPG`.
- **Extensionless source** — matches the sibling `Resize::filename()`'s existing handling of a falsy `$src_extension` (see #3285's Solution section for the full reasoning); avoids producing a stray `name-.jpg`.

## Impact

Same as #3285: off by default, no forced regeneration for sites that don't opt in. Sites that enable the filter get the new naming for every non-jpg source going forward. Existing already-converted `name.jpg` files are untouched either way.

## Usage Changes

No change for sites that don't opt in. Sites that enable `timber/image/collision_safe_filenames`: generated `tojpg` filenames for non-jpg sources now include the source extension. No API/signature changes.

## Considerations

Same as #3285: same filter name (chosen before finding @gchtr's `timber/image/advanced_file_names` suggestion on #2556 — happy to rename), and same `-` separator choice for consistency between the two sibling operations.

## Testing

Updated the four existing filename-based assertions in `tests/Image/Operation/ToJpgTest.php` affected by the naming change, reverted for the default (filter-off) case, added a test pinning the default-off collision as intentional, and added `testCollidingBasenamesProduceDistinctJpgWhenFilterEnabled()`, mirroring `ToWebp`'s regression test. Added `testFilenameKeepsBareNameForExtensionlessSource()` mirroring #3285's, for the same reason (direct call, not through the full pipeline, since an extensionless source can't reach `wp_check_filetype`-based format detection in `ToJpg::run()`).

**Disclosure**: same update as #3285 — earlier revisions were hand-traced only; since then, actually ran this branch's tests in the same PHP 8.2 + GD(WebP) + Mantle/SQLite container. `ToJpgTest` alone: 9/9 passed, 23 assertions. Full `image` testsuite: 178 passed / 3 skipped (Imagick-only, not installed here) / 0 failed. CI will still run the full matrix on top of this.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
